### PR TITLE
feat: real feed interactions, targeted announcements, and markdown

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -4,6 +4,7 @@ import { formatNZT } from "@/lib/dates";
 import * as Haptics from "expo-haptics";
 import { useRouter, type Href } from "expo-router";
 import { useCallback, useRef, useState } from "react";
+import Markdown from "react-native-markdown-display";
 import {
   ActivityIndicator,
   Image,
@@ -24,6 +25,7 @@ import { ThemedText } from "@/components/themed-text";
 import { Brand, Colors, FontFamily } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useFeed } from "@/hooks/use-feed";
+import { useFeedInteractions } from "@/hooks/use-feed-interactions";
 import { useProfile } from "@/hooks/use-profile";
 import { useShifts } from "@/hooks/use-shifts";
 import {
@@ -48,7 +50,15 @@ export default function HomeScreen() {
     items: feedItems,
     isLoading: feedLoading,
     refresh: refreshFeed,
+    updateItem: updateFeedItem,
   } = useFeed();
+
+  const {
+    toggleLike: apiToggleLike,
+    loadComments,
+    addComment: apiAddComment,
+    getCommentState,
+  } = useFeedInteractions();
 
   const nextShift = myShifts[0] ?? null;
   const hoursUntilShift = nextShift
@@ -62,21 +72,34 @@ export default function HomeScreen() {
     return start >= weekStart && start <= weekEnd;
   });
 
-  const [likedItems, setLikedItems] = useState<Set<string>>(new Set());
   const [likesSheetItem, setLikesSheetItem] = useState<FeedItem | null>(null);
-  const [localComments, setLocalComments] = useState<
-    Record<string, FeedComment[]>
-  >({});
 
