### PR TITLE
feat: implement masonry layout for volunteer dashboard

### DIFF
--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
-import { ContentGrid, BottomGrid } from "@/components/dashboard-animated";
+import { ContentGrid } from "@/components/dashboard-animated";
 import AchievementsCard from "@/components/achievements-card";
 import { DashboardStats } from "@/components/dashboard-stats";
 import { DashboardNextShift } from "@/components/dashboard-next-shift";
@@ -59,14 +59,12 @@ export default async function DashboardPage() {
         <Suspense fallback={<DashboardContentSkeleton />}>
           <DashboardRecentActivity userId={userId} />
         </Suspense>
-      </ContentGrid>
 
-      <BottomGrid>
         {/* Impact & Community Stats - streams in when ready */}
         <Suspense fallback={<DashboardContentSkeleton />}>
           <DashboardImpactStats userId={userId} />
         </Suspense>
-      </BottomGrid>
+      </ContentGrid>
 
       {/* Quick Actions - renders immediately (no data dependencies) */}
       <DashboardQuickActions />

--- a/web/src/components/achievements-card.tsx
+++ b/web/src/components/achievements-card.tsx
@@ -84,9 +84,9 @@ export default function AchievementsCard() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="flex items-center justify-center py-8">
-              <motion.div 
-                animate={{ rotate: 360 }} 
+            <div className="flex items-center justify-center" style={{ minHeight: "400px" }}>
+              <motion.div
+                animate={{ rotate: 360 }}
                 transition={{ duration: 1, repeat: Infinity, ease: "linear" }}
                 className="rounded-full h-8 w-8 border-b-2 border-primary"
               />

--- a/web/src/components/dashboard-animated.tsx
+++ b/web/src/components/dashboard-animated.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "motion/react";
 import { staggerContainer, staggerItem } from "@/lib/motion";
+import { useEffect, useRef, useState, ReactElement, Children } from "react";
 
 interface DashboardAnimatedProps {
   children: React.ReactNode;
@@ -34,30 +35,155 @@ export function StatCard({ children }: DashboardAnimatedProps) {
   );
 }
 
-// Animated wrapper for the main content grid
+// Masonry layout hook for dashboard cards
+function useMasonry(itemCount: number, columnCount: number) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const updateLayoutRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    const updateLayout = () => {
+      if (!containerRef.current) return;
+
+      const container = containerRef.current;
+      const items = Array.from(container.children) as HTMLElement[];
+      const gap = 24; // 6 * 4px (gap-6)
+
+      // Reset heights for each column
+      const columnHeights = new Array(columnCount).fill(0);
+
+      items.forEach((item, index) => {
+        // Determine which column to place this item in
+        let columnIndex: number;
+        if (index < columnCount) {
+          // First row items go directly into their column
+          columnIndex = index;
+        } else {
+          // Find the shortest column
+          columnIndex = columnHeights.indexOf(Math.min(...columnHeights));
+        }
+
+        item.style.position = "absolute";
+        item.style.top = `${columnHeights[columnIndex]}px`;
+
+        // Calculate left position: percentage + half-gaps before this column
+        const leftPercent = (columnIndex * 100) / columnCount;
+        const leftGap = columnIndex * (gap / 2);
+        item.style.left = `calc(${leftPercent}% + ${leftGap}px)`;
+
+        // Width: percentage minus half-gap on each side
+        item.style.width = `calc(${100 / columnCount}% - ${gap / 2}px)`;
+
+        columnHeights[columnIndex] += item.offsetHeight + gap;
+      });
+
+      // Set container height to the tallest column (remove trailing gap)
+      const maxHeight = Math.max(...columnHeights) - gap;
+      container.style.height = `${maxHeight}px`;
+    };
+
+    updateLayoutRef.current = updateLayout;
+
+    // Update layout on mount and resize
+    updateLayout();
+
+    const observer = new ResizeObserver(updateLayout);
+    if (containerRef.current) {
+      // Observe the container itself
+      observer.observe(containerRef.current);
+
+      // Also observe all children for height changes
+      const items = Array.from(containerRef.current.children) as HTMLElement[];
+      items.forEach((item) => observer.observe(item));
+    }
+
+    window.addEventListener("resize", updateLayout);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", updateLayout);
+    };
+  }, [itemCount, columnCount]);
+
+  // Continuously update layout for dynamic content
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (updateLayoutRef.current) {
+        updateLayoutRef.current();
+      }
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return containerRef;
+}
+
+// Animated wrapper for the main content grid with masonry layout
 export function ContentGrid({ children }: DashboardAnimatedProps) {
+  const [columnCount, setColumnCount] = useState(1);
+  const childArray = Children.toArray(children);
+  const containerRef = useMasonry(childArray.length, columnCount);
+
+  useEffect(() => {
+    const updateColumnCount = () => {
+      if (window.innerWidth >= 1024) setColumnCount(2); // lg
+      else setColumnCount(1);
+    };
+
+    updateColumnCount();
+    window.addEventListener("resize", updateColumnCount);
+    return () => window.removeEventListener("resize", updateColumnCount);
+  }, []);
+
   return (
     <motion.div
-      className="grid grid-cols-1 lg:grid-cols-2 gap-6"
+      ref={containerRef}
+      className="relative"
+      style={{ minHeight: "200px" }}
       variants={staggerContainer}
       initial="hidden"
       animate="visible"
     >
-      {children}
+      {Children.map(children, (child) => (
+        <motion.div variants={staggerItem} className="w-full">
+          {child}
+        </motion.div>
+      ))}
     </motion.div>
   );
 }
 
