### PR TITLE
Move custom labels to top of admin volunteer profile

### DIFF
--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -445,6 +445,12 @@ export default async function AdminVolunteerPage({
               </CardContent>
             </Card>
 
+            {/* Custom Labels */}
+            <UserCustomLabelsManager
+              userId={volunteer.id}
+              currentLabels={volunteer.customLabels}
+            />
+
             {/* Admin Actions */}
             <Card data-testid="admin-actions-card">
               <CardHeader>
@@ -556,12 +562,6 @@ export default async function AdminVolunteerPage({
                 <AdminNotesManager volunteerId={volunteer.id} />
               </CardContent>
             </Card>
-
-            {/* Custom Labels */}
-            <UserCustomLabelsManager
-              userId={volunteer.id}
-              currentLabels={volunteer.customLabels}
-            />
 
             {/* Contact Information */}
             <AdminContactInfoSection


### PR DESCRIPTION
## Summary
Repositioned the custom labels section to appear prominently at the top of the admin volunteer profile page, immediately after the basic information card.

## Changes
- Moved `UserCustomLabelsManager` component from position #4 to position #2 in the left column
- Custom labels now appear right after the basic information card, before admin actions
- No functional changes, only UI positioning improvement

## Benefits
- Quick identification of volunteer tags/categories at a glance
- Better admin workflow efficiency
- Improved visual hierarchy on the profile page

## Screenshots
Before: Custom labels were located after Admin Actions and Admin Notes
After: Custom labels now appear prominently near the top, immediately after volunteer's basic info

Fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)