### PR TITLE
feat: add select all rows option in shift shortage notifications

### DIFF
--- a/web/src/app/admin/notifications/notifications-content.tsx
+++ b/web/src/app/admin/notifications/notifications-content.tsx
@@ -682,6 +682,7 @@ export function NotificationsContent({
               onVolunteerToggle={handleVolunteerToggle}
               onSelectAll={handleSelectAll}
               onBatchToggle={handleBatchToggle}
+              onSelectAllRows={handleSelectAll}
             />
           </CardContent>
         </Card>

--- a/web/src/components/volunteers-data-table.tsx
+++ b/web/src/components/volunteers-data-table.tsx
@@ -33,6 +33,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { CheckCircle2, AlertCircle } from "lucide-react";
 import { VolunteerGradeBadge } from "@/components/volunteer-grade-badge";
 import { type VolunteerGrade } from "@/generated/client";
@@ -59,6 +60,7 @@ interface VolunteersDataTableProps {
   onVolunteerToggle: (volunteerId: string) => void;
   onSelectAll: () => void;
   onBatchToggle?: (volunteerIds: string[], shouldSelect: boolean) => void;
+  onSelectAllRows?: () => void;
 }
 
 export const columns: ColumnDef<Volunteer>[] = [
@@ -202,6 +204,7 @@ export function VolunteersDataTable({
   selectedVolunteers,
   onVolunteerToggle,
   onBatchToggle,
+  onSelectAllRows,
 }: VolunteersDataTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -317,6 +320,50 @@ export function VolunteersDataTable({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+
+      {/* Select all rows banner - shows when all page rows are selected but there are more */}
+      {onSelectAllRows &&
+        table.getIsAllPageRowsSelected() &&
+        table.getFilteredRowModel().rows.length >
+          table.getRowModel().rows.length && (
+          <Alert className="mb-4" data-testid="select-all-banner">
+            <AlertDescription className="flex items-center justify-between">
+              <span>
+                All {table.getRowModel().rows.length} volunteers on this page
+                are selected.
+              </span>
+              {selectedVolunteers.size ===
+              table.getFilteredRowModel().rows.length ? (
+                <Button
+                  variant="link"
+                  className="p-0 h-auto font-medium"
+                  onClick={() => {
+                    if (onBatchToggle) {
+                      onBatchToggle(
+                        volunteers.map((v) => v.id),
+                        false
+                      );
+                    }
+                  }}
+                  data-testid="clear-selection-button"
+                >
+                  Clear selection
+                </Button>
+              ) : (
+                <Button
+                  variant="link"
+                  className="p-0 h-auto font-medium"
+                  onClick={onSelectAllRows}
+                  data-testid="select-all-rows-button"
+                >
+                  Select all {table.getFilteredRowModel().rows.length}{" "}
+                  volunteers
+                </Button>
+              )}
+            </AlertDescription>
+          </Alert>
+        )}
+
       <div className="rounded-md border">
         <Table>
           <TableHeader>


### PR DESCRIPTION
## Summary
- Adds a banner that appears when all rows on the current page are selected
- Provides a "Select all X volunteers" button to select all filtered volunteers across all pages
- Shows "Clear selection" button when all volunteers are selected

Closes #495

## Test plan
- [ ] Navigate to Admin > Shortage Notifications
- [ ] Select a shift with shortage
- [ ] Use the table's header checkbox to select all rows on the current page
- [ ] Verify a banner appears with "Select all X volunteers" link
- [ ] Click the link and verify all filtered volunteers are selected
- [ ] Verify "Clear selection" button appears after selecting all
- [ ] Click "Clear selection" and verify selection is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)