### PR TITLE
Fix calendar alignment in shifts/mine page

### DIFF
--- a/web/src/app/shifts/mine/page.tsx
+++ b/web/src/app/shifts/mine/page.tsx
@@ -6,6 +6,9 @@ import {
   eachDayOfInterval,
   isSameDay,
   differenceInHours,
+  startOfWeek,
+  endOfWeek,
+  isSameMonth,
 } from "date-fns";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
@@ -338,10 +341,12 @@ export default async function MyShiftsPage({
 
   const [completedShifts, upcomingShifts] = totalStats;
 
-  // Generate calendar days
+  // Generate calendar days with proper week alignment
+  const calendarStart = startOfWeek(monthStart);
+  const calendarEnd = endOfWeek(monthEnd);
   const calendarDays = eachDayOfInterval({
-    start: monthStart,
-    end: monthEnd,
+    start: calendarStart,
+    end: calendarEnd,
   });
 
   // Group shifts by date
@@ -855,6 +860,7 @@ export default async function MyShiftsPage({
               const dateKey = format(day, "yyyy-MM-dd");
               const dayShifts = shiftsByDate.get(dateKey) || [];
               const availableShifts = availableShiftsByDate.get(dateKey) || [];
+              const isCurrentMonth = isSameMonth(day, viewMonth);
               const isToday = isSameDay(day, now);
               const isPast = day < now && !isToday;
               const shift = dayShifts[0]; // Since only 1 shift per day is allowed
@@ -867,7 +873,9 @@ export default async function MyShiftsPage({
                     min-h-[140px] p-3 rounded-xl relative flex flex-col
                     transition-all duration-200 ease-in-out hover:scale-[1.02] hover:shadow-lg
                     ${
-                      isPast
+                      !isCurrentMonth
+                        ? "bg-gray-50/50 dark:bg-gray-900/30 border border-gray-200/40 dark:border-gray-700/40 opacity-50"
+                        : isPast
                         ? "bg-gray-50/70 dark:bg-gray-900/30 border border-gray-200/60 dark:border-gray-700/60 shadow-sm"
                         : isToday
                         ? "bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-950/40 dark:to-indigo-950/40 border-2 border-blue-300 dark:border-blue-700 shadow-md ring-2 ring-blue-200/40 dark:ring-blue-800/40"
@@ -884,7 +892,9 @@ export default async function MyShiftsPage({
                       className={`
                         text-sm font-bold w-7 h-7 rounded-full flex items-center justify-center
                         ${
-                          isPast
+                          !isCurrentMonth
+                            ? "text-gray-400 dark:text-gray-600"
+                            : isPast
                             ? "text-gray-400 dark:text-gray-600"
                             : isToday
                             ? "text-white bg-blue-500 shadow-md"
@@ -990,12 +1000,13 @@ export default async function MyShiftsPage({
               const dateKey = format(day, "yyyy-MM-dd");
               const dayShifts = shiftsByDate.get(dateKey) || [];
               const availableShifts = availableShiftsByDate.get(dateKey) || [];
+              const isCurrentMonth = isSameMonth(day, viewMonth);
               const isToday = isSameDay(day, now);
               const isPast = day < now && !isToday;
               const shift = dayShifts[0];
 
-              // Skip days without shifts or available shifts unless it's today
-              if (!shift && availableShifts.length === 0 && !isToday) {
+              // Skip days without shifts or available shifts unless it's today, and skip non-current month days
+              if ((!shift && availableShifts.length === 0 && !isToday) || !isCurrentMonth) {
                 return null;
               }
 


### PR DESCRIPTION
## Summary
- Fix calendar grid alignment where days were misaligned with day-of-week headers
- Friday was showing as Thursday due to improper calendar generation logic
- Calendar now properly aligns with correct day-of-week positioning

## Changes Made
- **Calendar Generation**: Use `startOfWeek`/`endOfWeek` to create proper calendar grid with padding days
- **Current Month Detection**: Add `isSameMonth` logic to differentiate current month from padding days
- **Visual Styling**: Style non-current month days as muted/faded for visual clarity  
- **Mobile View**: Update mobile list to only show current month days
- **Imports**: Add required date-fns functions (`startOfWeek`, `endOfWeek`, `isSameMonth`)

## Technical Details
The issue was that `eachDayOfInterval({ start: monthStart, end: monthEnd })` only generated days 1-30 of the month, but placed them sequentially in grid cells regardless of what day of the week they fall on. 

Now using the same approach as the working `shifts-calendar.tsx` component:
- Generate full weeks using `startOfWeek(monthStart)` to `endOfWeek(monthEnd)`  
- Include padding days from previous/next months for proper alignment
- Style padding days as muted so they don't interfere with current month view

## Test Plan
- [x] Verify Friday shows in Friday column (not Thursday)
- [x] Check calendar alignment across different months
- [x] Test mobile list view only shows current month days
- [x] Confirm padding days are visually muted
- [x] Ensure "Today" highlighting works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)