### PR TITLE
Potential fix for code scanning alert no. 19: Use of externally-controlled format string

### DIFF
--- a/web/src/lib/migration-sse-utils.ts
+++ b/web/src/lib/migration-sse-utils.ts
@@ -11,7 +11,7 @@ export async function sendProgress(
   const writer = sessions.get(sessionId);
 
   if (!writer) {
-    console.log(`[SSE] No active session for ${sessionId}`);
+    console.log("[SSE] No active session for sessionId:", sessionId);
     return false;
   }
 
@@ -28,11 +28,13 @@ export async function sendProgress(
     await writer.write(encoder.encode(message));
 
     console.log(
-      `[SSE] Sent ${data.type || "progress"} event to session ${sessionId}`
+      "[SSE] Sent %s event to session %s",
+      data.type || "progress",
+      sessionId
     );
     return true;
   } catch (error) {
-    console.error(`[SSE] Failed to send to session ${sessionId}:`, error);
+    console.error("[SSE] Failed to send to session %s:", sessionId, error);
     sessions.delete(sessionId); // Remove dead session
     return false;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/everybody-eats-nz/volunteer-portal/security/code-scanning/19](https://github.com/everybody-eats-nz/volunteer-portal/security/code-scanning/19)

General fix approach: Avoid having any user-controlled data in the *format string* position of `console.log` / `console.error`. Instead, use either (a) a constant/literal string as the first argument and pass dynamic values as additional arguments, or (b) if you want to keep template literals, ensure that the first argument is not subsequently interpreted as a format string with additional substitution arguments (i.e., don’t combine it with more arguments that could be formatted).

Best fix here: For the two logging calls in `migration-sse-utils.ts` that include `sessionId` in a template literal, keep the message text but move `sessionId` (and any other dynamic info) into separate arguments. That way the first argument is a static string and cannot be influenced by the client, and `sessionId` is still visible in logs. We do not need to change how SSE sessions work or how `sessionId` is validated, only how it’s logged. The rest of the code in the other files (`batch-import-history`, `bulk-nova-migration`, `scrape-user-history`, `sse-utils`) does not need modification, because the only flagged sink is inside `migration-sse-utils.ts`.

Concrete changes (all in `web/src/lib/migration-sse-utils.ts`):

- Change

  ```ts
  console.log(`[SSE] No active session for ${sessionId}`);
  ```

  to

  ```ts
  console.log("[SSE] No active session for sessionId:", sessionId);
  ```

- Change

  ```ts
  console.log(
    `[SSE] Sent ${data.type || "progress"} event to session ${sessionId}`
  );
  ```

  to

  ```ts
  console.log(
    "[SSE] Sent %s event to session %s",
    data.type || "progress",
    sessionId
  );
  ```

  Here the format string is a constant and all untrusted values are separate arguments, which is explicitly recommended.

- Change

  ```ts
  console.error(`[SSE] Failed to send to session ${sessionId}:`, error);
  ```

  to

  ```ts
  console.error("[SSE] Failed to send to session %s:", sessionId, error);
  ```

No new imports or helpers are needed; we’re only adjusting the arguments to existing `console` calls.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
