### PR TITLE
feat: make emails and phone numbers clickable in admin pages

### DIFF
--- a/web/src/app/admin/parental-consent/parental-consent-table.tsx
+++ b/web/src/app/admin/parental-consent/parental-consent-table.tsx
@@ -172,7 +172,12 @@ export function ParentalConsentTable() {
                                 </Link>
                               </div>
                               <div className="text-sm text-muted-foreground">
-                                {user.email}
+                                <a
+                                  href={`mailto:${user.email}`}
+                                  className="hover:text-foreground hover:underline transition-colors"
+                                >
+                                  {user.email}
+                                </a>
                               </div>
                             </div>
                             {!user.profileCompleted && (
@@ -189,12 +194,22 @@ export function ParentalConsentTable() {
                           <div className="space-y-1">
                             <div className="flex items-center gap-1 text-sm">
                               <Mail className="h-3 w-3" />
-                              {user.email}
+                              <a
+                                href={`mailto:${user.email}`}
+                                className="hover:text-foreground hover:underline transition-colors"
+                              >
+                                {user.email}
+                              </a>
                             </div>
                             {user.phone && (
                               <div className="flex items-center gap-1 text-sm text-muted-foreground">
                                 <Phone className="h-3 w-3" />
-                                {user.phone}
+                                <a
+                                  href={`tel:${user.phone}`}
+                                  className="hover:text-foreground hover:underline transition-colors"
+                                >
+                                  {user.phone}
+                                </a>
                               </div>
                             )}
                           </div>
@@ -208,7 +223,12 @@ export function ParentalConsentTable() {
                               {user.emergencyContactPhone && (
                                 <div className="flex items-center gap-1 text-sm text-muted-foreground">
                                   <Phone className="h-3 w-3" />
-                                  {user.emergencyContactPhone}
+                                  <a
+                                    href={`tel:${user.emergencyContactPhone}`}
+                                    className="hover:text-foreground hover:underline transition-colors"
+                                  >
+                                    {user.emergencyContactPhone}
+                                  </a>
                                 </div>
                               )}
                             </div>

--- a/web/src/app/admin/regulars/regulars-table.tsx
+++ b/web/src/app/admin/regulars/regulars-table.tsx
@@ -254,7 +254,12 @@ export function RegularsTable({
                             {regular.user.firstName} {regular.user.lastName}
                           </div>
                           <div className="text-sm text-muted-foreground">
-                            {regular.user.email}
+                            <a
+                              href={`mailto:${regular.user.email}`}
+                              className="hover:text-foreground hover:underline transition-colors"
+                            >
+                              {regular.user.email}
+                            </a>
                           </div>
                         </div>
                       </div>

--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -296,7 +296,12 @@ export default async function AdminVolunteerPage({
                   data-testid="volunteer-email"
                 >
                   <Mail className="h-4 w-4" />
-                  <span className="text-sm">{volunteer.email}</span>
+                  <a
+                    href={`mailto:${volunteer.email}`}
+                    className="text-sm hover:text-foreground hover:underline transition-colors"
+                  >
+                    {volunteer.email}
+                  </a>
                 </div>
 
                 {/* Quick Info Row - Pronouns & Age */}
@@ -592,7 +597,16 @@ export default async function AdminVolunteerPage({
                 <div className="space-y-2">
                   <label className="text-sm font-medium">Phone</label>
                   <p className="text-sm text-muted-foreground">
-                    {volunteer.emergencyContactPhone || "Not provided"}
+                    {volunteer.emergencyContactPhone ? (
+                      <a
+                        href={`tel:${volunteer.emergencyContactPhone}`}
+                        className="hover:text-foreground hover:underline transition-colors"
+                      >
+                        {volunteer.emergencyContactPhone}
+                      </a>
+                    ) : (
+                      "Not provided"
+                    )}
                   </p>
                 </div>
               </CardContent>

--- a/web/src/components/admin-contact-info-section.tsx
+++ b/web/src/components/admin-contact-info-section.tsx
@@ -58,7 +58,16 @@ export function AdminContactInfoSection({
             </label>
             <div className="flex items-center gap-3 p-3 bg-muted/50 dark:bg-muted/30 rounded-lg">
               <p className="text-sm text-muted-foreground">
-                {phone || "Not provided"}
+                {phone ? (
+                  <a
+                    href={`tel:${phone}`}
+                    className="hover:text-foreground hover:underline transition-colors"
+                  >
+                    {phone}
+                  </a>
+                ) : (
+                  "Not provided"
+                )}
               </p>
             </div>
           </div>

--- a/web/src/components/admin-editable-field.tsx
+++ b/web/src/components/admin-editable-field.tsx
@@ -90,7 +90,16 @@ export function AdminEditableField({
     return (
       <div className="flex items-center gap-3 p-3 bg-muted/50 dark:bg-muted/30 rounded-lg group">
         <div className="flex-1 space-y-1">
-          <p className="text-sm text-muted-foreground">{displayValue}</p>
+          {fieldName === "email" && currentValue ? (
+            <a
+              href={`mailto:${currentValue}`}
+              className="text-sm text-muted-foreground hover:text-foreground hover:underline transition-colors"
+            >
+              {displayValue}
+            </a>
+          ) : (
+            <p className="text-sm text-muted-foreground">{displayValue}</p>
+          )}
         </div>
         <Button
           variant="ghost"

--- a/web/src/components/users-data-table.tsx
+++ b/web/src/components/users-data-table.tsx
@@ -143,7 +143,13 @@ export const columns: ColumnDef<User>[] = [
               data-testid={`user-email-${user.id}`}
             >
               <Mail className="h-3 w-3" />
-              {user.email}
+              <a
+                href={`mailto:${user.email}`}
+                className="hover:text-foreground hover:underline transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {user.email}
+              </a>
             </div>
           </div>
         </div>
@@ -191,7 +197,13 @@ export const columns: ColumnDef<User>[] = [
     cell: ({ row }) => {
       const phone = row.getValue("phone") as string | null;
       return phone ? (
-        <span className="text-sm font-medium">{phone}</span>
+        <a
+          href={`tel:${phone}`}
+          className="text-sm font-medium hover:text-foreground hover:underline transition-colors"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {phone}
+        </a>
       ) : (
         <span className="text-xs text-muted-foreground">No phone</span>
       );


### PR DESCRIPTION
## Summary
- Add `mailto:` links to all email addresses in admin interface
- Add `tel:` links to all phone numbers in admin interface
- Improve UX with hover effects on clickable contact information
- Prevent event propagation on links within clickable table rows

## Changes Made
- **Admin volunteer profile page**: Email in header and emergency contact phone
- **Users data table**: Email and phone in user list
- **Regulars table**: Email in volunteer information
- **Parental consent table**: All emails and phone numbers (user + emergency contact)
- **Admin contact info section**: Email and phone fields
- **Admin editable field component**: Email field when not editing

## Test plan
- [ ] Navigate to admin volunteer profile page and verify email is clickable
- [ ] Click email link and verify it opens default email client
- [ ] Click phone number and verify it opens phone dialer
- [ ] Verify hover effects work correctly
- [ ] Check that clicking email/phone in data tables doesn't trigger row click
- [ ] Test on both pending and approved sections of parental consent table

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)