### PR TITLE
Potential fix for code scanning alert no. 20: Use of externally-controlled format string

### DIFF
--- a/web/src/lib/laravel-nova-scraper.ts
+++ b/web/src/lib/laravel-nova-scraper.ts
@@ -343,7 +343,7 @@ export class LaravelNovaScraper {
           hasMorePages = false;
         }
       } catch (error) {
-        console.error(`Error scraping users page ${page}:`, error);
+        console.error("Error scraping users page %s:", page, error);
         hasMorePages = false;
       }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/everybody-eats-nz/volunteer-portal/security/code-scanning/20](https://github.com/everybody-eats-nz/volunteer-portal/security/code-scanning/20)

In general, to fix “externally-controlled format string” issues with `console.log` / `console.error` / `util.format`, avoid embedding untrusted data into the format string. Instead, use constant format strings (with or without `%s` placeholders) and pass untrusted values as subsequent arguments. This way, even if the untrusted data contains `%` or other special characters, it is always treated as a normal value, not as part of the formatting pattern.

For this specific case in `web/src/lib/laravel-nova-scraper.ts`, the only problematic call is inside the `catch` block of `scrapeUsers`:

```ts
console.error(`Error scraping users page ${page}:`, error);
```

Here, `page` is derived from untrusted input. We can fix it without changing the visible behavior by making the first argument a constant string and moving `page` into later arguments. For example:

```ts
console.error("Error scraping users page %s:", page, error);
```

This uses a literal format string and passes `page` as an argument to be substituted into the `%s` placeholder. It preserves the existing log content order while ensuring the format string itself does not depend on user data. No new imports or helper methods are needed, and the change is localized to that one line in `web/src/lib/laravel-nova-scraper.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
