### PR TITLE
feat: add option to sign up new regulars for existing future shifts

### DIFF
--- a/web/src/app/admin/regulars/regular-volunteer-form.tsx
+++ b/web/src/app/admin/regulars/regular-volunteer-form.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/select";
 import { Combobox } from "@/components/ui/combobox";
 import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Card,
   CardContent,
@@ -89,6 +90,7 @@ export function RegularVolunteerForm({
     frequency: "WEEKLY",
     availableDays: [] as string[],
     notes: "",
+    addToExistingShifts: true,
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -138,7 +140,14 @@ export function RegularVolunteerForm({
         throw new Error(errorMessage + errorDetails);
       }
 
-      toast.success("Regular volunteer created successfully");
+      const result = await response.json();
+      const signupsCreated = result.signupsCreated || 0;
+
+      if (signupsCreated > 0) {
+        toast.success(`Regular volunteer created and signed up for ${signupsCreated} existing shift${signupsCreated === 1 ? '' : 's'}`);
+      } else {
+        toast.success("Regular volunteer created successfully");
+      }
 
       // Reset form
       setFormData({
@@ -148,6 +157,7 @@ export function RegularVolunteerForm({
         frequency: "WEEKLY",
         availableDays: [],
         notes: "",
+        addToExistingShifts: true,
       });
 
       setIsOpen(false);
@@ -322,6 +332,31 @@ export function RegularVolunteerForm({
                     setFormData((prev) => ({ ...prev, notes: e.target.value }))
                   }
                 />
+              </div>
+
+              {/* Add to Existing Shifts */}
+              <div className="flex items-start space-x-3 p-4 rounded-lg border bg-muted/50">
+                <Checkbox
+                  id="addToExistingShifts"
+                  checked={formData.addToExistingShifts}
+                  onCheckedChange={(checked) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      addToExistingShifts: checked === true,
+                    }))
+                  }
+                />
+                <div className="space-y-1">
+                  <Label
+                    htmlFor="addToExistingShifts"
+                    className="text-sm font-medium cursor-pointer"
+                  >
+                    Add to existing future shifts
+                  </Label>
+                  <p className="text-sm text-muted-foreground">
+                    Automatically sign up this volunteer for matching future shifts that already exist in the system.
+                  </p>
+                </div>
               </div>
 
               {/* Action Buttons */}


### PR DESCRIPTION
## Summary
- Adds a checkbox option when creating a new regular volunteer to automatically sign them up for existing future shifts
- Checkbox is enabled by default for convenience
- Shows toast notification with the number of shifts the volunteer was signed up for

## Changes
- **regular-volunteer-form.tsx**: Added checkbox UI and updated success toast to show signup count
- **route.ts**: Added logic to find matching future shifts and create REGULAR_PENDING signups

## How it works
1. Admin opens "Add Regular Volunteer" form
2. Selects volunteer, shift type, location, frequency, and available days
3. "Add to existing future shifts" checkbox is checked by default
4. On submit, system creates regular record and optionally signs up for matching future shifts
5. Toast shows: "Regular volunteer created and signed up for X existing shifts"

## Test plan
- [ ] Create a new regular volunteer with the checkbox enabled - verify they get signed up for matching future shifts
- [ ] Create a new regular volunteer with the checkbox disabled - verify no auto-signups are created
- [ ] Verify frequency filtering works (weekly/fortnightly/monthly)
- [ ] Verify double-booking prevention works (user not signed up twice on same day)

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)