### PR TITLE
feat: add minimum volunteer age criterion to auto-accept rules

### DIFF
--- a/web/prisma/migrations/20260204200653_add_min_volunteer_age_to_auto_accept_rule/migration.sql
+++ b/web/prisma/migrations/20260204200653_add_min_volunteer_age_to_auto_accept_rule/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AutoAcceptRule" ADD COLUMN     "minVolunteerAge" INTEGER;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -552,6 +552,7 @@ model AutoAcceptRule {
   minAccountAgeDays          Int? // Days since registration
   maxDaysInAdvance           Int? // Only auto-accept if shift is X+ days away
   requireShiftTypeExperience Boolean         @default(false) // Must have done this shift type before
+  minVolunteerAge            Int? // Minimum volunteer age in years
 
   // Logic configuration
   criteriaLogic CriteriaLogic @default(AND) // AND or OR logic for criteria

--- a/web/src/app/admin/auto-accept-rules/auto-accept-rules-client.tsx
+++ b/web/src/app/admin/auto-accept-rules/auto-accept-rules-client.tsx
@@ -44,6 +44,7 @@ interface AutoAcceptRule {
   minAttendanceRate: number | null;
   minAccountAgeDays: number | null;
   maxDaysInAdvance: number | null;
+  minVolunteerAge: number | null;
   requireShiftTypeExperience: boolean;
   criteriaLogic: "AND" | "OR";
   stopOnMatch: boolean;
@@ -190,6 +191,9 @@ export default function AutoAcceptRulesClient({
     }
     if (rule.maxDaysInAdvance !== null) {
       criteria.push(`Max ${rule.maxDaysInAdvance} days ahead`);
+    }
+    if (rule.minVolunteerAge !== null) {
+      criteria.push(`Min Age: ${rule.minVolunteerAge} years`);
     }
     if (rule.requireShiftTypeExperience) {
       criteria.push("Shift type experience required");

--- a/web/src/app/api/admin/auto-accept-rules/[id]/route.ts
+++ b/web/src/app/api/admin/auto-accept-rules/[id]/route.ts
@@ -19,6 +19,7 @@ const updateRuleSchema = z.object({
   minAccountAgeDays: z.number().int().min(0).optional().nullable(),
   maxDaysInAdvance: z.number().int().min(0).optional().nullable(),
   requireShiftTypeExperience: z.boolean().optional(),
+  minVolunteerAge: z.number().int().min(0).optional().nullable(),
   criteriaLogic: z.enum(["AND", "OR"]).optional(),
   stopOnMatch: z.boolean().optional(),
 });

--- a/web/src/app/api/admin/auto-accept-rules/route.ts
+++ b/web/src/app/api/admin/auto-accept-rules/route.ts
@@ -19,6 +19,7 @@ const ruleSchema = z.object({
   minAccountAgeDays: z.number().int().min(0).optional().nullable(),
   maxDaysInAdvance: z.number().int().min(0).optional().nullable(),
   requireShiftTypeExperience: z.boolean().default(false),
+  minVolunteerAge: z.number().int().min(0).optional().nullable(),
   criteriaLogic: z.enum(["AND", "OR"]).default("AND"),
   stopOnMatch: z.boolean().default(true),
 });
@@ -123,13 +124,14 @@ export async function POST(req: Request) {
     }
 
     // Ensure at least one criterion is set
-    const hasCriteria = 
+    const hasCriteria =
       validatedData.minVolunteerGrade !== null ||
       validatedData.minCompletedShifts !== null ||
       validatedData.minAttendanceRate !== null ||
       validatedData.minAccountAgeDays !== null ||
       validatedData.maxDaysInAdvance !== null ||
-      validatedData.requireShiftTypeExperience;
+      validatedData.requireShiftTypeExperience ||
+      validatedData.minVolunteerAge !== null;
 
     if (!hasCriteria) {
       return NextResponse.json(

--- a/web/src/components/auto-accept/rule-form-dialog.tsx
+++ b/web/src/components/auto-accept/rule-form-dialog.tsx
@@ -57,6 +57,7 @@ const ruleFormSchema = z.object({
   maxDaysInAdvance: z
     .union([z.number().int().min(0), z.literal("")])
     .optional(),
+  minVolunteerAge: z.union([z.number().int().min(0), z.literal("")]).optional(),
   requireShiftTypeExperience: z.boolean(),
   criteriaLogic: z.enum(["AND", "OR"]),
   stopOnMatch: z.boolean(),
@@ -81,6 +82,7 @@ interface RuleFormDialogProps {
     minAttendanceRate: number | null;
     minAccountAgeDays: number | null;
     maxDaysInAdvance: number | null;
+    minVolunteerAge: number | null;
     requireShiftTypeExperience: boolean;
     criteriaLogic: "AND" | "OR";
     stopOnMatch: boolean;
@@ -117,6 +119,7 @@ export function RuleFormDialog({
       minAttendanceRate: "" as number | "",
       minAccountAgeDays: "" as number | "",
       maxDaysInAdvance: "" as number | "",
+      minVolunteerAge: "" as number | "",
       requireShiftTypeExperience: false,
       criteriaLogic: "AND" as const,
       stopOnMatch: true,
@@ -142,6 +145,7 @@ export function RuleFormDialog({
           minAttendanceRate: rule.minAttendanceRate ?? "",
           minAccountAgeDays: rule.minAccountAgeDays ?? "",
           maxDaysInAdvance: rule.maxDaysInAdvance ?? "",
+          minVolunteerAge: rule.minVolunteerAge ?? "",
           requireShiftTypeExperience: rule.requireShiftTypeExperience,
           criteriaLogic: rule.criteriaLogic,
           stopOnMatch: rule.stopOnMatch,
@@ -160,6 +164,7 @@ export function RuleFormDialog({
           minAttendanceRate: "" as number | "",
           minAccountAgeDays: "" as number | "",
           maxDaysInAdvance: "" as number | "",
+          minVolunteerAge: "" as number | "",
           requireShiftTypeExperience: false,
           criteriaLogic: "AND" as const,
           stopOnMatch: true,
@@ -219,6 +224,12 @@ export function RuleFormDialog({
             ? null
             : typeof values.maxDaysInAdvance === "number"
             ? values.maxDaysInAdvance
+            : null,
+        minVolunteerAge:
+          values.minVolunteerAge === ""
+            ? null
+            : typeof values.minVolunteerAge === "number"
+            ? values.minVolunteerAge
             : null,
       };
 
@@ -514,6 +525,28 @@ export function RuleFormDialog({
                       </FormControl>
                       <FormDescription>
                         Only auto-approve if shift is within X days
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="minVolunteerAge"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Minimum Volunteer Age (years)</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          min="0"
+                          placeholder="e.g., 18"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        Volunteer must be at least this age
                       </FormDescription>
                       <FormMessage />
                     </FormItem>

--- a/web/src/lib/auto-accept-rules.test.ts
+++ b/web/src/lib/auto-accept-rules.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "vitest";
+import { evaluateRule, UserWithStats } from "./auto-accept-rules";
+import type { AutoAcceptRule, Shift, ShiftType } from "@/generated/client";
+
+// Helper to create a base user with stats
+function createUserWithStats(
+  overrides: Partial<UserWithStats> = {}
+): UserWithStats {
+  return {
+    id: "user-1",
+    email: "test@example.com",
+    name: "Test User",
+    volunteerGrade: "GREEN",
+    createdAt: new Date("2024-01-01"),
+    completedShifts: 10,
+    canceledShifts: 0,
+    attendanceRate: 100,
+    hasShiftTypeExperience: true,
+    age: 25,
+    ...overrides,
+  };
+}
+
+// Helper to create a base shift with shift type
+function createShift(
+  overrides: Partial<Shift & { shiftType: ShiftType }> = {}
+): Shift & { shiftType: ShiftType } {
+  const now = new Date();
+  const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  return {
+    id: "shift-1",
+    shiftTypeId: "shift-type-1",
+    start: tomorrow,
+    end: new Date(tomorrow.getTime() + 4 * 60 * 60 * 1000),
+    capacity: 5,
+    signedUp: 0,
+    confirmedCount: 0,
+    notes: null,
+    location: "Auckland",
+    createdAt: now,
+    updatedAt: now,
+    emoji: null,
+    shiftType: {
+      id: "shift-type-1",
+      name: "Kitchen",
+      description: "Kitchen duties",
+      color: "#FF0000",
+      createdAt: now,
+      updatedAt: now,
+      archived: false,
+      requiredGrade: "GREEN",
+    },
+    ...overrides,
+  } as Shift & { shiftType: ShiftType };
+}
+
+// Helper to create a base rule
+function createRule(overrides: Partial<AutoAcceptRule> = {}): AutoAcceptRule {
+  const now = new Date();
+  return {
+    id: "rule-1",
+    name: "Test Rule",
+    description: null,
+    enabled: true,
+    priority: 0,
+    global: true,
+    shiftTypeId: null,
+    location: null,
+    minVolunteerGrade: null,
+    minCompletedShifts: null,
+    minAttendanceRate: null,
+    minAccountAgeDays: null,
+    maxDaysInAdvance: null,
+    requireShiftTypeExperience: false,
+    minVolunteerAge: null,
+    criteriaLogic: "AND",
+    stopOnMatch: true,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: "admin-1",
+    ...overrides,
+  } as AutoAcceptRule;
+}
+
+describe("auto-accept-rules", () => {
+  describe("evaluateRule", () => {
+    describe("age criterion", () => {
+      it("should approve when volunteer meets minimum age", () => {
+        const rule = createRule({ minVolunteerAge: 18 });
+        const user = createUserWithStats({ age: 25 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(true);
+      });
+
+      it("should approve when volunteer age exactly matches minimum", () => {
+        const rule = createRule({ minVolunteerAge: 18 });
+        const user = createUserWithStats({ age: 18 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(true);
+      });
+
+      it("should reject when volunteer is below minimum age", () => {
+        const rule = createRule({ minVolunteerAge: 18 });
+        const user = createUserWithStats({ age: 16 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(false);
+      });
+
+      it("should reject when volunteer has no date of birth", () => {
+        const rule = createRule({ minVolunteerAge: 18 });
+        const user = createUserWithStats({ age: null });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(false);
+      });
+
+      it("should work with AND logic combining age with other criteria - all pass", () => {
+        const rule = createRule({
+          minVolunteerAge: 18,
+          minCompletedShifts: 5,
+          criteriaLogic: "AND",
+        });
+        const user = createUserWithStats({ age: 25, completedShifts: 10 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(true);
+      });
+
+      it("should work with AND logic combining age with other criteria - age fails", () => {
+        const rule = createRule({
+          minVolunteerAge: 18,
+          minCompletedShifts: 5,
+          criteriaLogic: "AND",
+        });
+        const user = createUserWithStats({ age: 16, completedShifts: 10 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(false);
+      });
+
+      it("should work with AND logic combining age with other criteria - other criteria fails", () => {
+        const rule = createRule({
+          minVolunteerAge: 18,
+          minCompletedShifts: 5,
+          criteriaLogic: "AND",
+        });
+        const user = createUserWithStats({ age: 25, completedShifts: 2 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(false);
+      });
+
+      it("should work with OR logic combining age with other criteria - age passes", () => {
+        const rule = createRule({
+          minVolunteerAge: 18,
+          minCompletedShifts: 100,
+          criteriaLogic: "OR",
+        });
+        const user = createUserWithStats({ age: 25, completedShifts: 5 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(true);
+      });
+
+      it("should work with OR logic combining age with other criteria - other passes", () => {
+        const rule = createRule({
+          minVolunteerAge: 30,
+          minCompletedShifts: 5,
+          criteriaLogic: "OR",
+        });
+        const user = createUserWithStats({ age: 25, completedShifts: 10 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(true);
+      });
+
+      it("should work with OR logic combining age with other criteria - none pass", () => {
+        const rule = createRule({
+          minVolunteerAge: 30,
+          minCompletedShifts: 100,
+          criteriaLogic: "OR",
+        });
+        const user = createUserWithStats({ age: 25, completedShifts: 5 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("rule with no age criterion", () => {
+      it("should not consider age when minVolunteerAge is null", () => {
+        const rule = createRule({
+          minVolunteerAge: null,
+          minCompletedShifts: 5,
+        });
+        const user = createUserWithStats({ age: 16, completedShifts: 10 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        // Should pass because only minCompletedShifts is checked, not age
+        expect(result).toBe(true);
+      });
+
+      it("should work with null age when age criterion is not set", () => {
+        const rule = createRule({
+          minVolunteerAge: null,
+          minCompletedShifts: 5,
+        });
+        const user = createUserWithStats({ age: null, completedShifts: 10 });
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        // Should pass because age is not a criterion
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("rule with no criteria", () => {
+      it("should return false when no criteria are set", () => {
+        const rule = createRule({});
+        const user = createUserWithStats();
+        const shift = createShift();
+
+        const result = evaluateRule(rule, user, shift);
+
+        expect(result).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `minVolunteerAge` field to auto-accept rules allowing admins to require a minimum age for automatic shift approval
- Volunteers without a date of birth on file cannot pass the age criterion
- Works with AND/OR logic alongside existing criteria

## Changes

- **Database**: Add `minVolunteerAge Int?` field to `AutoAcceptRule` model with migration
- **Evaluation Logic**: Update `evaluateRule()` to check age using existing `calculateAge` utility
- **API**: Add validation to create/update endpoints
- **Admin UI**: Add form field and display criterion in rules list
- **Tests**: 13 new unit tests covering age filtering scenarios

## Test plan

- [x] Unit tests pass (`npm run test:run`)
- [x] TypeScript compiles
- [ ] Manual test: Create rule with min age criterion
- [ ] Manual test: Verify criterion displays in rules list
- [ ] Manual test: Test signup with volunteer under/over age limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)