### PR TITLE
feat: add localStorage persistence for admin location filters

### DIFF
--- a/web/src/app/admin/notifications/notifications-content.tsx
+++ b/web/src/app/admin/notifications/notifications-content.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { LOCATIONS, type Location } from "@/lib/locations";
 import { useSearchParams } from "next/navigation";
+import { useLocationPreferenceState } from "@/hooks/use-location-preference";
 import {
   Card,
   CardContent,
@@ -69,6 +70,7 @@ export function NotificationsContent({
   shiftTypes,
 }: NotificationsContentProps) {
   const searchParams = useSearchParams();
+  const { getLocationPreference, setLocationPreference } = useLocationPreferenceState();
   const [selectedShift, setSelectedShift] = useState<string>("");
   const [shifts, setShifts] = useState<Shift[]>([]);
   const [volunteers, setVolunteers] = useState<Volunteer[]>([]);
@@ -83,8 +85,11 @@ export function NotificationsContent({
   const [isLoading, setIsLoading] = useState(false);
   const [isSending, setIsSending] = useState(false);
 
-  // Filter states
-  const [filterLocation, setFilterLocation] = useState<string>("all");
+  // Filter states - initialize from localStorage if available
+  const [filterLocation, setFilterLocation] = useState<string>(() => {
+    const savedLocation = getLocationPreference();
+    return savedLocation || "all";
+  });
   const [filterShiftType, setFilterShiftType] = useState<string>("all");
   const [filterAvailability, setFilterAvailability] = useState<boolean>(false);
   const [filterMinShifts, setFilterMinShifts] = useState<number>(0);
@@ -107,6 +112,13 @@ export function NotificationsContent({
       setFilterLocation(locationParam);
     }
   }, [searchParams, shiftTypes]);
+
+  // Save location preference to localStorage when it changes
+  useEffect(() => {
+    if (filterLocation !== "all") {
+      setLocationPreference(filterLocation);
+    }
+  }, [filterLocation, setLocationPreference]);
 
   // Auto-select specific shift once shifts are loaded
   useEffect(() => {

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -9,8 +9,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Plus, Star as StarIcon, User as UserIcon } from "lucide-react";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { LocationFilterTabs } from "@/components/location-filter-tabs";
 import { LOCATIONS, LocationOption } from "@/lib/locations";
 
 export default async function AdminDashboardPage({
@@ -205,35 +205,11 @@ export default async function AdminDashboardPage({
       <div data-testid="admin-dashboard-page" className="space-y-6">
         <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
           {/* Compact location filter using tabs */}
-          <div className="flex flex-col gap-2">
-            <span
-              className="text-sm font-medium text-muted-foreground"
-              data-testid="location-filter-label"
-            >
-              Filter by location:
-            </span>
-            <Tabs value={selectedLocation || "all"} className="w-fit">
-              <TabsList>
-                <TabsTrigger value="all" asChild>
-                  <Link href="/admin" data-testid="location-filter-all">
-                    All
-                  </Link>
-                </TabsTrigger>
-                {LOCATIONS.map((loc) => (
-                  <TabsTrigger key={loc} value={loc} asChild>
-                    <Link
-                      href={{ pathname: "/admin", query: { location: loc } }}
-                      data-testid={`location-filter-${loc
-                        .toLowerCase()
-                        .replace(" ", "-")}`}
-                    >
-                      {loc}
-                    </Link>
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-            </Tabs>
-          </div>
+          <LocationFilterTabs
+            locations={LOCATIONS}
+            selectedLocation={selectedLocation}
+            basePath="/admin"
+          />
         </div>
 
         {/* Quick Stats Grid */}

--- a/web/src/components/location-filter-tabs.tsx
+++ b/web/src/components/location-filter-tabs.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useLocationPreference } from "@/hooks/use-location-preference";
+import { LocationOption } from "@/lib/locations";
+
+interface LocationFilterTabsProps {
+  locations: readonly LocationOption[];
+  selectedLocation?: LocationOption;
+  basePath: string;
+}
+
+export function LocationFilterTabs({
+  locations,
+  selectedLocation,
+  basePath,
+}: LocationFilterTabsProps) {
+  // Auto-restore location preference on mount
+  useLocationPreference(selectedLocation);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span
+        className="text-sm font-medium text-muted-foreground"
+        data-testid="location-filter-label"
+      >
+        Filter by location:
+      </span>
+      <Tabs value={selectedLocation || "all"} className="w-fit">
+        <TabsList>
+          <TabsTrigger value="all" asChild>
+            <Link href={basePath} data-testid="location-filter-all">
+              All
+            </Link>
+          </TabsTrigger>
+          {locations.map((loc) => (
+            <TabsTrigger key={loc} value={loc} asChild>
+              <Link
+                href={{ pathname: basePath, query: { location: loc } }}
+                data-testid={`location-filter-${loc
+                  .toLowerCase()
+                  .replace(" ", "-")}`}
+              >
+                {loc}
+              </Link>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+    </div>
+  );
+}

--- a/web/src/components/shift-location-selector.tsx
+++ b/web/src/components/shift-location-selector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useLocationPreference } from "@/hooks/use-location-preference";
 import {
   Select,
   SelectContent,
@@ -8,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { LocationOption } from "@/lib/locations";
 
 interface ShiftLocationSelectorProps {
   selectedLocation: string;
@@ -21,6 +23,9 @@ export function ShiftLocationSelector({
   locations,
 }: ShiftLocationSelectorProps) {
   const router = useRouter();
+
+  // Auto-restore location preference on mount
+  useLocationPreference(selectedLocation as LocationOption);
 
   const handleLocationChange = (value: string) => {
     router.push(`/admin/shifts?date=${dateString}&location=${value}`);

--- a/web/src/hooks/use-location-preference.ts
+++ b/web/src/hooks/use-location-preference.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { LocationOption } from "@/lib/locations";
+
+const LOCATION_PREFERENCE_KEY = "admin-location-preference";
+
+/**
+ * Hook to persist and restore location filter preferences across admin pages
+ * Saves the selected location to localStorage and auto-restores it on page load
+ */
+export function useLocationPreference(currentLocation?: LocationOption) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const isInitialMount = useRef(true);
+  const hasRestoredRef = useRef(false);
+
+  // Auto-restore location preference on mount if no location is in URL
+  // This MUST run before the save effect
+  useEffect(() => {
+    const locationParam = searchParams.get("location");
+
+    // Only auto-restore if there's no location in the URL and we haven't restored yet
+    if (!locationParam && !hasRestoredRef.current) {
+      const savedLocation = localStorage.getItem(LOCATION_PREFERENCE_KEY);
+
+      if (savedLocation) {
+        hasRestoredRef.current = true;
+        // Build new URL with saved location
+        const params = new URLSearchParams(searchParams.toString());
+        params.set("location", savedLocation);
+        router.replace(`${pathname}?${params.toString()}`);
+      }
+    }
+  }, [searchParams, pathname, router]);
+
+  // Save location preference when it changes (but not on initial mount)
+  useEffect(() => {
+    // Skip saving on the very first render to avoid overwriting with default value
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+
+    if (currentLocation) {
+      localStorage.setItem(LOCATION_PREFERENCE_KEY, currentLocation);
+    }
+  }, [currentLocation]);
+
+  return {
+    savedLocation: typeof window !== "undefined"
+      ? localStorage.getItem(LOCATION_PREFERENCE_KEY)
+      : null,
+  };
+}
+
+/**
+ * Hook for client components to get and set location preference
+ * Use this for components that manage location state locally (not via URL)
+ */
+export function useLocationPreferenceState() {
+  const getPreference = (): string | null => {
+    if (typeof window === "undefined") return null;
+    return localStorage.getItem(LOCATION_PREFERENCE_KEY);
+  };
+
+  const setPreference = (location: string) => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(LOCATION_PREFERENCE_KEY, location);
+  };
+
+  return {
+    getLocationPreference: getPreference,
+    setLocationPreference: setPreference,
+  };
+}


### PR DESCRIPTION
## Summary

Implements automatic saving and restoration of location filter preferences across all admin pages with location filtering (Dashboard, Shifts, Notifications).

## Changes Made

### New Files
- ✨ **`src/hooks/use-location-preference.ts`** - Custom hooks for location preference persistence
  - `useLocationPreference` - For URL-based location persistence (auto-restore on mount)
  - `useLocationPreferenceState` - For client-side state management
- ✨ **`src/components/location-filter-tabs.tsx`** - Reusable tab-based location filter component

### Updated Files
- 🔧 **Admin Dashboard** (`src/app/admin/page.tsx`) - Uses LocationFilterTabs component
- 🔧 **Shifts Page** (`src/components/shift-location-selector.tsx`) - Integrated location persistence
- 🔧 **Notifications Page** (`src/app/admin/notifications/notifications-content.tsx`) - Restores and saves preferences

## How It Works

1. **First Time**: User selects a location on any admin page
2. **Saved**: Selection is automatically saved to `localStorage` under `"admin-location-preference"`
3. **Next Visit**: When returning to any admin page with location filtering, the last selection is automatically restored
4. **URL Override**: URL parameters take precedence for deep linking (e.g., `/admin?location=Auckland`)

## Technical Details

- ✅ Uses React refs to prevent race conditions between save and restore effects
- ✅ Skips saving on initial mount to avoid overwriting saved preferences with default values
- ✅ Properly handles SSR by checking for `window` object
- ✅ Location preference is shared across all admin pages
- ✅ All changes are backwards compatible and non-breaking
- ✅ TypeScript compilation passes with no errors

## User Experience

### Before
- Users had to select their preferred location filter every time they navigated to an admin page
- Location selection was not preserved between page visits

### After
- Location preference is automatically remembered and restored
- Seamless experience across all admin pages
- One-time selection persists across sessions

## Test Plan

- [x] TypeScript compilation succeeds
- [ ] Manually test location filter on Admin Dashboard
- [ ] Manually test location filter on Shifts page  
- [ ] Manually test location filter on Notifications page
- [ ] Verify localStorage is updated when location changes
- [ ] Verify location is restored on page reload
- [ ] Verify URL parameters override saved preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)