### PR TITLE
fix: prevent past dates from showing available shifts on mobile in My Shifts

### DIFF
--- a/web/src/app/shifts/mine/page.tsx
+++ b/web/src/app/shifts/mine/page.tsx
@@ -273,11 +273,14 @@ export default async function MyShiftsPage({
           },
         }),
       ]),
-      // Available shifts in user's preferred locations for the month
+      // Available shifts in user's preferred locations for the month (future dates only)
       userPreferredLocations.length > 0
         ? prisma.shift.findMany({
             where: {
-              start: { gte: monthStart, lte: monthEnd },
+              start: {
+                gte: now > monthStart ? now : monthStart,
+                lte: monthEnd
+              },
               location: { in: userPreferredLocations },
               // Only shifts that aren't full and user hasn't signed up for
               signups: {


### PR DESCRIPTION
## Summary
- Fixed issue #410 where the My Shifts page was incorrectly showing past dates as having available shifts on mobile view
- Modified the `availableShifts` query to filter out shifts that have already started

## Changes
- Updated the date filter in the `availableShifts` query in `/web/src/app/shifts/mine/page.tsx`
- Changed from `start: { gte: monthStart, lte: monthEnd }` to `start: { gte: now > monthStart ? now : monthStart, lte: monthEnd }`
- This ensures only future shifts are shown as "available" when viewing the current month

## Impact
- Past dates in the current month will no longer incorrectly show "X available" shifts on mobile
- Future months continue to show all available shifts in that month as expected
- No impact on desktop calendar view, which already handles this correctly

## Test Plan
- [x] Verified development server starts successfully
- [ ] Manually test on mobile by navigating to My Shifts page
- [ ] Verify past dates no longer show "available shifts" indicator
- [ ] Verify future dates still show available shifts correctly
- [ ] Test across current month, past months, and future months

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)