### PR TITLE
feat: show waitlist status for full backup shifts

### DIFF
--- a/web/src/components/shift-signup-dialog.tsx
+++ b/web/src/components/shift-signup-dialog.tsx
@@ -576,11 +576,15 @@ export function ShiftSignupDialog({
                           {concurrentShift.shiftTypeDescription}
                         </p>
                       )}
-                      {concurrentShift.spotsRemaining > 0 && (
+                      {concurrentShift.spotsRemaining > 0 ? (
                         <p className="text-xs text-green-600">
                           {concurrentShift.spotsRemaining} spot
                           {concurrentShift.spotsRemaining !== 1 ? "s" : ""}{" "}
                           available
+                        </p>
+                      ) : (
+                        <p className="text-xs text-orange-600">
+                          Full - Waitlist available
                         </p>
                       )}
                     </div>


### PR DESCRIPTION
## Summary

When signing up for a shift, backup shift options now display appropriate status for both available and full shifts. Full backup shifts now show "Full - Waitlist available" instead of showing no status message.

## Changes

- Updated `shift-signup-dialog.tsx` to show "Full - Waitlist available" for backup shifts with 0 spots remaining
- Previously, full backup shifts would show no status message at all
- Now users can clearly see which backup shifts are full and that they can join the waitlist

## Test Plan

- [x] All existing e2e tests pass (`backup-shift-signup.spec.ts`)
- [x] Verified that backup shifts with available spots still show "X spots available" 
- [x] Verified that full backup shifts now show "Full - Waitlist available"

## Screenshots

Before: Full backup shifts showed no status
After: Full backup shifts show "Full - Waitlist available" in orange text

Fixes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)