### PR TITLE
Skip new volunteer label for users with shift history

### DIFF
--- a/web/src/lib/auto-label-utils.ts
+++ b/web/src/lib/auto-label-utils.ts
@@ -70,9 +70,25 @@ export async function autoLabelUnder16User(userId: string, dateOfBirth: Date | n
 
 /**
  * Automatically assigns the "New Volunteer" label to newly registered users
+ * who don't have any shift history (CONFIRMED or NO_SHOW signups)
  */
 export async function autoLabelNewVolunteer(userId: string) {
   try {
+    // Check if user has any shift history (CONFIRMED or NO_SHOW signups)
+    const shiftHistoryCount = await prisma.signup.count({
+      where: {
+        userId,
+        status: {
+          in: ["CONFIRMED", "NO_SHOW"],
+        },
+      },
+    });
+
+    if (shiftHistoryCount > 0) {
+      // User already has shift history, they're not a new volunteer
+      return;
+    }
+
     const newVolunteerLabel = await prisma.customLabel.findUnique({
       where: { name: "New Volunteer" },
     });


### PR DESCRIPTION
## Summary
- Adds a check for existing shift history (CONFIRMED or NO_SHOW signups) before applying the "New Volunteer" label
- Users who have already completed shifts won't be incorrectly labeled as new volunteers when editing their profile

Fixes #490

## Test plan
- [ ] Edit profile as a user with existing shift history - should NOT get "New Volunteer" label
- [ ] Register as a new user with no shift history - should get "New Volunteer" label
- [ ] Complete profile as OAuth user with no shift history - should get "New Volunteer" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)