### PR TITLE
feat: add emailAddress to user invitation email data

### DIFF
--- a/web/src/lib/email-service.ts
+++ b/web/src/lib/email-service.ts
@@ -127,6 +127,7 @@ interface SendParentalConsentApprovalParams {
 
 interface UserInvitationEmailData {
   firstName: string;
+  emailAddress: string;
   role: string;
   tempPassword: string;
   loginLink: string;
@@ -789,6 +790,7 @@ class EmailService {
           : `${firstName} <${params.to}>`,
       data: {
         firstName: firstName,
+        emailAddress: params.to,
         role: params.role.toLowerCase(),
         tempPassword: params.tempPassword,
         loginLink: loginLink,


### PR DESCRIPTION
## Summary
- add emailAddress field to the user invitation email payload so downstream automations receive the recipient’s address

## Testing
- not run