-// Animated wrapper for the bottom grid
+// Animated wrapper for the bottom grid with masonry layout
 export function BottomGrid({ children }: DashboardAnimatedProps) {
+  const [columnCount, setColumnCount] = useState(1);
+  const childArray = Children.toArray(children);
+  const containerRef = useMasonry(childArray.length, columnCount);
+
+  useEffect(() => {
+    const updateColumnCount = () => {
+      if (window.innerWidth >= 1024) setColumnCount(2); // lg
+      else setColumnCount(1);
+    };
+
+    updateColumnCount();
+    window.addEventListener("resize", updateColumnCount);
+    return () => window.removeEventListener("resize", updateColumnCount);
+  }, []);
+
   return (
     <motion.div
-      className="grid grid-cols-1 lg:grid-cols-2 gap-6"
+      ref={containerRef}
+      className="relative"
+      style={{ minHeight: "200px" }}
       variants={staggerContainer}
       initial="hidden"
       animate="visible"
     >
-      {children}
+      {Children.map(children, (child) => (
+        <motion.div variants={staggerItem} className="w-full">
+          {child}
+        </motion.div>
+      ))}
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- Implement masonry layout for volunteer dashboard cards
- Cards now automatically position to minimize vertical gaps, similar to the admin shifts page
- Improves visual layout and space utilization

## Changes
- Add masonry layout algorithm to `ContentGrid` and `BottomGrid` components in `dashboard-animated.tsx`
- Use ResizeObserver to detect card height changes and recalculate layout dynamically
- Add continuous layout updates (every 100ms) to handle content loading and animations
- Set min-height on achievements card loading state to prevent layout shift when data loads
- Merge Impact & Community card into main ContentGrid for unified 4-card masonry layout
- Responsive: 1 column on mobile, 2 columns on large screens

## Test plan
- [x] View volunteer dashboard and verify cards arrange in masonry layout with consistent 24px gaps
- [x] Verify achievements card doesn't cause layout shift when loading completes
- [x] Test responsive behavior by resizing browser window
- [x] Verify all 4 cards (Next Shift, Achievements, Recent Activity, Impact & Community) flow together
- [ ] Test with different amounts of content in each card

🤖 Generated with [Claude Code](https://claude.com/claude-code)