### PR TITLE
feat: add 4MB file size limit validation with user-friendly warnings

### DIFF
--- a/web/src/components/create-resource-dialog.tsx
+++ b/web/src/components/create-resource-dialog.tsx
@@ -156,7 +156,9 @@ export function CreateResourceDialog({ children }: CreateResourceDialogProps) {
     const file = e.target.files?.[0];
     if (file) {
       if (file.size > MAX_FILE_SIZE) {
-        toast.error(`File size exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`);
+        toast.error(
+          `File must be less than ${MAX_FILE_SIZE / 1024 / 1024}MB. Please compress or reduce your file size before uploading.`
+        );
         return;
       }
       setSelectedFile(file);

--- a/web/src/components/edit-resource-dialog.tsx
+++ b/web/src/components/edit-resource-dialog.tsx
@@ -179,7 +179,9 @@ export function EditResourceDialog({
     const file = e.target.files?.[0];
     if (file) {
       if (file.size > MAX_FILE_SIZE) {
-        toast.error(`File size exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`);
+        toast.error(
+          `File must be less than ${MAX_FILE_SIZE / 1024 / 1024}MB. Please compress or reduce your file size before uploading.`
+        );
         return;
       }
       setSelectedFile(file);

--- a/web/src/components/ui/profile-image-upload.tsx
+++ b/web/src/components/ui/profile-image-upload.tsx
@@ -160,11 +160,11 @@ export function ProfileImageUpload({
         return;
       }
 
-      // Validate file size (max 5MB)
-      if (file.size > 5 * 1024 * 1024) {
+      // Validate file size (max 4MB)
+      if (file.size > 4 * 1024 * 1024) {
         toast?.({
           title: "File too large",
-          description: "Image size must be less than 5MB",
+          description: "Image must be less than 4MB. Please compress your image before uploading.",
           variant: "destructive",
         });
         return;
@@ -397,7 +397,7 @@ export function ProfileImageUpload({
           />
 
           <p className="text-xs text-muted-foreground">
-            JPG, PNG up to 5MB. Square crop recommended.
+            JPG, PNG up to 4MB. Square crop recommended.
           </p>
         </div>
       </div>

--- a/web/src/lib/storage.ts
+++ b/web/src/lib/storage.ts
@@ -16,8 +16,8 @@ export const ALLOWED_FILE_TYPES = {
   ],
 };
 
-// Max file size: 50MB
-export const MAX_FILE_SIZE = 50 * 1024 * 1024;
+// Max file size: 4MB (Vercel serverless function payload limit)
+export const MAX_FILE_SIZE = 4 * 1024 * 1024;
 
 /**
  * Upload a file to Supabase storage (uses service role for admin uploads)


### PR DESCRIPTION
## Summary
Implements file size validation to warn users about the 4MB upload limit before attempting to upload files that exceed Vercel's serverless function payload restriction.

## Changes
- Updated `MAX_FILE_SIZE` constant from 50MB to 4MB in `storage.ts`
- Enhanced profile image upload component with clear 4MB limit messaging and compression suggestions
- Improved resource hub upload dialogs (create and edit) with user-friendly file size warnings
- Updated all helper text to reflect the new 4MB limit

## User Impact
Users will now see clear, actionable error messages when attempting to upload files over 4MB:
- **Profile images**: "Image must be less than 4MB. Please compress your image before uploading."
- **Resource files**: "File must be less than 4MB. Please compress or reduce your file size before uploading."

This prevents cryptic server errors and improves the overall user experience.

## Testing
- Test profile image upload with files over 4MB
- Test resource hub document upload with files over 4MB
- Verify error messages display correctly
- Confirm files under 4MB upload successfully

Fixes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)