### PR TITLE
feat: separate admin shifts by day and evening periods

### DIFF
--- a/web/src/app/admin/shifts/page.tsx
+++ b/web/src/app/admin/shifts/page.tsx
@@ -12,7 +12,7 @@ import { PageContainer } from "@/components/page-container";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { ShiftLocationSelector } from "@/components/shift-location-selector";
 import { ShiftCalendarWrapper } from "@/components/shift-calendar-wrapper";
-import { AnimatedShiftCardsWrapper } from "@/components/animated-shift-cards-wrapper";
+import { ShiftsByTimeOfDay } from "@/components/shifts-by-time-of-day";
 import { LOCATIONS, LocationOption, DEFAULT_LOCATION } from "@/lib/locations";
 
 interface AdminShiftsPageProps {
@@ -323,13 +323,7 @@ export default async function AdminShiftsPage({
             </Button>
           </div>
         ) : (
-          <>
-            <AnimatedShiftCardsWrapper
-              shifts={shifts}
-              dateString={dateString}
-              selectedLocation={selectedLocation}
-            />
-          </>
+          <ShiftsByTimeOfDay shifts={shifts} />
         )}
       </PageContainer>
     </AdminPageWrapper>

--- a/web/src/components/shifts-by-time-of-day.tsx
+++ b/web/src/components/shifts-by-time-of-day.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { AnimatedShiftCardsWrapper } from "@/components/animated-shift-cards-wrapper";
+
+interface Shift {
+  id: string;
+  start: Date;
+  end: Date;
+  location: string | null;
+  capacity: number;
+  notes: string | null;
+  shiftType: {
+    id: string;
+    name: string;
+  };
+  signups: Array<{
+    id: string;
+    status: string;
+    user: {
+      id: string;
+      name: string | null;
+      firstName: string | null;
+      lastName: string | null;
+      volunteerGrade: string | null;
+      profilePhotoUrl: string | null;
+      adminNotes: Array<{
+        id: string;
+        content: string;
+        createdAt: Date;
+        creator: {
+          name: string | null;
+          firstName: string | null;
+          lastName: string | null;
+        };
+      }>;
+    };
+  }>;
+  groupBookings: Array<{
+    signups: Array<{
+      status: string;
+    }>;
+  }>;
+}
+
+interface ShiftsByTimeOfDayProps {
+  shifts: Shift[];
+}
+
+export function ShiftsByTimeOfDay({ shifts }: ShiftsByTimeOfDayProps) {
+  // Helper function to determine if a shift is AM or PM
+  const isAMShift = (shift: Shift) => {
+    const hour = shift.start.getHours();
+    return hour < 16; // Before 4pm (16:00) is considered "AM"
+  };
+
+  // Group shifts by AM/PM
+  const amShifts = shifts.filter(isAMShift);
+  const pmShifts = shifts.filter(shift => !isAMShift(shift));
+
+  const hasAMShifts = amShifts.length > 0;
+  const hasPMShifts = pmShifts.length > 0;
+
+  return (
+    <div className="space-y-8">
+      {/* AM Shifts Section */}
+      {hasAMShifts && (
+        <section className="space-y-4" data-testid="admin-shifts-am-section">
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 bg-gradient-to-br from-amber-500 to-orange-600 rounded-lg flex items-center justify-center text-lg">
+              ☀️
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">Day Shifts</h3>
+              <p className="text-sm text-muted-foreground">
+                {amShifts.length} shift{amShifts.length !== 1 ? "s" : ""} available (before 4pm)
+              </p>
+            </div>
+          </div>
+          <AnimatedShiftCardsWrapper
+            shifts={amShifts}
+            dateString={amShifts[0]?.start ? new Date(amShifts[0].start).toISOString().split('T')[0] : ''}
+            selectedLocation={amShifts[0]?.location || ''}
+          />
+        </section>
+      )}
+
+      {/* PM Shifts Section */}
+      {hasPMShifts && (
+        <section className="space-y-4" data-testid="admin-shifts-pm-section">
+          <div className="flex items-center gap-3">
+            <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg flex items-center justify-center text-lg">
+              🌙
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">Evening Shifts</h3>
+              <p className="text-sm text-muted-foreground">
+                {pmShifts.length} shift{pmShifts.length !== 1 ? "s" : ""} available (4pm onwards)
+              </p>
+            </div>
+          </div>
+          <AnimatedShiftCardsWrapper
+            shifts={pmShifts}
+            dateString={pmShifts[0]?.start ? new Date(pmShifts[0].start).toISOString().split('T')[0] : ''}
+            selectedLocation={pmShifts[0]?.location || ''}
+          />
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add day/evening separation to admin manage shifts page, matching the public shifts page behavior
- Create new `ShiftsByTimeOfDay` component to organize shifts into day (before 4pm) and evening (4pm onwards) sections
- Replace single grid display with sectioned view for better organization

## Changes Made
- **New Component**: `ShiftsByTimeOfDay` - handles grouping and displaying shifts by time period
- **Updated Admin Shifts Page**: Now uses the new component instead of `AnimatedShiftCardsWrapper` directly
- **Consistent UX**: Admin page now matches the day/evening separation pattern from public shifts page

## Visual Improvements
- Day shifts section with ☀️ sun icon and "before 4pm" description  
- Evening shifts section with 🌙 moon icon and "4pm onwards" description
- Clear section headers with shift counts
- Maintains existing admin functionality (edit, delete, grade badges, etc.)

## Test Plan
- [ ] Verify day shifts (before 4pm) appear in "Day Shifts" section
- [ ] Verify evening shifts (4pm onwards) appear in "Evening Shifts" section  
- [ ] Test with mixed day/evening shifts on same date
- [ ] Confirm all existing admin functionality still works (edit, delete, volunteer management)
- [ ] Test empty states and single time period scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)