### PR TITLE
Hide bulk assign button for manual surveys

### DIFF
--- a/web/src/app/admin/surveys/surveys-content.tsx
+++ b/web/src/app/admin/surveys/surveys-content.tsx
@@ -344,19 +344,21 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
                     </p>
                   </div>
                   <div className="flex items-center gap-2 ml-4">
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => openBulkAssignDialog(survey)}
-                          data-testid={`bulk-assign-survey-${survey.id}`}
-                        >
-                          <Users className="h-4 w-4" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Bulk Assign</TooltipContent>
-                    </Tooltip>
+                    {survey.triggerType !== "MANUAL" && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openBulkAssignDialog(survey)}
+                            data-testid={`bulk-assign-survey-${survey.id}`}
+                          >
+                            <Users className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Bulk Assign</TooltipContent>
+                      </Tooltip>
+                    )}
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <Button


### PR DESCRIPTION
## Summary
- Hides the bulk assign button for surveys with `MANUAL` trigger type, since bulk assigning all volunteers doesn't apply to manual assignments
- Manual surveys retain the prominent "Assign" button for hand-picking individual volunteers

## Test plan
- [ ] Verify bulk assign button is hidden for MANUAL trigger type surveys
- [ ] Verify bulk assign button still appears for other trigger types (SHIFTS_COMPLETED, HOURS_VOLUNTEERED, FIRST_SHIFT)
- [ ] Verify manual assign button still works correctly for all survey types

🤖 Generated with [Claude Code](https://claude.com/claude-code)