### PR TITLE
Fix: Resource hub file upload validation error

### DIFF
--- a/web/src/lib/storage.ts
+++ b/web/src/lib/storage.ts
@@ -34,7 +34,33 @@ export async function uploadFile(
   // Generate unique file path
   const timestamp = Date.now();
   const randomString = Math.random().toString(36).substring(2, 8);
-  const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, "_");
+
+  // Extract file extension and base name
+  const fileExtension = getFileExtension(file.name);
+  const baseName = file.name.substring(0, file.name.lastIndexOf('.')) || file.name;
+
+  // Sanitize base name more strictly for Supabase compatibility
+  // - Replace all non-alphanumeric characters (except hyphens/underscores) with underscores
+  // - Remove multiple consecutive underscores/hyphens
+  // - Remove leading/trailing underscores/hyphens
+  const sanitizedBaseName = baseName
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .replace(/[_-]+/g, "_")
+    .replace(/^[_-]+|[_-]+$/g, "")
+    .toLowerCase();
+
+  // Build filename with sanitized name and original extension
+  const sanitizedFileName = fileExtension
+    ? `${sanitizedBaseName}.${fileExtension}`
+    : sanitizedBaseName;
+
+  // Ensure we have a valid filename after sanitization
+  if (!sanitizedBaseName) {
+    throw new Error(
+      "Invalid filename: could not generate a valid name from the file. Please rename your file with alphanumeric characters."
+    );
+  }
+
   const filePath = `${folder}/${timestamp}-${randomString}-${sanitizedFileName}`;
 
   // Use admin client for uploads (bypasses RLS policies)


### PR DESCRIPTION
## Summary

Fixes the "The string did not match the expected pattern" error that occurs when uploading files to the resource hub.

### Problem
Supabase Storage was rejecting file uploads with certain filename patterns (multiple dots, special characters at the beginning/end, mixed case, etc.) due to insufficiently strict filename sanitization.

### Solution
Implemented robust filename sanitization in `src/lib/storage.ts`:
- Separates file extension from base name for independent processing
- Replaces all special characters (except hyphens/underscores) with underscores
- Removes consecutive special characters
- Trims leading/trailing special characters
- Normalizes to lowercase for consistency
- Validates that filename is not empty after sanitization

### Examples
- `My...Document (1).pdf` → `my_document_1.pdf` ✅
- `___test___.pdf` → `test.pdf` ✅
- `file@#$%name.docx` → `file_name.docx` ✅

## Test plan

- [ ] Verify that files with normal names upload successfully
- [ ] Test uploading files with special characters in names (spaces, dots, symbols)
- [ ] Test edge cases (files starting/ending with special chars, multiple consecutive dots)
- [ ] Confirm error handling for completely invalid filenames (all special characters)
- [ ] Verify uploaded files are accessible and download correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)