### PR TITLE
fix: update GitHub remote URL in version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Push changes
         if: steps.version-type.outputs.bump_type != 'skip'
         run: |
-          git remote set-url origin git@github.com:malinmalliyawadu/volunteer-portal.git
+          git remote set-url origin git@github.com:everybody-eats-nz/volunteer-portal.git
           git push origin main "v${{ steps.bump-version.outputs.new_version }}"
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
• Updates the remote URL in the version-bump.yml workflow file to reflect the new repository location

## Test plan
- [x] Verify workflow file syntax is correct
- [ ] Test that version bumping works correctly with new remote URL

🤖 Generated with [Claude Code](https://claude.ai/code)