### PR TITLE
feat: enable GitHub Dependabot for automated npm package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # Main web application
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
@@ -32,4 +33,62 @@ updates:
     pull-request-branch-name:
       separator: "-"
     # Allow both direct and indirect updates
+    versioning-strategy: auto
+
+  # Documentation site
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Pacific/Auckland"
+    open-pull-requests-limit: 5
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "patch"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "-"
+    versioning-strategy: auto
+
+  # Documentation widget
+  - package-ecosystem: "npm"
+    directory: "/docs/widget"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Pacific/Auckland"
+    open-pull-requests-limit: 5
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "patch"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "-"
     versioning-strategy: auto


### PR DESCRIPTION
## Summary
Implements automated npm package updates using GitHub Dependabot as outlined in #203.

This PR adds a Dependabot configuration file that will:
- Create automated PRs for npm package updates across **all three npm projects** in the repository
- Run weekly on Mondays at 9 AM NZT
- Group related updates together to reduce PR noise
- Keep major version updates separate for careful review
- Auto-label PRs with 'dependencies' for easy filtering

## Monitored Directories

Dependabot will monitor and update dependencies in:
1. **`/web`** - Main Next.js application
2. **`/docs`** - Documentation site
3. **`/docs/widget`** - Documentation widget

All three projects use the same update strategy and schedule.

## Configuration Details

### Update Schedule
- **Frequency:** Weekly on Mondays
- **Time:** 9:00 AM Pacific/Auckland timezone
- **Max open PRs:** 5 per directory (prevents PR spam)

### Grouping Strategy
To reduce the number of PRs while maintaining control:

1. **Development dependencies** - Groups all minor and patch updates together
   - Examples: ESLint, Prettier, TypeScript, testing tools
   - Low risk since they don't affect production

2. **Production dependencies** - Groups patch updates only
   - Examples: React, Next.js, Prisma patch updates
   - Safer to group since patches are typically bug fixes

3. **Major updates** - Always separate PRs
   - Allows careful review of breaking changes
   - Gives time to update code if needed

### Benefits
- 🔒 **Security:** Faster response to vulnerability patches (GitHub already detected 6 vulnerabilities in our dependencies)
- ⏱️ **Time savings:** Eliminates manual dependency checking across all projects
- 📊 **Visibility:** Consistent update schedule and clear PR labels
- 🐛 **Bug fixes:** Automatic access to latest fixes and improvements
- 🤖 **Automation:** All CI checks will run on Dependabot PRs

## Test Plan
- [x] Configuration file created at `.github/dependabot.yml`
- [x] YAML syntax validated
- [x] All three npm project directories confirmed
- [ ] Wait for first Dependabot PR (should appear within a week)
- [ ] Verify CI checks run successfully on Dependabot PRs

## Implementation Notes
- Dependabot is free and built into GitHub
- No additional setup required - works automatically once merged
- PRs will include release notes and changelogs
- Team can set up auto-merge later for low-risk updates

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)