### PR TITLE
fix: improve privacy in suggested friends by showing first name and last initial only

### DIFF
--- a/web/src/components/recommended-friends.tsx
+++ b/web/src/components/recommended-friends.tsx
@@ -133,10 +133,22 @@ export function RecommendedFriends() {
           animate="visible"
         >
           {recommendedFriends.map((friend) => {
-            const displayName =
-              friend.name ||
-              `${friend.firstName || ""} ${friend.lastName || ""}`.trim() ||
-              "Volunteer";
+            // Privacy-focused: show first name + last initial only
+            let displayName = "Volunteer";
+            if (friend.firstName && friend.lastName) {
+              displayName = `${friend.firstName} ${friend.lastName[0]}.`;
+            } else if (friend.firstName) {
+              displayName = friend.firstName;
+            } else if (friend.name) {
+              // If only 'name' field exists, try to extract first name
+              const nameParts = friend.name.split(" ");
+              if (nameParts.length > 1) {
+                displayName = `${nameParts[0]} ${nameParts[nameParts.length - 1][0]}.`;
+              } else {
+                displayName = friend.name;
+              }
+            }
+
             const initials = (
               friend.firstName?.[0] ||
               friend.name?.[0] ||


### PR DESCRIPTION
## Summary

- Changed suggested friends display format from full names to "FirstName L." format for better privacy
- Users now see "Sarah M." instead of "Sarah Miller" in suggested friends
- Backend API unchanged - only frontend display logic updated
- Toast notifications also use the privacy-friendly format

## Privacy Logic

The new display name format:
- If both first and last name exist: `"FirstName L."` (e.g., "Sarah M.")
- If only first name exists: Shows just the first name  
- If only the `name` field exists: Tries to extract first name and last initial
- Fallback: "Volunteer" if no name data available

## Test Plan

- [x] Verify suggested friends show "FirstName L." format instead of full names
- [x] Verify toast notification uses privacy-friendly name when sending friend request
- [x] Verify avatar initials still display correctly
- [ ] Test with different name configurations (firstName only, name field only, etc.)
- [ ] Verify on mobile/tablet viewports
- [ ] Confirm shared shifts count and recent shifts still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)