### PR TITLE
Fix My Shifts timezone - show correct 'today'

### DIFF
--- a/web/src/app/shifts/mine/page.tsx
+++ b/web/src/app/shifts/mine/page.tsx
@@ -4,14 +4,12 @@ import {
   startOfMonth,
   endOfMonth,
   eachDayOfInterval,
-  isSameDay,
   differenceInHours,
   startOfWeek,
   endOfWeek,
   isSameMonth,
-  startOfDay,
 } from "date-fns";
-import { formatInNZT, getStartOfDayUTC } from "@/lib/timezone";
+import { formatInNZT, getStartOfDayUTC, isSameDayInNZT } from "@/lib/timezone";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { safeParseAvailability } from "@/lib/parse-availability";
@@ -118,6 +116,8 @@ export default async function MyShiftsPage({
 
   const params = await searchParams;
   const now = new Date();
+  // Get start of today in NZ timezone for proper date comparisons
+  const startOfTodayNZ = getStartOfDayUTC(now);
 
   // Parse month/year for calendar navigation
   const currentMonth = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -860,8 +860,8 @@ export default async function MyShiftsPage({
               const dayShifts = shiftsByDate.get(dateKey) || [];
               const availableShifts = availableShiftsByDate.get(dateKey) || [];
               const isCurrentMonth = isSameMonth(day, viewMonth);
-              const isToday = isSameDay(day, now);
-              const isPast = day < now && !isToday;
+              const isToday = isSameDayInNZT(day, now);
+              const isPast = day < startOfTodayNZ;
               const shift = dayShifts[0]; // Since only 1 shift per day is allowed
               const isWeekend = day.getDay() === 0 || day.getDay() === 6;
 
@@ -1000,8 +1000,8 @@ export default async function MyShiftsPage({
               const dayShifts = shiftsByDate.get(dateKey) || [];
               const availableShifts = availableShiftsByDate.get(dateKey) || [];
               const isCurrentMonth = isSameMonth(day, viewMonth);
-              const isToday = isSameDay(day, now);
-              const isPast = day < now && !isToday;
+              const isToday = isSameDayInNZT(day, now);
+              const isPast = day < startOfTodayNZ;
               const shift = dayShifts[0];
 
               // Skip days without shifts or available shifts unless it's today, and skip non-current month days
@@ -1162,7 +1162,7 @@ export default async function MyShiftsPage({
               const dateKey = format(day, "yyyy-MM-dd");
               const dayShifts = shiftsByDate.get(dateKey) || [];
               const availableShifts = availableShiftsByDate.get(dateKey) || [];
-              const isToday = isSameDay(day, now);
+              const isToday = isSameDayInNZT(day, now);
               return (
                 dayShifts.length === 0 &&
                 availableShifts.length === 0 &&


### PR DESCRIPTION
## Summary
- Uses NZ timezone utilities (`isSameDayInNZT`, `getStartOfDayUTC`) instead of UTC-based comparisons for "today" detection
- Fixes calendar showing yesterday's shift as "today" when UTC and NZT are on different calendar days
- Affects both desktop calendar and mobile list views

## Test plan
- [ ] Check "My Shifts" page on mobile when NZT is a different date than UTC (e.g., early morning NZT)
- [ ] Verify "Today" badge appears on the correct calendar day
- [ ] Verify past shifts are correctly greyed out

Fixes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)