### PR TITLE
feat: allow multiple shift types per regular volunteer

### DIFF
--- a/web/prisma/migrations/20260206011055_allow_multiple_shift_types_per_regular_volunteer/migration.sql
+++ b/web/prisma/migrations/20260206011055_allow_multiple_shift_types_per_regular_volunteer/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "RegularVolunteer_userId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RegularVolunteer_userId_shiftTypeId_key" ON "RegularVolunteer"("userId", "shiftTypeId");

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -91,8 +91,8 @@ model User {
   // Restaurant Manager
   restaurantManager RestaurantManager?
 
-  // Regular volunteer relation
-  regularVolunteer RegularVolunteer?
+  // Regular volunteer relations (one per shift type)
+  regularVolunteers RegularVolunteer[]
 
   notificationGroupMembers NotificationGroupMember[]
 
@@ -464,7 +464,7 @@ model RestaurantManager {
 
 model RegularVolunteer {
   id             String    @id @default(cuid())
-  userId         String    @unique
+  userId         String
   user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   shiftTypeId    String
   shiftType      ShiftType @relation(fields: [shiftTypeId], references: [id])
@@ -484,6 +484,7 @@ model RegularVolunteer {
   // Track auto-generated signups
   autoSignups RegularSignup[]
 
+  @@unique([userId, shiftTypeId]) // One regular record per user per shift type
   @@index([userId, isActive])
   @@index([shiftTypeId, location, isActive])
 }

--- a/web/src/app/admin/regulars/edit-regular-volunteer-dialog.tsx
+++ b/web/src/app/admin/regulars/edit-regular-volunteer-dialog.tsx
@@ -76,15 +76,23 @@ export function EditRegularVolunteerDialog({
   open,
   onOpenChange,
   locations,
+  otherShiftTypeIds = [],
 }: {
   regular: RegularVolunteer;
   shiftTypes: ShiftType[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
   locations: readonly string[];
+  otherShiftTypeIds?: string[]; // Shift type IDs this user is already regular for (excluding current)
 }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+
+  // Filter out shift types that the user is already regular for (excluding current)
+  const unavailableShiftTypeIds = new Set(otherShiftTypeIds);
+  const availableShiftTypes = shiftTypes.filter(
+    (st) => st.id === regular.shiftType.id || !unavailableShiftTypeIds.has(st.id)
+  );
 
   const [formData, setFormData] = useState({
     shiftTypeId: regular.shiftType.id,
@@ -207,13 +215,21 @@ export function EditRegularVolunteerDialog({
                     <SelectValue placeholder="Select shift type..." />
                   </SelectTrigger>
                   <SelectContent>
-                    {shiftTypes.map((t) => (
+                    {availableShiftTypes.map((t) => (
                       <SelectItem key={t.id} value={t.id}>
                         {t.name}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
+                {otherShiftTypeIds.length > 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    Already regular for: {shiftTypes
+                      .filter((st) => unavailableShiftTypeIds.has(st.id))
+                      .map((st) => st.name)
+                      .join(", ")}
+                  </p>
+                )}
               </div>
 
               {/* Location */}

--- a/web/src/app/admin/regulars/page.tsx
+++ b/web/src/app/admin/regulars/page.tsx
@@ -75,11 +75,10 @@ export default async function RegularVolunteersPage({
     },
   });
 
-  // Get all volunteers for the form
+  // Get all volunteers for the form (now allows multiple regulars per volunteer)
   const volunteers = await prisma.user.findMany({
     where: {
       role: "VOLUNTEER",
-      regularVolunteer: null, // Only show volunteers who aren't already regulars
     },
     select: {
       id: true,
@@ -87,6 +86,11 @@ export default async function RegularVolunteersPage({
       firstName: true,
       lastName: true,
       email: true,
+      regularVolunteers: {
+        select: {
+          shiftTypeId: true,
+        },
+      },
     },
     orderBy: [{ firstName: "asc" }, { lastName: "asc" }],
   });

--- a/web/src/app/admin/regulars/regulars-table.tsx
+++ b/web/src/app/admin/regulars/regulars-table.tsx
@@ -95,6 +95,23 @@ export function RegularsTable({
   const [toggleId, setToggleId] = useState<string | null>(null);
   const [editRegular, setEditRegular] = useState<RegularVolunteer | null>(null);
 
+  // Group regulars by userId to know each user's other shift types
+  const regularsByUserId = regulars.reduce((acc, regular) => {
+    if (!acc[regular.userId]) {
+      acc[regular.userId] = [];
+    }
+    acc[regular.userId].push(regular);
+    return acc;
+  }, {} as Record<string, RegularVolunteer[]>);
+
+  // Get other shift type IDs for a given regular (excluding itself)
+  const getOtherShiftTypeIds = (regular: RegularVolunteer): string[] => {
+    const userRegulars = regularsByUserId[regular.userId] || [];
+    return userRegulars
+      .filter((r) => r.id !== regular.id)
+      .map((r) => r.shiftType.id);
+  };
+
   const handleToggle = async (id: string, currentStatus: boolean) => {
     try {
       const response = await fetch(`/api/admin/regulars/${id}/toggle`, {
@@ -431,6 +448,7 @@ export function RegularsTable({
             }
           }}
           locations={locations}
+          otherShiftTypeIds={getOtherShiftTypeIds(editRegular)}
         />
       )}
     </>

--- a/web/src/app/api/admin/regulars/[id]/route.ts
+++ b/web/src/app/api/admin/regulars/[id]/route.ts
@@ -115,6 +115,25 @@ export async function PUT(
       );
     }
 
+    // Check if changing shift type would create a duplicate
+    if (validated.shiftTypeId !== undefined && validated.shiftTypeId !== existing.shiftTypeId) {
+      const duplicate = await prisma.regularVolunteer.findUnique({
+        where: {
+          userId_shiftTypeId: {
+            userId: existing.userId,
+            shiftTypeId: validated.shiftTypeId,
+          },
+        },
+      });
+
+      if (duplicate) {
+        return NextResponse.json(
+          { error: "User is already a regular volunteer for this shift type" },
+          { status: 400 }
+        );
+      }
+    }
+
     // Prepare update data
     const updateData: Record<string, unknown> = {
       lastModifiedBy: session?.user?.id,

--- a/web/src/app/api/admin/regulars/route.ts
+++ b/web/src/app/api/admin/regulars/route.ts
@@ -129,16 +129,19 @@ export async function POST(req: NextRequest) {
     console.log("Creating regular volunteer with data:", body);
     const validated = createRegularVolunteerSchema.parse(body);
 
-    // Check if user already has a regular volunteer record
+    // Check if user already has a regular volunteer record for this shift type
     const existing = await prisma.regularVolunteer.findUnique({
       where: {
-        userId: validated.userId,
+        userId_shiftTypeId: {
+          userId: validated.userId,
+          shiftTypeId: validated.shiftTypeId,
+        },
       },
     });
 
     if (existing) {
       return NextResponse.json(
-        { error: "User is already a regular volunteer" },
+        { error: "User is already a regular volunteer for this shift type" },
         { status: 400 }
       );
     }

--- a/web/src/app/profile/regular-schedule/regular-schedule-manager.tsx
+++ b/web/src/app/profile/regular-schedule/regular-schedule-manager.tsx
@@ -14,13 +14,6 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -47,6 +40,18 @@ type RegularVolunteer = {
     id: string;
     name: string;
   };
+  autoSignups?: {
+    id: string;
+    signup: {
+      id: string;
+      status: string;
+      shift: {
+        id: string;
+        start: Date;
+        end: Date;
+      };
+    };
+  }[];
 };
 
 const FREQUENCIES = [
@@ -102,6 +107,7 @@ export function RegularScheduleManager({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          regularVolunteerId: regularVolunteer.id,
           frequency: editForm.frequency,
           availableDays: editForm.availableDays,
           volunteerNotes: editForm.volunteerNotes || null,
@@ -134,6 +140,7 @@ export function RegularScheduleManager({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          regularVolunteerId: regularVolunteer.id,
           isPaused: !resume,
           pausedUntil: resume ? null : pauseForm.pausedUntil || null,
           reason: resume ? "Resumed by volunteer" : pauseForm.reason,
@@ -175,61 +182,50 @@ export function RegularScheduleManager({
 
   return (
     <>
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <EditIcon className="h-5 w-5" />
-            Manage Schedule
-          </CardTitle>
-          <CardDescription>
-            Update your regular volunteer schedule settings
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="flex flex-wrap gap-3">
+      <div>
+        <div className="flex flex-wrap gap-3">
+          <Button
+            onClick={() => setEditDialogOpen(true)}
+            variant="outline"
+            className="flex items-center gap-2"
+          >
+            <EditIcon className="h-4 w-4" />
+            Edit Schedule
+          </Button>
+
+          {regularVolunteer.isPausedByUser ? (
             <Button
-              onClick={() => setEditDialogOpen(true)}
-              variant="outline"
-              className="flex items-center gap-2"
+              onClick={() => handlePause(true)}
+              disabled={loading}
+              className="flex items-center gap-2 bg-green-600 hover:bg-green-700"
             >
-              <EditIcon className="h-4 w-4" />
-              Edit Schedule
+              <PlayIcon className="h-4 w-4" />
+              {loading ? "Resuming..." : "Resume Schedule"}
             </Button>
-
-            {regularVolunteer.isPausedByUser ? (
-              <Button
-                onClick={() => handlePause(true)}
-                disabled={loading}
-                className="flex items-center gap-2 bg-green-600 hover:bg-green-700"
-              >
-                <PlayIcon className="h-4 w-4" />
-                {loading ? "Resuming..." : "Resume Schedule"}
-              </Button>
-            ) : (
-              <Button
-                onClick={() => setPauseDialogOpen(true)}
-                variant="outline"
-                className="flex items-center gap-2 text-yellow-600 hover:text-yellow-700 hover:bg-yellow-50"
-              >
-                <PauseIcon className="h-4 w-4" />
-                Pause Schedule
-              </Button>
-            )}
-          </div>
-
-          {regularVolunteer.isPausedByUser && regularVolunteer.pausedUntil && (
-            <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-              <div className="flex items-center gap-2">
-                <CalendarIcon className="h-4 w-4 text-yellow-600" />
-                <span className="text-sm font-medium text-yellow-800">
-                  Paused until{" "}
-                  {format(regularVolunteer.pausedUntil, "MMMM d, yyyy")}
-                </span>
-              </div>
-            </div>
+          ) : (
+            <Button
+              onClick={() => setPauseDialogOpen(true)}
+              variant="outline"
+              className="flex items-center gap-2 text-yellow-600 hover:text-yellow-700 hover:bg-yellow-50"
+            >
+              <PauseIcon className="h-4 w-4" />
+              Pause Schedule
+            </Button>
           )}
-        </CardContent>
-      </Card>
+        </div>
+
+        {regularVolunteer.isPausedByUser && regularVolunteer.pausedUntil && (
+          <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+            <div className="flex items-center gap-2">
+              <CalendarIcon className="h-4 w-4 text-yellow-600" />
+              <span className="text-sm font-medium text-yellow-800">
+                Paused until{" "}
+                {format(regularVolunteer.pausedUntil, "MMMM d, yyyy")}
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
 
       {/* Edit Dialog */}
       <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>

--- a/web/src/components/merge-user-dialog.tsx
+++ b/web/src/components/merge-user-dialog.tsx
@@ -572,13 +572,18 @@ export function MergeUserDialog({ user, children }: MergeUserDialogProps) {
                       </span>
                     </div>
                   )}
-                  {preview.estimatedStats.regularVolunteer && (
+                  {preview.estimatedStats.regularVolunteers.toTransfer > 0 && (
                     <div className="flex justify-between col-span-2">
                       <span className="text-muted-foreground">
-                        Regular Volunteer status
+                        Regular Volunteer schedules
                       </span>
-                      <span className="font-medium text-green-600">
-                        Will transfer
+                      <span className="font-medium">
+                        {preview.estimatedStats.regularVolunteers.toTransfer}
+                        {preview.estimatedStats.regularVolunteers.toSkip > 0 && (
+                          <span className="text-amber-600 ml-1">
+                            (+{preview.estimatedStats.regularVolunteers.toSkip} skip)
+                          </span>
+                        )}
                       </span>
                     </div>
                   )}
@@ -588,7 +593,8 @@ export function MergeUserDialog({ user, children }: MergeUserDialogProps) {
               {/* Conflict warnings */}
               {(preview.conflicts.duplicateSignups > 0 ||
                 preview.conflicts.duplicateAchievements > 0 ||
-                preview.conflicts.duplicateFriendships > 0) && (
+                preview.conflicts.duplicateFriendships > 0 ||
+                preview.conflicts.duplicateRegularVolunteers > 0) && (
                 <InfoBox
                   title="Duplicates will be skipped"
                   variant="amber"
@@ -609,6 +615,11 @@ export function MergeUserDialog({ user, children }: MergeUserDialogProps) {
                     {preview.conflicts.duplicateFriendships > 0 && (
                       <li>
                         {preview.conflicts.duplicateFriendships} friendship(s) (duplicates or self-refs)
+                      </li>
+                    )}
+                    {preview.conflicts.duplicateRegularVolunteers > 0 && (
+                      <li>
+                        {preview.conflicts.duplicateRegularVolunteers} regular schedule(s) for same shift type
                       </li>
                     )}
                   </ul>


### PR DESCRIPTION
## Summary

Closes #545

- Allow volunteers to have multiple `RegularVolunteer` records, one per shift type
- A volunteer can now be regular for both "Dining Room" on Mondays and "Kitchen" on Wednesdays
- Previously, a volunteer could only be regular for ONE shift type due to the `userId @unique` constraint

## Changes

### Database Schema
- Removed `@unique` constraint from `userId` field in `RegularVolunteer`
- Added composite unique constraint `@@unique([userId, shiftTypeId])`
- Updated `User.regularVolunteer` relation to `User.regularVolunteers` (array)

### API Updates
- **POST /api/admin/regulars** - Validates `(userId, shiftTypeId)` combo instead of just `userId`
- **PUT /api/admin/regulars/[id]** - Validates shift type changes don't create duplicates
- **GET /api/profile/regular-schedule** - Returns array of schedules
- **PUT /api/profile/regular-schedule** - Requires `regularVolunteerId` to target specific schedule
- **PATCH /api/profile/regular-schedule/pause** - Requires `regularVolunteerId`
- **GET /api/profile/regular-schedule/preview** - Supports optional `regularVolunteerId` param

### Admin UI
- Form shows existing shift types for selected volunteer, filtering available options
- Table tracks other shift types per volunteer, passes to edit dialog
- Edit dialog filters shift type options to prevent duplicates

### Profile UI
- Displays multiple schedules as separate cards
- Each schedule can be paused/resumed independently

### User Merge
- Transfers non-conflicting regular volunteer records
- Skips duplicates (same shift type)
- Shows conflict warnings in preview

## Test plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] All 55 unit tests pass
- [ ] Create a regular volunteer for User A with Shift Type X
- [ ] Create another regular for User A with Shift Type Y (should succeed)
- [ ] Try to create duplicate for User A with Shift Type X (should fail)
- [ ] Check profile page shows both schedules
- [ ] Test pause/resume on individual schedules
- [ ] E2E tests: `npx playwright test regular-volunteers.spec.ts --project=chromium`

🤖 Generated with [Claude Code](https://claude.com/claude-code)