### PR TITLE
Add demo environment indicator to header logos

### DIFF
--- a/web/src/components/admin-sidebar.tsx
+++ b/web/src/components/admin-sidebar.tsx
@@ -21,6 +21,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { NotificationBell } from "@/components/notification-bell";
 import { adminNavCategories, publicNavItems } from "@/lib/admin-navigation";
 import { Session } from "next-auth";
+import { isDemoEnvironment, getDemoEnvironmentLabel } from "@/lib/environment";
 
 interface AdminSidebarProps {
   session: Session | null;
@@ -41,6 +42,8 @@ export function AdminSidebar({
   displayName,
 }: AdminSidebarProps) {
   const pathname = usePathname();
+  const showDemoIndicator = isDemoEnvironment();
+  const demoLabel = getDemoEnvironmentLabel();
 
   const isActive = (href: string, exact = false) => {
     if (exact) {
@@ -54,14 +57,21 @@ export function AdminSidebar({
       <SidebarHeader className="border-b border-sidebar-border">
         <div className="flex items-center justify-between gap-3 px-2">
           <Link href="/" className="flex items-center gap-2 group">
-            <Image
-              src="/logo.svg"
-              alt="Everybody Eats"
-              width={120}
-              height={44}
-              priority
-              className="h-8 w-auto transition-all duration-300 group-hover:scale-105 filter invert dark:invert-0"
-            />
+            <div className="relative">
+              <Image
+                src="/logo.svg"
+                alt="Everybody Eats"
+                width={120}
+                height={44}
+                priority
+                className="h-8 w-auto transition-all duration-300 group-hover:scale-105 filter invert dark:invert-0"
+              />
+              {showDemoIndicator && (
+                <div className="absolute -top-1 -right-1 bg-orange-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full shadow-sm">
+                  {demoLabel}
+                </div>
+              )}
+            </div>
           </Link>
 
           {userProfile?.id && (

--- a/web/src/components/site-header.tsx
+++ b/web/src/components/site-header.tsx
@@ -11,6 +11,7 @@ import { NotificationBell } from "@/components/notification-bell";
 import { cn } from "@/lib/utils";
 import { Session } from "next-auth";
 import { Menu, X } from "lucide-react";
+import { isDemoEnvironment, getDemoEnvironmentLabel } from "@/lib/environment";
 
 interface SiteHeaderProps {
   session: Session | null;
@@ -31,6 +32,8 @@ export function SiteHeader({
 }: SiteHeaderProps) {
   const pathname = usePathname();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const showDemoIndicator = isDemoEnvironment();
+  const demoLabel = getDemoEnvironmentLabel();
 
   const isActive = (path: string) => {
     return pathname === path;
@@ -83,6 +86,11 @@ export function SiteHeader({
                 priority
                 className="h-14 w-auto transition-all duration-300 ease-out group-hover:scale-105 group-active:scale-95 drop-shadow-sm"
               />
+              {showDemoIndicator && (
+                <div className="absolute -top-1 -right-1 bg-orange-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full shadow-sm">
+                  {demoLabel}
+                </div>
+              )}
               <div className="absolute inset-0 bg-white/10 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity duration-300 -z-10 blur-xl" />
             </div>
             <span className="sr-only">Everybody Eats logo</span>

--- a/web/src/lib/environment.ts
+++ b/web/src/lib/environment.ts
@@ -1,0 +1,33 @@
+/**
+ * Environment detection utilities
+ */
+
+export function isDemoEnvironment(): boolean {
+  const vercelEnv = process.env.VERCEL_ENV;
+
+  // Show demo indicator for:
+  // 1. Local development (no VERCEL_ENV)
+  // 2. Demo environments (VERCEL_ENV=demo)
+  // 3. Preview environments (VERCEL_ENV=preview)
+  // 4. Staging environments (VERCEL_ENV=staging)
+  return !vercelEnv || vercelEnv === 'demo' || vercelEnv === 'preview' || vercelEnv === 'staging';
+}
+
+export function getDemoEnvironmentLabel(): string {
+  const vercelEnv = process.env.VERCEL_ENV;
+
+  if (!vercelEnv) {
+    return 'DEV';
+  }
+
+  switch (vercelEnv) {
+    case 'demo':
+      return 'DEMO';
+    case 'preview':
+      return 'PREVIEW';
+    case 'staging':
+      return 'STAGING';
+    default:
+      return 'DEV';
+  }
+}


### PR DESCRIPTION
## Summary
- Add visual indicator badges to both admin and volunteer page headers when running in non-production environments
- Create environment detection utility to identify demo/dev/preview/staging environments  
- Show appropriate environment labels (DEV, DEMO, PREVIEW, STAGING) with orange badge overlay on logos
- Hidden in production environments for clean user experience

## Test plan
- [ ] Test in local development environment (should show "DEV" badge)
- [ ] Test with VERCEL_ENV=demo (should show "DEMO" badge)
- [ ] Test with VERCEL_ENV=preview (should show "PREVIEW" badge)
- [ ] Test with VERCEL_ENV=staging (should show "STAGING" badge)
- [ ] Verify no badge shows in production
- [ ] Test admin sidebar logo indicator
- [ ] Test volunteer header logo indicator
- [ ] Verify responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)