### PR TITLE
feat: daily menus admin + Webflow embed

### DIFF
--- a/web/docs/webflow-menu-embed.html
+++ b/web/docs/webflow-menu-embed.html
@@ -1,0 +1,111 @@
+<!--
+  Everybody Eats — Daily Menu embed for Webflow
+  ─────────────────────────────────────────────
+  Setup:
+    1. In Webflow, add an "Embed" element where you want the menu to appear.
+    2. Paste this entire file into the embed code box.
+    3. Change API_BASE and LOCATION at the top of the script.
+
+  That's it. The script creates the full menu HTML inside an empty wrapper div,
+  using the same CSS classes your existing Webflow styles already target.
+  No data attributes needed on other elements.
+-->
+<div id="ee-daily-menu"></div>
+
+<script>
+(function () {
+  var API_BASE = 'https://your-portal-domain.com'; // ← REPLACE with your portal URL
+  var LOCATION = 'Wellington';                      // ← REPLACE with location name
+  var CONTAINER_ID = 'ee-daily-menu';
+
+  function esc(str) {
+    if (!str) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function renderCourse(label, items) {
+    if (!items || items.length === 0) return '';
+    var filled = items.filter(function(i) { return (i.name || i || '').trim() !== ''; });
+    if (filled.length === 0) return '';
+
+    var inner = '';
+    filled.forEach(function(item, i) {
+      if (i > 0) inner += '<p class="paragraph-9">or</p>';
+      inner += '<p>' + esc(item.name || item) + '</p>';
+    });
+
+    return (
+      '<div class="col">' +
+        '<p class="caps-sm">' + esc(label) + '</p>' +
+        '<div><div class="menu-item__name">' + inner + '</div></div>' +
+      '</div>'
+    );
+  }
+
+  function renderMenu(data) {
+    var container = document.getElementById(CONTAINER_ID);
+    if (!container) return;
+
+    if (!data || data.menu === null) {
+      container.innerHTML = '';
+      return;
+    }
+
+    var dateStr = data.updatedAt
+      ? new Date(data.updatedAt).toLocaleDateString('en-NZ', {
+          day: 'numeric', month: 'long', year: 'numeric',
+          timeZone: 'Pacific/Auckland'
+        })
+      : '';
+
+    var html = '<h2>Today\'s menu</h2>';
+
+    // Last updated + announcement
+    html += '<div>';
+    html += '<div class="div-block-88"><div>Last updated:</div><div>' + esc(dateStr) + '</div></div>';
+    if (data.announcement) {
+      html += '<div class="paragraph"><em>' + esc(data.announcement) + '</em></div>';
+    }
+    html += '</div>';
+
+    // Chef name
+    if (data.chefName) {
+      html += '<div class="div-block-87"><h4>Chef: </h4><h4 class="heading-18">' + esc(data.chefName) + '</h4></div>';
+    }
+
+    // Courses row
+    html += '<div class="row">';
+    html += renderCourse('kai tīmata / Starter', data.starter);
+    html += renderCourse('kai matua / main', data.mains);
+    if (data.drink && data.drink.length > 0) {
+      html += renderCourse('inu / Drink', data.drink);
+    }
+    html += renderCourse('kai reka / dessert', data.dessert);
+    html += '</div>';
+
+    container.innerHTML = html;
+  }
+
+  function fetchMenu() {
+    var nzDate = new Date().toLocaleDateString('en-CA', { timeZone: 'Pacific/Auckland' });
+    var url = API_BASE + '/api/menus?date=' + nzDate + '&location=' + encodeURIComponent(LOCATION);
+
+    fetch(url)
+      .then(function (r) { return r.json(); })
+      .then(renderMenu)
+      .catch(function (err) {
+        console.warn('Everybody Eats: could not load menu', err);
+      });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', fetchMenu);
+  } else {
+    fetchMenu();
+  }
+})();
+</script>

--- a/web/prisma/migrations/20260415000001_add_daily_menus/migration.sql
+++ b/web/prisma/migrations/20260415000001_add_daily_menus/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "DailyMenu" (
+    "id" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "location" TEXT NOT NULL,
+    "chefName" TEXT,
+    "announcement" TEXT,
+    "starter" JSONB NOT NULL DEFAULT '[]',
+    "mains" JSONB NOT NULL DEFAULT '[]',
+    "drink" JSONB NOT NULL DEFAULT '[]',
+    "dessert" JSONB NOT NULL DEFAULT '[]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdBy" TEXT,
+
+    CONSTRAINT "DailyMenu_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DailyMenu_date_location_key" ON "DailyMenu"("date", "location");
+
+-- CreateIndex
+CREATE INDEX "DailyMenu_location_date_idx" ON "DailyMenu"("location", "date");
+
+-- CreateIndex
+CREATE INDEX "DailyMenu_date_idx" ON "DailyMenu"("date");

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -837,6 +837,29 @@ model FeedComment {
   @@index([userId])
 }
 
+// ─── Daily Menus ─────────────────────────────────────────────────────────────
+
+// Daily menu per location, published to the Webflow public website.
+// Each course holds an array of MenuItem objects: {name: string, description?: string}
+model DailyMenu {
+  id           String   @id @default(cuid())
+  date         DateTime // Date for this menu (stored as midnight UTC, treated as date-only)
+  location     String   // Location name (matches Location.name)
+  chefName     String?  // Optional chef name displayed on website
+  announcement String?  // Optional daily message shown above the menu
+  starter      Json     // Array of MenuItem: [{name, description?}]
+  mains        Json     // Array of MenuItem: [{name, description?}]
+  drink        Json     // Array of MenuItem for beverages (may be empty)
+  dessert      Json     // Array of MenuItem: [{name, description?}]
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  createdBy    String?  // Admin user ID who last saved
+
+  @@unique([date, location])
+  @@index([location, date])
+  @@index([date])
+}
+
 // ─── Announcements ────────────────────────────────────────────────────────────
 
 /// Admin-authored announcements surfaced in the mobile feed.

--- a/web/src/app/admin/menus/menus-content.tsx
+++ b/web/src/app/admin/menus/menus-content.tsx
@@ -1,0 +1,624 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { format, parseISO } from "date-fns";
+import {
+  Plus, Trash2, Save, UtensilsCrossed, Clock, ChefHat,
+  Wine, Salad, Coffee, Eye, EyeOff,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Card, CardContent, CardDescription, CardHeader, CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel,
+  AlertDialogContent, AlertDialogDescription,
+  AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+// Items are plain strings — e.g. "Pulled jackfruit bao buns w/ sesame seeds"
+interface MenuDraft {
+  chefName: string;
+  announcement: string;
+  starter: string[];
+  mains: string[];
+  drink: string[];
+  dessert: string[];
+}
+
+interface RecentMenu {
+  id: string;
+  date: Date | string;
+  location: string;
+  chefName: string | null;
+  updatedAt: Date | string;
+}
+
+interface MenusContentProps {
+  locations: { id: string; name: string }[];
+  initialRecentMenus: RecentMenu[];
+}
+
+const emptyDraft = (): MenuDraft => ({
+  chefName: "",
+  announcement: "",
+  starter: [""],
+  mains: [""],
+  drink: [],
+  dessert: [""],
+});
+
+function todayNZ(): string {
+  return new Date().toLocaleDateString("en-CA", { timeZone: "Pacific/Auckland" });
+}
+
+// ─── Course Item Editor ───────────────────────────────────────────────────────
+
+interface CourseEditorProps {
+  label: string;
+  icon: React.ReactNode;
+  items: string[];
+  onChange: (items: string[]) => void;
+  optional?: boolean;
+  placeholder?: string;
+}
+
+function CourseEditor({ label, icon, items, onChange, optional, placeholder }: CourseEditorProps) {
+  const addItem = () => onChange([...items, ""]);
+  const updateItem = (i: number, value: string) =>
+    onChange(items.map((item, idx) => (idx === i ? value : item)));
+  const removeItem = (i: number) => onChange(items.filter((_, idx) => idx !== i));
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground">{icon}</span>
+          <h4 className="text-sm font-semibold">{label}</h4>
+          {optional && <Badge variant="secondary" className="text-xs">optional</Badge>}
+        </div>
+        <Button type="button" variant="ghost" size="sm" onClick={addItem} className="h-7 text-xs gap-1">
+          <Plus className="w-3 h-3" />
+          Add item
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-xs text-muted-foreground italic pl-1">
+          No items — click "Add item" to add one.
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {items.map((item, i) => (
+            <div key={i} className="flex gap-2 items-center">
+              <Input
+                placeholder={placeholder ?? "e.g. Pulled jackfruit bao buns w/ sesame seeds"}
+                value={item}
+                onChange={(e) => updateItem(i, e.target.value)}
+                className="h-8 text-sm"
+              />
+              <Button
+                type="button" variant="ghost" size="icon"
+                onClick={() => removeItem(i)}
+                className="h-8 w-8 text-muted-foreground hover:text-destructive shrink-0"
+                aria-label="Remove item"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Menu Preview ─────────────────────────────────────────────────────────────
+// Renders the exact same HTML structure as the Webflow embed script.
+// Scoped CSS approximates the Webflow site's visual styles.
+
+const PREVIEW_STYLES = `
+  .ee-preview { font-family: inherit; }
+  .ee-preview h2 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.75rem; }
+  .ee-preview .div-block-88 { display: flex; gap: 0.35rem; font-size: 0.8rem; color: #888; margin-bottom: 0.4rem; }
+  .ee-preview .paragraph { font-size: 0.875rem; font-style: italic; color: #999; margin-bottom: 0.75rem; }
+  .ee-preview .div-block-87 { display: flex; align-items: baseline; gap: 0.2rem; margin-bottom: 0.75rem; }
+  .ee-preview .div-block-87 h4 { font-size: 0.875rem; color: #888; font-weight: 400; margin: 0; }
+  .ee-preview .heading-18 { font-size: 0.875rem; font-weight: 600; margin: 0; }
+  .ee-preview .row { display: flex; gap: 1.5rem; flex-wrap: wrap; padding-top: 0.75rem; border-top: 1px solid #e5e7eb; }
+  .ee-preview .col { flex: 1; min-width: 8rem; }
+  .ee-preview .caps-sm { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 700; color: #888; margin: 0 0 0.6rem; }
+  .ee-preview .menu-item__name p { font-size: 0.9rem; line-height: 1.45; margin: 0 0 0.15rem; }
+  .ee-preview .paragraph-9 { font-size: 0.75rem; font-style: italic; color: #aaa; margin: 0.2rem 0; }
+  @media (prefers-color-scheme: dark) {
+    .ee-preview .div-block-88, .ee-preview .paragraph, .ee-preview .div-block-87 h4,
+    .ee-preview .caps-sm, .ee-preview .paragraph-9 { color: #888; }
+    .ee-preview .row { border-top-color: #374151; }
+  }
+`;
+
+interface MenuPreviewProps {
+  draft: MenuDraft;
+  location: string;
+  date: string;
+}
+
+function MenuPreview({ draft, location, date }: MenuPreviewProps) {
+  const formattedDate = date
+    ? format(parseISO(date), "d MMMM yyyy")
+    : format(new Date(), "d MMMM yyyy");
+
+  const hasDrink = draft.drink.some((i) => i.trim() !== "");
+
+  const renderCourse = (label: string, items: string[]) => {
+    const filled = items.filter((i) => i.trim() !== "");
+    if (filled.length === 0) return null;
+    return (
+      <div className="col" key={label}>
+        <p className="caps-sm">{label}</p>
+        <div>
+          <div className="menu-item__name">
+            {filled.map((item, i) => (
+              <span key={i}>
+                {i > 0 && <p className="paragraph-9">or</p>}
+                <p>{item}</p>
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="rounded-xl border border-border/60 bg-card overflow-hidden shadow-sm"
+      data-testid="menu-preview"
+    >
+      {/* Location badge outside the Webflow-classed area */}
+      {location && (
+        <div className="px-5 pt-3 pb-0 flex justify-end">
+          <Badge variant="secondary" className="text-xs">{location}</Badge>
+        </div>
+      )}
+
+      {/* Webflow-structured content */}
+      <div className="ee-preview px-5 py-4">
+        <style dangerouslySetInnerHTML={{ __html: PREVIEW_STYLES }} />
+
+        <h2>Today&apos;s menu</h2>
+
+        <div>
+          <div className="div-block-88">
+            <div>Last updated:</div>
+            <div>{formattedDate}</div>
+          </div>
+          {draft.announcement.trim() && (
+            <div className="paragraph">
+              <em>{draft.announcement}</em>
+            </div>
+          )}
+        </div>
+
+        {draft.chefName.trim() && (
+          <div className="div-block-87">
+            <h4>Chef: </h4>
+            <h4 className="heading-18">{draft.chefName}</h4>
+          </div>
+        )}
+
+        <div className="row">
+          {renderCourse("kai tīmata / Starter", draft.starter)}
+          {renderCourse("kai matua / main", draft.mains)}
+          {hasDrink && renderCourse("inu / Drink", draft.drink)}
+          {renderCourse("kai reka / dessert", draft.dessert)}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+export function MenusContent({ locations, initialRecentMenus }: MenusContentProps) {
+  const [selectedDate, setSelectedDate] = useState(todayNZ());
+  const [selectedLocation, setSelectedLocation] = useState<string>(
+    locations.length === 1 ? locations[0].name : ""
+  );
+  const [draft, setDraft] = useState<MenuDraft>(emptyDraft());
+  const [existingId, setExistingId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [showPreview, setShowPreview] = useState(true);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [recentMenus, setRecentMenus] = useState<RecentMenu[]>(initialRecentMenus);
+
+  const loadMenu = useCallback(async (date: string, location: string) => {
+    if (!date || !location) return;
+    setIsLoading(true);
+    try {
+      const res = await fetch(
+        `/api/admin/menus?date=${date}&location=${encodeURIComponent(location)}`
+      );
+      if (!res.ok) throw new Error("Failed to load");
+      const data = await res.json();
+
+      const toStrings = (raw: unknown): string[] => {
+        if (!Array.isArray(raw)) return [""];
+        if (raw.length === 0) return [""];
+        // Support both legacy {name} objects and plain strings
+        return raw.map((i) =>
+          typeof i === "string" ? i : (i as { name?: string }).name ?? ""
+        );
+      };
+
+      if (data) {
+        setExistingId(data.id);
+        setDraft({
+          chefName: data.chefName ?? "",
+          announcement: data.announcement ?? "",
+          starter: toStrings(data.starter),
+          mains: toStrings(data.mains),
+          drink: Array.isArray(data.drink) && data.drink.length > 0
+            ? data.drink.map((i: unknown) => typeof i === "string" ? i : (i as { name?: string }).name ?? "")
+            : [],
+          dessert: toStrings(data.dessert),
+        });
+      } else {
+        setExistingId(null);
+        setDraft(emptyDraft());
+      }
+    } catch {
+      toast.error("Failed to load menu");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (selectedDate && selectedLocation) {
+      loadMenu(selectedDate, selectedLocation);
+    }
+  }, [selectedDate, selectedLocation, loadMenu]);
+
+  const handleSave = async () => {
+    if (!selectedDate || !selectedLocation) return;
+    setIsSaving(true);
+    try {
+      const clean = (items: string[]) =>
+        items.filter((i) => i.trim() !== "").map((i) => ({ name: i.trim() }));
+
+      const body = {
+        date: selectedDate,
+        location: selectedLocation,
+        chefName: draft.chefName.trim() || null,
+        announcement: draft.announcement.trim() || null,
+        starter: clean(draft.starter),
+        mains: clean(draft.mains),
+        drink: clean(draft.drink),
+        dessert: clean(draft.dessert),
+      };
+
+      const res = await fetch("/api/admin/menus", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error("Save failed");
+      const saved = await res.json();
+      setExistingId(saved.id);
+      toast.success(existingId ? "Menu updated" : "Menu created");
+
+      const listRes = await fetch("/api/admin/menus");
+      if (listRes.ok) setRecentMenus(await listRes.json());
+    } catch {
+      toast.error("Failed to save menu");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!existingId) return;
+    try {
+      const res = await fetch(`/api/admin/menus/${existingId}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Delete failed");
+      setExistingId(null);
+      setDraft(emptyDraft());
+      toast.success("Menu deleted");
+      const listRes = await fetch("/api/admin/menus");
+      if (listRes.ok) setRecentMenus(await listRes.json());
+    } catch {
+      toast.error("Failed to delete menu");
+    }
+    setDeleteConfirmOpen(false);
+  };
+
+  const handleRecentClick = (menu: RecentMenu) => {
+    const dateStr =
+      typeof menu.date === "string"
+        ? menu.date.slice(0, 10)
+        : format(menu.date as Date, "yyyy-MM-dd");
+    setSelectedDate(dateStr);
+    setSelectedLocation(menu.location);
+  };
+
+  const canEdit = Boolean(selectedDate && selectedLocation);
+
+  return (
+    <div className="space-y-6">
+      {/* Date & Location picker */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <UtensilsCrossed className="w-4 h-4" />
+            Select Date & Location
+          </CardTitle>
+          <CardDescription>
+            Choose which restaurant and day you&apos;d like to edit the menu for.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="flex-1 space-y-1.5">
+              <Label htmlFor="menu-date">Date</Label>
+              <Input
+                id="menu-date"
+                type="date"
+                value={selectedDate}
+                onChange={(e) => setSelectedDate(e.target.value)}
+                className="w-full"
+              />
+            </div>
+            <div className="flex-1 space-y-1.5">
+              <Label htmlFor="menu-location">Location</Label>
+              <Select value={selectedLocation} onValueChange={setSelectedLocation}>
+                <SelectTrigger id="menu-location">
+                  <SelectValue placeholder="Select a location…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {locations.map((loc) => (
+                    <SelectItem key={loc.id} value={loc.name}>{loc.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Editor + Preview side-by-side on large screens */}
+      {canEdit && (
+        <div className={cn(
+          "grid gap-6",
+          showPreview ? "xl:grid-cols-2" : "grid-cols-1"
+        )}>
+          {/* Editor */}
+          <Card data-testid="menu-editor">
+            <CardHeader>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <CardTitle className="text-base">
+                    {selectedLocation} —{" "}
+                    {selectedDate ? format(parseISO(selectedDate), "EEEE, d MMMM yyyy") : ""}
+                  </CardTitle>
+                  <CardDescription className="mt-1">
+                    {isLoading
+                      ? "Loading…"
+                      : existingId
+                        ? "Menu exists — edit and save to update."
+                        : "No menu for this day yet. Fill in the details and save."}
+                  </CardDescription>
+                </div>
+                <div className="flex gap-2 shrink-0 flex-wrap justify-end">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowPreview((p) => !p)}
+                    className="gap-1.5"
+                  >
+                    {showPreview ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
+                    {showPreview ? "Hide preview" : "Preview"}
+                  </Button>
+                  {existingId && (
+                    <Button
+                      variant="outline" size="sm"
+                      onClick={() => setDeleteConfirmOpen(true)}
+                      className="text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="w-3.5 h-3.5 mr-1.5" />
+                      Delete
+                    </Button>
+                  )}
+                  <Button size="sm" onClick={handleSave} disabled={isSaving || isLoading}>
+                    <Save className="w-3.5 h-3.5 mr-1.5" />
+                    {isSaving ? "Saving…" : existingId ? "Update" : "Save"}
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+
+            <CardContent
+              className={cn("space-y-6", isLoading && "opacity-50 pointer-events-none")}
+            >
+              {/* Chef + Announcement */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="chef-name" className="flex items-center gap-1.5">
+                    <ChefHat className="w-3.5 h-3.5 text-muted-foreground" />
+                    Chef name
+                    <span className="text-muted-foreground font-normal text-xs">(optional)</span>
+                  </Label>
+                  <Input
+                    id="chef-name"
+                    placeholder="e.g. Harri"
+                    value={draft.chefName}
+                    onChange={(e) => setDraft((d) => ({ ...d, chefName: e.target.value }))}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="announcement" className="flex items-center gap-1.5">
+                    <Clock className="w-3.5 h-3.5 text-muted-foreground" />
+                    Announcement
+                    <span className="text-muted-foreground font-normal text-xs">(optional)</span>
+                  </Label>
+                  <Textarea
+                    id="announcement"
+                    placeholder="e.g. Menu updated around 1pm on service days. We cater to most dietary requirements."
+                    value={draft.announcement}
+                    onChange={(e) => setDraft((d) => ({ ...d, announcement: e.target.value }))}
+                    rows={2}
+                    className="resize-none text-sm"
+                  />
+                </div>
+              </div>
+
+              <div className="border-t border-border/50 pt-4 space-y-5">
+                <CourseEditor
+                  label="Starter"
+                  icon={<Salad className="w-4 h-4" />}
+                  items={draft.starter}
+                  onChange={(starter) => setDraft((d) => ({ ...d, starter }))}
+                  placeholder="e.g. Bánh mì crostini: vegetable pâté, rock melon, pickled onion"
+                />
+                <CourseEditor
+                  label="Mains"
+                  icon={<UtensilsCrossed className="w-4 h-4" />}
+                  items={draft.mains}
+                  onChange={(mains) => setDraft((d) => ({ ...d, mains }))}
+                  placeholder="e.g. Vegetarian cơm chiên (add multiple for alternatives)"
+                />
+                <CourseEditor
+                  label="Drink"
+                  icon={<Wine className="w-4 h-4" />}
+                  items={draft.drink}
+                  onChange={(drink) => setDraft((d) => ({ ...d, drink }))}
+                  optional
+                  placeholder="e.g. House kombucha: ginger & lemon"
+                />
+                <CourseEditor
+                  label="Dessert"
+                  icon={<Coffee className="w-4 h-4" />}
+                  items={draft.dessert}
+                  onChange={(dessert) => setDraft((d) => ({ ...d, dessert }))}
+                  placeholder="e.g. Bánh flan, feijoa compote, oat crumble"
+                />
+              </div>
+
+              <div className="flex justify-end pt-2 border-t border-border/50">
+                <Button onClick={handleSave} disabled={isSaving || isLoading}>
+                  <Save className="w-3.5 h-3.5 mr-1.5" />
+                  {isSaving ? "Saving…" : existingId ? "Update menu" : "Save menu"}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Live Preview */}
+          {showPreview && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <Eye className="w-4 h-4 text-muted-foreground" />
+                <h3 className="text-sm font-medium text-muted-foreground">Website preview</h3>
+                <Badge variant="secondary" className="text-xs">live</Badge>
+              </div>
+              <MenuPreview
+                draft={draft}
+                location={selectedLocation}
+                date={selectedDate}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Recent menus history */}
+      {recentMenus.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Recent Menus</CardTitle>
+            <CardDescription>Click a row to load that menu for editing.</CardDescription>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="divide-y divide-border/50">
+              {recentMenus.map((menu) => {
+                const dateStr =
+                  typeof menu.date === "string"
+                    ? menu.date.slice(0, 10)
+                    : format(menu.date as Date, "yyyy-MM-dd");
+                const isSelected =
+                  dateStr === selectedDate && menu.location === selectedLocation;
+                return (
+                  <button
+                    key={menu.id}
+                    type="button"
+                    onClick={() => handleRecentClick(menu)}
+                    className={cn(
+                      "w-full text-left px-6 py-3 flex items-center gap-4 hover:bg-muted/50 transition-colors",
+                      isSelected && "bg-muted"
+                    )}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-medium">
+                          {format(parseISO(dateStr + "T00:00:00"), "EEE, d MMM yyyy")}
+                        </span>
+                        <Badge variant="outline" className="text-xs">{menu.location}</Badge>
+                        {menu.chefName && (
+                          <span className="text-xs text-muted-foreground">
+                            Chef: {menu.chefName}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <span className="text-xs text-muted-foreground shrink-0">
+                      Updated{" "}
+                      {typeof menu.updatedAt === "string"
+                        ? format(parseISO(menu.updatedAt), "d MMM, h:mm a")
+                        : format(menu.updatedAt as Date, "d MMM, h:mm a")}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Delete confirmation */}
+      <AlertDialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this menu?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently remove the menu for{" "}
+              <strong>{selectedLocation}</strong> on{" "}
+              <strong>
+                {selectedDate ? format(parseISO(selectedDate), "d MMMM yyyy") : "this day"}
+              </strong>
+              . The website will show no menu for that day.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete menu
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/web/src/app/admin/menus/menus-content.tsx
+++ b/web/src/app/admin/menus/menus-content.tsx
@@ -94,7 +94,7 @@ function CourseEditor({ label, icon, items, onChange, optional, placeholder }: C
 
       {items.length === 0 ? (
         <p className="text-xs text-muted-foreground italic pl-1">
-          No items — click "Add item" to add one.
+          No items — click &ldquo;Add item&rdquo; to add one.
         </p>
       ) : (
         <div className="space-y-1.5">

--- a/web/src/app/admin/menus/page.tsx
+++ b/web/src/app/admin/menus/page.tsx
@@ -1,0 +1,40 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { MenusContent } from "./menus-content";
+
+export default async function MenusPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) redirect("/login?callbackUrl=/admin/menus");
+  if (session.user.role !== "ADMIN") redirect("/dashboard");
+
+  const [locations, recentMenus] = await Promise.all([
+    prisma.location.findMany({
+      where: { isActive: true },
+      orderBy: { name: "asc" },
+      select: { id: true, name: true },
+    }),
+    prisma.dailyMenu.findMany({
+      orderBy: [{ date: "desc" }, { location: "asc" }],
+      take: 30,
+      select: {
+        id: true,
+        date: true,
+        location: true,
+        chefName: true,
+        updatedAt: true,
+      },
+    }),
+  ]);
+
+  return (
+    <AdminPageWrapper
+      title="Daily Menus"
+      description="Set the menu for each restaurant location each day. Published to the website automatically."
+    >
+      <MenusContent locations={locations} initialRecentMenus={recentMenus} />
+    </AdminPageWrapper>
+  );
+}

--- a/web/src/app/api/admin/menus/[id]/route.ts
+++ b/web/src/app/api/admin/menus/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  try {
+    await prisma.dailyMenu.delete({ where: { id } });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting menu:", error);
+    return NextResponse.json({ error: "Failed to delete menu" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/admin/menus/route.ts
+++ b/web/src/app/api/admin/menus/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+
+function requireAdmin() {
+  return getServerSession(authOptions).then((session) => {
+    if (!session || session.user.role !== "ADMIN") {
+      return null;
+    }
+    return session;
+  });
+}
+
+/**
+ * GET /api/admin/menus
+ *
+ * With ?date=YYYY-MM-DD&location=X  → returns specific menu or null
+ * Otherwise                          → returns recent 30 menus (all locations)
+ */
+export async function GET(request: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const dateParam = searchParams.get("date");
+  const location = searchParams.get("location");
+
+  if (dateParam && location) {
+    const date = new Date(`${dateParam}T00:00:00.000Z`);
+    if (isNaN(date.getTime())) {
+      return NextResponse.json({ error: "Invalid date" }, { status: 400 });
+    }
+
+    const menu = await prisma.dailyMenu.findUnique({
+      where: { date_location: { date, location } },
+    });
+
+    return NextResponse.json(menu ?? null);
+  }
+
+  // List mode
+  const menus = await prisma.dailyMenu.findMany({
+    orderBy: [{ date: "desc" }, { location: "asc" }],
+    take: 30,
+    select: {
+      id: true,
+      date: true,
+      location: true,
+      chefName: true,
+      updatedAt: true,
+    },
+  });
+
+  return NextResponse.json(menus);
+}
+
+/**
+ * POST /api/admin/menus
+ *
+ * Creates or replaces the menu for a given date + location.
+ * Body: { date, location, chefName?, announcement?, starter, mains, drink, dessert }
+ */
+export async function POST(request: NextRequest) {
+  const session = await requireAdmin();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  let body: {
+    date: string;
+    location: string;
+    chefName?: string;
+    announcement?: string;
+    starter: { name: string; description?: string }[];
+    mains: { name: string; description?: string }[];
+    drink: { name: string; description?: string }[];
+    dessert: { name: string; description?: string }[];
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { date: dateParam, location, chefName, announcement, starter, mains, drink, dessert } = body;
+
+  if (!dateParam || !location) {
+    return NextResponse.json(
+      { error: "date and location are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!Array.isArray(starter) || !Array.isArray(mains) || !Array.isArray(drink) || !Array.isArray(dessert)) {
+    return NextResponse.json(
+      { error: "starter, mains, drink, and dessert must be arrays" },
+      { status: 400 }
+    );
+  }
+
+  const date = new Date(`${dateParam}T00:00:00.000Z`);
+  if (isNaN(date.getTime())) {
+    return NextResponse.json({ error: "Invalid date" }, { status: 400 });
+  }
+
+  try {
+    const menu = await prisma.dailyMenu.upsert({
+      where: { date_location: { date, location } },
+      create: {
+        date,
+        location,
+        chefName: chefName ?? null,
+        announcement: announcement ?? null,
+        starter,
+        mains,
+        drink,
+        dessert,
+        createdBy: session.user.id,
+      },
+      update: {
+        chefName: chefName ?? null,
+        announcement: announcement ?? null,
+        starter,
+        mains,
+        drink,
+        dessert,
+        createdBy: session.user.id,
+      },
+    });
+
+    return NextResponse.json(menu);
+  } catch (error) {
+    console.error("Error saving menu:", error);
+    return NextResponse.json({ error: "Failed to save menu" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/menus/route.ts
+++ b/web/src/app/api/menus/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+// CORS headers for Webflow and other external consumers
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders });
+}
+
+/**
+ * Public menu endpoint consumed by Webflow.
+ *
+ * Query params:
+ *   location  (required) – e.g. "Wellington"
+ *   date      (optional) – YYYY-MM-DD; defaults to today (NZ time via TZ env var)
+ *
+ * Returns the menu JSON or { menu: null } if none found for that day.
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const location = searchParams.get("location");
+  const dateParam = searchParams.get("date");
+
+  if (!location) {
+    return NextResponse.json(
+      { error: "location parameter is required" },
+      { status: 400, headers: corsHeaders }
+    );
+  }
+
+  // Resolve the target date as midnight UTC
+  let targetDate: Date;
+  if (dateParam) {
+    targetDate = new Date(`${dateParam}T00:00:00.000Z`);
+    if (isNaN(targetDate.getTime())) {
+      return NextResponse.json(
+        { error: "Invalid date format. Use YYYY-MM-DD" },
+        { status: 400, headers: corsHeaders }
+      );
+    }
+  } else {
+    // Default to today in NZ time (TZ env var is Pacific/Auckland)
+    const now = new Date();
+    const nzDate = now.toLocaleDateString("en-CA", {
+      timeZone: process.env.TZ ?? "Pacific/Auckland",
+    }); // "YYYY-MM-DD"
+    targetDate = new Date(`${nzDate}T00:00:00.000Z`);
+  }
+
+  try {
+    const menu = await prisma.dailyMenu.findUnique({
+      where: { date_location: { date: targetDate, location } },
+    });
+
+    if (!menu) {
+      return NextResponse.json({ menu: null }, { headers: corsHeaders });
+    }
+
+    return NextResponse.json(
+      {
+        id: menu.id,
+        date: menu.date.toISOString().split("T")[0],
+        location: menu.location,
+        chefName: menu.chefName ?? null,
+        announcement: menu.announcement ?? null,
+        starter: menu.starter,
+        mains: menu.mains,
+        drink: menu.drink,
+        dessert: menu.dessert,
+        updatedAt: menu.updatedAt.toISOString(),
+      },
+      { headers: corsHeaders }
+    );
+  } catch (error) {
+    console.error("Error fetching menu:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch menu" },
+      { status: 500, headers: corsHeaders }
+    );
+  }
+}

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -20,6 +20,7 @@ import {
   Activity,
   MessageSquare,
   Megaphone,
+  UtensilsCrossed,
 } from "lucide-react";
 
 export interface AdminNavItem {
@@ -141,6 +142,13 @@ export const adminNavCategories: AdminNavCategory[] = [
   {
     label: "Restaraunt Management",
     items: [
+      {
+        title: "Daily Menus",
+        href: "/admin/menus",
+        icon: UtensilsCrossed,
+        description: "Set daily menus published to the website",
+        commandKey: "menus",
+      },
       {
         title: "Restaurant Locations",
         href: "/admin/locations",
@@ -277,6 +285,9 @@ export const getIconColor = (
     "Custom Labels": "text-indigo-600",
     Achievements: "text-amber-600",
     "Newsletter Lists": "text-cyan-600",
+
+    // Restaurant Management
+    "Daily Menus": "text-orange-600",
 
     // Shift Management
     "Create Shift": "text-green-600",


### PR DESCRIPTION
## Summary

- Adds a **Daily Menus** admin page (`/admin/menus`) where admins set each restaurant's menu per day — starter, mains, optional drink, dessert, chef name, and announcement
- Menus are stored in a new `DailyMenu` table (one record per date + location)
- A **live preview panel** in the admin renders the exact HTML the website will show, updating as you type
- A **public API** (`GET /api/menus?location=X&date=YYYY-MM-DD`) serves the menu as JSON with CORS headers so Webflow can fetch it
- A **Webflow embed script** (`web/docs/webflow-menu-embed.html`) drops into a Webflow Embed element — it fetches today's menu and renders the complete HTML using the site's existing CSS classes (`.row`, `.col`, `.caps-sm`, `.menu-item__name`, etc.)

## Database

New migration: `20260415000001_add_daily_menus`
Run `npm run prisma:migrate` to apply.

## Webflow setup

1. Delete (or hide) the existing static menu block in Webflow
2. Add an **Embed** element in its place
3. Paste the contents of `web/docs/webflow-menu-embed.html` into the embed
4. Set `API_BASE` to the portal URL and `LOCATION` to the location name
5. Publish — the menu will load dynamically from the portal each page load

## Test plan

- [ ] Run migration and start dev server
- [ ] Visit `/admin/menus`, select today + a location — editor and preview appear
- [ ] Enter menu items, verify preview updates live with correct Webflow HTML structure
- [ ] Save — confirm toast and menu appears in recent menus list
- [ ] Load a past menu from recent list, edit and update
- [ ] Delete a menu — confirm it clears and is removed from list
- [ ] Hit `GET /api/menus?location=Wellington` — confirm JSON response with CORS headers
- [ ] Paste embed script into a Webflow preview embed and verify menu renders

🤖 Generated with [Claude Code](https://claude.ai/claude-code)