### PR TITLE
fix: show email verification warning and disable signup buttons for unverified users

### DIFF
--- a/web/src/app/api/profile/route.ts
+++ b/web/src/app/api/profile/route.ts
@@ -48,6 +48,7 @@ export async function GET() {
     select: {
       id: true,
       email: true,
+      emailVerified: true,
       name: true,
       firstName: true,
       lastName: true,


### PR DESCRIPTION
## Summary

Fixes #407 

Previously, users could attempt to sign up for shifts without verifying their email, only to receive an error **after** clicking the signup button. This created confusion and a poor user experience.

This PR adds upfront email verification warnings and disables signup buttons for unverified users, giving them clear feedback and a path to resolve the issue.

## Changes

### API Changes
- **`/api/profile`**: Added `emailVerified` field to GET endpoint response

### UI Changes
- **Shift Signup Dialog** (`shift-signup-dialog.tsx`):
  - Checks email verification status when dialog opens
  - Shows prominent red warning banner when email is not verified
  - Disables signup button when email is not verified
  - Provides "Resend Verification Email" button
  - Shows success message after resending

- **Group Booking Dialog** (`group-booking-dialog.tsx`):
  - Same email verification checks as shift signup
  - Disables "Create Group" button when email is not verified
  - Includes resend verification functionality

## User Experience

**Before:**
1. User clicks "Sign Up Now" button
2. Dialog opens, user fills in details
3. User clicks "Confirm Signup"
4. ❌ Error appears: "Email verification required"

**After:**
1. User clicks "Sign Up Now" button
2. Dialog opens
3. ⚠️ Warning banner appears: "Email verification required"
4. ✅ Signup button is disabled with clear explanation
5. ✅ User can click "Resend Verification Email" button
6. ✅ Success message confirms email was sent

## Testing

- ✅ TypeScript compilation passes
- ✅ ESLint passes (no new warnings)
- ✅ Follows existing code patterns
- ✅ Includes data-testid attributes for e2e testing
- ✅ Proper error handling and loading states

## Screenshots

_Add screenshots of the warning banner and disabled state when testing_

🤖 Generated with [Claude Code](https://claude.com/claude-code)