### PR TITLE
Fix admin sidebar not closing on mobile when clicking links

### DIFF
--- a/web/src/components/admin-sidebar.tsx
+++ b/web/src/components/admin-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarMenuBadge,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { UserMenu } from "@/components/user-menu";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -44,6 +45,7 @@ export function AdminSidebar({
   pendingParentalConsentCount,
 }: AdminSidebarProps) {
   const pathname = usePathname();
+  const { isMobile, setOpenMobile } = useSidebar();
   const showDemoIndicator = showEnvironmentLabel();
   const demoLabel = getEnvironmentLabel();
 
@@ -52,6 +54,12 @@ export function AdminSidebar({
       return pathname === href;
     }
     return pathname.startsWith(href);
+  };
+
+  const handleLinkClick = () => {
+    if (isMobile) {
+      setOpenMobile(false);
+    }
   };
 
   return (
@@ -112,7 +120,7 @@ export function AdminSidebar({
                         isActive={isActive(item.href, true)}
                         data-testid={testId}
                       >
-                        <Link href={item.href}>
+                        <Link href={item.href} onClick={handleLinkClick}>
                           <item.icon className="w-4 h-4" />
                           <span>{item.title}</span>
                         </Link>
@@ -157,6 +165,7 @@ export function AdminSidebar({
                     >
                       <Link
                         href={item.href}
+                        onClick={handleLinkClick}
                         target={item.opensInNewTab ? "_blank" : undefined}
                         rel={
                           item.opensInNewTab ? "noopener noreferrer" : undefined


### PR DESCRIPTION
## Summary
- Fixes the admin sidebar drawer not closing on mobile when navigation links are clicked
- Improves mobile UX by automatically closing the sidebar after link selection

## Changes Made
- Added `useSidebar` hook to access mobile state and control functions
- Created `handleLinkClick` function that closes the sidebar on mobile devices
- Applied onClick handler to all admin navigation links
- Applied onClick handler to all public navigation links

## Rationale
On mobile devices, the admin sidebar is displayed as a Sheet (drawer/modal). When users clicked navigation links, the sidebar remained open, obscuring the new page content and requiring manual dismissal. This is a common UX pattern - mobile drawers should close automatically when a navigation action is taken.

The fix checks if the device is mobile using the existing `isMobile` state from the sidebar context, and programmatically closes the sidebar via `setOpenMobile(false)` when any link is clicked.

## Test Plan
- Manual testing on mobile viewport:
  1. Open admin sidebar on mobile
  2. Click any admin navigation link (e.g., "Shifts", "Users")
  3. Verify sidebar closes automatically
  4. Test public navigation links as well
  5. Verify behavior unchanged on desktop

Fixes #305