### PR TITLE
fix: attach ICS calendar files to shift confirmation emails

### DIFF
--- a/web/src/app/api/shifts/[id]/calendar/route.ts
+++ b/web/src/app/api/shifts/[id]/calendar/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { generateICSContent } from "@/lib/calendar-utils";
+
+/**
+ * Public API endpoint to download ICS calendar file for a shift
+ * This endpoint is intentionally public so calendar links work in emails
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    // Fetch shift with shift type details
+    const shift = await prisma.shift.findUnique({
+      where: { id },
+      include: {
+        shiftType: true,
+      },
+    });
+
+    if (!shift) {
+      return NextResponse.json({ error: "Shift not found" }, { status: 404 });
+    }
+
+    // Generate ICS content
+    const icsContent = generateICSContent({
+      id: shift.id,
+      start: shift.start,
+      end: shift.end,
+      location: shift.location,
+      shiftType: {
+        name: shift.shiftType.name,
+        description: shift.shiftType.description,
+      },
+    });
+
+    // Return ICS file with proper headers
+    return new NextResponse(icsContent, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/calendar; charset=utf-8",
+        "Content-Disposition": `attachment; filename="shift-${shift.shiftType.name.replace(/\s+/g, "-").toLowerCase()}.ics"`,
+        "Cache-Control": "no-cache",
+      },
+    });
+  } catch (error) {
+    console.error("[GET /api/shifts/[id]/calendar] Error:", error);
+    return NextResponse.json(
+      { error: "Failed to generate calendar file" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #257 - Replace broken Apple Calendar data URL link with proper ICS file attachment and public download endpoint.

## Changes
- ✅ Created public API endpoint (`/api/shifts/[id]/calendar`) to serve downloadable ICS calendar files
- ✅ Updated shift confirmation emails to attach ICS files directly as email attachments
- ✅ Added working download link for Apple Calendar and other calendar applications
- ✅ Maintained existing Google Calendar and Outlook web links
- ✅ Added proper New Zealand timezone information to ICS files

## Technical Details
**New Files:**
- `web/src/app/api/shifts/[id]/calendar/route.ts` - Public API endpoint for ICS downloads

**Modified Files:**
- `web/src/lib/calendar-utils.ts` - Added `generateICSContent()` and `generateCalendarData()` functions
- `web/src/lib/email-service.ts` - Updated to attach ICS files and generate download links

## How It Works
When a shift confirmation email is sent, volunteers now receive:
1. **Google Calendar** link (web-based, unchanged)
2. **Outlook** link (web-based, unchanged)  
3. **Apple Calendar / Download** link - Now works! Points to public API endpoint
4. **Email Attachment** - ICS file attached directly to the email

All calendar integrations include proper Pacific/Auckland timezone data and work with major calendar applications.

## Testing
✅ TypeScript compilation passes  
✅ ESLint passes with no warnings  
✅ All existing functionality maintained

## Campaign Monitor Template Update Required
After merging, update the shift confirmation email template in Campaign Monitor:
- The `{{addToCalendarIcsLink}}` variable now contains a working download URL
- Consider labeling it as "Add to Apple Calendar" or "Download Calendar File"
- The ICS file is automatically attached to all confirmation emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)