### PR TITLE
fix: increase timeout for Nova migration API routes

### DIFF
--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,5 +1,8 @@
 {
   "functions": {
+    "app/api/admin/migration/**/*.ts": {
+      "maxDuration": 60
+    },
     "app/api/**/*.ts": {
       "maxDuration": 30
     }


### PR DESCRIPTION
## Summary
- Increases `maxDuration` from 30s to 60s for migration API routes (`/api/admin/migration/**`)
- Keeps other API routes at 30s timeout
- Resolves Vercel deployment timeouts during bulk Nova data migration

## Problem
The bulk Nova migration endpoint was timing out on Vercel when processing large batches of users with historical data. The migration involves:
- Scraping users from external Nova system
- Creating user records in database
- Fetching and importing historical event signups
- Multiple database operations per user

## Solution
Added a specific Vercel function configuration in `vercel.json` for migration routes with 60s timeout (the maximum for Vercel Pro plans), while maintaining 30s for other API endpoints.

## Test plan
- [ ] Deploy to Vercel
- [ ] Run bulk Nova migration with batch size of 50 users
- [ ] Verify migration completes without timeout errors
- [ ] Confirm other API routes still work with 30s timeout

## Additional Notes
If 60s is still insufficient for very large batches, consider:
- Reducing batch size parameter
- Processing users across multiple API calls using `startPage` parameter
- Upgrading to Vercel Enterprise (up to 900s timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)