### PR TITLE
fix: disable profile links for non-friend public users in shifts calendar

### DIFF
--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -38,6 +38,7 @@ interface ShiftSummary {
       email: string;
       profilePhotoUrl: string | null;
     };
+    isFriend: boolean;
   }>;
 }
 
@@ -176,6 +177,7 @@ export default async function ShiftsCalendarPage({
       email: string;
       profilePhotoUrl: string | null;
     };
+    isFriend: boolean;
   };
   let friendSignupsMap: Record<string, FriendSignup[]> = {};
 
@@ -223,7 +225,10 @@ export default async function ShiftsCalendarPage({
       })
       .reduce<Record<string, FriendSignup[]>>((acc, signup) => {
         if (!acc[signup.shiftId]) acc[signup.shiftId] = [];
-        acc[signup.shiftId].push(signup);
+        acc[signup.shiftId].push({
+          user: signup.user,
+          isFriend: userFriendIds.includes(signup.user.id),
+        });
         return acc;
       }, {});
   }

--- a/web/src/components/shifts-calendar.tsx
+++ b/web/src/components/shifts-calendar.tsx
@@ -44,6 +44,7 @@ interface ShiftSummary {
       email: string;
       profilePhotoUrl: string | null;
     };
+    isFriend: boolean;
   }>;
 }
 
@@ -68,6 +69,7 @@ interface DayShifts {
       email: string;
       profilePhotoUrl: string | null;
     };
+    isFriend: boolean;
   }>;
 }
 
@@ -397,6 +399,12 @@ export function ShiftsCalendar({
                                     )}
                                     maxDisplay={2}
                                     size="sm"
+                                    enableLinks={(user) => {
+                                      const signup = dayShifts.allFriendSignups.find(
+                                        (s) => s.user.id === user.id
+                                      );
+                                      return signup?.isFriend ?? false;
+                                    }}
                                   />
                                 </div>
                               )}

--- a/web/src/components/ui/avatar-list.tsx
+++ b/web/src/components/ui/avatar-list.tsx
@@ -24,7 +24,7 @@ interface AvatarListProps {
   size?: "sm" | "md" | "lg";
   className?: string;
   maxDisplay?: number;
-  enableLinks?: boolean;
+  enableLinks?: boolean | ((user: AvatarUser) => boolean);
 }
 
 export function AvatarList({
@@ -69,6 +69,12 @@ export function AvatarList({
     return getDisplayName(user);
   };
 
+  const shouldEnableLink = (user: AvatarUser) => {
+    if (typeof enableLinks === "function") {
+      return enableLinks(user);
+    }
+    return enableLinks ?? true;
+  };
 
   return (
     <div className={cn("flex items-center", className)}>
@@ -76,7 +82,7 @@ export function AvatarList({
         {displayUsers.map((user, index) => (
           <Tooltip key={user.id}>
             <TooltipTrigger asChild>
-              {enableLinks ? (
+              {shouldEnableLink(user) ? (
                 <Link href={`/friends/${user.id}`} className="cursor-pointer">
                   <div
                     className={cn(


### PR DESCRIPTION
## Summary
Fixes #421

When volunteers with public profiles (but not friends) appeared in the shifts calendar, their avatars were displayed as clickable links. However, clicking these links led to 404 pages because the `/friends/:id` route only works for actual friends.

## Changes

- **Added `isFriend` field** to shift signup data structure to track friendship status
- **Updated `AvatarList` component** to support per-user link control via a function parameter
- **Modified shifts calendar** to only enable links for actual friends, not just public profile users

## Technical Details

The shifts calendar displays volunteers in two categories:
1. Actual friends (with FRIENDS_ONLY or PUBLIC visibility)
2. Non-friends with PUBLIC visibility

Previously, both groups had clickable avatars linking to `/friends/:id`, but only actual friends have accessible profile pages at that route.

Now, the `AvatarList` component accepts either:
- A boolean to enable/disable links for all users
- A function `(user) => boolean` to enable links on a per-user basis

The shifts calendar uses the function approach to check the `isFriend` status for each user.

## Test Plan

- [x] Build passes
- [x] Linter passes
- [ ] Manual testing: Verify non-friend public users in calendar have non-clickable avatars
- [ ] Manual testing: Verify friend users in calendar still have clickable avatars

🤖 Generated with [Claude Code](https://claude.com/claude-code)