### PR TITLE
fix: shift signup dialog not closing after successful signup

### DIFF
--- a/web/src/app/api/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/shifts/[id]/signup/route.ts
@@ -224,12 +224,10 @@ export async function POST(
     // Achievements will be calculated when user visits dashboard/achievements page
 
     // Return signup with updated status and auto-approval flag
-    const updatedSignup = await prisma.signup.findUnique({
-      where: { id: signup.id },
-    });
-
+    // Use the signup object we already have and update its status based on auto-approval result
     return NextResponse.json({
-      ...updatedSignup,
+      ...signup,
+      status: autoApprovalResult.status,
       autoApproved: autoApprovalResult.autoApproved,
     });
   } catch {


### PR DESCRIPTION
## Summary
Fixes #219 - Dialog not closing after successful shift signup (both auto-approved and regular signups).

## Problem
The shift signup dialog was not closing after successful signup in production (Vercel). The signup would succeed, but:
- Dialog remained open
- No success notification appeared
- Console showed only "Error"
- Issue affected both auto-approved and regular signups

## Root Cause
After creating a signup and processing auto-approval, the API was refetching the signup from the database:

```typescript
const updatedSignup = await prisma.signup.findUnique({
  where: { id: signup.id },
});

return NextResponse.json({
  ...updatedSignup,
  autoApproved: autoApprovalResult.autoApproved,
});
```

In production (Vercel), this refetch could fail or return `null` due to:
- Database replication lag
- Connection issues
- Race conditions

When `updatedSignup` was `null`, spreading it resulted in an incomplete response `{ autoApproved: true }` that was missing expected fields like `status`, causing client-side response handling to fail.

## Solution
Eliminated the unnecessary database refetch and instead construct the response using the signup object we already have:

```typescript
return NextResponse.json({
  ...signup,
  status: autoApprovalResult.status,
  autoApproved: autoApprovalResult.autoApproved,
});
```

This ensures:
- Complete response object with all expected fields
- No additional database query needed
- Reliable behavior in all environments
- Faster response time

## Testing
- ✅ Build passes with no TypeScript errors
- ✅ Eliminates race condition that could cause incomplete responses
- Ready for testing in Vercel preview deployment

## Type of Change
Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)