### PR TITLE
feat: add placeholder count for walk-in volunteers

### DIFF
--- a/web/prisma/migrations/20260219063309_add_placeholder_count_to_shift/migration.sql
+++ b/web/prisma/migrations/20260219063309_add_placeholder_count_to_shift/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Shift" ADD COLUMN     "placeholderCount" INTEGER NOT NULL DEFAULT 0;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -196,12 +196,13 @@ model Shift {
   end           DateTime
   location      String?
   capacity      Int
-  notes         String?
-  createdAt     DateTime       @default(now())
-  updatedAt     DateTime       @updatedAt
-  shiftType     ShiftType      @relation(fields: [shiftTypeId], references: [id])
-  signups       Signup[]
-  groupBookings GroupBooking[]
+  notes            String?
+  placeholderCount Int            @default(0)
+  createdAt        DateTime       @default(now())
+  updatedAt        DateTime       @updatedAt
+  shiftType        ShiftType      @relation(fields: [shiftTypeId], references: [id])
+  signups          Signup[]
+  groupBookings    GroupBooking[]
 }
 
 model Signup {

--- a/web/src/app/admin/notifications/notifications-content.tsx
+++ b/web/src/app/admin/notifications/notifications-content.tsx
@@ -47,6 +47,7 @@ interface Shift {
   end: string;
   location: string;
   capacity: number;
+  placeholderCount: number;
   _count: {
     signups: number;
   };
@@ -288,7 +289,7 @@ export function NotificationsContent({
       const summary = summariesMap.get(dateKey)!;
       summary.count++;
       summary.totalCapacity += shift.capacity;
-      summary.totalConfirmed += shift._count.signups;
+      summary.totalConfirmed += shift._count.signups + (shift.placeholderCount || 0);
 
       if (!summary.locations.includes(location)) {
         summary.locations.push(location);
@@ -562,8 +563,9 @@ export function NotificationsContent({
   };
 
   const getShiftShortageInfo = (shift: Shift) => {
-    const shortage = shift.capacity - shift._count.signups;
-    const percentFilled = (shift._count.signups / shift.capacity) * 100;
+    const effectiveConfirmed = shift._count.signups + (shift.placeholderCount || 0);
+    const shortage = shift.capacity - effectiveConfirmed;
+    const percentFilled = (effectiveConfirmed / shift.capacity) * 100;
     return { shortage, percentFilled };
   };
 
@@ -695,7 +697,7 @@ export function NotificationsContent({
                           <div className="text-sm text-muted-foreground">
                             {formatInNZT(new Date(shift.start), "h:mm a")} -{" "}
                             {formatInNZT(new Date(shift.end), "h:mm a")} •{" "}
-                            {shift.location} • {shift._count.signups}/
+                            {shift.location} • {shift._count.signups + (shift.placeholderCount || 0)}/
                             {shift.capacity} ({percentFilled.toFixed(0)}%)
                           </div>
                         </div>

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -220,6 +220,7 @@ export default async function AdminDashboardPage({
   type ShiftWithSignups = {
     id: string;
     capacity: number;
+    placeholderCount: number;
     shiftType: { name: string };
     signups: Array<{ status: string }>;
   };
@@ -227,7 +228,7 @@ export default async function AdminDashboardPage({
   // Filter shifts that need attention (less than 50% capacity filled)
   const lowSignupShifts = shiftsNeedingAttention.filter(
     (shift: ShiftWithSignups) => {
-      const confirmedCount = shift.signups.length;
+      const confirmedCount = shift.signups.length + shift.placeholderCount;
       const fillRate = shift.capacity > 0 ? confirmedCount / shift.capacity : 0;
       return fillRate < 0.5;
     }
@@ -498,7 +499,7 @@ export default async function AdminDashboardPage({
                   {lowSignupShifts
                     .slice(0, 2)
                     .map((shift: ShiftWithSignups) => {
-                      const confirmedCount = shift.signups.length;
+                      const confirmedCount = shift.signups.length + shift.placeholderCount;
                       const fillRate =
                         shift.capacity > 0
                           ? (confirmedCount / shift.capacity) * 100

--- a/web/src/app/admin/shifts/page.tsx
+++ b/web/src/app/admin/shifts/page.tsx
@@ -178,7 +178,7 @@ export default async function AdminShiftsPage({
 
   // Check if any shifts are understaffed (less than 50% confirmed)
   const hasUnderstaffedShifts = shifts.some((shift) => {
-    const confirmed = shift.signups.filter((s) => s.status === "CONFIRMED").length;
+    const confirmed = shift.signups.filter((s) => s.status === "CONFIRMED").length + shift.placeholderCount;
     const percentage = (confirmed / shift.capacity) * 100;
     return percentage < 50;
   });
@@ -198,6 +198,7 @@ export default async function AdminShiftsPage({
       start: true,
       location: true,
       capacity: true,
+      placeholderCount: true,
       shiftType: {
         select: {
           name: true,
@@ -249,7 +250,7 @@ export default async function AdminShiftsPage({
     const summary = shiftSummariesMap.get(dateKey)!;
     summary.count++;
     summary.totalCapacity += shift.capacity;
-    summary.totalConfirmed += shift.signups.length;
+    summary.totalConfirmed += shift.signups.length + shift.placeholderCount;
 
     if (!summary.locations.includes(location)) {
       summary.locations.push(location);

--- a/web/src/app/api/admin/shifts/[id]/assign/route.ts
+++ b/web/src/app/api/admin/shifts/[id]/assign/route.ts
@@ -114,7 +114,7 @@ export async function POST(
     }
 
     // Check capacity (warn if over capacity for CONFIRMED assignments)
-    const confirmedCount = shift.signups.length;
+    const confirmedCount = shift.signups.length + shift.placeholderCount;
     const isOverCapacity = confirmedCount >= shift.capacity;
 
     // Check if volunteer already has a confirmed or pending signup for the same date and period (AM/PM)

--- a/web/src/app/api/admin/shifts/[id]/placeholders/route.ts
+++ b/web/src/app/api/admin/shifts/[id]/placeholders/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+  });
+
+  if (!user || user.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403 }
+    );
+  }
+
+  const { id: shiftId } = await params;
+
+  try {
+    const body = await req.json();
+    const { placeholderCount } = body;
+
+    if (typeof placeholderCount !== "number" || placeholderCount < 0) {
+      return NextResponse.json(
+        { error: "placeholderCount must be a non-negative integer" },
+        { status: 400 }
+      );
+    }
+
+    const shift = await prisma.shift.update({
+      where: { id: shiftId },
+      data: { placeholderCount: Math.floor(placeholderCount) },
+      select: {
+        id: true,
+        placeholderCount: true,
+      },
+    });
+
+    return NextResponse.json(shift);
+  } catch (error) {
+    console.error("Error updating placeholder count:", error);
+    return NextResponse.json(
+      { error: "Failed to update placeholder count" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/app/api/admin/shifts/shortages/route.ts
+++ b/web/src/app/api/admin/shifts/shortages/route.ts
@@ -39,11 +39,14 @@ export async function GET() {
 
     // Filter to only show shifts with shortages (admin can decide what constitutes a shortage)
     // We'll show all shifts and let the admin decide based on the numbers
-    const shiftsWithInfo = upcomingShifts.map(shift => ({
-      ...shift,
-      shortage: shift.capacity - shift._count.signups,
-      percentFilled: (shift._count.signups / shift.capacity) * 100,
-    }));
+    const shiftsWithInfo = upcomingShifts.map(shift => {
+      const effectiveConfirmed = shift._count.signups + shift.placeholderCount;
+      return {
+        ...shift,
+        shortage: shift.capacity - effectiveConfirmed,
+        percentFilled: (effectiveConfirmed / shift.capacity) * 100,
+      };
+    });
 
     return NextResponse.json(shiftsWithInfo);
   } catch (error) {

--- a/web/src/app/api/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/shifts/[id]/signup/route.ts
@@ -86,7 +86,7 @@ export async function POST(
   if (!shift)
     return NextResponse.json({ error: "Shift not found" }, { status: 404 });
 
-  let confirmedCount = 0;
+  let confirmedCount = shift.placeholderCount;
   for (const signup of shift.signups) {
     if (signup.status === "CONFIRMED") confirmedCount += 1;
   }

--- a/web/src/app/shifts/[id]/page.tsx
+++ b/web/src/app/shifts/[id]/page.tsx
@@ -207,7 +207,7 @@ export default async function ShiftDetailPage({
   // Fetch concurrent shifts for backup options
   const concurrentShifts = await getConcurrentShifts(id);
 
-  const confirmedCount = shift._count.signups;
+  const confirmedCount = shift._count.signups + shift.placeholderCount;
   const isWaitlist = confirmedCount >= shift.capacity;
   const spotsRemaining = Math.max(0, shift.capacity - confirmedCount);
   const theme = SHIFT_THEMES[shift.shiftType.name as keyof typeof SHIFT_THEMES] || DEFAULT_THEME;

--- a/web/src/app/shifts/details/page.tsx
+++ b/web/src/app/shifts/details/page.tsx
@@ -74,7 +74,7 @@ function getConcurrentShiftsFromList(
     .map((shift) => {
       const confirmedCount = shift.signups.filter(
         (s) => s.status === "CONFIRMED" || s.status === "PENDING" || s.status === "REGULAR_PENDING"
-      ).length;
+      ).length + (shift.placeholderCount || 0);
       return {
         id: shift.id,
         shiftTypeName: shift.shiftType.name,
@@ -91,6 +91,7 @@ interface ShiftWithRelations {
   location: string | null;
   capacity: number;
   notes: string | null;
+  placeholderCount: number;
   shiftType: {
     id: string;
     name: string;
@@ -145,7 +146,7 @@ function ShiftCard({
   const concurrentShifts = getConcurrentShiftsFromList(shift, allShifts);
 
   // Calculate signup counts - only count non-canceled signups
-  let confirmedCount = 0;
+  let confirmedCount = shift.placeholderCount || 0;
   let pendingCount = 0;
 
   for (const signup of shift.signups) {

--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -275,7 +275,7 @@ export default async function ShiftsCalendarPage({
     end: shift.end,
     location: shift.location,
     capacity: shift.capacity,
-    confirmedCount: shift._count.signups, // This includes CONFIRMED, PENDING, and REGULAR_PENDING
+    confirmedCount: shift._count.signups + shift.placeholderCount, // Includes CONFIRMED, PENDING, REGULAR_PENDING + placeholders
     pendingCount: 0, // For calendar view, we simplify by putting all counts in confirmedCount
     shiftType: {
       name: shift.shiftType.name,

--- a/web/src/components/animated-shift-cards-wrapper.tsx
+++ b/web/src/components/animated-shift-cards-wrapper.tsx
@@ -10,6 +10,7 @@ interface Shift {
   location: string | null;
   capacity: number;
   notes: string | null;
+  placeholderCount: number;
   shiftType: {
     id: string;
     name: string;

--- a/web/src/components/placeholder-count-control.tsx
+++ b/web/src/components/placeholder-count-control.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Minus, Plus, Users } from "lucide-react";
+
+interface PlaceholderCountControlProps {
+  shiftId: string;
+  initialCount: number;
+}
+
+export function PlaceholderCountControl({
+  shiftId,
+  initialCount,
+}: PlaceholderCountControlProps) {
+  const [count, setCount] = useState(initialCount);
+  const [isPending, startTransition] = useTransition();
+  const router = useRouter();
+
+  const updateCount = async (newCount: number) => {
+    const previous = count;
+    setCount(newCount);
+
+    try {
+      const response = await fetch(
+        `/api/admin/shifts/${shiftId}/placeholders`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ placeholderCount: newCount }),
+        }
+      );
+
+      if (!response.ok) {
+        setCount(previous);
+        return;
+      }
+
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch {
+      setCount(previous);
+    }
+  };
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      data-testid={`placeholder-control-${shiftId}`}
+    >
+      <Users className="h-4 w-4 text-slate-500 dark:text-slate-400" />
+      <span className="text-xs font-medium text-slate-600 dark:text-slate-300">
+        Walk-ins
+      </span>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 w-7 p-0"
+          disabled={count <= 0 || isPending}
+          onClick={() => updateCount(count - 1)}
+          data-testid={`placeholder-decrease-${shiftId}`}
+        >
+          <Minus className="h-3 w-3" />
+        </Button>
+        <span
+          className="w-6 text-center text-sm font-semibold tabular-nums"
+          data-testid={`placeholder-count-${shiftId}`}
+        >
+          {count}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 w-7 p-0"
+          disabled={isPending}
+          onClick={() => updateCount(count + 1)}
+          data-testid={`placeholder-increase-${shiftId}`}
+        >
+          <Plus className="h-3 w-3" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/shifts-by-time-of-day.tsx
+++ b/web/src/components/shifts-by-time-of-day.tsx
@@ -10,6 +10,7 @@ interface Shift {
   location: string | null;
   capacity: number;
   notes: string | null;
+  placeholderCount: number;
   shiftType: {
     id: string;
     name: string;

--- a/web/src/lib/placeholder-utils.test.ts
+++ b/web/src/lib/placeholder-utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { getEffectiveConfirmedCount } from "./placeholder-utils";
+
+describe("getEffectiveConfirmedCount", () => {
+  it("should add confirmed signups and placeholder count", () => {
+    expect(getEffectiveConfirmedCount(3, 2)).toBe(5);
+  });
+
+  it("should return just confirmed signups when placeholders are 0", () => {
+    expect(getEffectiveConfirmedCount(4, 0)).toBe(4);
+  });
+
+  it("should clamp negative placeholder count to 0", () => {
+    expect(getEffectiveConfirmedCount(3, -5)).toBe(3);
+  });
+
+  it("should handle zero for both values", () => {
+    expect(getEffectiveConfirmedCount(0, 0)).toBe(0);
+  });
+
+  it("should handle large values", () => {
+    expect(getEffectiveConfirmedCount(100, 50)).toBe(150);
+  });
+});

--- a/web/src/lib/placeholder-utils.ts
+++ b/web/src/lib/placeholder-utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns the effective confirmed count including placeholder (walk-in) volunteers.
+ * Clamps placeholderCount to >= 0 for safety.
+ */
+export function getEffectiveConfirmedCount(
+  confirmedSignups: number,
+  placeholderCount: number
+): number {
+  return confirmedSignups + Math.max(0, placeholderCount);
+}


### PR DESCRIPTION
## Summary
- Adds `placeholderCount` integer field to the `Shift` model so admins can record walk-in volunteers who don't have accounts
- Adds inline +/- controls on admin shift cards to adjust the count
- Placeholders count toward capacity everywhere (staffing badges, shortage emails, volunteer-facing "spots left", signup capacity checks) but don't create `Signup` records or affect achievements/stats

## Changes
- **Schema:** Added `placeholderCount Int @default(0)` to `Shift` model with migration
- **API:** New `PATCH /api/admin/shifts/[id]/placeholders` endpoint (admin-only)
- **Component:** `PlaceholderCountControl` — client component with +/- buttons and optimistic updates
- **Admin shift cards:** Badge shows `3+2/6` format when placeholders > 0, control added to footer
- **Capacity checks:** Both admin assign and volunteer self-signup routes include placeholders
- **Shortage system:** Shortages API and notifications page include placeholders in calculations
- **Volunteer pages:** Shift detail, shift list, and calendar all reflect placeholders in spots remaining
- **Admin dashboard:** "Needs Attention" section includes placeholders in fill-rate calculations
- **Utility:** `getEffectiveConfirmedCount()` with 5 unit tests

## Test plan
- [x] `npm run prisma:generate` succeeds
- [x] `npm run test:run` — 65 unit tests pass (including 5 new placeholder tests)
- [x] `npm run build` — production build succeeds with no type errors
- [ ] Manual: admin shift card shows +/- walk-in controls, adjusting count updates the badge
- [ ] Manual: volunteer-facing shift page shows reduced spots when placeholders are added
- [ ] Manual: shortage notifications account for placeholders

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)