### PR TITLE
feat: support HEIC/HEIF image uploads for iPhone profile photos

### DIFF
--- a/web/src/components/ui/profile-image-upload.tsx
+++ b/web/src/components/ui/profile-image-upload.tsx
@@ -184,11 +184,17 @@ export function ProfileImageUpload({
       const file = e.target.files?.[0];
       if (!file) return;
 
-      // Validate file type
-      if (!file.type.startsWith("image/")) {
+      // Validate file type - check MIME type and fall back to extension
+      // for formats like HEIC/HEIF that may not have a MIME type on some devices
+      const validExtensions = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".heic", ".heif"];
+      const hasValidMime = file.type.startsWith("image/");
+      const hasValidExtension = validExtensions.some((ext) =>
+        file.name.toLowerCase().endsWith(ext)
+      );
+      if (!hasValidMime && !hasValidExtension) {
         toast?.({
           title: "Invalid file type",
-          description: "Please select an image file",
+          description: "Please select an image file (JPG, PNG, HEIC, WebP)",
           variant: "destructive",
         });
         return;
@@ -526,7 +532,7 @@ export function ProfileImageUpload({
           />
 
           <p className="text-xs text-muted-foreground">
-            JPG, PNG up to 4MB. Square crop recommended.
+            JPG, PNG, HEIC, WebP up to 4MB. Square crop recommended.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add file extension fallback validation for HEIC/HEIF files that may not report a standard MIME type on some devices
- Update help text from "JPG, PNG" to "JPG, PNG, HEIC, WebP" to reflect all supported formats
- Improve error message to list accepted formats

Closes #629

## Test plan
- [ ] Upload a HEIC photo from an iPhone and verify it is accepted
- [ ] Upload JPG/PNG and verify they still work
- [ ] Verify the help text shows "JPG, PNG, HEIC, WebP up to 4MB"
- [ ] Verify invalid file types are still rejected with an informative error

🤖 Generated with [Claude Code](https://claude.com/claude-code)