### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/everybody-eats-nz/volunteer-portal/security/code-scanning/5](https://github.com/everybody-eats-nz/volunteer-portal/security/code-scanning/5)

To fix the problem, you should add an explicit `permissions:` block to limit the permissions of the `GITHUB_TOKEN` used by this workflow. The optimal location is at the workflow root (above `jobs:`), which sets the default permissions for all jobs, unless individual jobs require an override. For this workflow, none of the jobs appear to require write access; they simply check out code, run tests, and upload/download artifacts with standard GitHub actions. The minimal recommended starting point is `contents: read`, which only allows reading repository contents. If you discover that a job fails because it requires extra permissions (e.g., uploading releases, creating PRs), you can expand permissions or add more granular permissions at the job level. The edit should be performed in the `.github/workflows/test.yml` file, adding a new block after `name:` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
