### PR TITLE
feat: improve shift details page and dashboard next shift card

### DIFF
--- a/web/src/components/dashboard-next-shift.tsx
+++ b/web/src/components/dashboard-next-shift.tsx
@@ -5,9 +5,11 @@ import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { MotionContentCard } from "@/components/motion-content-card";
-import { Clock, Calendar, MapPin } from "lucide-react";
+import { AvatarList } from "@/components/ui/avatar-list";
+import { Clock, Calendar, MapPin, CalendarPlus } from "lucide-react";
 import Link from "next/link";
 import { LOCATION_ADDRESSES, type Location } from "@/lib/locations";
+import { generateCalendarUrls } from "@/lib/calendar-utils";
 
 interface DashboardNextShiftProps {
   userId: string;
@@ -16,6 +18,24 @@ interface DashboardNextShiftProps {
 export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
   const now = new Date();
 
+  // Get user's friend IDs
+  const friendships = await prisma.friendship.findMany({
+    where: {
+      AND: [
+        { OR: [{ userId: userId }, { friendId: userId }] },
+        { status: "ACCEPTED" },
+      ],
+    },
+    select: {
+      userId: true,
+      friendId: true,
+    },
+  });
+
+  const userFriendIds = friendships.map((f) =>
+    f.userId === userId ? f.friendId : f.userId
+  );
+
   // Next upcoming shift (confirmed or pending)
   const nextShift = await prisma.signup.findFirst({
     where: {
@@ -23,9 +43,48 @@ export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
       shift: { start: { gte: now } },
       status: { in: ["PENDING", "CONFIRMED"] },
     },
-    include: { shift: { include: { shiftType: true } } },
+    include: {
+      shift: {
+        include: {
+          shiftType: true,
+        },
+      },
+    },
     orderBy: { shift: { start: "asc" } },
   });
+
+  // Get friends on this shift (separate query for cleaner typing)
+  let friendsOnShift: {
+    id: string;
+    name: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    email: string;
+    profilePhotoUrl: string | null;
+  }[] = [];
+
+  if (nextShift && userFriendIds.length > 0) {
+    const friendSignups = await prisma.signup.findMany({
+      where: {
+        shiftId: nextShift.shiftId,
+        userId: { in: userFriendIds },
+        status: { in: ["CONFIRMED", "PENDING", "REGULAR_PENDING"] },
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+            profilePhotoUrl: true,
+          },
+        },
+      },
+    });
+    friendsOnShift = friendSignups.map((s) => s.user);
+  }
 
   return (
     <MotionContentCard className="h-fit flex-1 min-w-80" delay={0.2}>
@@ -40,9 +99,13 @@ export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <div>
-                <h3 className="font-semibold text-lg">
+                <Link
+                  href={`/shifts/${nextShift.shift.id}`}
+                  className="block font-semibold text-lg hover:text-primary transition-colors"
+                  data-testid="next-shift-details-link"
+                >
                   {nextShift.shift.shiftType.name}
-                </h3>
+                </Link>
                 {nextShift.shift.location && (
                   <a
                     href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
@@ -54,7 +117,9 @@ export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
                     data-testid="shift-location-link"
                   >
                     <MapPin className="w-4 h-4" />
-                    {LOCATION_ADDRESSES[nextShift.shift.location as Location]?.replace(', New Zealand', '') || nextShift.shift.location}
+                    {LOCATION_ADDRESSES[
+                      nextShift.shift.location as Location
+                    ]?.replace(", New Zealand", "") || nextShift.shift.location}
                   </a>
                 )}
               </div>
@@ -88,13 +153,83 @@ export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
                 {formatInNZT(nextShift.shift.end, "h:mm a")}
               </div>
             </div>
+
             {nextShift.shift.notes && (
-              <div className="p-3 bg-accent/10 dark:bg-yellow-900/20 rounded-lg">
-                <p className="text-sm dark:text-gray-200">
+              <div className="p-3 bg-muted/50 rounded-lg">
+                <p className="text-sm text-muted-foreground">
                   {nextShift.shift.notes}
                 </p>
               </div>
             )}
+
+            {/* Friends joining */}
+            {friendsOnShift.length > 0 && (
+              <div>
+                <div className="text-sm font-medium mb-2">Friends Joining</div>
+                <AvatarList users={friendsOnShift} size="md" maxDisplay={6} />
+              </div>
+            )}
+
+            {/* Add to Calendar */}
+            <div className="pt-2 border-t">
+              <div className="text-sm font-medium text-muted-foreground mb-2">
+                Add to Calendar
+              </div>
+              <div className="flex gap-2 flex-wrap">
+                {(() => {
+                  const urls = generateCalendarUrls(nextShift.shift);
+                  return (
+                    <>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="gap-1.5"
+                        asChild
+                      >
+                        <a
+                          href={urls.google}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <CalendarPlus className="h-3.5 w-3.5" />
+                          Google
+                        </a>
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="gap-1.5"
+                        asChild
+                      >
+                        <a
+                          href={urls.outlook}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <CalendarPlus className="h-3.5 w-3.5" />
+                          Outlook
+                        </a>
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="gap-1.5"
+                        asChild
+                      >
+                        <a
+                          href={urls.ics}
+                          download={`shift-${nextShift.shift.id}.ics`}
+                        >
+                          <CalendarPlus className="h-3.5 w-3.5" />
+                          .ics
+                        </a>
+                      </Button>
+                    </>
+                  );
+                })()}
+              </div>
+            </div>
+
             <Button asChild size="sm" className="w-full">
               <Link href="/shifts/mine">View All My Shifts</Link>
             </Button>


### PR DESCRIPTION
## Summary
- Improve shift details page with better emoji rendering, embedded map, calendar links, and cleaner design
- Enhance dashboard next shift card with friends list, calendar links, and link to details page
- Move signup status to top of card for better visibility

## Changes

### Shift Details Page
- Fix emoji rendering with colored gradient container (was losing color due to text-transparent)
- Show friends joining with AvatarList and "+X more" badge for other volunteers
- Add embedded Google Map with full address and "Get Directions" button
- Add "Add to Calendar" buttons (Google, Outlook, .ics)
- Move "You're signed up!" status to top of card for above-the-fold visibility
- Cleaner card design without shift-type colored backgrounds
- Remove redundant "About this shift" section (description already shown in header)

### Dashboard Next Shift Card
- Add link to shift details page from shift name
- Show "Friends Joining" section with AvatarList
- Add "Add to Calendar" buttons
- Cleaner notes styling with neutral background

## Test plan
- [ ] Visit a shift details page and verify emoji displays with color
- [ ] Check friends vs other volunteers display correctly
- [ ] Test embedded map loads and shows correct location
- [ ] Test "Get Directions" and calendar buttons work
- [ ] Sign up for a shift and verify status appears at top
- [ ] Check dashboard next shift card shows friends and calendar options

🤖 Generated with [Claude Code](https://claude.com/claude-code)