### PR TITLE
feat: show shift type in achievement tooltips for specialization achievements

### DIFF
--- a/web/src/app/api/achievements/route.ts
+++ b/web/src/app/api/achievements/route.ts
@@ -33,11 +33,17 @@ export async function GET(request: Request) {
     const newAchievements = await checkAndUnlockAchievements(user.id);
 
     // Get user's current achievements and available ones
-    const [userAchievements, availableAchievements, progress] =
+    const [userAchievements, availableAchievements, progress, shiftTypes] =
       await Promise.all([
         getUserAchievements(user.id),
         getAvailableAchievements(user.id),
         calculateUserProgress(user.id),
+        prisma.shiftType.findMany({
+          select: {
+            id: true,
+            name: true,
+          },
+        }),
       ]);
 
     // Calculate total points
@@ -52,6 +58,7 @@ export async function GET(request: Request) {
       progress: typeof progress;
       totalPoints: number;
       newAchievements: string[];
+      shiftTypes: typeof shiftTypes;
       ranking?: {
         userRank: number;
         totalUsers: number;
@@ -69,6 +76,7 @@ export async function GET(request: Request) {
       progress,
       totalPoints,
       newAchievements,
+      shiftTypes,
     };
 
     // Include ranking data if requested

--- a/web/src/components/achievements-card.tsx
+++ b/web/src/components/achievements-card.tsx
@@ -34,6 +34,11 @@ interface UserAchievement {
   achievement: Achievement;
 }
 
+interface ShiftType {
+  id: string;
+  name: string;
+}
+
 interface AchievementsData {
   userAchievements: UserAchievement[];
   availableAchievements: Achievement[];
@@ -48,6 +53,7 @@ interface AchievementsData {
   };
   totalPoints: number;
   newAchievements: string[];
+  shiftTypes: ShiftType[];
 }
 
 const CATEGORY_COLORS = {
@@ -76,6 +82,22 @@ interface AchievementProgress {
   target: number;
   percentage: number;
   label: string;
+}
+
+function getShiftTypeName(
+  criteria: string,
+  shiftTypes: ShiftType[]
+): string | undefined {
+  try {
+    const parsedCriteria: AchievementCriteria = JSON.parse(criteria);
+    if (parsedCriteria.type === "specific_shift_type" && parsedCriteria.shiftType) {
+      const shiftType = shiftTypes.find(st => st.id === parsedCriteria.shiftType);
+      return shiftType?.name;
+    }
+  } catch (error) {
+    console.error("Error parsing criteria for shift type:", error);
+  }
+  return undefined;
 }
 
 function calculateAchievementProgress(
@@ -192,7 +214,7 @@ export default function AchievementsCard() {
     return null;
   }
 
-  const { userAchievements, availableAchievements, totalPoints } =
+  const { userAchievements, availableAchievements, totalPoints, shiftTypes } =
     achievementsData;
   const recentAchievements = userAchievements.slice(0, 3);
 
@@ -290,7 +312,8 @@ export default function AchievementsCard() {
                       <TooltipContent>
                         <p className="font-medium">
                           {formatAchievementCriteria(
-                            userAchievement.achievement.criteria
+                            userAchievement.achievement.criteria,
+                            getShiftTypeName(userAchievement.achievement.criteria, shiftTypes)
                           )}
                         </p>
                       </TooltipContent>
@@ -371,7 +394,10 @@ export default function AchievementsCard() {
                       </TooltipTrigger>
                       <TooltipContent>
                         <p className="font-medium">
-                          {formatAchievementCriteria(achievement.criteria)}
+                          {formatAchievementCriteria(
+                            achievement.criteria,
+                            getShiftTypeName(achievement.criteria, shiftTypes)
+                          )}
                         </p>
                       </TooltipContent>
                     </Tooltip>


### PR DESCRIPTION
## Summary
- Updated achievement tooltips on the dashboard to display the specific shift type name for specialization achievements
- Previously showed generic "Complete X shift(s) of a specific type"
- Now shows "Complete X 'Shift Type Name' shift(s)" with the actual shift type

## Implementation Details
- Modified `/api/achievements` endpoint to include shift types in the response
- Added `getShiftTypeName()` helper function to extract shift type names from achievement criteria
- Updated both tooltip locations (recent achievements and next goals) to pass shift type names to the formatter
- The `formatAchievementCriteria()` utility already supported this via an optional `shiftTypeName` parameter

## Test Plan
- [x] TypeScript compilation passes
- [x] Linting passes with no new warnings
- [x] Verified existing achievements list component already has proper implementation
- [ ] Manual testing: Create a specialization achievement and verify tooltip shows shift type name

## Related
Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)