### PR TITLE
chore: add GitHub Actions to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,23 @@
 version: 2
 updates:
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Pacific/Auckland"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    pull-request-branch-name:
+      separator: "-"
+
   # Main web application
   - package-ecosystem: "npm"
     directory: "/web"


### PR DESCRIPTION
## Summary
- Configure Dependabot to monitor and update GitHub Actions workflow dependencies
- Adds `github-actions` package ecosystem to `.github/dependabot.yml`
- Ensures action versions in workflows stay up-to-date automatically

## Changes
- Added GitHub Actions configuration to Dependabot with:
  - Weekly schedule (Mondays at 9:00 AM NZ time)
  - Labels: `dependencies`, `github-actions`
  - Limit of 5 open PRs
  - Consistent commit message format

## Test plan
- [x] Dependabot configuration syntax is valid
- [ ] Wait for Dependabot to create PRs for outdated actions (if any exist)
- [ ] Verify PRs are properly labeled and formatted

Fixes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)