### PR TITLE
fix: add canonical URLs to resolve Google Search Console indexing

### DIFF
--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -33,10 +33,12 @@ export async function generateMetadata({
   let title = "Browse Volunteer Shifts";
   let description =
     "Explore available volunteer opportunities at Everybody Eats. From prep work to service, find shifts that fit your schedule.";
+  let path = "/shifts";
 
   if (location && LOCATIONS.includes(location as LocationOption)) {
     title = `Volunteer Shifts in ${location}`;
     description = `Browse upcoming volunteer shifts at Everybody Eats ${location}. From prep work to service, find opportunities that fit your schedule.`;
+    path = `/shifts?location=${encodeURIComponent(location)}`;
   } else if (showAll) {
     title = "All Volunteer Shifts";
     description =
@@ -46,7 +48,7 @@ export async function generateMetadata({
   return buildPageMetadata({
     title,
     description,
-    path: "/shifts",
+    path,
   });
 }
 

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma";
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = getBaseUrl();
 
-  // Static public pages
+  // Static public pages that should be indexed
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
@@ -33,7 +33,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ];
 
-  // Get unique locations from shift types
+  // Get unique locations from shift types for location-specific pages
+  // These help with local SEO (e.g., "volunteer Wellington")
   const locations = await prisma.shift.findMany({
     distinct: ["location"],
     where: {
@@ -52,7 +53,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `${baseUrl}/shifts?location=${encodeURIComponent(item.location!)}`,
       lastModified: new Date(),
       changeFrequency: "daily" as const,
-      priority: 0.8,
+      priority: 0.7, // Lower priority than main shifts page
     }));
 
   return [...staticPages, ...locationPages];

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -31,6 +31,9 @@ export function buildPageMetadata(options: MetadataOptions): Metadata {
   return {
     title,
     description,
+    alternates: {
+      canonical: url,
+    },
     openGraph: {
       title,
       description,


### PR DESCRIPTION
## Problem

Google Search Console shows "No referring sitemaps detected" for pages in our sitemap, preventing them from being indexed. The root cause is that our pages don't have canonical meta tags, so Google cannot match the sitemap URLs to the actual pages.

## Solution

This PR adds canonical URLs to all public pages, ensuring Google can properly associate sitemap entries with their corresponding pages.

## Changes

### 1. Added Canonical URLs to All Pages (`src/lib/seo.ts`)
- Modified `buildPageMetadata()` to include `alternates.canonical`
- Every page using this function now has a canonical URL matching its path
- Applies to: homepage, login, register, and shifts pages

### 2. Location-Specific Canonical URLs (`src/app/shifts/page.tsx`)
- Updated `generateMetadata()` to set canonical URLs for location-filtered pages
- Example: `/shifts?location=Wellington` now has its own canonical URL
- Matches the URLs in the sitemap for proper association

### 3. Maintained Location Pages in Sitemap (`src/app/sitemap.ts`)
- Kept location-specific URLs for local SEO benefits
- These help with searches like "volunteer Wellington" or "volunteer Auckland"
- Set priority to 0.7 (lower than main `/shifts` page at 0.9)

## Expected Outcome

After deployment and Google re-crawls:
- ✅ Canonical URLs will match sitemap URLs
- ✅ "No referring sitemaps detected" will change to show sitemap reference
- ✅ Pages will be indexed within 3-7 days
- ✅ Location pages will improve local SEO

## Testing

Build verified successful:
- ✅ TypeScript compilation passes
- ✅ No build errors or warnings
- ✅ Sitemap generation working correctly

## Post-Deployment Actions

After merging, the following actions are needed in Google Search Console:

1. **Verify canonical tags** are live on production
2. **Force re-crawl** by either:
   - Removing and resubmitting sitemap, OR
   - Using URL Inspection tool to request indexing for key pages
3. **Monitor** Coverage report for indexing improvements (3-7 days)

## Related

Fixes Google Search Console indexing issues reported where pages show as "URL is not indexed: URL is unknown to Google" with "No referring sitemaps detected".