### PR TITLE
Add bulk survey assignment for admins

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -216,23 +216,12 @@ export default async function AdminDashboardPage({
 
   const [monthlyShifts, monthlySignups, newUsersThisMonth] = monthlyStats;
 
-  // Define types for better type safety
-  type ShiftWithSignups = {
-    id: string;
-    capacity: number;
-    placeholderCount: number;
-    shiftType: { name: string };
-    signups: Array<{ status: string }>;
-  };
-
   // Filter shifts that need attention (less than 50% capacity filled)
-  const lowSignupShifts = shiftsNeedingAttention.filter(
-    (shift: ShiftWithSignups) => {
-      const confirmedCount = shift.signups.length + shift.placeholderCount;
-      const fillRate = shift.capacity > 0 ? confirmedCount / shift.capacity : 0;
-      return fillRate < 0.5;
-    }
-  );
+  const lowSignupShifts = shiftsNeedingAttention.filter((shift) => {
+    const confirmedCount = shift.signups.length + shift.placeholderCount;
+    const fillRate = shift.capacity > 0 ? confirmedCount / shift.capacity : 0;
+    return fillRate < 0.5;
+  });
 
   return (
     <AdminPageWrapper
@@ -498,7 +487,7 @@ export default async function AdminDashboardPage({
                   </p>
                   {lowSignupShifts
                     .slice(0, 2)
-                    .map((shift: ShiftWithSignups) => {
+                    .map((shift) => {
                       const confirmedCount = shift.signups.length + shift.placeholderCount;
                       const fillRate =
                         shift.capacity > 0

--- a/web/src/app/admin/surveys/bulk-assign-survey-dialog.tsx
+++ b/web/src/app/admin/surveys/bulk-assign-survey-dialog.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog";
+import { Users, Loader2, Send, AlertCircle } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { EmailPreviewDialog } from "@/components/email-preview-dialog";
+import { SURVEY_TRIGGER_DISPLAY } from "@/types/survey";
+import type { SurveyTriggerType } from "@/generated/client";
+
+interface Survey {
+  id: string;
+  title: string;
+  triggerType: SurveyTriggerType;
+  triggerValue: number;
+  triggerMaxValue: number | null;
+}
+
+interface PreviewData {
+  eligibleUserIds: string[];
+  totalEligible: number;
+  alreadyAssigned: number;
+  sampleUsers: { id: string; name: string | null; email: string }[];
+}
+
+interface BulkAssignSurveyDialogProps {
+  survey: Survey;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAssigned?: () => void;
+}
+
+export function BulkAssignSurveyDialog({
+  survey,
+  open,
+  onOpenChange,
+  onAssigned,
+}: BulkAssignSurveyDialogProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isAssigning, setIsAssigning] = useState(false);
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  const fetchPreview = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/admin/surveys/${survey.id}/bulk-assign`
+      );
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to load preview");
+      }
+      const data: PreviewData = await response.json();
+      setPreview(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load preview");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [survey.id]);
+
+  useEffect(() => {
+    if (open) {
+      setPreview(null);
+      setError(null);
+      fetchPreview();
+    }
+  }, [open, fetchPreview]);
+
+  const handleBulkAssign = async () => {
+    setIsAssigning(true);
+    try {
+      const response = await fetch(
+        `/api/admin/surveys/${survey.id}/bulk-assign`,
+        { method: "POST" }
+      );
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to assign survey");
+      }
+      const result = await response.json();
+
+      toast({
+        title: "Bulk Assignment Complete",
+        description: result.message,
+      });
+
+      onOpenChange(false);
+      onAssigned?.();
+    } catch (err) {
+      toast({
+        title: "Error",
+        description:
+          err instanceof Error ? err.message : "Failed to assign survey",
+        variant: "destructive",
+      });
+    } finally {
+      setIsAssigning(false);
+    }
+  };
+
+  const triggerDisplay = SURVEY_TRIGGER_DISPLAY[survey.triggerType];
+  const triggerDescription =
+    survey.triggerType === "MANUAL"
+      ? "All volunteers (manual assignment)"
+      : survey.triggerMaxValue !== null
+        ? `${triggerDisplay.label}: ${survey.triggerValue}–${survey.triggerMaxValue}`
+        : `${triggerDisplay.label}: ${survey.triggerValue}+`;
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDialogContent className="sm:max-w-[480px]">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Bulk Assign Survey
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Assign &quot;{survey.title}&quot; to all eligible users matching the
+            trigger criteria.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <div className="space-y-4">
+          {/* Trigger info */}
+          <div className="rounded-lg bg-muted p-3 text-sm">
+            <p className="font-medium">Trigger Criteria</p>
+            <p className="text-muted-foreground">{triggerDescription}</p>
+          </div>
+
+          {/* Loading state */}
+          {isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              <span className="ml-2 text-sm text-muted-foreground">
+                Finding eligible users...
+              </span>
+            </div>
+          )}
+
+          {/* Error state */}
+          {error && (
+            <div className="flex items-center gap-2 rounded-lg border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertCircle className="h-4 w-4 shrink-0" />
+              {error}
+            </div>
+          )}
+
+          {/* Preview results */}
+          {preview && !isLoading && (
+            <>
+              <div className="space-y-3">
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="rounded-lg border p-3 text-center">
+                    <p className="text-2xl font-bold">
+                      {preview.totalEligible}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Eligible Users
+                    </p>
+                  </div>
+                  <div className="rounded-lg border p-3 text-center">
+                    <p className="text-2xl font-bold">
+                      {preview.alreadyAssigned}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Already Assigned
+                    </p>
+                  </div>
+                </div>
+
+                {/* Sample users */}
+                {preview.sampleUsers.length > 0 && (
+                  <div>
+                    <p className="text-sm font-medium mb-2">
+                      {preview.totalEligible <= 10
+                        ? "Eligible users:"
+                        : `Sample of ${preview.sampleUsers.length} eligible users:`}
+                    </p>
+                    <div className="rounded-lg border divide-y max-h-40 overflow-y-auto">
+                      {preview.sampleUsers.map((user) => (
+                        <div
+                          key={user.id}
+                          className="px-3 py-2 text-sm flex justify-between"
+                        >
+                          <span className="font-medium truncate">
+                            {user.name || "Unnamed"}
+                          </span>
+                          <span className="text-muted-foreground truncate ml-2">
+                            {user.email}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                    {preview.totalEligible > 10 && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        ...and {preview.totalEligible - 10} more
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {preview.totalEligible === 0 && (
+                  <div className="text-center py-4 text-sm text-muted-foreground">
+                    <Users className="h-8 w-8 mx-auto mb-2 opacity-50" />
+                    <p>No eligible users found.</p>
+                    <p className="text-xs mt-1">
+                      All matching users have already been assigned this survey.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-between items-center pt-2">
+            <EmailPreviewDialog
+              emailType="surveyNotification"
+              triggerLabel="Preview Email"
+              triggerVariant="outline"
+            />
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isAssigning}
+              >
+                Cancel
+              </Button>
+              <Button
+                onClick={handleBulkAssign}
+                disabled={
+                  isLoading ||
+                  isAssigning ||
+                  !preview ||
+                  preview.totalEligible === 0
+                }
+                data-testid="bulk-assign-survey-submit"
+              >
+                {isAssigning ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Assigning...
+                  </>
+                ) : (
+                  <>
+                    <Send className="h-4 w-4 mr-2" />
+                    Assign to {preview?.totalEligible || 0} Users
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  );
+}

--- a/web/src/app/admin/surveys/surveys-content.tsx
+++ b/web/src/app/admin/surveys/surveys-content.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { SurveyDialog } from "./survey-dialog";
 import { AssignSurveyDialog } from "./assign-survey-dialog";
+import { BulkAssignSurveyDialog } from "./bulk-assign-survey-dialog";
 import { useToast } from "@/hooks/use-toast";
 import { SURVEY_TRIGGER_DISPLAY } from "@/types/survey";
 import type { Survey, SurveyTriggerType } from "@/generated/client";
@@ -67,6 +68,8 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
   const [surveyToDelete, setSurveyToDelete] = useState<SurveyWithStats | null>(null);
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
   const [surveyToAssign, setSurveyToAssign] = useState<SurveyWithStats | null>(null);
+  const [bulkAssignDialogOpen, setBulkAssignDialogOpen] = useState(false);
+  const [surveyToBulkAssign, setSurveyToBulkAssign] = useState<SurveyWithStats | null>(null);
   const { toast } = useToast();
 
   const handleCreateSurvey = async (data: {
@@ -247,6 +250,11 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
     setAssignDialogOpen(true);
   };
 
+  const openBulkAssignDialog = (survey: SurveyWithStats) => {
+    setSurveyToBulkAssign(survey);
+    setBulkAssignDialogOpen(true);
+  };
+
   const handleAssignmentComplete = () => {
     // Refresh surveys to update assignment counts
     window.location.reload();
@@ -336,6 +344,19 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
                     </p>
                   </div>
                   <div className="flex items-center gap-2 ml-4">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => openBulkAssignDialog(survey)}
+                          data-testid={`bulk-assign-survey-${survey.id}`}
+                        >
+                          <Users className="h-4 w-4" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Bulk Assign</TooltipContent>
+                    </Tooltip>
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button
@@ -463,6 +484,18 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
           onOpenChange={(open) => {
             setAssignDialogOpen(open);
             if (!open) setSurveyToAssign(null);
+          }}
+          onAssigned={handleAssignmentComplete}
+        />
+      )}
+
+      {surveyToBulkAssign && (
+        <BulkAssignSurveyDialog
+          survey={surveyToBulkAssign}
+          open={bulkAssignDialogOpen}
+          onOpenChange={(open) => {
+            setBulkAssignDialogOpen(open);
+            if (!open) setSurveyToBulkAssign(null);
           }}
           onAssigned={handleAssignmentComplete}
         />

--- a/web/src/app/api/admin/surveys/[id]/bulk-assign/route.ts
+++ b/web/src/app/api/admin/surveys/[id]/bulk-assign/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import {
+  findEligibleUsersForSurvey,
+  manuallyAssignSurvey,
+} from "@/lib/survey-triggers";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+// GET /api/admin/surveys/[id]/bulk-assign - Preview eligible users
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  try {
+    const { id: surveyId } = await params;
+    const result = await findEligibleUsersForSurvey(surveyId);
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error previewing bulk assignment:", error);
+    const message =
+      error instanceof Error ? error.message : "Failed to preview bulk assignment";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+const BATCH_SIZE = 50;
+
+// POST /api/admin/surveys/[id]/bulk-assign - Execute bulk assignment
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  try {
+    const { id: surveyId } = await params;
+    const { eligibleUserIds, totalEligible } =
+      await findEligibleUsersForSurvey(surveyId);
+
+    if (eligibleUserIds.length === 0) {
+      return NextResponse.json({
+        totalAssigned: 0,
+        totalSkipped: 0,
+        totalEligible: 0,
+        message: "No eligible users found",
+      });
+    }
+
+    let totalAssigned = 0;
+    let totalSkipped = 0;
+
+    // Process in batches to avoid overloading the database
+    for (let i = 0; i < eligibleUserIds.length; i += BATCH_SIZE) {
+      const batch = eligibleUserIds.slice(i, i + BATCH_SIZE);
+      const result = await manuallyAssignSurvey(surveyId, batch);
+      totalAssigned += result.assigned.length;
+      totalSkipped += result.skipped.length;
+    }
+
+    return NextResponse.json({
+      totalAssigned,
+      totalSkipped,
+      totalEligible,
+      message: `Survey assigned to ${totalAssigned} user(s)`,
+    });
+  } catch (error) {
+    console.error("Error executing bulk assignment:", error);
+    const message =
+      error instanceof Error ? error.message : "Failed to execute bulk assignment";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a **Bulk Assign** button to each survey card in Admin > Surveys, allowing admins to proactively assign surveys to all eligible users at once
- Uses efficient bulk DB queries (GROUP BY/HAVING) instead of per-user progress calculations to find eligible users
- Two-step dialog: preview eligible count and sample users, then confirm to execute assignment in batches of 50
- Fixes a pre-existing type annotation issue in the admin dashboard page

## Context
Survey notifications are currently only evaluated when a user visits the site (via `/api/achievements`). Volunteers who don't return never receive surveys — particularly problematic for "first shift" surveys where negative-experience volunteers are the ones who won't come back.

## Changes
| File | Change |
|------|--------|
| `web/src/lib/survey-triggers.ts` | Add `findEligibleUsersForSurvey()` with bulk queries for each trigger type |
| `web/src/app/api/admin/surveys/[id]/bulk-assign/route.ts` | New API: GET for preview, POST for execution |
| `web/src/app/admin/surveys/bulk-assign-survey-dialog.tsx` | New two-step dialog component |
| `web/src/app/admin/surveys/surveys-content.tsx` | Add Bulk Assign button + dialog wiring |
| `web/src/app/admin/page.tsx` | Fix pre-existing `ShiftWithSignups` type annotation |

## Test plan
- [ ] Navigate to Admin > Surveys, verify "Bulk Assign" button appears on each survey card
- [ ] Click bulk assign on an auto-triggered survey — verify preview shows correct eligible count
- [ ] Confirm assignment — verify assignments created, emails sent, toast shown
- [ ] Click bulk assign again on same survey — verify 0 eligible (all already assigned)
- [ ] Test with MANUAL survey — verify it targets all volunteers

🤖 Generated with [Claude Code](https://claude.com/claude-code)