### PR TITLE
fix: use NZ date format and getBaseUrl for password reset emails

### DIFF
--- a/web/src/app/admin/migration/migrated-users.tsx
+++ b/web/src/app/admin/migration/migrated-users.tsx
@@ -310,7 +310,7 @@ export function MigratedUsers() {
                         <TableCell>
                           {user.invitationSent ? (
                             <div className="text-sm">
-                              <div>Sent: {new Date(user.invitationSentAt!).toLocaleDateString()}</div>
+                              <div>Sent: {new Date(user.invitationSentAt!).toLocaleDateString('en-NZ')}</div>
                               {user.invitationCount > 1 && (
                                 <div className="text-muted-foreground">
                                   Resent {user.invitationCount - 1} time(s)

--- a/web/src/app/admin/migration/migration-status.tsx
+++ b/web/src/app/admin/migration/migration-status.tsx
@@ -249,10 +249,10 @@ export function MigrationStatus() {
                       </div>
                       <div className="text-right">
                         <p className="text-sm font-medium">
-                          {new Date(user.createdAt).toLocaleDateString()}
+                          {new Date(user.createdAt).toLocaleDateString('en-NZ')}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          {new Date(user.createdAt).toLocaleTimeString()}
+                          {new Date(user.createdAt).toLocaleTimeString('en-NZ')}
                         </p>
                       </div>
                     </div>
@@ -293,7 +293,7 @@ export function MigrationStatus() {
                           </span>
                         </div>
                         <p className="text-sm text-muted-foreground">
-                          {new Date(shift.createdAt).toLocaleDateString()}
+                          {new Date(shift.createdAt).toLocaleDateString('en-NZ')}
                         </p>
                       </div>
                       <div className="space-y-1">
@@ -380,10 +380,10 @@ export function MigrationStatus() {
                       </div>
                       <div className="text-right">
                         <p className="text-sm font-medium">
-                          {new Date(signup.createdAt).toLocaleDateString()}
+                          {new Date(signup.createdAt).toLocaleDateString('en-NZ')}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          {new Date(signup.createdAt).toLocaleTimeString()}
+                          {new Date(signup.createdAt).toLocaleTimeString('en-NZ')}
                         </p>
                       </div>
                     </div>
@@ -427,10 +427,10 @@ export function MigrationStatus() {
                       </div>
                       <div className="text-right">
                         <p className="text-sm font-medium">
-                          {new Date(shiftType.createdAt).toLocaleDateString()}
+                          {new Date(shiftType.createdAt).toLocaleDateString('en-NZ')}
                         </p>
                         <p className="text-xs text-muted-foreground">
-                          {new Date(shiftType.createdAt).toLocaleTimeString()}
+                          {new Date(shiftType.createdAt).toLocaleTimeString('en-NZ')}
                         </p>
                       </div>
                     </div>

--- a/web/src/app/admin/migration/nova-bulk-migration.tsx
+++ b/web/src/app/admin/migration/nova-bulk-migration.tsx
@@ -173,7 +173,7 @@ export function NovaBulkMigration() {
     setMigrationLogs([]);
 
     // Add initial log entry
-    const timestamp = new Date().toLocaleTimeString();
+    const timestamp = new Date().toLocaleTimeString('en-NZ');
     setMigrationLogs([
       `[${timestamp}] 🚀 Starting ${migrationMode} migration...`,
     ]);
@@ -202,7 +202,7 @@ export function NovaBulkMigration() {
       eventSource.onopen = () => {
         console.log("SSE connection opened");
         reconnectAttempts = 0;
-        const timestamp = new Date().toLocaleTimeString();
+        const timestamp = new Date().toLocaleTimeString('en-NZ');
         setMigrationLogs((prev) => [
           ...prev,
           `[${timestamp}] 📡 Connected to progress stream`,
@@ -215,7 +215,7 @@ export function NovaBulkMigration() {
           console.log("SSE received:", data);
 
           // Add log entry with timestamp
-          const timestamp = new Date().toLocaleTimeString();
+          const timestamp = new Date().toLocaleTimeString('en-NZ');
 
           // Filter out ping/connected messages from logs
           if (data.type !== "connected" && data.message) {
@@ -237,7 +237,7 @@ export function NovaBulkMigration() {
           }
         } catch (error) {
           console.error("SSE parse error:", error);
-          const timestamp = new Date().toLocaleTimeString();
+          const timestamp = new Date().toLocaleTimeString('en-NZ');
           setMigrationLogs((prev) => [
             ...prev,
             `[${timestamp}] ⚠️ Error parsing progress data`,
@@ -247,7 +247,7 @@ export function NovaBulkMigration() {
 
       eventSource.onerror = (error) => {
         console.error("SSE error:", error);
-        const timestamp = new Date().toLocaleTimeString();
+        const timestamp = new Date().toLocaleTimeString('en-NZ');
 
         if (eventSource?.readyState === EventSource.CLOSED) {
           // Connection was closed
@@ -309,7 +309,7 @@ export function NovaBulkMigration() {
         console.log("Single user migration response:", singleUserData);
 
         // Log the API response
-        const timestamp = new Date().toLocaleTimeString();
+        const timestamp = new Date().toLocaleTimeString('en-NZ');
         setMigrationLogs((prev) => [
           ...prev,
           `[${timestamp}] 📡 API Response: ${
@@ -407,7 +407,7 @@ export function NovaBulkMigration() {
         setResult(data);
 
         // Log the bulk migration results
-        const timestamp = new Date().toLocaleTimeString();
+        const timestamp = new Date().toLocaleTimeString('en-NZ');
         setMigrationLogs((prev) => [
           ...prev,
           `[${timestamp}] 🎯 Bulk Migration Results:`,
@@ -447,7 +447,7 @@ export function NovaBulkMigration() {
         }
       }
     } catch (error) {
-      const timestamp = new Date().toLocaleTimeString();
+      const timestamp = new Date().toLocaleTimeString('en-NZ');
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
       setMigrationLogs((prev) => [

--- a/web/src/app/admin/migration/user-invitations.tsx
+++ b/web/src/app/admin/migration/user-invitations.tsx
@@ -220,9 +220,9 @@ export function UserInvitations() {
   const formatDateTime = (dateString?: string): string => {
     if (!dateString) return "Never";
     return (
-      new Date(dateString).toLocaleDateString() +
+      new Date(dateString).toLocaleDateString('en-NZ') +
       " at " +
-      new Date(dateString).toLocaleTimeString()
+      new Date(dateString).toLocaleTimeString('en-NZ')
     );
   };
 

--- a/web/src/app/api/admin/volunteer-movement/route.ts
+++ b/web/src/app/api/admin/volunteer-movement/route.ts
@@ -184,7 +184,7 @@ export async function POST(request: Request) {
 
       // Create notification for the volunteer about their movement
       const notificationTitle = "You've been moved to a different shift";
-      const notificationMessage = `You've been moved from ${signup.shift.shiftType.name} to ${targetShift.shiftType.name} on ${targetShift.start.toLocaleDateString()} at ${targetShift.location}`;
+      const notificationMessage = `You've been moved from ${signup.shift.shiftType.name} to ${targetShift.shiftType.name} on ${targetShift.start.toLocaleDateString('en-NZ')} at ${targetShift.location}`;
 
       await tx.notification.create({
         data: {

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -231,7 +231,7 @@ export default async function ProfilePage() {
                         Date of Birth
                       </span>
                       <span className="font-medium">
-                        {new Date(userProfile.dateOfBirth).toLocaleDateString()}
+                        {new Date(userProfile.dateOfBirth).toLocaleDateString('en-NZ')}
                       </span>
                     </div>
                   )}

--- a/web/src/components/friend-profile-dialog.tsx
+++ b/web/src/components/friend-profile-dialog.tsx
@@ -126,7 +126,7 @@ export function FriendProfileDialog({
             <div>
               <h2 className="text-lg font-semibold">{displayName}</h2>
               <p className="text-sm text-gray-600">
-                Friends since {new Date(friend.friendsSince).toLocaleDateString()}
+                Friends since {new Date(friend.friendsSince).toLocaleDateString('en-NZ')}
               </p>
             </div>
           </ResponsiveDialogTitle>

--- a/web/src/components/friends-manager.tsx
+++ b/web/src/components/friends-manager.tsx
@@ -218,7 +218,7 @@ export function FriendsManager() {
                             {friend.name || `${friend.firstName || ""} ${friend.lastName || ""}`.trim() || friend.email}
                           </h3>
                           <p className="text-sm text-gray-600">
-                            Friends since {new Date(friend.friendsSince).toLocaleDateString()}
+                            Friends since {new Date(friend.friendsSince).toLocaleDateString('en-NZ')}
                           </p>
                         </div>
                       </div>
@@ -281,12 +281,12 @@ export function FriendsManager() {
                         </Avatar>
                         <div>
                           <h3 className="font-medium">
-                            {request.fromUser.name || 
-                             `${request.fromUser.firstName || ""} ${request.fromUser.lastName || ""}`.trim() || 
+                            {request.fromUser.name ||
+                             `${request.fromUser.firstName || ""} ${request.fromUser.lastName || ""}`.trim() ||
                              request.fromUser.email}
                           </h3>
                           <p className="text-sm text-gray-600">
-                            Sent {new Date(request.createdAt).toLocaleDateString()}
+                            Sent {new Date(request.createdAt).toLocaleDateString('en-NZ')}
                           </p>
                           {request.message && (
                             <p className="text-sm mt-1 italic">

--- a/web/src/components/ui/calendar.tsx
+++ b/web/src/components/ui/calendar.tsx
@@ -190,7 +190,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString()}
+      data-day={day.date.toLocaleDateString('en-NZ')}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/web/src/lib/actions/password-reset.ts
+++ b/web/src/lib/actions/password-reset.ts
@@ -6,6 +6,7 @@ import bcrypt from "bcrypt";
 import { redirect } from "next/navigation";
 import { campaignMonitorService } from "@/lib/services/campaign-monitor";
 import { validatePassword } from "@/lib/utils/password-validation";
+import { getBaseUrl } from "@/lib/utils";
 
 interface ForgotPasswordResult {
   success: boolean;
@@ -61,7 +62,7 @@ export async function forgotPasswordAction(
       });
 
       // Send password reset email via Campaign Monitor
-      const resetUrl = `${process.env.NEXTAUTH_URL}/reset-password?token=${resetToken}`;
+      const resetUrl = `${getBaseUrl()}/reset-password?token=${resetToken}`;
       
       try {
         await campaignMonitorService.sendPasswordResetEmail({


### PR DESCRIPTION
## Summary
- Update all date displays to use New Zealand locale (DD/MM/YYYY format)
- Update password reset email to use `getBaseUrl()` instead of `NEXTAUTH_URL`
- Ensures consistent date formatting across the application for NZ users
- Fixes password reset links in demo/preview environments

## Changes Made

### Date Formatting (NZ Locale)
Updated all instances of `toLocaleDateString()` and `toLocaleTimeString()` to use `'en-NZ'` locale:

**User-facing pages:**
- Profile page: date of birth display
- Friends manager: friends since dates and request sent dates
- Friend profile dialog: friends since date

**Admin pages:**
- Migration status: created dates for users, shifts, signups, and shift types
- User invitations: date/time formatting
- Migrated users: invitation sent dates
- Nova bulk migration: log timestamps

**API:**
- Volunteer movement notifications: shift date in notification message

**Components:**
- Calendar component: data attribute

### Password Reset Email
Updated `src/lib/actions/password-reset.ts`:
- Import `getBaseUrl` from `@/lib/utils`
- Use `getBaseUrl()` instead of `process.env.NEXTAUTH_URL` for password reset links
- This ensures correct URLs in all environments (local, preview, production)

## Testing
- TypeScript compilation passes
- All date formats now display as DD/MM/YYYY for NZ users
- Password reset links will work correctly in demo/preview deployments

## Related Issues
Fixes date formatting inconsistency and password reset email URL issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)