### PR TITLE
Fix: Align migration duplicate detection logic across all import methods

### DIFF
--- a/web/src/app/api/admin/migration/batch-import-history/route.ts
+++ b/web/src/app/api/admin/migration/batch-import-history/route.ts
@@ -400,7 +400,7 @@ export async function POST(request: NextRequest) {
                   }
                 }
 
-                // Check if shift already exists
+                // Check if shift already exists by Nova Event ID (same logic as single user import)
                 let shift;
                 if (dryRun) {
                   shift = {
@@ -411,9 +411,9 @@ export async function POST(request: NextRequest) {
                 } else {
                   const existingShift = await prisma.shift.findFirst({
                     where: {
-                      start: shiftData.start,
-                      end: shiftData.end,
-                      shiftTypeId: shiftType.id,
+                      notes: {
+                        contains: `Nova ID: ${eventResource.id.value}`,
+                      },
                     },
                   });
 
@@ -423,7 +423,7 @@ export async function POST(request: NextRequest) {
                     if (shiftData.notes && shiftData.notes.trim()) {
                       noteParts.push(shiftData.notes.trim());
                     }
-                    noteParts.push(`Nova ID: ${eventId}`);
+                    noteParts.push(`Nova ID: ${eventResource.id.value}`);
 
                     shift = await prisma.shift.create({
                       data: {

--- a/web/src/app/api/admin/migration/scrape-user-history/route.ts
+++ b/web/src/app/api/admin/migration/scrape-user-history/route.ts
@@ -572,7 +572,7 @@ export async function POST(request: NextRequest) {
                       where: {
                         // Match based on event name and date
                         notes: {
-                          contains: `Nova Event ID: ${eventDetail.id.value}`,
+                          contains: `Nova ID: ${eventDetail.id.value}`,
                         },
                       },
                     });


### PR DESCRIPTION
## Summary
This PR fixes inconsistencies in how historical shift migration detects and prevents duplicate shifts across different import methods (single user import, batch import, and historical data selector).

## Problem
There were two issues discovered during code review:

1. **Inconsistent note format in scrape-user-history**: The code was searching for `"Nova Event ID:"` but saving `"Nova ID:"`, which could cause duplicate shifts to be created
2. **Different duplicate detection methods**: 
   - Single user import used `eventResource.id.value` (from fetched event)
   - Batch import was using `eventId` from `belongsToId` (from signup)

## Changes
- ✅ Fixed scrape-user-history to use consistent note format: searches for and saves `"Nova ID:"`
- ✅ Updated batch-import-history to use `eventResource.id.value` instead of `belongsToId`
- ✅ Both methods now use identical duplicate detection logic

## Impact
- Prevents duplicate shifts when the same user is imported through multiple migration paths
- Ensures all migration methods use the proper event ID from the fetched event resource
- Maintains idempotency - migrations can be safely re-run without creating duplicates

## Testing
- [x] Code reviewed for consistency across both migration endpoints
- [ ] Manual testing recommended: Run both single user and batch imports for the same user to verify no duplicates are created

## Files Changed
- `web/src/app/api/admin/migration/scrape-user-history/route.ts` - Fixed inconsistent note format
- `web/src/app/api/admin/migration/batch-import-history/route.ts` - Updated to use eventResource.id.value

🤖 Generated with [Claude Code](https://claude.com/claude-code)