### PR TITLE
Fix: Date picker opens to selected date's month

### DIFF
--- a/web/src/components/shift-calendar.tsx
+++ b/web/src/components/shift-calendar.tsx
@@ -137,6 +137,7 @@ export function ShiftCalendar({
           <Calendar
             mode="single"
             selected={selectedDate}
+            defaultMonth={selectedDate}
             onSelect={handleDateSelect}
             modifiers={{
               hasShifts: (date) => hasShifts(date),


### PR DESCRIPTION
## Summary
- Fixed date picker on admin shifts page to open to the month of the selected date instead of today's month
- Added `defaultMonth={selectedDate}` prop to the Calendar component

## Changes
- Modified `web/src/components/shift-calendar.tsx` to include `defaultMonth` prop

## Why This Change?
Previously, when viewing shifts from a different month (e.g., March 2024), clicking the date picker would open to today's month (December 2025), requiring extra navigation to get back to the month being viewed. Now it opens directly to the selected date's month for a better user experience.

## Test Plan
- [ ] Navigate to admin shifts page
- [ ] Select a date in a different month using the date picker
- [ ] Click the date picker button again
- [ ] Verify the calendar opens showing the month of the selected date, not today's month

Fixes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)