-  const toggleLike = useCallback((id: string) => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setLikedItems((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, []);
+  const toggleLike = useCallback(
+    async (item: FeedItem) => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      // Optimistic update
+      const wasLiked = item.likedByMe;
+      updateFeedItem(item.id, {
+        likedByMe: !wasLiked,
+        likeCount: item.likeCount + (wasLiked ? -1 : 1),
+      });
+      // API call — revert on failure
+      const result = await apiToggleLike(item.id);
+      if (result) {
+        updateFeedItem(item.id, {
+          likedByMe: result.liked,
+          likeCount: result.likeCount,
+        });
+      } else {
+        // Revert
+        updateFeedItem(item.id, {
+          likedByMe: wasLiked,
+          likeCount: item.likeCount,
+        });
+      }
+    },
+    [apiToggleLike, updateFeedItem]
+  );
 
   const ME_AS_LIKER: LikeUser = {
     id: profile?.id ?? "",
@@ -85,38 +108,48 @@ export default function HomeScreen() {
   };
 
   const getLikersForItem = useCallback(
-    (item: FeedItem, isLikedByMe: boolean): LikeUser[] => {
-      const likers = [...item.likes];
-      if (isLikedByMe) likers.unshift(ME_AS_LIKER);
+    (item: FeedItem): LikeUser[] => {
+      const likers = [...item.recentLikers];
+      if (item.likedByMe) likers.unshift(ME_AS_LIKER);
       return likers;
     },
     [ME_AS_LIKER]
   );
 
   const getCommentsForItem = useCallback(
-    (item: FeedItem): FeedComment[] => {
-      return [...(item.comments ?? []), ...(localComments[item.id] ?? [])];
+    (itemId: string): FeedComment[] => {
+      return getCommentState(itemId).comments;
     },
-    [localComments]
+    [getCommentState]
+  );
+
+  const handleOpenSheet = useCallback(
+    (item: FeedItem) => {
+      setLikesSheetItem(item);
+      loadComments(item.id);
+    },
+    [loadComments]
   );
 
   const addComment = useCallback(
-    (itemId: string, text: string) => {
+    async (itemId: string, text: string) => {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-      const comment: FeedComment = {
-        id: `local-${Date.now()}`,
-        userId: profile?.id ?? "",
-        userName: profile?.firstName ?? "You",
-        profilePhotoUrl: profile?.image ?? undefined,
+      const result = await apiAddComment(
+        itemId,
         text,
-        timestamp: new Date().toISOString(),
-      };
-      setLocalComments((prev) => ({
-        ...prev,
-        [itemId]: [...(prev[itemId] ?? []), comment],
-      }));
+        profile?.id ?? "",
+        profile?.firstName ?? "You",
+        profile?.image ?? undefined
+      );
+      if (result) {
+        // Update comment count in the feed item
+        const item = feedItems.find((i) => i.id === itemId);
+        if (item) {
+          updateFeedItem(itemId, { commentCount: item.commentCount + 1 });
+        }
+      }
     },
-    [profile]
+    [apiAddComment, profile, feedItems, updateFeedItem]
   );
 
   return (
@@ -269,10 +302,10 @@ export default function HomeScreen() {
               item={item}
               colors={colors}
               isLast={index === feedItems.length - 1}
-              liked={likedItems.has(item.id)}
-              onToggleLike={() => toggleLike(item.id)}
-              onShowSheet={() => setLikesSheetItem(item)}
-              commentCount={getCommentsForItem(item).length}
+              liked={item.likedByMe}
+              onToggleLike={() => toggleLike(item)}
+              onShowSheet={() => handleOpenSheet(item)}
+              commentCount={item.commentCount}
             />
           ))}
         </View>
@@ -282,16 +315,14 @@ export default function HomeScreen() {
       {likesSheetItem && (
         <FeedItemSheet
           item={likesSheetItem}
-          likers={getLikersForItem(
-            likesSheetItem,
-            likedItems.has(likesSheetItem.id)
-          )}
-          liked={likedItems.has(likesSheetItem.id)}
-          onToggleLike={() => toggleLike(likesSheetItem.id)}
+          likers={getLikersForItem(likesSheetItem)}
+          liked={likesSheetItem.likedByMe}
+          onToggleLike={() => toggleLike(likesSheetItem)}
           onClose={() => setLikesSheetItem(null)}
           colors={colors}
           isDark={colorScheme === "dark"}
-          comments={getCommentsForItem(likesSheetItem)}
+          comments={getCommentsForItem(likesSheetItem.id)}
+          isLoadingComments={getCommentState(likesSheetItem.id).isLoading}
           onAddComment={(text) => addComment(likesSheetItem.id, text)}
         />
       )}
@@ -447,7 +478,7 @@ function FeedCard({
       }
     : undefined;
 
-  const likeCount = (liked ? 1 : 0) + item.likes.length;
+  const likeCount = item.likeCount;
 
   const socialButtons = (
     <View style={styles.feedSocialRow}>
@@ -482,7 +513,7 @@ function FeedCard({
 
   const renderContent = () => {
     if (item.type === "announcement") {
-      return (
+      const iconAndBody = (
         <>
           <View style={[styles.feedIcon, { backgroundColor: "#fef9c3" }]}>
             <Text style={styles.feedIconEmoji}>📢</Text>
@@ -519,6 +550,23 @@ function FeedCard({
               {socialButtons}
             </View>
           </View>
+        </>
+      );
+
+      return (
+        <>
+          {item.imageUrl && (
+            <Image
+              source={{ uri: item.imageUrl }}
+              style={styles.announcementImage}
+              resizeMode="cover"
+            />
+          )}
+          {item.imageUrl ? (
+            <View style={styles.feedCard}>{iconAndBody}</View>
+          ) : (
+            iconAndBody
+          )}
         </>
       );
     }
@@ -746,12 +794,16 @@ function FeedCard({
     return null;
   };
 
+  const hasAnnouncementImage =
+    item.type === "announcement" && !!item.imageUrl;
+
   return (
     <Pressable
       onPress={onShowSheet}
       style={({ pressed }) => [
         styles.feedCard,
         borderStyle,
+        hasAnnouncementImage && styles.feedCardColumn,
         { opacity: pressed ? 0.7 : 1 },
       ]}
       accessibilityRole="button"
@@ -835,6 +887,7 @@ function FeedItemSheet({
   colors,
   isDark,
   comments,
+  isLoadingComments,
   onAddComment,
 }: {
   item: FeedItem;
@@ -845,6 +898,7 @@ function FeedItemSheet({
   colors: (typeof Colors)["light"];
   isDark: boolean;
   comments: FeedComment[];
+  isLoadingComments?: boolean;
   onAddComment: (text: string) => void;
 }) {
   const insets = useSafeAreaInsets();
@@ -1065,10 +1119,24 @@ function FeedItemSheet({
               {/* Title */}
               <Text style={[sheet.title, { color: colors.text }]}>{title}</Text>
 
-              {/* Body text */}
-              <Text style={[sheet.body, { color: colors.textSecondary }]}>
-                {body}
-              </Text>
+              {/* Body text — use Markdown renderer for announcements */}
+              {item.type === "announcement" ? (
+                <Markdown
+                  style={{
+                    body: { color: colors.textSecondary, fontSize: 14, lineHeight: 20, fontFamily: FontFamily.regular },
+                    strong: { color: colors.text },
+                    link: { color: colors.primary },
+                    bullet_list: { marginVertical: 4 },
+                    ordered_list: { marginVertical: 4 },
+                  }}
+                >
+                  {body}
+                </Markdown>
+              ) : (
+                <Text style={[sheet.body, { color: colors.textSecondary }]}>
+                  {body}
+                </Text>
+              )}
 
               {/* Meta pills */}
               <View style={sheet.metaRow}>
@@ -1179,6 +1247,15 @@ function FeedItemSheet({
             </View>
 
             {/* ── Photo gallery (for photo_post type) ── */}
+            {/* Announcement image */}
+            {item.type === "announcement" && item.imageUrl && (
+              <Image
+                source={{ uri: item.imageUrl }}
+                style={[sheet.photoSingle, { borderRadius: 12, marginBottom: 12 }]}
+                resizeMode="cover"
+              />
+            )}
+
             {item.type === "photo_post" && item.photos.length > 0 && (
               <View
                 style={[
@@ -1368,7 +1445,13 @@ function FeedItemSheet({
               />
 
               {/* Comments */}
-              {comments.length > 0 ? (
+              {isLoadingComments ? (
+                <ActivityIndicator
+                  size="small"
+                  color={colors.primary}
+                  style={{ marginVertical: 12 }}
+                />
+              ) : comments.length > 0 ? (
                 <View style={sheet.commentsList}>
                   {comments.map((comment) => {
                     const initial = comment.userName.charAt(0).toUpperCase();
@@ -1662,6 +1745,16 @@ const styles = StyleSheet.create({
     alignItems: "flex-start",
     paddingVertical: 14,
     gap: 12,
+  },
+  feedCardColumn: {
+    flexDirection: "column",
+    gap: 0,
+  },
+  announcementImage: {
+    width: "100%",
+    height: 160,
+    borderRadius: 10,
+    marginBottom: 10,
   },
   feedIcon: {
     width: 42,

--- a/mobile/hooks/use-feed-interactions.ts
+++ b/mobile/hooks/use-feed-interactions.ts
@@ -1,0 +1,173 @@
+import { useCallback, useState } from "react";
+import { api } from "@/lib/api";
+import type { FeedComment } from "@/lib/dummy-data";
+
+type LikeResponse = {
+  liked: boolean;
+  likeCount: number;
+};
+
+type CommentsResponse = {
+  comments: FeedComment[];
+};
+
+type AddCommentResponse = {
+  comment: FeedComment;
+};
+
+type CommentState = {
+  comments: FeedComment[];
+  isLoading: boolean;
+  error: string | null;
+};
+
+type UseFeedInteractionsReturn = {
+  /** Toggle like on a feed item. Returns the new liked state and count. */
+  toggleLike: (itemId: string) => Promise<LikeResponse | null>;
+
+  /** Load all comments for a feed item (call when the sheet opens). */
+  loadComments: (itemId: string) => Promise<void>;
+
+  /** Add a comment to a feed item. Returns the new comment. */
+  addComment: (itemId: string, text: string, currentUserId: string, currentUserName: string, currentUserPhoto?: string) => Promise<FeedComment | null>;
+
+  /** Get cached comment state for an item. */
+  getCommentState: (itemId: string) => CommentState;
+};
+
+/**
+ * Manages real-time like/comment interactions on feed items.
+ *
+ * Likes: optimistic toggle — updates local state immediately, then calls API.
+ * Comments: loaded lazily when the sheet opens, then appended optimistically on add.
+ */
+export function useFeedInteractions(): UseFeedInteractionsReturn {
+  // Map of itemId → comment state
+  const [commentStates, setCommentStates] = useState<
+    Record<string, CommentState>
+  >({});
+
+  const toggleLike = useCallback(
+    async (itemId: string): Promise<LikeResponse | null> => {
+      try {
+        const result = await api<LikeResponse>(
+          `/api/mobile/feed/${encodeURIComponent(itemId)}/like`,
+          { method: "POST" }
+        );
+        return result;
+      } catch {
+        return null;
+      }
+    },
+    []
+  );
+
+  const loadComments = useCallback(async (itemId: string) => {
+    // Skip if already loaded
+    const existing = commentStates[itemId];
+    if (existing?.comments.length > 0) return;
+
+    setCommentStates((prev) => ({
+      ...prev,
+      [itemId]: { comments: [], isLoading: true, error: null },
+    }));
+
+    try {
+      const result = await api<CommentsResponse>(
+        `/api/mobile/feed/${encodeURIComponent(itemId)}/comments`
+      );
+      setCommentStates((prev) => ({
+        ...prev,
+        [itemId]: { comments: result.comments, isLoading: false, error: null },
+      }));
+    } catch (err) {
+      setCommentStates((prev) => ({
+        ...prev,
+        [itemId]: {
+          comments: [],
+          isLoading: false,
+          error: err instanceof Error ? err.message : "Failed to load comments",
+        },
+      }));
+    }
+  }, [commentStates]);
+
+  const addComment = useCallback(
+    async (
+      itemId: string,
+      text: string,
+      currentUserId: string,
+      currentUserName: string,
+      currentUserPhoto?: string
+    ): Promise<FeedComment | null> => {
+      // Optimistic comment
+      const optimistic: FeedComment = {
+        id: `optimistic-${Date.now()}`,
+        userId: currentUserId,
+        userName: currentUserName,
+        profilePhotoUrl: currentUserPhoto,
+        text,
+        timestamp: new Date().toISOString(),
+      };
+
+      setCommentStates((prev) => {
+        const existing = prev[itemId] ?? { comments: [], isLoading: false, error: null };
+        return {
+          ...prev,
+          [itemId]: {
+            ...existing,
+            comments: [...existing.comments, optimistic],
+          },
+        };
+      });
+
+      try {
+        const result = await api<AddCommentResponse>(
+          `/api/mobile/feed/${encodeURIComponent(itemId)}/comments`,
+          { method: "POST", body: { text } }
+        );
+
+        // Replace optimistic with real comment
+        setCommentStates((prev) => {
+          const existing = prev[itemId] ?? { comments: [], isLoading: false, error: null };
+          return {
+            ...prev,
+            [itemId]: {
+              ...existing,
+              comments: existing.comments.map((c) =>
+                c.id === optimistic.id ? result.comment : c
+              ),
+            },
+          };
+        });
+
+        return result.comment;
+      } catch {
+        // Remove optimistic comment on failure
+        setCommentStates((prev) => {
+          const existing = prev[itemId] ?? { comments: [], isLoading: false, error: null };
+          return {
+            ...prev,
+            [itemId]: {
+              ...existing,
+              comments: existing.comments.filter((c) => c.id !== optimistic.id),
+            },
+          };
+        });
+        return null;
+      }
+    },
+    []
+  );
+
+  const getCommentState = useCallback(
+    (itemId: string): CommentState => {
+      return (
+        commentStates[itemId] ?? { comments: [], isLoading: false, error: null }
+      );
+    },
+    [commentStates]
+  );
+
+  return { toggleLike, loadComments, addComment, getCommentState };
+}

--- a/mobile/hooks/use-feed.ts
+++ b/mobile/hooks/use-feed.ts
@@ -2,13 +2,13 @@ import { useCallback, useEffect, useState } from "react";
 
 import { api } from "@/lib/api";
 import {
-  FEED_ITEMS as DUMMY_FEED_ITEMS,
+  FEED_ITEMS as DUMMY_PHOTO_POSTS,
   type FeedItem,
 } from "@/lib/dummy-data";
 
-/** Feed items that have no real data source yet — announcements and photo posts */
-const DUMMY_ONLY_ITEMS = DUMMY_FEED_ITEMS.filter(
-  (item) => item.type === "announcement" || item.type === "photo_post"
+/** Photo posts are the only items without a real data source. */
+const DUMMY_ONLY_ITEMS = DUMMY_PHOTO_POSTS.filter(
+  (item) => item.type === "photo_post"
 );
 
 type FeedResponse = {
@@ -20,12 +20,16 @@ type UseFeedReturn = {
   isLoading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
+  /** Update a single item's interaction counts in-place (used by useFeedInteractions) */
+  updateItem: (id: string, patch: Partial<Pick<FeedItem, "likeCount" | "likedByMe" | "commentCount">>) => void;
 };
 
 /**
  * Fetches real feed data from the API and merges it with
- * dummy items (announcements, photo posts) that don't have
- * a real data source yet.
+ * dummy photo posts (which don't have a real data source yet).
+ *
+ * The API now populates likeCount, likedByMe, recentLikers, commentCount
+ * on every item, so all interaction data comes from the DB.
  */
 export function useFeed(): UseFeedReturn {
   const [realItems, setRealItems] = useState<FeedItem[]>([]);
@@ -39,7 +43,6 @@ export function useFeed(): UseFeedReturn {
       setRealItems(result.items);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load feed");
-      // On error, fall back to empty real items — dummy items still show
       setRealItems([]);
     } finally {
       setIsLoading(false);
@@ -55,10 +58,22 @@ export function useFeed(): UseFeedReturn {
     await fetchFeed();
   }, [fetchFeed]);
 
-  // Merge real items with dummy-only items, sorted by timestamp descending
+  const updateItem = useCallback(
+    (id: string, patch: Partial<Pick<FeedItem, "likeCount" | "likedByMe" | "commentCount">>) => {
+      setRealItems((prev) =>
+        prev.map((item) =>
+          item.id === id ? { ...item, ...patch } : item
+        )
+      );
+    },
+    []
+  );
+
+  // Merge real items with dummy photo posts, sorted by timestamp descending.
+  // Note: photo posts also go through the real interaction system (their IDs are stable).
   const items = [...realItems, ...DUMMY_ONLY_ITEMS].sort(
     (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
   );
 
-  return { items, isLoading, error, refresh };
+  return { items, isLoading, error, refresh, updateItem };
 }

--- a/mobile/lib/dummy-data.ts
+++ b/mobile/lib/dummy-data.ts
@@ -507,14 +507,22 @@ const LIKERS: LikeUser[] = [
   { id: 'u-9', name: 'Olivia Ma', profilePhotoUrl: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=200&h=200&fit=crop&crop=face' },
 ];
 
+/** Shared interaction fields present on every feed item */
+type FeedInteractions = {
+  likeCount: number;
+  likedByMe: boolean;
+  recentLikers: LikeUser[]; // top likers for the sheet
+  commentCount: number;
+};
+
 /** Feed item types */
 export type FeedItem =
-  | { type: 'announcement'; id: string; title: string; body: string; timestamp: string; author: string; likes: LikeUser[]; comments: FeedComment[] }
-  | { type: 'achievement'; id: string; userName: string; profilePhotoUrl?: string; achievementName: string; achievementIcon: string; description: string; timestamp: string; isFriend: boolean; likes: LikeUser[]; comments: FeedComment[] }
-  | { type: 'milestone'; id: string; userName: string; profilePhotoUrl?: string; count: number; timestamp: string; isFriend: boolean; likes: LikeUser[]; comments: FeedComment[] }
-  | { type: 'photo_post'; id: string; userName: string; profilePhotoUrl?: string; caption: string; photos: string[]; shiftDate: string; period: 'AM' | 'PM'; location: string; timestamp: string; isFriend: boolean; likes: LikeUser[]; comments: FeedComment[] }
-  | { type: 'friend_signup'; id: string; userName: string; profilePhotoUrl?: string; shiftTypeName: string; shiftDate: string; location: string; timestamp: string; isFriend: boolean; likes: LikeUser[]; comments: FeedComment[] }
-  | { type: 'shift_recap'; id: string; location: string; date: string; mealsServed: number; volunteerHours: number; volunteerCount: number; timestamp: string; likes: LikeUser[]; comments: FeedComment[] };
+  | ({ type: 'announcement'; id: string; title: string; body: string; imageUrl?: string; timestamp: string; author: string } & FeedInteractions)
+  | ({ type: 'achievement'; id: string; userName: string; profilePhotoUrl?: string; achievementName: string; achievementIcon: string; description: string; timestamp: string; isFriend: boolean } & FeedInteractions)
+  | ({ type: 'milestone'; id: string; userName: string; profilePhotoUrl?: string; count: number; timestamp: string; isFriend: boolean } & FeedInteractions)
+  | ({ type: 'photo_post'; id: string; userName: string; profilePhotoUrl?: string; caption: string; photos: string[]; shiftDate: string; period: 'AM' | 'PM'; location: string; timestamp: string; isFriend: boolean } & FeedInteractions)
+  | ({ type: 'friend_signup'; id: string; userName: string; profilePhotoUrl?: string; shiftTypeName: string; shiftDate: string; location: string; timestamp: string; isFriend: boolean } & FeedInteractions)
+  | ({ type: 'shift_recap'; id: string; location: string; date: string; mealsServed: number; volunteerHours: number; volunteerCount: number; timestamp: string } & FeedInteractions);
 
 function hoursAgo(hours: number): string {
   const d = new Date();
@@ -822,39 +830,14 @@ export const DUMMY_FRIEND_PROFILES: Record<string, FriendProfile> = {
   },
 };
 
+// Photo posts are dummy-only items (no real data source yet).
+// Announcements, achievements, milestones, friend signups, and recaps all come from the API.
+// likeCount/likedByMe/commentCount start at 0 — the API will populate them for real items,
+// but dummy photo posts use the real interaction system via their stable IDs.
 export const FEED_ITEMS: FeedItem[] = [
   {
-    type: 'announcement',
-    id: 'feed-1',
-    title: 'New Location Opening!',
-    body: "We're excited to announce that our Onehunga kitchen is now open for evening service on Thursdays. Sign up for shifts now!",
-    timestamp: hoursAgo(2),
-    author: 'Everybody Eats Team',
-    likes: [LIKERS[0], LIKERS[1], LIKERS[2], LIKERS[4], LIKERS[5], LIKERS[7]],
-    comments: [
-      { id: 'c-1', userId: 'u-2', userName: 'Sarah Chen', profilePhotoUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&h=200&fit=crop&crop=face', text: 'Amazing news! Can\'t wait to volunteer there 🎉', timestamp: hoursAgo(1) },
-      { id: 'c-2', userId: 'u-3', userName: 'James Tūhoe', profilePhotoUrl: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&h=200&fit=crop&crop=face', text: 'Ka pai! Onehunga needs this', timestamp: hoursAgo(1.5) },
-      { id: 'c-3', userId: 'u-7', userName: 'Hana Patel', profilePhotoUrl: 'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=200&h=200&fit=crop&crop=face', text: 'Signing up for the first Thursday shift!', timestamp: hoursAgo(1.8) },
-    ],
-  },
-  {
-    type: 'achievement',
-    id: 'feed-2',
-    userName: 'Sarah Chen',
-    profilePhotoUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&h=200&fit=crop&crop=face',
-    achievementName: 'Making a Difference',
-    achievementIcon: 'star',
-    description: 'Completed 10 volunteer shifts',
-    timestamp: hoursAgo(4),
-    isFriend: true,
-    likes: [LIKERS[1], LIKERS[4], LIKERS[7]],
-    comments: [
-      { id: 'c-4', userId: 'u-4', userName: 'Mia Johnson', profilePhotoUrl: 'https://images.unsplash.com/photo-1580489944761-15a19d654956?w=200&h=200&fit=crop&crop=face', text: 'Congrats Sarah! Well deserved 💚', timestamp: hoursAgo(3) },
-    ],
-  },
-  {
     type: 'photo_post',
-    id: 'feed-2b',
+    id: 'photo-post-2b',
     userName: 'James Tūhoe',
     profilePhotoUrl: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&h=200&fit=crop&crop=face',
     caption: 'Beautiful night at the kitchen — whānau energy was next level tonight 🌿🍽️',
@@ -867,42 +850,14 @@ export const FEED_ITEMS: FeedItem[] = [
     location: 'Everybody Eats — Auckland CBD',
     timestamp: hoursAgo(3),
     isFriend: true,
-    likes: [LIKERS[0], LIKERS[2], LIKERS[4], LIKERS[5], LIKERS[6], LIKERS[7]],
-    comments: [
-      { id: 'c-5', userId: 'u-4', userName: 'Mia Johnson', profilePhotoUrl: 'https://images.unsplash.com/photo-1580489944761-15a19d654956?w=200&h=200&fit=crop&crop=face', text: 'These photos are stunning! What a night 📸', timestamp: hoursAgo(2) },
-      { id: 'c-6', userId: 'u-6', userName: 'Te Rina Kahurangi', profilePhotoUrl: 'https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=200&h=200&fit=crop&crop=face', text: 'Love this whānau energy 🌿', timestamp: hoursAgo(2.5) },
-    ],
-  },
-  {
-    type: 'milestone',
-    id: 'feed-4',
-    userName: 'James Tūhoe',
-    profilePhotoUrl: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&h=200&fit=crop&crop=face',
-    count: 50,
-    timestamp: hoursAgo(8),
-    isFriend: true,
-    likes: [LIKERS[0], LIKERS[2], LIKERS[3], LIKERS[4], LIKERS[5], LIKERS[6], LIKERS[7]],
-    comments: [
-      { id: 'c-7', userId: 'u-2', userName: 'Sarah Chen', profilePhotoUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&h=200&fit=crop&crop=face', text: '50 shifts!! Legend status 🙌', timestamp: hoursAgo(7) },
-      { id: 'c-8', userId: 'u-4', userName: 'Mia Johnson', profilePhotoUrl: 'https://images.unsplash.com/photo-1580489944761-15a19d654956?w=200&h=200&fit=crop&crop=face', text: 'Ngā mihi James! Absolute inspiration', timestamp: hoursAgo(7.5) },
-      { id: 'c-9', userId: 'u-7', userName: 'Hana Patel', profilePhotoUrl: 'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=200&h=200&fit=crop&crop=face', text: 'So well deserved! 💚', timestamp: hoursAgo(7.8) },
-    ],
-  },
-  {
-    type: 'achievement',
-    id: 'feed-5',
-    userName: 'You',
-    achievementName: 'Getting Started',
-    achievementIcon: 'ribbon',
-    description: 'Completed 5 volunteer shifts',
-    timestamp: hoursAgo(12),
-    isFriend: false,
-    likes: [LIKERS[0], LIKERS[1], LIKERS[2], LIKERS[5]],
-    comments: [],
+    likeCount: 0,
+    likedByMe: false,
+    recentLikers: [],
+    commentCount: 0,
   },
   {
     type: 'photo_post',
-    id: 'feed-5b',
+    id: 'photo-post-5b',
     userName: 'Te Rina Kahurangi',
     profilePhotoUrl: 'https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=200&h=200&fit=crop&crop=face',
     caption: 'Service night vibes! So proud of the crew tonight 💚',
@@ -916,24 +871,14 @@ export const FEED_ITEMS: FeedItem[] = [
     location: 'Everybody Eats — Onehunga',
     timestamp: hoursAgo(18),
     isFriend: true,
-    likes: [LIKERS[0], LIKERS[1], LIKERS[3], LIKERS[5], LIKERS[7]],
-    comments: [
-      { id: 'c-10', userId: 'u-2', userName: 'Sarah Chen', profilePhotoUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&h=200&fit=crop&crop=face', text: 'Such a vibe! Love the crew 💪', timestamp: hoursAgo(17) },
-    ],
-  },
-  {
-    type: 'announcement',
-    id: 'feed-6',
-    title: 'Kitchen Safety Refresher',
-    body: 'All volunteers please review the updated kitchen safety guidelines before your next shift. Check the Chat tab if you have questions!',
-    timestamp: hoursAgo(24),
-    author: 'Aroha (Head Chef)',
-    likes: [LIKERS[1], LIKERS[6]],
-    comments: [],
+    likeCount: 0,
+    likedByMe: false,
+    recentLikers: [],
+    commentCount: 0,
   },
   {
     type: 'photo_post',
-    id: 'feed-6b',
+    id: 'photo-post-6b',
     userName: 'Hana Patel',
     profilePhotoUrl: 'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=200&h=200&fit=crop&crop=face',
     caption: 'Community kai at its finest — love this place 🌱',
@@ -945,23 +890,10 @@ export const FEED_ITEMS: FeedItem[] = [
     location: 'Everybody Eats — Auckland CBD',
     timestamp: hoursAgo(28),
     isFriend: false,
-    likes: [LIKERS[2], LIKERS[4]],
-    comments: [],
-  },
-  {
-    type: 'achievement',
-    id: 'feed-8',
-    userName: 'Mia Johnson',
-    profilePhotoUrl: 'https://images.unsplash.com/photo-1580489944761-15a19d654956?w=200&h=200&fit=crop&crop=face',
-    achievementName: 'First Steps',
-    achievementIcon: 'footsteps',
-    description: 'Completed first volunteer shift',
-    timestamp: hoursAgo(30),
-    isFriend: true,
-    likes: [LIKERS[0], LIKERS[1], LIKERS[3], LIKERS[4], LIKERS[6]],
-    comments: [
-      { id: 'c-11', userId: 'u-2', userName: 'Sarah Chen', profilePhotoUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=200&h=200&fit=crop&crop=face', text: 'Welcome to the whānau Mia! 🌱', timestamp: hoursAgo(29) },
-    ],
+    likeCount: 0,
+    likedByMe: false,
+    recentLikers: [],
+    commentCount: 0,
   },
 ];
 

--- a/web/prisma/migrations/20260414000000_add_feed_interactions_and_announcements/migration.sql
+++ b/web/prisma/migrations/20260414000000_add_feed_interactions_and_announcements/migration.sql
@@ -1,0 +1,63 @@
+-- CreateTable
+CREATE TABLE "FeedLike" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "feedItemId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FeedLike_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FeedComment" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "feedItemId" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FeedComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Announcement" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "imageUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+    "createdBy" TEXT NOT NULL,
+    "targetLocations" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "targetGrades" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "targetLabelIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+
+    CONSTRAINT "Announcement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FeedLike_userId_feedItemId_key" ON "FeedLike"("userId", "feedItemId");
+
+-- CreateIndex
+CREATE INDEX "FeedLike_feedItemId_idx" ON "FeedLike"("feedItemId");
+
+-- CreateIndex
+CREATE INDEX "FeedComment_feedItemId_idx" ON "FeedComment"("feedItemId");
+
+-- CreateIndex
+CREATE INDEX "FeedComment_userId_idx" ON "FeedComment"("userId");
+
+-- CreateIndex
+CREATE INDEX "Announcement_createdAt_idx" ON "Announcement"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "Announcement_expiresAt_idx" ON "Announcement"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "FeedLike" ADD CONSTRAINT "FeedLike_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FeedComment" ADD CONSTRAINT "FeedComment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Announcement" ADD CONSTRAINT "Announcement_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -120,6 +120,13 @@ model User {
   // Survey system
   surveyAssignments SurveyAssignment[]
   createdSurveys    Survey[]           @relation("SurveyCreator")
+
+  // Feed interactions
+  feedLikes     FeedLike[]
+  feedComments  FeedComment[]
+
+  // Announcements authored by this user (admin)
+  announcements Announcement[] @relation("AnnouncementAuthor")
 }
 
 model Passkey {
@@ -798,4 +805,59 @@ model ShortageNotificationLog {
   @@index([sentAt])
   @@index([sentBy])
   @@index([recipientId])
+}
+
+// ─── Feed Interactions ────────────────────────────────────────────────────────
+
+/// A like on any feed item (achievement, milestone, friend_signup, shift_recap, announcement).
+/// feedItemId is a stable computed string, e.g. "achievement-clxxx", "shift-recap-Auckland-2026-04-14".
+model FeedLike {
+  id         String   @id @default(cuid())
+  userId     String
+  feedItemId String
+  createdAt  DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, feedItemId])
+  @@index([feedItemId])
+}
+
+/// A comment on any feed item.
+model FeedComment {
+  id         String   @id @default(cuid())
+  userId     String
+  feedItemId String
+  text       String
+  createdAt  DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([feedItemId])
+  @@index([userId])
+}
+
+// ─── Announcements ────────────────────────────────────────────────────────────
+
+/// Admin-authored announcements surfaced in the mobile feed.
+/// Targeting arrays are OR-within-dimension, AND-across-dimensions.
+/// Empty array on any dimension means "all volunteers" for that dimension.
+model Announcement {
+  id        String    @id @default(cuid())
+  title     String
+  body      String    // Markdown content
+  imageUrl  String?   // Optional Supabase image URL
+  createdAt DateTime  @default(now())
+  expiresAt DateTime? // If set, hidden from feed after this date
+  createdBy String
+
+  // Targeting — empty = everyone on that dimension
+  targetLocations String[] @default([]) // Location names, e.g. ["Auckland", "Wellington"]
+  targetGrades    String[] @default([]) // VolunteerGrade values, e.g. ["GREEN", "YELLOW"]
+  targetLabelIds  String[] @default([]) // CustomLabel IDs
+
+  author User @relation("AnnouncementAuthor", fields: [createdBy], references: [id])
+
+  @@index([createdAt])
+  @@index([expiresAt])
 }

--- a/web/src/app/admin/announcements/announcements-content.tsx
+++ b/web/src/app/admin/announcements/announcements-content.tsx
@@ -1,0 +1,751 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import ReactMarkdown from "react-markdown";
+import { format } from "date-fns";
+import {
+  Plus,
+  Trash2,
+  Eye,
+  EyeOff,
+  Upload,
+  X,
+  Megaphone,
+  Users,
+  Clock,
+  ImageIcon,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+const VOLUNTEER_GRADES = [
+  { value: "GREEN", label: "Green", description: "Standard volunteers" },
+  { value: "YELLOW", label: "Yellow", description: "Experienced volunteers" },
+  { value: "PINK", label: "Pink", description: "Shift leaders" },
+];
+
+type Announcement = {
+  id: string;
+  title: string;
+  body: string;
+  imageUrl: string | null;
+  createdAt: string;
+  expiresAt: string | null;
+  createdBy: string;
+  targetLocations: string[];
+  targetGrades: string[];
+  targetLabelIds: string[];
+  author: {
+    id: string;
+    name: string | null;
+    firstName: string | null;
+    email: string;
+  };
+};
+
+type Label = {
+  id: string;
+  name: string;
+  color: string;
+  icon: string | null;
+};
+
+interface AnnouncementsContentProps {
+  initialAnnouncements: Announcement[];
+  labels: Label[];
+  locations: string[];
+}
+
+export function AnnouncementsContent({
+  initialAnnouncements,
+  labels,
+  locations,
+}: AnnouncementsContentProps) {
+  const [announcements, setAnnouncements] =
+    useState<Announcement[]>(initialAnnouncements);
+  const [showForm, setShowForm] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Announcement | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [previewMode, setPreviewMode] = useState(false);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  // Form state
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState("");
+  const [targetLocations, setTargetLocations] = useState<string[]>([]);
+  const [targetGrades, setTargetGrades] = useState<string[]>([]);
+  const [targetLabelIds, setTargetLabelIds] = useState<string[]>([]);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const [recipientPreview, setRecipientPreview] = useState<number | null>(null);
+  const [isCountingRecipients, setIsCountingRecipients] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const recipientDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetForm = () => {
+    setTitle("");
+    setBody("");
+    setImageUrl(null);
+    setExpiresAt("");
+    setTargetLocations([]);
+    setTargetGrades([]);
+    setTargetLabelIds([]);
+    setPreviewMode(false);
+    setRecipientPreview(null);
+  };
+
+  // Debounced recipient count preview
+  const updateRecipientPreview = useCallback(
+    (locs: string[], grades: string[], labelIds: string[]) => {
+      if (recipientDebounceRef.current) {
+        clearTimeout(recipientDebounceRef.current);
+      }
+      setIsCountingRecipients(true);
+      recipientDebounceRef.current = setTimeout(async () => {
+        try {
+          const response = await fetch(
+            "/api/admin/announcements/recipient-count",
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                targetLocations: locs,
+                targetGrades: grades,
+                targetLabelIds: labelIds,
+              }),
+            }
+          );
+          if (response.ok) {
+            const data = await response.json();
+            setRecipientPreview(data.count ?? null);
+          }
+        } catch {
+          // ignore preview errors
+        } finally {
+          setIsCountingRecipients(false);
+        }
+      }, 600);
+    },
+    []
+  );
+
+  const handleLocationToggle = (loc: string) => {
+    const next = targetLocations.includes(loc)
+      ? targetLocations.filter((l) => l !== loc)
+      : [...targetLocations, loc];
+    setTargetLocations(next);
+    updateRecipientPreview(next, targetGrades, targetLabelIds);
+  };
+
+  const handleGradeToggle = (grade: string) => {
+    const next = targetGrades.includes(grade)
+      ? targetGrades.filter((g) => g !== grade)
+      : [...targetGrades, grade];
+    setTargetGrades(next);
+    updateRecipientPreview(targetLocations, next, targetLabelIds);
+  };
+
+  const handleLabelToggle = (labelId: string) => {
+    const next = targetLabelIds.includes(labelId)
+      ? targetLabelIds.filter((l) => l !== labelId)
+      : [...targetLabelIds, labelId];
+    setTargetLabelIds(next);
+    updateRecipientPreview(targetLocations, targetGrades, next);
+  };
+
+  const handleImageUpload = async (file: File) => {
+    setIsUploadingImage(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const response = await fetch(
+        "/api/admin/announcements/upload-image",
+        { method: "POST", body: fd }
+      );
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.error ?? "Upload failed");
+      }
+      const { url } = await response.json();
+      setImageUrl(url);
+      toast.success("Image uploaded");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Image upload failed");
+    } finally {
+      setIsUploadingImage(false);
+    }
+  };
+
+  const handleFileDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) handleImageUpload(file);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !body.trim()) {
+      toast.error("Title and body are required");
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const response = await fetch("/api/admin/announcements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          imageUrl,
+          expiresAt: expiresAt || null,
+          targetLocations,
+          targetGrades,
+          targetLabelIds,
+        }),
+      });
+
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.error ?? "Failed to create announcement");
+      }
+
+      const { announcement } = await response.json();
+      setAnnouncements((prev) => [announcement, ...prev]);
+      resetForm();
+      setShowForm(false);
+      toast.success("Announcement published");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create announcement"
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      const response = await fetch(
+        `/api/admin/announcements/${deleteTarget.id}`,
+        { method: "DELETE" }
+      );
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.error ?? "Failed to delete");
+      }
+      setAnnouncements((prev) => prev.filter((a) => a.id !== deleteTarget.id));
+      toast.success("Announcement deleted");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to delete announcement"
+      );
+    } finally {
+      setIsDeleting(false);
+      setDeleteTarget(null);
+    }
+  };
+
+  const isExpired = (ann: Announcement) =>
+    ann.expiresAt ? new Date(ann.expiresAt) < new Date() : false;
+
+  const getTargetingSummary = (ann: Announcement): string => {
+    const parts: string[] = [];
+    if (ann.targetLocations.length > 0) {
+      parts.push(ann.targetLocations.join(", "));
+    }
+    if (ann.targetGrades.length > 0) {
+      parts.push(
+        ann.targetGrades
+          .map(
+            (g) =>
+              VOLUNTEER_GRADES.find((vg) => vg.value === g)?.label ?? g
+          )
+          .join(", ") + " grade"
+      );
+    }
+    if (ann.targetLabelIds.length > 0) {
+      const labelNames = ann.targetLabelIds
+        .map((id) => labels.find((l) => l.id === id)?.name ?? id)
+        .join(", ");
+      parts.push(labelNames);
+    }
+    return parts.length > 0 ? parts.join(" · ") : "All volunteers";
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header action */}
+      <div className="flex justify-end">
+        <Button
+          onClick={() => {
+            setShowForm(!showForm);
+            if (showForm) resetForm();
+          }}
+          className="gap-2"
+        >
+          {showForm ? (
+            <>
+              <X className="w-4 h-4" /> Cancel
+            </>
+          ) : (
+            <>
+              <Plus className="w-4 h-4" /> New Announcement
+            </>
+          )}
+        </Button>
+      </div>
+
+      {/* Create form */}
+      {showForm && (
+        <Card className="border-2 border-primary/20">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Megaphone className="w-5 h-5 text-orange-500" />
+              New Announcement
+            </CardTitle>
+            <CardDescription>
+              Write your announcement in Markdown. Use targeting to reach specific
+              volunteer groups.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {/* Title */}
+              <div className="space-y-2">
+                <Label htmlFor="ann-title">Title *</Label>
+                <Input
+                  id="ann-title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="e.g. Important update for Auckland volunteers"
+                  maxLength={200}
+                  required
+                />
+              </div>
+
+              {/* Body with Markdown editor/preview tabs */}
+              <div className="space-y-2">
+                <Label>Body * (Markdown supported)</Label>
+                <Tabs
+                  value={previewMode ? "preview" : "edit"}
+                  onValueChange={(v) => setPreviewMode(v === "preview")}
+                >
+                  <TabsList className="h-8">
+                    <TabsTrigger value="edit" className="gap-1.5 text-xs h-7">
+                      <EyeOff className="w-3 h-3" /> Edit
+                    </TabsTrigger>
+                    <TabsTrigger value="preview" className="gap-1.5 text-xs h-7">
+                      <Eye className="w-3 h-3" /> Preview
+                    </TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="edit" className="mt-2">
+                    <Textarea
+                      value={body}
+                      onChange={(e) => setBody(e.target.value)}
+                      placeholder={`Write your announcement here...\n\nMarkdown tips:\n**bold**, *italic*, [link](url)\n- bullet points\n1. numbered lists`}
+                      className="min-h-[200px] font-mono text-sm resize-y"
+                      required
+                    />
+                  </TabsContent>
+                  <TabsContent value="preview" className="mt-2">
+                    <div className="min-h-[200px] rounded-md border bg-muted/30 px-4 py-3">
+                      {body ? (
+                        <div className="prose prose-sm dark:prose-invert max-w-none">
+                          <ReactMarkdown>{body}</ReactMarkdown>
+                        </div>
+                      ) : (
+                        <p className="text-sm text-muted-foreground italic">
+                          Nothing to preview yet — start typing in the Edit tab.
+                        </p>
+                      )}
+                    </div>
+                  </TabsContent>
+                </Tabs>
+              </div>
+
+              {/* Image upload */}
+              <div className="space-y-2">
+                <Label>Featured Image (optional)</Label>
+                {imageUrl ? (
+                  <div className="relative inline-block">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={imageUrl}
+                      alt="Announcement image"
+                      className="h-40 w-auto rounded-lg object-cover border"
+                    />
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="icon"
+                      className="absolute -top-2 -right-2 h-6 w-6"
+                      onClick={() => setImageUrl(null)}
+                    >
+                      <X className="w-3 h-3" />
+                    </Button>
+                  </div>
+                ) : (
+                  <div
+                    className={cn(
+                      "border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors",
+                      "hover:border-primary/50 hover:bg-muted/30",
+                      isUploadingImage && "opacity-50 pointer-events-none"
+                    )}
+                    onDrop={handleFileDrop}
+                    onDragOver={(e) => e.preventDefault()}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept="image/jpeg,image/png,image/webp,image/gif"
+                      className="hidden"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) handleImageUpload(file);
+                      }}
+                    />
+                    <ImageIcon className="w-8 h-8 mx-auto mb-2 text-muted-foreground" />
+                    <p className="text-sm text-muted-foreground">
+                      {isUploadingImage
+                        ? "Uploading…"
+                        : "Drag & drop or click to upload (JPEG, PNG, WebP, GIF · max 5MB)"}
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {/* Expiry */}
+              <div className="space-y-2">
+                <Label htmlFor="ann-expires">Expiry Date (optional)</Label>
+                <Input
+                  id="ann-expires"
+                  type="datetime-local"
+                  value={expiresAt}
+                  onChange={(e) => setExpiresAt(e.target.value)}
+                  className="w-auto"
+                />
+                <p className="text-xs text-muted-foreground">
+                  If set, the announcement will stop appearing in the feed after this date/time.
+                </p>
+              </div>
+
+              {/* Targeting */}
+              <div className="space-y-4 rounded-lg border bg-muted/20 p-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="font-medium text-sm flex items-center gap-2">
+                    <Users className="w-4 h-4" />
+                    Targeting
+                  </h3>
+                  {recipientPreview !== null && (
+                    <span className="text-xs text-muted-foreground">
+                      {isCountingRecipients
+                        ? "Counting…"
+                        : `~${recipientPreview} volunteer${recipientPreview === 1 ? "" : "s"}`}
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground -mt-2">
+                  Leave all empty to send to all volunteers. Multiple selections within a
+                  category use OR logic; across categories use AND logic.
+                </p>
+
+                {/* Locations */}
+                {locations.length > 0 && (
+                  <div className="space-y-2">
+                    <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      Locations
+                    </Label>
+                    <div className="flex flex-wrap gap-2">
+                      {locations.map((loc) => (
+                        <label
+                          key={loc}
+                          className="flex items-center gap-1.5 cursor-pointer"
+                        >
+                          <Checkbox
+                            checked={targetLocations.includes(loc)}
+                            onCheckedChange={() => handleLocationToggle(loc)}
+                          />
+                          <span className="text-sm">{loc}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Grades */}
+                <div className="space-y-2">
+                  <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Volunteer Grade
+                  </Label>
+                  <div className="flex flex-wrap gap-4">
+                    {VOLUNTEER_GRADES.map((g) => (
+                      <label
+                        key={g.value}
+                        className="flex items-center gap-1.5 cursor-pointer"
+                      >
+                        <Checkbox
+                          checked={targetGrades.includes(g.value)}
+                          onCheckedChange={() => handleGradeToggle(g.value)}
+                        />
+                        <span className="text-sm">
+                          {g.label}{" "}
+                          <span className="text-muted-foreground text-xs">
+                            ({g.description})
+                          </span>
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Labels */}
+                {labels.length > 0 && (
+                  <div className="space-y-2">
+                    <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      Custom Labels
+                    </Label>
+                    <div className="flex flex-wrap gap-2">
+                      {labels.map((label) => (
+                        <label
+                          key={label.id}
+                          className="flex items-center gap-1.5 cursor-pointer"
+                        >
+                          <Checkbox
+                            checked={targetLabelIds.includes(label.id)}
+                            onCheckedChange={() => handleLabelToggle(label.id)}
+                          />
+                          <span
+                            className={cn(
+                              "text-xs px-2 py-0.5 rounded-full border font-medium",
+                              label.color
+                            )}
+                          >
+                            {label.icon && (
+                              <span className="mr-1">{label.icon}</span>
+                            )}
+                            {label.name}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Submit */}
+              <div className="flex items-center gap-3 pt-2">
+                <Button type="submit" disabled={isSubmitting} className="gap-2">
+                  <Upload className="w-4 h-4" />
+                  {isSubmitting ? "Publishing…" : "Publish Announcement"}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    resetForm();
+                    setShowForm(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Announcements list */}
+      {announcements.length === 0 ? (
+        <Card>
+          <CardContent className="py-16 text-center">
+            <Megaphone className="w-10 h-10 mx-auto mb-3 text-muted-foreground/40" />
+            <p className="text-sm font-medium text-muted-foreground">
+              No announcements yet
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              Create one above to broadcast to volunteers in their mobile feed.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {announcements.map((ann) => {
+            const expired = isExpired(ann);
+            const expanded = expandedIds.has(ann.id);
+
+            return (
+              <Card
+                key={ann.id}
+                className={cn(
+                  "transition-opacity",
+                  expired && "opacity-60"
+                )}
+              >
+                <CardContent className="pt-4 pb-3">
+                  <div className="flex items-start gap-3">
+                    {/* Icon */}
+                    <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-orange-50 dark:bg-orange-950 flex items-center justify-center">
+                      <Megaphone className="w-4 h-4 text-orange-500" />
+                    </div>
+
+                    {/* Main content */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-start justify-between gap-2">
+                        <div>
+                          <h3 className="font-semibold text-sm leading-snug">
+                            {ann.title}
+                          </h3>
+                          <div className="flex items-center gap-2 mt-1 flex-wrap">
+                            <span className="text-xs text-muted-foreground flex items-center gap-1">
+                              <Clock className="w-3 h-3" />
+                              {format(new Date(ann.createdAt), "d MMM yyyy, h:mm a")}
+                            </span>
+                            <span className="text-xs text-muted-foreground">
+                              by{" "}
+                              {ann.author.firstName ??
+                                ann.author.name ??
+                                ann.author.email}
+                            </span>
+                            {expired && (
+                              <Badge
+                                variant="outline"
+                                className="text-xs py-0 border-orange-300 text-orange-600"
+                              >
+                                Expired
+                              </Badge>
+                            )}
+                            {ann.expiresAt && !expired && (
+                              <span className="text-xs text-muted-foreground">
+                                Expires{" "}
+                                {format(new Date(ann.expiresAt), "d MMM, h:mm a")}
+                              </span>
+                            )}
+                          </div>
+                          {/* Targeting badge */}
+                          <div className="mt-1.5 flex items-center gap-1">
+                            <Users className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+                            <span className="text-xs text-muted-foreground">
+                              {getTargetingSummary(ann)}
+                            </span>
+                          </div>
+                        </div>
+
+                        {/* Actions */}
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            onClick={() =>
+                              setExpandedIds((prev) => {
+                                const next = new Set(prev);
+                                if (next.has(ann.id)) next.delete(ann.id);
+                                else next.add(ann.id);
+                                return next;
+                              })
+                            }
+                            aria-label={expanded ? "Collapse" : "Expand"}
+                          >
+                            {expanded ? (
+                              <ChevronUp className="w-4 h-4" />
+                            ) : (
+                              <ChevronDown className="w-4 h-4" />
+                            )}
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
+                            onClick={() => setDeleteTarget(ann)}
+                            aria-label="Delete announcement"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </Button>
+                        </div>
+                      </div>
+
+                      {/* Expanded body preview */}
+                      {expanded && (
+                        <div className="mt-3 pt-3 border-t space-y-3">
+                          {ann.imageUrl && (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                              src={ann.imageUrl}
+                              alt=""
+                              className="h-32 w-auto rounded-md object-cover"
+                            />
+                          )}
+                          <div className="prose prose-sm dark:prose-invert max-w-none text-sm">
+                            <ReactMarkdown>{ann.body}</ReactMarkdown>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Delete confirmation */}
+      <AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Announcement?</AlertDialogTitle>
+            <AlertDialogDescription>
+              &ldquo;{deleteTarget?.title}&rdquo; will be permanently removed from the
+              feed. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/web/src/app/admin/announcements/page.tsx
+++ b/web/src/app/admin/announcements/page.tsx
@@ -1,0 +1,52 @@
+import { Metadata } from "next";
+import { connection } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { AnnouncementsContent } from "./announcements-content";
+
+export const metadata: Metadata = {
+  title: "Announcements | Admin",
+  description: "Send targeted announcements to volunteers",
+};
+
+export default async function AnnouncementsPage() {
+  await connection();
+
+  const [announcements, labels, locations] = await Promise.all([
+    prisma.announcement.findMany({
+      include: {
+        author: {
+          select: { id: true, name: true, firstName: true, email: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    }),
+    prisma.customLabel.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true, color: true, icon: true },
+      orderBy: { name: "asc" },
+    }),
+    prisma.location.findMany({
+      where: { isActive: true },
+      select: { name: true },
+      orderBy: { name: "asc" },
+    }),
+  ]);
+
+  return (
+    <AdminPageWrapper
+      title="Announcements"
+      description="Send targeted announcements to volunteers in the mobile feed"
+    >
+      <AnnouncementsContent
+        initialAnnouncements={announcements.map((a) => ({
+          ...a,
+          createdAt: a.createdAt.toISOString(),
+          expiresAt: a.expiresAt?.toISOString() ?? null,
+        }))}
+        labels={labels}
+        locations={locations.map((l) => l.name)}
+      />
+    </AdminPageWrapper>
+  );
+}

--- a/web/src/app/api/admin/announcements/[id]/route.ts
+++ b/web/src/app/api/admin/announcements/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+import { deleteFile, extractFilePathFromUrl, STORAGE_BUCKET } from "@/lib/storage";
+
+/**
+ * DELETE /api/admin/announcements/[id]
+ *
+ * Deletes an announcement and its associated image (if any).
+ */
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const announcement = await prisma.announcement.findUnique({
+    where: { id },
+    select: { id: true, imageUrl: true },
+  });
+
+  if (!announcement) {
+    return NextResponse.json({ error: "Announcement not found" }, { status: 404 });
+  }
+
+  // Delete the image from Supabase if one exists
+  if (announcement.imageUrl) {
+    const filePath = extractFilePathFromUrl(announcement.imageUrl);
+    if (filePath) {
+      await deleteFile(filePath, STORAGE_BUCKET).catch((err) => {
+        console.warn("Could not delete announcement image:", err);
+      });
+    }
+  }
+
+  await prisma.announcement.delete({ where: { id } });
+
+  return NextResponse.json({ success: true });
+}

--- a/web/src/app/api/admin/announcements/recipient-count/route.ts
+++ b/web/src/app/api/admin/announcements/recipient-count/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * POST /api/admin/announcements/recipient-count
+ *
+ * Returns how many volunteers would receive an announcement
+ * with the given targeting filters. Does not create any records.
+ *
+ * Body: { targetLocations?, targetGrades?, targetLabelIds? }
+ */
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const { targetLocations = [], targetGrades = [], targetLabelIds = [] } = body;
+
+  const where: Record<string, unknown> = { role: "VOLUNTEER" };
+
+  if (Array.isArray(targetLocations) && targetLocations.length > 0) {
+    where.OR = targetLocations.map((loc: string) => ({
+      availableLocations: { contains: loc },
+    }));
+  }
+
+  if (Array.isArray(targetGrades) && targetGrades.length > 0) {
+    where.volunteerGrade = { in: targetGrades };
+  }
+
+  if (Array.isArray(targetLabelIds) && targetLabelIds.length > 0) {
+    where.customLabels = {
+      some: { labelId: { in: targetLabelIds } },
+    };
+  }
+
+  const count = await prisma.user.count({ where });
+
+  return NextResponse.json({ count });
+}

--- a/web/src/app/api/admin/announcements/recipient-count/route.ts
+++ b/web/src/app/api/admin/announcements/recipient-count/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/client";
 
 /**
  * POST /api/admin/announcements/recipient-count
@@ -20,25 +21,35 @@ export async function POST(request: Request) {
   const body = await request.json().catch(() => ({}));
   const { targetLocations = [], targetGrades = [], targetLabelIds = [] } = body;
 
-  const where: Record<string, unknown> = { role: "VOLUNTEER" };
+  const conditions: Prisma.Sql[] = [Prisma.sql`role = 'VOLUNTEER'`];
 
   if (Array.isArray(targetLocations) && targetLocations.length > 0) {
-    where.OR = targetLocations.map((loc: string) => ({
-      availableLocations: { contains: loc },
-    }));
+    // Split availableLocations on commas (trimming spaces) and check for exact overlap.
+    // Prisma's `contains` would do substring matching and false-match partial location names.
+    conditions.push(
+      Prisma.sql`string_to_array(regexp_replace(COALESCE("availableLocations", ''), '\\s*,\\s*', ',', 'g'), ',') && ARRAY[${Prisma.join(targetLocations as string[])}]::text[]`
+    );
   }
 
   if (Array.isArray(targetGrades) && targetGrades.length > 0) {
-    where.volunteerGrade = { in: targetGrades };
+    conditions.push(
+      Prisma.sql`"volunteerGrade"::text = ANY(ARRAY[${Prisma.join(targetGrades as string[])}]::text[])`
+    );
   }
 
   if (Array.isArray(targetLabelIds) && targetLabelIds.length > 0) {
-    where.customLabels = {
-      some: { labelId: { in: targetLabelIds } },
-    };
+    conditions.push(
+      Prisma.sql`EXISTS (
+        SELECT 1 FROM "UserCustomLabel"
+        WHERE "userId" = id
+        AND "labelId" = ANY(ARRAY[${Prisma.join(targetLabelIds as string[])}]::text[])
+      )`
+    );
   }
 
-  const count = await prisma.user.count({ where });
+  const result = await prisma.$queryRaw<[{ count: bigint }]>(
+    Prisma.sql`SELECT COUNT(*) AS count FROM "User" WHERE ${Prisma.join(conditions, " AND ")}`
+  );
 
-  return NextResponse.json({ count });
+  return NextResponse.json({ count: Number(result[0].count) });
 }

--- a/web/src/app/api/admin/announcements/route.ts
+++ b/web/src/app/api/admin/announcements/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/client";
 
 /**
  * GET /api/admin/announcements
@@ -114,31 +115,45 @@ export async function POST(request: Request) {
 /**
  * Count how many volunteers will receive an announcement based on targeting filters.
  * Each filter dimension is OR-within, AND-across. Empty = "all" for that dimension.
+ *
+ * Uses $queryRaw for location matching because availableLocations is a comma-separated
+ * string field — Prisma's `contains` would do substring matching and false-match
+ * (e.g. targeting "land" would match users with "Auckland"). string_to_array splits
+ * on commas (normalising surrounding whitespace) and && checks array overlap.
  */
 async function countRecipients(
   targetLocations: string[],
   targetGrades: string[],
   targetLabelIds: string[]
 ): Promise<number> {
-  // Build where clause based on targeting
-  const where: Record<string, unknown> = { role: "VOLUNTEER" };
+  const conditions: Prisma.Sql[] = [Prisma.sql`role = 'VOLUNTEER'`];
 
   if (targetLocations.length > 0) {
-    // availableLocations is a comma-separated string field
-    where.OR = targetLocations.map((loc) => ({
-      availableLocations: { contains: loc },
-    }));
+    // Split availableLocations on commas (trimming spaces) and check for exact overlap
+    conditions.push(
+      Prisma.sql`string_to_array(regexp_replace(COALESCE("availableLocations", ''), '\\s*,\\s*', ',', 'g'), ',') && ARRAY[${Prisma.join(targetLocations)}]::text[]`
+    );
   }
 
   if (targetGrades.length > 0) {
-    where.volunteerGrade = { in: targetGrades };
+    conditions.push(
+      Prisma.sql`"volunteerGrade"::text = ANY(ARRAY[${Prisma.join(targetGrades)}]::text[])`
+    );
   }
 
   if (targetLabelIds.length > 0) {
-    where.customLabels = {
-      some: { labelId: { in: targetLabelIds } },
-    };
+    conditions.push(
+      Prisma.sql`EXISTS (
+        SELECT 1 FROM "UserCustomLabel"
+        WHERE "userId" = id
+        AND "labelId" = ANY(ARRAY[${Prisma.join(targetLabelIds)}]::text[])
+      )`
+    );
   }
 
-  return prisma.user.count({ where });
+  const result = await prisma.$queryRaw<[{ count: bigint }]>(
+    Prisma.sql`SELECT COUNT(*) AS count FROM "User" WHERE ${Prisma.join(conditions, " AND ")}`
+  );
+
+  return Number(result[0].count);
 }

--- a/web/src/app/api/admin/announcements/route.ts
+++ b/web/src/app/api/admin/announcements/route.ts
@@ -1,0 +1,144 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/admin/announcements
+ *
+ * Returns all announcements with author info and interaction counts.
+ */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const announcements = await prisma.announcement.findMany({
+    include: {
+      author: {
+        select: { id: true, name: true, firstName: true, email: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  // Count total recipients for each announcement
+  const results = await Promise.all(
+    announcements.map(async (ann) => {
+      const recipientCount = await countRecipients(
+        ann.targetLocations,
+        ann.targetGrades,
+        ann.targetLabelIds
+      );
+      return {
+        ...ann,
+        createdAt: ann.createdAt.toISOString(),
+        expiresAt: ann.expiresAt?.toISOString() ?? null,
+        recipientCount,
+      };
+    })
+  );
+
+  return NextResponse.json({ announcements: results });
+}
+
+/**
+ * POST /api/admin/announcements
+ *
+ * Creates a new announcement.
+ * Body: { title, body, imageUrl?, expiresAt?, targetLocations?, targetGrades?, targetLabelIds? }
+ */
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const adminUser = await prisma.user.findUnique({
+    where: { email: session.user.email! },
+    select: { id: true },
+  });
+  if (!adminUser) {
+    return NextResponse.json({ error: "Admin user not found" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => null);
+  if (!body) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { title, body: announcementBody, imageUrl, expiresAt, targetLocations, targetGrades, targetLabelIds } = body;
+
+  if (!title?.trim()) {
+    return NextResponse.json({ error: "Title is required" }, { status: 400 });
+  }
+  if (!announcementBody?.trim()) {
+    return NextResponse.json({ error: "Body is required" }, { status: 400 });
+  }
+
+  const announcement = await prisma.announcement.create({
+    data: {
+      title: title.trim(),
+      body: announcementBody.trim(),
+      imageUrl: imageUrl?.trim() || null,
+      expiresAt: expiresAt ? new Date(expiresAt) : null,
+      createdBy: adminUser.id,
+      targetLocations: Array.isArray(targetLocations) ? targetLocations : [],
+      targetGrades: Array.isArray(targetGrades) ? targetGrades : [],
+      targetLabelIds: Array.isArray(targetLabelIds) ? targetLabelIds : [],
+    },
+    include: {
+      author: {
+        select: { id: true, name: true, firstName: true, email: true },
+      },
+    },
+  });
+
+  const recipientCount = await countRecipients(
+    announcement.targetLocations,
+    announcement.targetGrades,
+    announcement.targetLabelIds
+  );
+
+  return NextResponse.json({
+    announcement: {
+      ...announcement,
+      createdAt: announcement.createdAt.toISOString(),
+      expiresAt: announcement.expiresAt?.toISOString() ?? null,
+      recipientCount,
+    },
+  });
+}
+
+/**
+ * Count how many volunteers will receive an announcement based on targeting filters.
+ * Each filter dimension is OR-within, AND-across. Empty = "all" for that dimension.
+ */
+async function countRecipients(
+  targetLocations: string[],
+  targetGrades: string[],
+  targetLabelIds: string[]
+): Promise<number> {
+  // Build where clause based on targeting
+  const where: Record<string, unknown> = { role: "VOLUNTEER" };
+
+  if (targetLocations.length > 0) {
+    // availableLocations is a comma-separated string field
+    where.OR = targetLocations.map((loc) => ({
+      availableLocations: { contains: loc },
+    }));
+  }
+
+  if (targetGrades.length > 0) {
+    where.volunteerGrade = { in: targetGrades };
+  }
+
+  if (targetLabelIds.length > 0) {
+    where.customLabels = {
+      some: { labelId: { in: targetLabelIds } },
+    };
+  }
+
+  return prisma.user.count({ where });
+}

--- a/web/src/app/api/admin/announcements/upload-image/route.ts
+++ b/web/src/app/api/admin/announcements/upload-image/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { uploadFile, STORAGE_BUCKET } from "@/lib/storage";
+
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+/**
+ * POST /api/admin/announcements/upload-image
+ *
+ * Uploads an announcement image to Supabase Storage.
+ * Returns { url: string }.
+ */
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const formData = await request.formData().catch(() => null);
+  const file = formData?.get("file");
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { error: "Only JPEG, PNG, WebP, and GIF images are allowed" },
+      { status: 400 }
+    );
+  }
+
+  if (file.size > MAX_IMAGE_SIZE) {
+    return NextResponse.json(
+      { error: "Image must be under 5MB" },
+      { status: 400 }
+    );
+  }
+
+  const { url } = await uploadFile(file, "announcements", STORAGE_BUCKET);
+
+  return NextResponse.json({ url });
+}

--- a/web/src/app/api/mobile/feed/[itemId]/comments/route.ts
+++ b/web/src/app/api/mobile/feed/[itemId]/comments/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireMobileUser } from "@/lib/mobile-auth";
+
+/**
+ * GET /api/mobile/feed/[itemId]/comments
+ *
+ * Returns all comments for a feed item, oldest first.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ itemId: string }> }
+) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { itemId } = await params;
+
+  if (!itemId || itemId.length > 200) {
+    return NextResponse.json({ error: "Invalid item ID" }, { status: 400 });
+  }
+
+  const comments = await prisma.feedComment.findMany({
+    where: { feedItemId: itemId },
+    include: {
+      user: {
+        select: { id: true, name: true, firstName: true, profilePhotoUrl: true },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const result = comments.map((c) => ({
+    id: c.id,
+    userId: c.userId,
+    userName: c.user.firstName ?? c.user.name ?? "Volunteer",
+    profilePhotoUrl: c.user.profilePhotoUrl ?? undefined,
+    text: c.text,
+    timestamp: c.createdAt.toISOString(),
+  }));
+
+  return NextResponse.json({ comments: result });
+}
+
+/**
+ * POST /api/mobile/feed/[itemId]/comments
+ *
+ * Adds a comment to a feed item. Body: { text: string }
+ * Returns the created comment.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ itemId: string }> }
+) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { userId } = auth;
+  const { itemId } = await params;
+
+  if (!itemId || itemId.length > 200) {
+    return NextResponse.json({ error: "Invalid item ID" }, { status: 400 });
+  }
+
+  const body = await request.json().catch(() => null);
+  const text = typeof body?.text === "string" ? body.text.trim() : "";
+
+  if (!text || text.length === 0) {
+    return NextResponse.json({ error: "Comment text is required" }, { status: 400 });
+  }
+  if (text.length > 1000) {
+    return NextResponse.json({ error: "Comment too long (max 1000 characters)" }, { status: 400 });
+  }
+
+  const [comment, user] = await Promise.all([
+    prisma.feedComment.create({
+      data: { userId, feedItemId: itemId, text },
+    }),
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: { name: true, firstName: true, profilePhotoUrl: true },
+    }),
+  ]);
+
+  return NextResponse.json({
+    comment: {
+      id: comment.id,
+      userId: comment.userId,
+      userName: user?.firstName ?? user?.name ?? "Volunteer",
+      profilePhotoUrl: user?.profilePhotoUrl ?? undefined,
+      text: comment.text,
+      timestamp: comment.createdAt.toISOString(),
+    },
+  });
+}

--- a/web/src/app/api/mobile/feed/[itemId]/like/route.ts
+++ b/web/src/app/api/mobile/feed/[itemId]/like/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireMobileUser } from "@/lib/mobile-auth";
+
+/**
+ * POST /api/mobile/feed/[itemId]/like
+ *
+ * Toggles a like on a feed item for the authenticated user.
+ * Returns { liked: boolean, likeCount: number }.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ itemId: string }> }
+) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { userId } = auth;
+  const { itemId } = await params;
+
+  if (!itemId || itemId.length > 200) {
+    return NextResponse.json({ error: "Invalid item ID" }, { status: 400 });
+  }
+
+  // Check if already liked
+  const existing = await prisma.feedLike.findUnique({
+    where: { userId_feedItemId: { userId, feedItemId: itemId } },
+  });
+
+  if (existing) {
+    // Unlike
+    await prisma.feedLike.delete({
+      where: { userId_feedItemId: { userId, feedItemId: itemId } },
+    });
+  } else {
+    // Like
+    await prisma.feedLike.create({
+      data: { userId, feedItemId: itemId },
+    });
+  }
+
+  const likeCount = await prisma.feedLike.count({
+    where: { feedItemId: itemId },
+  });
+
+  return NextResponse.json({ liked: !existing, likeCount });
+}

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -169,13 +169,27 @@ export async function GET(request: Request) {
       distinct: ["shiftId"],
     }),
 
-    // Announcements targeted at this user
+    // Announcements: fetch all non-expired ones from the window, then filter by
+    // user targeting in app code. Grade and label are pre-filtered at DB level;
+    // location targeting uses in-memory exact matching (availableLocations is a
+    // comma-separated string so we can't safely do it in Prisma without raw SQL).
     prisma.announcement.findMany({
       where: {
         createdAt: { gte: since },
         OR: [
           { expiresAt: null },
           { expiresAt: { gt: now } },
+        ],
+        // Pre-filter: skip announcements that explicitly exclude this user's grade
+        AND: [
+          userProfile?.volunteerGrade
+            ? {
+                OR: [
+                  { targetGrades: { isEmpty: true } },
+                  { targetGrades: { has: userProfile.volunteerGrade } },
+                ],
+              }
+            : {},
         ],
       },
       include: {
@@ -184,7 +198,6 @@ export async function GET(request: Request) {
         },
       },
       orderBy: { createdAt: "desc" },
-      take: 10,
     }),
   ]);
 

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -8,11 +8,13 @@ import { getStartOfDayUTC, formatInNZT } from "@/lib/timezone";
  *
  * Returns a unified activity feed for the mobile home screen.
  * Pulls real data from:
+ * - Admin announcements (targeted to the requesting user)
  * - Recent achievement unlocks (friends + own)
  * - Milestone events (volunteers crossing shift count thresholds)
  * - Friend signups (friends signing up for shifts)
  * - Shift recaps (aggregate stats for completed shifts at user's locations)
  *
+ * Every item includes likeCount, likedByMe, recentLikers, commentCount.
  * Items are sorted by timestamp descending and limited to the last 14 days.
  */
 export async function GET(request: Request) {
@@ -24,129 +26,167 @@ export async function GET(request: Request) {
   const { userId } = auth;
   const since = new Date();
   since.setDate(since.getDate() - 14);
+  const now = new Date();
 
-  // Get the user's accepted friend IDs first
-  const friendships = await prisma.friendship.findMany({
-    where: {
-      status: "ACCEPTED",
-      OR: [{ userId }, { friendId: userId }],
-    },
-    select: { userId: true, friendId: true },
-  });
+  // Get the user's profile for targeting checks
+  const [userProfile, friendships] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        volunteerGrade: true,
+        availableLocations: true,
+        customLabels: { select: { labelId: true } },
+      },
+    }),
+    prisma.friendship.findMany({
+      where: {
+        status: "ACCEPTED",
+        OR: [{ userId }, { friendId: userId }],
+      },
+      select: { userId: true, friendId: true },
+    }),
+  ]);
 
   const friendIds = friendships.map((f) =>
     f.userId === userId ? f.friendId : f.userId
   );
-  // Include self + friends for feed visibility
   const visibleUserIds = [userId, ...friendIds];
 
-  // Run remaining queries in parallel
-  const [recentAchievements, milestoneUsers, friendSignups, userLocations] =
-    await Promise.all([
-      // Recent achievement unlocks (friends + own, last 14 days)
-      prisma.userAchievement.findMany({
-        where: {
-          unlockedAt: { gte: since },
-          userId: { in: visibleUserIds },
-        },
-        include: {
-          user: {
-            select: {
-              id: true,
-              name: true,
-              firstName: true,
-              profilePhotoUrl: true,
-            },
-          },
-          achievement: {
-            select: {
-              name: true,
-              description: true,
-              icon: true,
-              category: true,
-            },
-          },
-        },
-        orderBy: { unlockedAt: "desc" },
-        take: 10,
-      }),
+  const userLabelIds = (userProfile?.customLabels ?? []).map((l) => l.labelId);
+  const userLocations = userProfile?.availableLocations
+    ? userProfile.availableLocations.split(",").map((l) => l.trim()).filter(Boolean)
+    : [];
+  const userGrade = userProfile?.volunteerGrade ?? "GREEN";
 
-      // Milestone candidates: volunteers who recently completed a shift and
-      // whose total confirmed-shift count just crossed a milestone threshold.
-      prisma.signup.findMany({
-        where: {
-          status: "CONFIRMED",
-          userId: { in: visibleUserIds },
-          shift: { end: { lt: new Date(), gte: since } },
+  // Run all data queries in parallel
+  const [
+    recentAchievements,
+    milestoneUsers,
+    friendSignups,
+    userSignupLocations,
+    announcements,
+  ] = await Promise.all([
+    // Recent achievement unlocks (friends + own, last 14 days)
+    prisma.userAchievement.findMany({
+      where: {
+        unlockedAt: { gte: since },
+        userId: { in: visibleUserIds },
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            firstName: true,
+            profilePhotoUrl: true,
+          },
         },
-        select: {
-          userId: true,
-          shift: { select: { end: true } },
-          user: {
-            select: {
-              id: true,
-              name: true,
-              firstName: true,
-              profilePhotoUrl: true,
-              _count: {
-                select: {
-                  signups: {
-                    where: {
-                      status: "CONFIRMED",
-                      shift: { end: { lt: new Date() } },
-                    },
+        achievement: {
+          select: {
+            name: true,
+            description: true,
+            icon: true,
+            category: true,
+          },
+        },
+      },
+      orderBy: { unlockedAt: "desc" },
+      take: 10,
+    }),
+
+    // Milestone candidates: volunteers who recently completed a shift
+    prisma.signup.findMany({
+      where: {
+        status: "CONFIRMED",
+        userId: { in: visibleUserIds },
+        shift: { end: { lt: now, gte: since } },
+      },
+      select: {
+        userId: true,
+        shift: { select: { end: true } },
+        user: {
+          select: {
+            id: true,
+            name: true,
+            firstName: true,
+            profilePhotoUrl: true,
+            _count: {
+              select: {
+                signups: {
+                  where: {
+                    status: "CONFIRMED",
+                    shift: { end: { lt: now } },
                   },
                 },
               },
             },
           },
         },
-        orderBy: { shift: { end: "desc" } },
-        take: 50,
-      }),
+      },
+      orderBy: { shift: { end: "desc" } },
+      take: 50,
+    }),
 
-      // Friend signups: friends who recently signed up for upcoming shifts
-      prisma.signup.findMany({
-        where: {
-          status: "CONFIRMED",
-          userId: { in: friendIds },
-          createdAt: { gte: since },
-        },
-        select: {
-          id: true,
-          userId: true,
-          createdAt: true,
-          user: {
-            select: {
-              id: true,
-              name: true,
-              firstName: true,
-              profilePhotoUrl: true,
-            },
-          },
-          shift: {
-            select: {
-              start: true,
-              location: true,
-              shiftType: { select: { name: true } },
-            },
+    // Friend signups: friends who recently confirmed onto upcoming shifts
+    prisma.signup.findMany({
+      where: {
+        status: "CONFIRMED",
+        userId: { in: friendIds },
+        createdAt: { gte: since },
+      },
+      select: {
+        id: true,
+        userId: true,
+        createdAt: true,
+        user: {
+          select: {
+            id: true,
+            name: true,
+            firstName: true,
+            profilePhotoUrl: true,
           },
         },
-        orderBy: { createdAt: "desc" },
-        take: 15,
-      }),
-
-      // Locations the current user has signed up for (to scope shift recaps)
-      prisma.signup.findMany({
-        where: {
-          userId,
-          status: "CONFIRMED",
-          shift: { location: { not: null } },
+        shift: {
+          select: {
+            start: true,
+            location: true,
+            shiftType: { select: { name: true } },
+          },
         },
-        select: { shift: { select: { location: true } } },
-        distinct: ["shiftId"],
-      }),
-    ]);
+      },
+      orderBy: { createdAt: "desc" },
+      take: 15,
+    }),
+
+    // Locations the current user has signed up for (to scope shift recaps)
+    prisma.signup.findMany({
+      where: {
+        userId,
+        status: "CONFIRMED",
+        shift: { location: { not: null } },
+      },
+      select: { shift: { select: { location: true } } },
+      distinct: ["shiftId"],
+    }),
+
+    // Announcements targeted at this user
+    prisma.announcement.findMany({
+      where: {
+        createdAt: { gte: since },
+        OR: [
+          { expiresAt: null },
+          { expiresAt: { gt: now } },
+        ],
+      },
+      include: {
+        author: {
+          select: { id: true, name: true, firstName: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 10,
+    }),
+  ]);
 
   type FeedItem = {
     type: string;
@@ -157,11 +197,51 @@ export async function GET(request: Request) {
 
   const items: FeedItem[] = [];
 
-  // Transform achievements into feed items
+  // Filter announcements to those targeting this user
   const friendIdSet = new Set(friendIds);
+
+  for (const ann of announcements) {
+    // Location targeting: empty = all locations
+    const locationMatch =
+      ann.targetLocations.length === 0 ||
+      ann.targetLocations.some((loc) => userLocations.includes(loc));
+
+    // Grade targeting: empty = all grades
+    const gradeMatch =
+      ann.targetGrades.length === 0 ||
+      ann.targetGrades.includes(userGrade);
+
+    // Label targeting: empty = all labels
+    const labelMatch =
+      ann.targetLabelIds.length === 0 ||
+      ann.targetLabelIds.some((lid) => userLabelIds.includes(lid));
+
+    if (!locationMatch || !gradeMatch || !labelMatch) continue;
+
+    const authorName =
+      ann.author.firstName ?? ann.author.name ?? "Admin";
+
+    items.push({
+      type: "announcement",
+      id: `announcement-${ann.id}`,
+      title: ann.title,
+      body: ann.body,
+      imageUrl: ann.imageUrl ?? undefined,
+      timestamp: ann.createdAt.toISOString(),
+      author: authorName,
+      likeCount: 0,
+      likedByMe: false,
+      recentLikers: [],
+      commentCount: 0,
+    });
+  }
+
+  // Transform achievements into feed items
   for (const ua of recentAchievements) {
     const isMe = ua.user.id === userId;
-    const displayName = isMe ? "You" : (ua.user.firstName ?? ua.user.name ?? "A volunteer");
+    const displayName = isMe
+      ? "You"
+      : (ua.user.firstName ?? ua.user.name ?? "A volunteer");
 
     items.push({
       type: "achievement",
@@ -173,8 +253,10 @@ export async function GET(request: Request) {
       description: ua.achievement.description,
       timestamp: ua.unlockedAt.toISOString(),
       isFriend: friendIdSet.has(ua.user.id),
-      likes: [],
-      comments: [],
+      likeCount: 0,
+      likedByMe: false,
+      recentLikers: [],
+      commentCount: 0,
     });
   }
 
@@ -184,20 +266,21 @@ export async function GET(request: Request) {
 
   for (const signup of milestoneUsers) {
     const totalShifts = signup.user._count.signups;
-    // Find the highest milestone they just crossed
-    const milestone = [...MILESTONE_THRESHOLDS].reverse().find((t) => totalShifts >= t);
+    const milestone = [...MILESTONE_THRESHOLDS]
+      .reverse()
+      .find((t) => totalShifts >= t);
     if (!milestone) continue;
 
-    // Deduplicate: one milestone per user per threshold
     const key = `${signup.userId}-${milestone}`;
     if (seenMilestones.has(key)) continue;
     seenMilestones.add(key);
 
-    // Only include if they're right at or just past the threshold (within 2 shifts)
     if (totalShifts - milestone > 2) continue;
 
     const isMe = signup.userId === userId;
-    const displayName = isMe ? "You" : (signup.user.firstName ?? signup.user.name ?? "A volunteer");
+    const displayName = isMe
+      ? "You"
+      : (signup.user.firstName ?? signup.user.name ?? "A volunteer");
 
     items.push({
       type: "milestone",
@@ -207,8 +290,10 @@ export async function GET(request: Request) {
       count: milestone,
       timestamp: signup.shift.end.toISOString(),
       isFriend: friendIdSet.has(signup.userId),
-      likes: [],
-      comments: [],
+      likeCount: 0,
+      likedByMe: false,
+      recentLikers: [],
+      commentCount: 0,
     });
   }
 
@@ -227,26 +312,27 @@ export async function GET(request: Request) {
       location: signup.shift.location ?? "",
       timestamp: signup.createdAt.toISOString(),
       isFriend: true,
-      likes: [],
-      comments: [],
+      likeCount: 0,
+      likedByMe: false,
+      recentLikers: [],
+      commentCount: 0,
     });
   }
 
-  // Build shift recaps — aggregate completed shifts by location+date,
-  // but only for locations the user has volunteered at
-  const myLocations = new Set(
-    userLocations
+  // Build shift recaps
+  const mySignupLocations = new Set(
+    userSignupLocations
       .map((s) => s.shift.location)
       .filter((loc): loc is string => loc !== null)
   );
 
-  if (myLocations.size > 0) {
-    const locationsList = [...myLocations];
+  if (mySignupLocations.size > 0) {
+    const locationsList = [...mySignupLocations];
     const [recapShifts, mealsServedRecords, locationDefaults] =
       await Promise.all([
         prisma.shift.findMany({
           where: {
-            end: { lt: new Date(), gte: since },
+            end: { lt: now, gte: since },
             location: { in: locationsList },
           },
           select: {
@@ -271,15 +357,12 @@ export async function GET(request: Request) {
           },
           select: { date: true, location: true, mealsServed: true },
         }),
-        // Fallback defaults for days without recorded meals
         prisma.location.findMany({
           where: { name: { in: locationsList } },
           select: { name: true, defaultMealsServed: true },
         }),
       ]);
 
-    // Index meals served by location + NZ-timezone date key
-    // MealsServed.date is stored as start-of-day in NZ timezone (as UTC)
     const mealsMap = new Map<string, number>();
     for (const record of mealsServedRecords) {
       const key = `${record.location}-${record.date.toISOString()}`;
@@ -290,7 +373,6 @@ export async function GET(request: Request) {
       locationDefaults.map((loc) => [loc.name, loc.defaultMealsServed])
     );
 
-    // Group by location + date (NZ timezone day)
     const recapGroups = new Map<
       string,
       {
@@ -303,13 +385,11 @@ export async function GET(request: Request) {
       }
     >();
 
-    // Track unique volunteers per recap group
     const recapVolunteers = new Map<string, Set<string>>();
 
     for (const shift of recapShifts) {
       if (!shift.location || shift._count.signups === 0) continue;
 
-      // Use NZ timezone date for grouping and display
       const nzStartOfDay = getStartOfDayUTC(shift.start);
       const mealsKey = `${shift.location}-${nzStartOfDay.toISOString()}`;
       const displayDate = formatInNZT(shift.start, "yyyy-MM-dd");
@@ -319,13 +399,12 @@ export async function GET(request: Request) {
         (shift.end.getTime() - shift.start.getTime()) / (1000 * 60 * 60);
       const totalHours = shiftDurationHours * shift._count.signups;
 
-      // Collect unique volunteer IDs for this group
       if (!recapVolunteers.has(groupKey)) {
         recapVolunteers.set(groupKey, new Set());
       }
       const volunteerSet = recapVolunteers.get(groupKey)!;
-      for (const signup of shift.signups) {
-        volunteerSet.add(signup.userId);
+      for (const s of shift.signups) {
+        volunteerSet.add(s.userId);
       }
 
       const existing = recapGroups.get(groupKey);
@@ -336,7 +415,6 @@ export async function GET(request: Request) {
           existing.latestStart = shift.start;
         }
       } else {
-        // Look up actual meals, fall back to location default
         const meals =
           mealsMap.get(mealsKey) ?? defaultsMap.get(shift.location) ?? 0;
 
@@ -361,15 +439,95 @@ export async function GET(request: Request) {
         volunteerHours: Math.round(recap.volunteerHours),
         volunteerCount: recap.volunteerCount,
         timestamp: recap.latestStart.toISOString(),
-        likes: [],
+        likeCount: 0,
+        likedByMe: false,
+        recentLikers: [],
+        commentCount: 0,
       });
     }
   }
 
   // Sort by timestamp descending
   items.sort(
-    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    (a, b) =>
+      new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
   );
+
+  if (items.length === 0) {
+    return NextResponse.json({ items });
+  }
+
+  // Batch-fetch real like/comment data for all items
+  const itemIds = items.map((i) => i.id);
+
+  const [likeCounts, likedByMeRows, commentCounts, recentLikerRows] =
+    await Promise.all([
+      // Total like count per item
+      prisma.feedLike.groupBy({
+        by: ["feedItemId"],
+        where: { feedItemId: { in: itemIds } },
+        _count: { id: true },
+      }),
+
+      // Which items the current user has liked
+      prisma.feedLike.findMany({
+        where: { userId, feedItemId: { in: itemIds } },
+        select: { feedItemId: true },
+      }),
+
+      // Total comment count per item
+      prisma.feedComment.groupBy({
+        by: ["feedItemId"],
+        where: { feedItemId: { in: itemIds } },
+        _count: { id: true },
+      }),
+
+      // Top 6 likers per item (for the likes sheet)
+      prisma.feedLike.findMany({
+        where: { feedItemId: { in: itemIds } },
+        include: {
+          user: {
+            select: { id: true, name: true, firstName: true, profilePhotoUrl: true },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        take: itemIds.length * 6,
+      }),
+    ]);
+
+  // Build lookup maps
+  const likeCountMap = new Map(
+    likeCounts.map((r) => [r.feedItemId, r._count.id])
+  );
+  const likedByMeSet = new Set(likedByMeRows.map((r) => r.feedItemId));
+  const commentCountMap = new Map(
+    commentCounts.map((r) => [r.feedItemId, r._count.id])
+  );
+
+  // Group recent likers by feedItemId, cap at 6
+  const recentLikersMap = new Map<
+    string,
+    Array<{ id: string; name: string; profilePhotoUrl?: string }>
+  >();
+  for (const like of recentLikerRows) {
+    const existing = recentLikersMap.get(like.feedItemId) ?? [];
+    if (existing.length < 6) {
+      existing.push({
+        id: like.user.id,
+        name: like.user.firstName ?? like.user.name ?? "Volunteer",
+        profilePhotoUrl: like.user.profilePhotoUrl ?? undefined,
+      });
+      recentLikersMap.set(like.feedItemId, existing);
+    }
+  }
+
+  // Merge interaction data into items
+  for (const item of items) {
+    item.likeCount = likeCountMap.get(item.id) ?? 0;
+    item.likedByMe = likedByMeSet.has(item.id);
+    item.commentCount = commentCountMap.get(item.id) ?? 0;
+    item.recentLikers = recentLikersMap.get(item.id) ?? [];
+  }
 
   return NextResponse.json({ items });
 }

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -19,6 +19,7 @@ import {
   ClipboardList,
   Activity,
   MessageSquare,
+  Megaphone,
 } from "lucide-react";
 
 export interface AdminNavItem {
@@ -194,6 +195,13 @@ export const adminNavCategories: AdminNavCategory[] = [
         description: "Manage AI chat assistant context",
         commandKey: "chat-guides",
       },
+      {
+        title: "Announcements",
+        href: "/admin/announcements",
+        icon: Megaphone,
+        description: "Send targeted announcements to volunteers",
+        commandKey: "announcements",
+      },
     ],
   },
   {
@@ -281,6 +289,7 @@ export const getIconColor = (
     "Resource Hub": "text-blue-500",
     "Site Settings": "text-slate-600",
     "Chat Guides": "text-emerald-500",
+    "Announcements": "text-orange-500",
 
     // User Migration
     "Bulk Migration": "text-blue-600",


### PR DESCRIPTION
## Summary

- **Feed likes & comments** — replaced local-only state with a persistent DB-backed system (`FeedLike`, `FeedComment` models). Likes are optimistically toggled and synced to the API; comments load lazily when the sheet opens and are added optimistically.
- **Targeted announcements** — new `Announcement` model with multi-dimension targeting (location × volunteer grade × custom label). Empty dimension = all volunteers on that axis. New admin page at `/admin/announcements` with markdown editor + live preview, drag-and-drop image upload to Supabase, expiry date, and a live recipient count preview that debounces as you change targeting.
- **Markdown + image support** — announcement body is stored as markdown and rendered via `react-native-markdown-display` in the mobile feed. Optional hero image appears above the card and in the detail sheet.
- Feed GET updated to batch-fetch real `likeCount`, `likedByMe`, `commentCount`, `recentLikers` for all items in a single round-trip after building the item list.

## New API routes

| Route | Purpose |
|---|---|
| `POST /api/mobile/feed/[itemId]/like` | Toggle like |
| `GET /api/mobile/feed/[itemId]/comments` | Load all comments |
| `POST /api/mobile/feed/[itemId]/comments` | Add comment |
| `GET /api/admin/announcements` | List announcements |
| `POST /api/admin/announcements` | Create announcement |
| `DELETE /api/admin/announcements/[id]` | Delete (removes Supabase image) |
| `POST /api/admin/announcements/recipient-count` | Preview recipient count |
| `POST /api/admin/announcements/upload-image` | Upload hero image |

## Test plan

- [ ] Create an announcement in `/admin/announcements` — check it appears in the mobile feed for targeted users
- [ ] Like a feed item, pull-to-refresh — like count persists
- [ ] Open the sheet on a feed item, add a comment — comment persists after refresh
- [ ] Create an announcement with an image — image renders in feed card and sheet
- [ ] Create an announcement with markdown body — renders correctly in sheet
- [ ] Set expiry date in the past — announcement does not appear in feed
- [ ] Target by location/grade/label — only matching users see the announcement
- [ ] Recipient count preview updates live as targeting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)