### PR TITLE
feat: make profile photos optional during registration

### DIFF
--- a/web/src/app/register/register-client.tsx
+++ b/web/src/app/register/register-client.tsx
@@ -410,14 +410,6 @@ export default function RegisterClient({ locationOptions, shiftTypes }: Register
           });
           return false;
         }
-        if (!formData.profilePhotoUrl) {
-          toast({
-            title: "Profile photo required",
-            description: "Please upload a profile photo to continue",
-            variant: "destructive",
-          });
-          return false;
-        }
         break;
       case 3: // Medical & Background
         if (!formData.howDidYouHearAboutUs || formData.howDidYouHearAboutUs === "not_specified") {

--- a/web/src/components/forms/user-profile-form.tsx
+++ b/web/src/components/forms/user-profile-form.tsx
@@ -517,7 +517,7 @@ export function PersonalInfoStep({
 
       <div className="space-y-2">
         <Label htmlFor="profilePhoto" className="text-sm font-medium">
-          Profile Photo {isRegistration ? "*" : ""}
+          Profile Photo
         </Label>
         <ProfileImageUpload
           currentImage={formData.profilePhotoUrl}
@@ -533,13 +533,8 @@ export function PersonalInfoStep({
                 )}`.toUpperCase()
               : "?"
           }
-          required={isRegistration}
+          required={false}
         />
-        {isRegistration && (
-          <p className="text-xs text-muted-foreground">
-            A profile photo is required for all volunteer accounts
-          </p>
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Makes profile photos optional during the volunteer registration process, allowing users to complete registration without uploading a photo.

## Changes

- Removed frontend validation that prevented registration without a profile photo
- Removed required indicator (*) from the "Profile Photo" label during registration
- Removed helper text stating "A profile photo is required for all volunteer accounts"
- Profile photo upload functionality remains available for those who want to use it

## Technical Details

- Database schema already supported optional photos (`profilePhotoUrl String?`)
- API backend already accepted optional photos (`profilePhotoUrl: z.string().optional()`)
- Frontend now matches backend behavior
- Profile photos can be added later through the profile edit page

## Testing

- ✅ TypeScript compilation passes with no errors
- Profile photo field remains visible and functional during registration
- Users can proceed through registration with or without uploading a photo

## Related Issue

Fixes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)