### PR TITLE
fix: mark migrated users as email verified upon registration

### DIFF
--- a/web/src/app/api/auth/complete-migration/route.ts
+++ b/web/src/app/api/auth/complete-migration/route.ts
@@ -63,6 +63,7 @@ export async function GET(request: NextRequest) {
       // Transfer OAuth data to migration user and mark as completed
       const updateData: Record<string, unknown> = {
         profileCompleted: true,
+        emailVerified: true, // Mark as verified since they received migration invitation email
         migrationInvitationToken: null,
         migrationTokenExpiresAt: null,
       };
@@ -97,6 +98,7 @@ export async function GET(request: NextRequest) {
         where: { id: migrationUser.id },
         data: {
           profileCompleted: true,
+          emailVerified: true, // Mark as verified since they received migration invitation email
           migrationInvitationToken: null,
           migrationTokenExpiresAt: null,
         },

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -225,6 +225,7 @@ export async function POST(req: Request) {
           ...userData,
           profileCompleted: true, // Mark profile as completed for migrated users
           isMigrated: true, // Ensure migrated flag is set
+          emailVerified: true, // Mark as verified since they received migration invitation email
           migrationInvitationToken: null, // Clear the token after successful registration
           migrationTokenExpiresAt: null, // Clear the expiry
         },


### PR DESCRIPTION
## Summary
Fixes issue where migrated users from Nova couldn't sign up for shifts after completing migration registration because they were never marked as email verified.

## Problem
Migrated users who completed their registration (via password or OAuth) were not being marked as `emailVerified: true`, which prevented them from signing up for shifts since the shift signup API checks email verification status.

## Solution
Migrated users are now automatically marked as email verified when they complete their registration, since they already proved they control their email by receiving and clicking the migration invitation link.

## Changes
- **`/api/auth/register`**: Set `emailVerified: true` for migration registrations (password flow)
- **`/api/auth/complete-migration`**: Set `emailVerified: true` for OAuth migration flow (both merge and same-user scenarios)

## Test Plan
- [ ] Verify new migrated users (password flow) are marked as verified
- [ ] Verify new migrated users (OAuth flow) are marked as verified
- [ ] Confirm verified migrated users can sign up for shifts
- [ ] Check that regular (non-migrated) users still go through normal email verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)