### PR TITLE
fix: resolve double counting in friendship statistics page

### DIFF
--- a/web/src/app/friends/stats/page.tsx
+++ b/web/src/app/friends/stats/page.tsx
@@ -32,27 +32,13 @@ export default async function FriendsStatsPage() {
   // Get comprehensive friends data and stats
   const [friendsData, friendsShiftStats] = await Promise.all([
     // Friends with their basic info and recent activity
+    // Query only where userId matches to avoid double counting from bidirectional records
     prisma.friendship.findMany({
       where: {
-        AND: [
-          {
-            OR: [{ userId: user.id }, { friendId: user.id }],
-          },
-          { status: "ACCEPTED" },
-        ],
+        userId: user.id,
+        status: "ACCEPTED",
       },
       include: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            firstName: true,
-            lastName: true,
-            email: true,
-            profilePhotoUrl: true,
-            friendVisibility: true,
-          },
-        },
         friend: {
           select: {
             id: true,
@@ -125,13 +111,11 @@ export default async function FriendsStatsPage() {
 
   // Process friends data to get the friend objects
   const friends = friendsData.map((friendship) => {
-    const friend =
-      friendship.userId === user.id ? friendship.friend : friendship.user;
     const friendshipDate = friendship.createdAt;
     const daysSinceFriendship = differenceInDays(new Date(), friendshipDate);
 
     return {
-      ...friend,
+      ...friendship.friend,
       friendshipDate,
       daysSinceFriendship,
     };


### PR DESCRIPTION
## Summary
- Fixed double counting bug in the Friendship Statistics page
- The friendship query was using an OR condition that matched both bidirectional records for each friendship
- Changed to only query friendships where `userId` matches the current user

## Root Cause
Friendships are stored bidirectionally - when users A and B become friends, two records are created:
- `{ userId: A, friendId: B }`
- `{ userId: B, friendId: A }`

The stats page query was using `OR: [{ userId: user.id }, { friendId: user.id }]`, which matched **both** records, causing stats like "Total Friends" to show double the actual count.

## Test plan
- [ ] Visit `/friends/stats` page
- [ ] Verify "Total Friends" count matches actual number of friends
- [ ] Verify other stats (Active This Month, New This Month, Avg. Days Connected) are accurate
- [ ] Check that the Recent Friendships list shows correct friends without duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)