### PR TITLE
fix: enforce email verification before shift signups

### DIFF
--- a/web/src/app/api/shifts/[id]/group-booking/route.ts
+++ b/web/src/app/api/shifts/[id]/group-booking/route.ts
@@ -21,10 +21,27 @@ export async function POST(req: Request) {
 
     const user = await prisma.user.findUnique({
       where: { email: session.user.email },
+      select: {
+        id: true,
+        email: true,
+        emailVerified: true,
+      },
     });
 
     if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 401 });
+    }
+
+    // Check email verification
+    if (!user.emailVerified) {
+      return NextResponse.json(
+        {
+          error: "Email verification required",
+          message:
+            "Please verify your email address before creating group bookings. Check your inbox for a verification email.",
+        },
+        { status: 403 }
+      );
     }
 
     // Extract shift ID from URL

--- a/web/src/app/api/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/shifts/[id]/signup/route.ts
@@ -30,6 +30,7 @@ export async function POST(
     select: {
       id: true,
       email: true,
+      emailVerified: true,
       requiresParentalConsent: true,
       parentalConsentReceived: true,
       firstName: true,
@@ -40,6 +41,18 @@ export async function POST(
   });
   if (!user)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  // Check email verification
+  if (!user.emailVerified) {
+    return NextResponse.json(
+      {
+        error: "Email verification required",
+        message:
+          "Please verify your email address before signing up for shifts. Check your inbox for a verification email.",
+      },
+      { status: 403 }
+    );
+  }
 
   // Check parental consent for minors
   if (user.requiresParentalConsent && !user.parentalConsentReceived) {


### PR DESCRIPTION
## Summary

This PR prevents users from signing up for shifts or creating group bookings until their email address has been verified, addressing issue #244.

## Changes

- **Shift Signup API** (`/api/shifts/[id]/signup`): Added email verification check before allowing shift signups
- **Group Booking API** (`/api/shifts/[id]/group-booking`): Added email verification check before allowing group booking creation
- Email verification is now checked before parental consent validation for a logical flow of requirements
- Users receive clear error messages directing them to verify their email addresses

## Technical Details

- Added `emailVerified` field to user queries in both routes
- Returns HTTP 403 (Forbidden) with descriptive error message if email is not verified
- Follows the same pattern as the existing parental consent check
- All type checking, linting, and build processes pass successfully

## Test Plan

- [ ] Attempt to sign up for a shift with an unverified email (should be blocked)
- [ ] Attempt to create a group booking with an unverified email (should be blocked)
- [ ] Verify email and attempt shift signup again (should succeed)
- [ ] Verify that existing verified users can still sign up normally

## Related Issues

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)