### PR TITLE
fix: use stable demo URL for registration links

### DIFF
--- a/web/src/app/api/admin/migration/resend-invitation/route.ts
+++ b/web/src/app/api/admin/migration/resend-invitation/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { randomBytes } from "crypto";
 import { getEmailService } from "@/lib/email-service";
+import { getBaseUrl } from "@/lib/utils";
 
 interface InvitationWebhookData {
   email: string;
@@ -102,9 +103,7 @@ export async function POST(request: NextRequest) {
     expiresAt.setDate(expiresAt.getDate() + 7); // 7 days expiry
 
     // Create registration link
-    const baseUrl = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : "http://localhost:3000";
+    const baseUrl = getBaseUrl();
     const registrationLink = `${baseUrl}/register/migrate?token=${invitationToken}`;
 
     // Generate webhook data

--- a/web/src/app/api/admin/migration/send-invitations/route.ts
+++ b/web/src/app/api/admin/migration/send-invitations/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { randomBytes } from "crypto";
 import { getEmailService } from "@/lib/email-service";
+import { getBaseUrl } from "@/lib/utils";
 
 interface InvitationWebhookData {
   email: string;
@@ -107,9 +108,7 @@ export async function POST(request: NextRequest) {
         expiresAt.setDate(expiresAt.getDate() + 7); // 7 days expiry
 
         // Create registration link
-        const baseUrl = process.env.VERCEL_URL
-          ? `https://${process.env.VERCEL_URL}`
-          : "http://localhost:3000";
+        const baseUrl = getBaseUrl();
         const registrationLink = `${baseUrl}/register/migrate?token=${invitationToken}`;
 
         // Generate webhook data

--- a/web/src/app/api/migration/send-invite/route.ts
+++ b/web/src/app/api/migration/send-invite/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth-options';
 import { getEmailService } from '@/lib/email-service';
 import { prisma } from '@/lib/prisma';
 import { randomBytes } from 'crypto';
+import { getBaseUrl } from '@/lib/utils';
 
 export async function POST(request: NextRequest) {
   try {
@@ -77,9 +78,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Generate migration link
-    const baseUrl = process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : 'http://localhost:3000';
+    const baseUrl = getBaseUrl();
     const migrationLink = `${baseUrl}/migrate?token=${token}`;
 
     // Send email

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -19,3 +19,18 @@ export function calculateAge(dateOfBirth: Date): number {
   }
   return age;
 }
+
+// Get the base URL for the application
+// For demo environment, use the stable demo URL instead of commit-specific URLs
+export function getBaseUrl(): string {
+  // Check if we're in the demo environment
+  if (process.env.VERCEL_ENV === 'preview') {
+    return 'https://demo.everybody-eats.vercel.app';
+  }
+
+  // For other Vercel deployments or local development
+  const vercelUrl = process.env.VERCEL_URL;
+  return vercelUrl
+    ? `https://${vercelUrl}`
+    : 'http://localhost:3000';
+}


### PR DESCRIPTION
## Summary
- Fixes registration links in demo environment to use stable `demo.everybody-eats.vercel.app` URL instead of commit-specific URLs
- Creates centralized `getBaseUrl()` utility function for consistent URL generation across all migration routes

## Changes
- Added `getBaseUrl()` function in `src/lib/utils.ts` that detects demo environment using `VERCEL_ENV`
- Updated all three migration invitation routes to use the common utility:
  - `/api/admin/migration/send-invitations`
  - `/api/admin/migration/resend-invitation`
  - `/api/migration/send-invite`

## Impact
Registration links sent in emails will now consistently use the stable demo URL, preventing issues where commit-specific URLs become invalid or confusing for users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)