### PR TITLE
feat: Add admin ability to edit volunteer email and date of birth

### DIFF
--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -13,7 +13,6 @@ import {
   Calendar,
   Clock,
   MapPin,
-  Phone,
   Mail,
   User,
   Heart,
@@ -37,6 +36,7 @@ import { UserCustomLabelsManager } from "@/components/user-custom-labels-manager
 import { type VolunteerGrade } from "@prisma/client";
 import { LOCATIONS, LocationOption } from "@/lib/locations";
 import { ImpersonateUserButton } from "@/components/impersonate-user-button";
+import { AdminContactInfoSection } from "@/components/admin-contact-info-section";
 
 interface AdminVolunteerPageProps {
   params: Promise<{ id: string }>;
@@ -507,40 +507,12 @@ export default async function AdminVolunteerPage({
             />
 
             {/* Contact Information */}
-            <Card data-testid="contact-information-card">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Phone className="h-5 w-5 text-primary dark:text-primary" />
-                  Contact Information
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="space-y-4">
-                  <div className="flex items-center gap-3 p-3 bg-muted/50 dark:bg-muted/30 rounded-lg">
-                    <Phone className="h-4 w-4 text-muted-foreground" />
-                    <div className="space-y-1">
-                      <label className="text-sm font-medium">Phone</label>
-                      <p className="text-sm text-muted-foreground">
-                        {volunteer.phone || "Not provided"}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3 p-3 bg-muted/50 dark:bg-muted/30 rounded-lg">
-                    <Calendar className="h-4 w-4 text-muted-foreground" />
-                    <div className="space-y-1">
-                      <label className="text-sm font-medium">
-                        Date of Birth
-                      </label>
-                      <p className="text-sm text-muted-foreground">
-                        {volunteer.dateOfBirth
-                          ? format(volunteer.dateOfBirth, "dd MMM yyyy")
-                          : "Not provided"}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+            <AdminContactInfoSection
+              volunteerId={volunteer.id}
+              email={volunteer.email}
+              phone={volunteer.phone}
+              dateOfBirth={volunteer.dateOfBirth}
+            />
 
             {/* Emergency Contact */}
             <Card data-testid="emergency-contact-card">

--- a/web/src/app/api/admin/users/[id]/profile/route.ts
+++ b/web/src/app/api/admin/users/[id]/profile/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { z } from "zod";
+
+const updateProfileSchema = z.object({
+  email: z.string().email("Please enter a valid email address").optional(),
+  dateOfBirth: z.string().optional().refine(
+    (val) => {
+      if (!val) return true;
+      const date = new Date(val);
+      return !isNaN(date.getTime()) && date <= new Date();
+    },
+    { message: "Please enter a valid date of birth in the past" }
+  ),
+});
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const currentUser = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!currentUser || currentUser.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403 }
+    );
+  }
+
+  const { id: userId } = await params;
+
+  if (!userId) {
+    return NextResponse.json({ error: "User ID is required" }, { status: 400 });
+  }
+
+  try {
+    const body = await req.json();
+    const validatedData = updateProfileSchema.parse(body);
+
+    // Check if the target user exists
+    const targetUser = await prisma.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!targetUser) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Prevent changing own email/DOB through admin endpoint (use profile endpoint instead)
+    if (currentUser.id === targetUser.id) {
+      return NextResponse.json(
+        { error: "Cannot update your own profile through admin endpoint" },
+        { status: 400 }
+      );
+    }
+
+    // If email is being changed, check if new email is already in use
+    if (validatedData.email && validatedData.email !== targetUser.email) {
+      const emailExists = await prisma.user.findUnique({
+        where: { email: validatedData.email },
+      });
+
+      if (emailExists) {
+        return NextResponse.json(
+          { error: "Email address is already in use by another user" },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Build the update object with only provided fields
+    const updateData: { email?: string; dateOfBirth?: Date } = {};
+
+    if (validatedData.email) {
+      updateData.email = validatedData.email;
+    }
+
+    if (validatedData.dateOfBirth) {
+      updateData.dateOfBirth = new Date(validatedData.dateOfBirth);
+    }
+
+    // Update the user
+    const updatedUser = await prisma.user.update({
+      where: { id: userId },
+      data: updateData,
+      select: {
+        id: true,
+        email: true,
+        dateOfBirth: true,
+        name: true,
+      },
+    });
+
+    return NextResponse.json({
+      message: "Profile updated successfully",
+      user: updatedUser,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Validation failed", details: error.issues },
+        { status: 400 }
+      );
+    }
+
+    console.error("Profile update error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/components/admin-contact-info-section.tsx
+++ b/web/src/components/admin-contact-info-section.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React, { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Phone, Calendar, Mail } from "lucide-react";
+import { format } from "date-fns";
+import { AdminEditableField } from "@/components/admin-editable-field";
+
+interface AdminContactInfoSectionProps {
+  volunteerId: string;
+  email: string;
+  phone: string | null;
+  dateOfBirth: Date | null;
+}
+
+export function AdminContactInfoSection({
+  volunteerId,
+  email: initialEmail,
+  phone,
+  dateOfBirth: initialDateOfBirth,
+}: AdminContactInfoSectionProps) {
+  const [email, setEmail] = useState(initialEmail);
+  const [dateOfBirth, setDateOfBirth] = useState<Date | null>(
+    initialDateOfBirth
+  );
+
+  return (
+    <Card data-testid="contact-information-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Phone className="h-5 w-5 text-primary dark:text-primary" />
+          Contact Information
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-4">
+          <div>
+            <label className="text-sm font-medium mb-2 flex items-center gap-2">
+              <Mail className="h-4 w-4 text-muted-foreground" />
+              Email Address
+            </label>
+            <AdminEditableField
+              userId={volunteerId}
+              fieldName="email"
+              currentValue={email}
+              displayValue={email}
+              onUpdate={setEmail}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Click the edit button to update the email address
+            </p>
+          </div>
+
+          <div>
+            <label className="text-sm font-medium mb-2 flex items-center gap-2">
+              <Phone className="h-4 w-4 text-muted-foreground" />
+              Phone
+            </label>
+            <div className="flex items-center gap-3 p-3 bg-muted/50 dark:bg-muted/30 rounded-lg">
+              <p className="text-sm text-muted-foreground">
+                {phone || "Not provided"}
+              </p>
+            </div>
+          </div>
+
+          <div>
+            <label className="text-sm font-medium mb-2 flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-muted-foreground" />
+              Date of Birth
+            </label>
+            <AdminEditableField
+              userId={volunteerId}
+              fieldName="dateOfBirth"
+              currentValue={
+                dateOfBirth ? format(dateOfBirth, "yyyy-MM-dd") : null
+              }
+              displayValue={
+                dateOfBirth ? format(dateOfBirth, "dd MMM yyyy") : "Not provided"
+              }
+              onUpdate={(newValue) => setDateOfBirth(new Date(newValue))}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Click the edit button to update the date of birth
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/admin-editable-field.tsx
+++ b/web/src/components/admin-editable-field.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Edit2, X, Check, CalendarIcon } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { format } from "date-fns";
+import { cn } from "@/lib/utils";
+
+interface AdminEditableFieldProps {
+  userId: string;
+  fieldName: "email" | "dateOfBirth";
+  currentValue: string | null;
+  displayValue: string;
+  onUpdate: (newValue: string) => void;
+}
+
+export function AdminEditableField({
+  userId,
+  fieldName,
+  currentValue,
+  displayValue,
+  onUpdate,
+}: AdminEditableFieldProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(currentValue || "");
+  const [loading, setLoading] = useState(false);
+  const [dobOpen, setDobOpen] = useState(false);
+  const { toast } = useToast();
+
+  const handleSave = async () => {
+    if (!value || value === currentValue) {
+      setIsEditing(false);
+      setValue(currentValue || "");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch(`/api/admin/users/${userId}/profile`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ [fieldName]: value }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || "Failed to update field");
+      }
+
+      await response.json();
+      toast({
+        title: "Updated successfully",
+        description: `${fieldName === "email" ? "Email address" : "Date of birth"} has been updated.`,
+      });
+
+      onUpdate(value);
+      setIsEditing(false);
+    } catch (error) {
+      toast({
+        title: "Error updating field",
+        description:
+          error instanceof Error ? error.message : "Failed to update field",
+        variant: "destructive",
+      });
+      setValue(currentValue || "");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setValue(currentValue || "");
+    setIsEditing(false);
+    setDobOpen(false);
+  };
+
+  const selectedDate = value ? new Date(value) : undefined;
+
+  if (!isEditing) {
+    return (
+      <div className="flex items-center gap-3 p-3 bg-muted/50 dark:bg-muted/30 rounded-lg group">
+        <div className="flex-1 space-y-1">
+          <p className="text-sm text-muted-foreground">{displayValue}</p>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setIsEditing(true)}
+          className="opacity-0 group-hover:opacity-100 transition-opacity"
+          data-testid={`edit-${fieldName}-button`}
+        >
+          <Edit2 className="h-4 w-4" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 p-3 bg-muted/50 dark:bg-muted/30 rounded-lg border-2 border-primary">
+      <div className="flex-1">
+        {fieldName === "email" ? (
+          <Input
+            type="email"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="email@example.com"
+            disabled={loading}
+            className="h-9"
+            data-testid={`${fieldName}-input`}
+            autoFocus
+          />
+        ) : (
+          <Popover open={dobOpen} onOpenChange={setDobOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className={cn(
+                  "w-full justify-start text-left font-normal h-9",
+                  !selectedDate && "text-muted-foreground"
+                )}
+                disabled={loading}
+                data-testid={`${fieldName}-input`}
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {selectedDate ? (
+                  format(selectedDate, "PPP")
+                ) : (
+                  <span>Select date of birth</span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <Calendar
+                mode="single"
+                selected={selectedDate}
+                onSelect={(date) => {
+                  if (date) {
+                    setValue(format(date, "yyyy-MM-dd"));
+                    setDobOpen(false);
+                  }
+                }}
+                disabled={(date) => {
+                  const today = new Date();
+                  today.setHours(0, 0, 0, 0);
+                  return date >= today || loading;
+                }}
+                captionLayout="dropdown"
+                fromYear={1900}
+                toYear={new Date().getFullYear()}
+                initialFocus
+              />
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleSave}
+        disabled={loading}
+        className="text-green-600 hover:text-green-700 hover:bg-green-50 dark:hover:bg-green-950/20"
+        data-testid={`save-${fieldName}-button`}
+      >
+        <Check className="h-4 w-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleCancel}
+        disabled={loading}
+        className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950/20"
+        data-testid={`cancel-${fieldName}-button`}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds functionality for admins to update volunteer email addresses and dates of birth directly from the admin volunteer detail page. These fields are locked for regular users to prevent unauthorized changes.

## Changes
- **New API endpoint**: `PATCH /api/admin/users/[id]/profile`
  - Admin-only access with role validation
  - Email uniqueness validation
  - Date of birth format validation
  - Prevents self-editing through admin endpoint

- **New components**:
  - `AdminEditableField`: Reusable inline editing component with email/date inputs
  - `AdminContactInfoSection`: Client component wrapper for editable contact fields

- **Updated pages**:
  - Admin volunteer detail page now uses editable contact information section

## Features
✅ Hover-to-reveal edit buttons for clean UI  
✅ Inline editing with save/cancel actions  
✅ Calendar date picker for date of birth  
✅ Real-time validation and error handling  
✅ Toast notifications for user feedback  
✅ Email uniqueness checks  
✅ Date validation (must be in past)  

## Security
- Admin-only access enforced via session check
- Email uniqueness validation to prevent duplicates  
- Prevents admins from editing their own profile through admin endpoint
- Proper error handling with informative messages

## Testing
- ✅ TypeScript compilation passes
- ✅ No new linting errors introduced
- ✅ Existing profile editing for regular users unchanged

## Screenshots
Admins can now edit email and date of birth fields by hovering over them in the Contact Information section and clicking the edit button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)