### PR TITLE
fix: friend request notifications now route to requests tab

### DIFF
--- a/web/prisma/seed-demo.js
+++ b/web/prisma/seed-demo.js
@@ -1512,7 +1512,7 @@ async function main() {
           message: `${
             otherUsers[0].firstName || otherUsers[0].name || "Someone"
           } sent you a friend request`,
-          actionUrl: "/friends",
+          actionUrl: "/friends?tab=requests",
           relatedId: "fake-friend-request-id",
           isRead: false,
           createdAt: new Date(now.getTime() - 2 * 60 * 60 * 1000), // 2 hours ago

--- a/web/src/app/friends/page.tsx
+++ b/web/src/app/friends/page.tsx
@@ -12,7 +12,11 @@ import { BarChart3 } from "lucide-react";
 import ErrorBoundary from "@/components/error-boundary";
 import { FriendsErrorFallback } from "@/components/friends-error-fallback";
 
-export default async function FriendsPage() {
+export default async function FriendsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
   const session = await getServerSession(authOptions);
 
   if (!session) {
@@ -25,6 +29,10 @@ export default async function FriendsPage() {
   if (!friendsData) {
     redirect("/login");
   }
+
+  // Get the tab from searchParams
+  const { tab } = await searchParams;
+  const initialTab = tab === "requests" ? "requests" : "friends";
 
   return (
     <MotionPageContainer>
@@ -92,7 +100,7 @@ export default async function FriendsPage() {
             </div>
           }
         >
-          <FriendsManagerServer initialData={friendsData} />
+          <FriendsManagerServer initialData={friendsData} initialTab={initialTab} />
         </Suspense>
       </ErrorBoundary>
     </MotionPageContainer>

--- a/web/src/components/friends-manager-server.tsx
+++ b/web/src/components/friends-manager-server.tsx
@@ -15,10 +15,12 @@ import { motion } from "motion/react";
 
 interface FriendsManagerServerProps {
   initialData: FriendsData;
+  initialTab?: "friends" | "requests";
 }
 
 export function FriendsManagerServer({
   initialData,
+  initialTab = "friends",
 }: FriendsManagerServerProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [showSendRequest, setShowSendRequest] = useState(false);
@@ -71,7 +73,7 @@ export function FriendsManagerServer({
         </div>
       </div>
 
-      <Tabs defaultValue="friends" className="space-y-8">
+      <Tabs defaultValue={initialTab} className="space-y-8">
         <TabsList
           data-testid="friends-tabs"
           aria-label="Friends and requests navigation"

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -215,7 +215,7 @@ export async function createFriendRequestNotification(
     type: "FRIEND_REQUEST_RECEIVED",
     title: "New friend request",
     message: `${senderName} sent you a friend request`,
-    actionUrl: "/friends",
+    actionUrl: "/friends?tab=requests",
     relatedId: friendRequestId,
   });
 }


### PR DESCRIPTION
## Summary

- Friend request notifications now link directly to the "Requests" tab on the friends page
- Users no longer need to manually switch tabs after clicking a friend request notification
- Improved user experience by taking users directly to where they need to go

## Problem

Previously, when users clicked on a friend request notification:
1. They were taken to `/friends` (the friends page)
2. The page defaulted to showing the "Friends" tab
3. Users had to manually click the "Requests" tab to see their pending friend requests

This created an unnecessary extra step and poor UX.

## Solution

Updated the notification routing to use query parameters:
- Friend request notifications now link to `/friends?tab=requests`
- The friends page reads the `tab` query parameter
- The "Requests" tab is automatically shown when coming from a notification
- Backward compatible: visiting `/friends` without params still defaults to "Friends" tab

## Changes

- `src/lib/notifications.ts`: Updated `createFriendRequestNotification` to use `/friends?tab=requests`
- `src/app/friends/page.tsx`: Added `searchParams` support to read tab parameter and determine initial tab
- `src/components/friends-manager-server.tsx`: Added `initialTab` prop with type safety
- `prisma/seed-demo.js`: Updated seed data notification to match new URL pattern

## Test plan

- [ ] Verify friend request notifications link to `/friends?tab=requests`
- [ ] Click a friend request notification and confirm "Requests" tab is shown
- [ ] Visit `/friends` directly and confirm "Friends" tab is shown by default
- [ ] Visit `/friends?tab=requests` directly and confirm "Requests" tab is shown
- [ ] Visit `/friends?tab=friends` and confirm "Friends" tab is shown
- [ ] TypeScript compilation passes (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)