### PR TITLE
Fix excessive padding on registration page mobile

### DIFF
--- a/web/src/app/register/register-client.tsx
+++ b/web/src/app/register/register-client.tsx
@@ -644,7 +644,7 @@ export default function RegisterClient({ locationOptions, shiftTypes }: Register
 
   return (
     <MotionPageContainer className="min-h-screen" data-testid="register-page">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 space-y-8">
+      <div className="max-w-4xl mx-auto space-y-8">
         <PageHeader
           title="Join Everybody Eats"
           description="Create your volunteer account and start making a difference in your community. The registration process takes about 5-10 minutes to complete."


### PR DESCRIPTION
## Summary
- Removes duplicate padding from registration page that was causing excessive whitespace on mobile
- MainContentWrapper already provides `px-4 py-6` for all pages
- Registration page was adding additional `px-4 sm:px-6 py-6`, resulting in double padding

## Changes
- Removed `px-4 sm:px-6 py-6` from registration page inner container
- Registration page now uses consistent padding with login, dashboard, and other pages

## Test plan
- [ ] Test registration page on mobile - verify padding matches other pages
- [ ] Test registration page on desktop - verify layout still looks correct
- [ ] Compare with login page and dashboard to ensure consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)