### PR TITLE
feat: App Store UGC compliance (Guideline 1.2)

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -7,6 +7,7 @@ import { useCallback, useRef, useState } from "react";
 import Markdown from "react-native-markdown-display";
 import {
   ActivityIndicator,
+  Alert,
   Image,
   KeyboardAvoidingView,
   Modal,
@@ -58,6 +59,7 @@ export default function HomeScreen() {
     loadComments,
     addComment: apiAddComment,
     getCommentState,
+    reportItem,
   } = useFeedInteractions();
 
   const nextShift = myShifts[0] ?? null;
@@ -306,6 +308,28 @@ export default function HomeScreen() {
               onToggleLike={() => toggleLike(item)}
               onShowSheet={() => handleOpenSheet(item)}
               commentCount={item.commentCount}
+              onReport={() => {
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                Alert.alert(
+                  "Report Content",
+                  "Why are you reporting this?",
+                  [
+                    {
+                      text: "Offensive or abusive content",
+                      onPress: () => reportItem("post", item.id, "Offensive or abusive content"),
+                    },
+                    {
+                      text: "Spam",
+                      onPress: () => reportItem("post", item.id, "Spam"),
+                    },
+                    {
+                      text: "Harassment",
+                      onPress: () => reportItem("post", item.id, "Harassment"),
+                    },
+                    { text: "Cancel", style: "cancel" },
+                  ]
+                );
+              }}
             />
           ))}
         </View>
@@ -459,6 +483,7 @@ function FeedCard({
   onToggleLike,
   onShowSheet,
   commentCount,
+  onReport,
 }: {
   item: FeedItem;
   colors: (typeof Colors)["light"];
@@ -467,6 +492,7 @@ function FeedCard({
   onToggleLike: () => void;
   onShowSheet: () => void;
   commentCount: number;
+  onReport: () => void;
 }) {
   const timeAgo = formatDistanceToNow(new Date(item.timestamp), {
     addSuffix: true,
@@ -809,6 +835,31 @@ function FeedCard({
       accessibilityRole="button"
     >
       {renderContent()}
+      {/* Report button — positioned top-right, only for user-generated items */}
+      {(item.type === "achievement" ||
+        item.type === "milestone" ||
+        item.type === "friend_signup" ||
+        item.type === "announcement") && (
+        <Pressable
+          onPress={(e) => {
+            e.stopPropagation();
+            onReport();
+          }}
+          hitSlop={10}
+          style={({ pressed }) => [
+            styles.reportBtn,
+            { opacity: pressed ? 0.4 : 0.35 },
+          ]}
+          accessibilityLabel="Report this post"
+          accessibilityRole="button"
+        >
+          <Ionicons
+            name="ellipsis-horizontal"
+            size={16}
+            color={colors.textSecondary}
+          />
+        </Pressable>
+      )}
     </Pressable>
   );
 }
@@ -1749,6 +1800,12 @@ const styles = StyleSheet.create({
   feedCardColumn: {
     flexDirection: "column",
     gap: 0,
+  },
+  reportBtn: {
+    position: "absolute",
+    top: 10,
+    right: 10,
+    padding: 4,
   },
   announcementImage: {
     width: "100%",

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -60,6 +60,7 @@ export default function HomeScreen() {
     addComment: apiAddComment,
     getCommentState,
     reportItem,
+    hasReported,
   } = useFeedInteractions();
 
   const nextShift = myShifts[0] ?? null;
@@ -308,7 +309,12 @@ export default function HomeScreen() {
               onToggleLike={() => toggleLike(item)}
               onShowSheet={() => handleOpenSheet(item)}
               commentCount={item.commentCount}
+              isReported={hasReported(item.id)}
               onReport={() => {
+                if (hasReported(item.id)) {
+                  Alert.alert("Already reported", "You've already reported this content. Our team will review it within 24 hours.");
+                  return;
+                }
                 Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                 Alert.alert(
                   "Report Content",
@@ -484,6 +490,7 @@ function FeedCard({
   onShowSheet,
   commentCount,
   onReport,
+  isReported = false,
 }: {
   item: FeedItem;
   colors: (typeof Colors)["light"];
@@ -493,6 +500,7 @@ function FeedCard({
   onShowSheet: () => void;
   commentCount: number;
   onReport: () => void;
+  isReported?: boolean;
 }) {
   const timeAgo = formatDistanceToNow(new Date(item.timestamp), {
     addSuffix: true,
@@ -848,15 +856,15 @@ function FeedCard({
           hitSlop={10}
           style={({ pressed }) => [
             styles.reportBtn,
-            { opacity: pressed ? 0.4 : 0.35 },
+            { opacity: pressed ? 0.5 : isReported ? 0.7 : 0.35 },
           ]}
-          accessibilityLabel="Report this post"
+          accessibilityLabel={isReported ? "Already reported" : "Report this post"}
           accessibilityRole="button"
         >
           <Ionicons
-            name="ellipsis-horizontal"
-            size={16}
-            color={colors.textSecondary}
+            name={isReported ? "flag" : "ellipsis-horizontal"}
+            size={14}
+            color={isReported ? "#f97316" : colors.textSecondary}
           />
         </Pressable>
       )}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -3,7 +3,7 @@ import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
-import { useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import 'react-native-reanimated';
 
 import {
@@ -21,12 +21,14 @@ import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useAuth } from '@/lib/auth';
 import { Brand } from '@/constants/theme';
 import { AuthGate } from '@/components/auth-gate';
+import { EulaModal } from '@/components/eula-modal';
 
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const { isLoading, restoreSession } = useAuth();
+  const [eulaAccepted, setEulaAccepted] = React.useState(false);
 
   const [fontsLoaded] = useFonts({
     LibreFranklin_400Regular,
@@ -67,12 +69,15 @@ export default function RootLayout() {
     },
   }), []);
 
+  const handleEulaAccepted = useCallback(() => setEulaAccepted(true), []);
+
   if (isLoading || !fontsLoaded) {
     return null;
   }
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? eeDark : eeLight}>
+      <EulaModal onAccepted={handleEulaAccepted} />
       <AuthGate>
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -28,7 +28,6 @@ SplashScreen.preventAutoHideAsync();
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const { isLoading, restoreSession } = useAuth();
-  const [eulaAccepted, setEulaAccepted] = React.useState(false);
 
   const [fontsLoaded] = useFonts({
     LibreFranklin_400Regular,
@@ -69,7 +68,7 @@ export default function RootLayout() {
     },
   }), []);
 
-  const handleEulaAccepted = useCallback(() => setEulaAccepted(true), []);
+  const handleEulaAccepted = useCallback(() => {}, []);
 
   if (isLoading || !fontsLoaded) {
     return null;

--- a/mobile/app/friend/[id].tsx
+++ b/mobile/app/friend/[id].tsx
@@ -3,8 +3,10 @@ import { differenceInDays } from "date-fns";
 import { formatNZT } from "@/lib/dates";
 import * as Haptics from "expo-haptics";
 import { useLocalSearchParams, useRouter } from "expo-router";
+import { useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Image,
   Pressable,
   ScrollView,
@@ -12,6 +14,7 @@ import {
   Text,
   View,
 } from "react-native";
+import { api } from "@/lib/api";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { ThemedText } from "@/components/themed-text";
@@ -42,6 +45,75 @@ export default function FriendProfileScreen() {
   const insets = useSafeAreaInsets();
 
   const { profile: friend, isLoading, error } = useFriendProfile(id);
+  const [isBlocking, setIsBlocking] = useState(false);
+
+  const handleBlock = () => {
+    Alert.alert(
+      "Block User",
+      `Block ${friend?.name ?? "this user"}? Their content will be immediately removed from your feed. The Everybody Eats team will be notified.`,
+      [
+        {
+          text: "Block",
+          style: "destructive",
+          onPress: async () => {
+            setIsBlocking(true);
+            try {
+              await api(`/api/mobile/users/${id}/block`, { method: "POST" });
+              Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+              Alert.alert(
+                "User Blocked",
+                `${friend?.name ?? "This user"} has been blocked and removed from your feed.`,
+                [{ text: "OK", onPress: () => router.back() }]
+              );
+            } catch {
+              Alert.alert("Error", "Could not block this user. Please try again.");
+            } finally {
+              setIsBlocking(false);
+            }
+          },
+        },
+        { text: "Cancel", style: "cancel" },
+      ]
+    );
+  };
+
+  const handleReport = () => {
+    Alert.alert(
+      "Report User",
+      `Why are you reporting ${friend?.name ?? "this user"}?`,
+      [
+        {
+          text: "Offensive or abusive behaviour",
+          onPress: async () => {
+            try {
+              await api("/api/mobile/report", {
+                method: "POST",
+                body: { targetType: "user", targetId: id, reason: "Offensive or abusive behaviour" },
+              });
+              Alert.alert("Report Submitted", "Thank you. The Everybody Eats team will review this within 24 hours.");
+            } catch {
+              Alert.alert("Error", "Could not submit report. Please try again.");
+            }
+          },
+        },
+        {
+          text: "Harassment",
+          onPress: async () => {
+            try {
+              await api("/api/mobile/report", {
+                method: "POST",
+                body: { targetType: "user", targetId: id, reason: "Harassment" },
+              });
+              Alert.alert("Report Submitted", "Thank you. The Everybody Eats team will review this within 24 hours.");
+            } catch {
+              Alert.alert("Error", "Could not submit report. Please try again.");
+            }
+          },
+        },
+        { text: "Cancel", style: "cancel" },
+      ]
+    );
+  };
 
   if (isLoading) {
     return (
@@ -388,6 +460,48 @@ export default function FriendProfileScreen() {
           >
             <Ionicons name="calendar-outline" size={18} color="#ffffff" />
             <Text style={styles.ctaText}>Browse Shifts Together</Text>
+          </Pressable>
+        </View>
+
+        {/* ── Safety Actions ── */}
+        <View style={[styles.section, styles.safetySection]}>
+          <Pressable
+            onPress={handleReport}
+            style={({ pressed }) => [
+              styles.safetyBtn,
+              {
+                borderColor: colors.border,
+                backgroundColor: colors.card,
+                opacity: pressed ? 0.7 : 1,
+              },
+            ]}
+            accessibilityLabel="Report this user"
+            accessibilityRole="button"
+          >
+            <Ionicons name="flag-outline" size={16} color={colors.textSecondary} />
+            <Text style={[styles.safetyBtnText, { color: colors.textSecondary }]}>
+              Report User
+            </Text>
+          </Pressable>
+
+          <Pressable
+            onPress={handleBlock}
+            disabled={isBlocking}
+            style={({ pressed }) => [
+              styles.safetyBtn,
+              {
+                borderColor: "#fca5a5",
+                backgroundColor: isDark ? "rgba(220,38,38,0.08)" : "#fff5f5",
+                opacity: pressed || isBlocking ? 0.6 : 1,
+              },
+            ]}
+            accessibilityLabel="Block this user"
+            accessibilityRole="button"
+          >
+            <Ionicons name="ban-outline" size={16} color="#dc2626" />
+            <Text style={[styles.safetyBtnText, { color: "#dc2626" }]}>
+              {isBlocking ? "Blocking…" : "Block User"}
+            </Text>
           </Pressable>
         </View>
       </ScrollView>
@@ -805,5 +919,26 @@ const styles = StyleSheet.create({
     color: "#ffffff",
     fontSize: 15,
     fontFamily: FontFamily.semiBold,
+  },
+
+  /* Safety actions */
+  safetySection: {
+    flexDirection: "row",
+    gap: 10,
+    paddingBottom: 8,
+  },
+  safetyBtn: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  safetyBtnText: {
+    fontSize: 13,
+    fontFamily: FontFamily.medium,
   },
 });

--- a/mobile/components/eula-modal.tsx
+++ b/mobile/components/eula-modal.tsx
@@ -1,0 +1,332 @@
+import * as SecureStore from "expo-secure-store";
+import * as Haptics from "expo-haptics";
+import React, { useEffect, useState } from "react";
+import {
+  Alert,
+  Linking,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { Brand, Colors, FontFamily } from "@/constants/theme";
+import { useColorScheme } from "@/hooks/use-color-scheme";
+
+const EULA_STORAGE_KEY = "eula_accepted_v1";
+
+const TERMS_SECTIONS = [
+  {
+    title: "1. Community Standards",
+    body: "Everybody Eats is a whānau community. We expect all volunteers to treat each other with kindness and respect. Objectionable, offensive, or abusive content is not tolerated and will result in removal from the platform.",
+  },
+  {
+    title: "2. User-Generated Content",
+    body: "By using this app you may post comments and interact with other volunteers' activity. You are responsible for the content you post. Content must not be harmful, threatening, hateful, sexually explicit, or otherwise objectionable.",
+  },
+  {
+    title: "3. Reporting & Moderation",
+    body: "You can flag any content or block any user at any time. Reports are reviewed by the Everybody Eats team within 24 hours. Confirmed violations result in content removal and potential account suspension.",
+  },
+  {
+    title: "4. Blocking",
+    body: "You may block any user to immediately remove their content from your feed. The Everybody Eats team is notified of blocks and will investigate where appropriate.",
+  },
+  {
+    title: "5. Privacy",
+    body: "Your data is handled in accordance with our Privacy Policy. Your volunteer activity (shifts, achievements) is visible to friends you approve. You control your visibility settings in your profile.",
+  },
+  {
+    title: "6. Enforcement",
+    body: "Everybody Eats reserves the right to remove content or suspend accounts that violate these terms without prior notice. We are committed to maintaining a safe environment for all volunteers.",
+  },
+];
+
+interface EulaModalProps {
+  onAccepted: () => void;
+}
+
+export function EulaModal({ onAccepted }: EulaModalProps) {
+  const [visible, setVisible] = useState(false);
+  const [checking, setChecking] = useState(true);
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme];
+  const isDark = colorScheme === "dark";
+  const insets = useSafeAreaInsets();
+
+  useEffect(() => {
+    SecureStore.getItemAsync(EULA_STORAGE_KEY)
+      .then((value) => {
+        if (value === "true") {
+          onAccepted();
+        } else {
+          setVisible(true);
+        }
+      })
+      .catch(() => {
+        // On error, show the modal to be safe
+        setVisible(true);
+      })
+      .finally(() => setChecking(false));
+  }, [onAccepted]);
+
+  const handleAccept = async () => {
+    Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    await SecureStore.setItemAsync(EULA_STORAGE_KEY, "true").catch(() => {});
+    setVisible(false);
+    onAccepted();
+  };
+
+  const handleDecline = () => {
+    Alert.alert(
+      "Terms Required",
+      "You need to agree to the Terms of Use to access Everybody Eats. These terms help keep our community safe for all volunteers.",
+      [
+        { text: "Review Terms", style: "cancel" },
+      ]
+    );
+  };
+
+  if (checking || !visible) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={handleDecline}
+    >
+      <View
+        style={[
+          styles.container,
+          {
+            backgroundColor: colors.background,
+            paddingTop: Platform.OS === "ios" ? insets.top + 8 : 24,
+            paddingBottom: Math.max(insets.bottom, 20),
+          },
+        ]}
+      >
+        {/* Header */}
+        <View style={styles.header}>
+          <View
+            style={[
+              styles.logoCircle,
+              { backgroundColor: isDark ? Brand.greenDark : Brand.greenLight },
+            ]}
+          >
+            <Text style={styles.logoEmoji}>🌿</Text>
+          </View>
+          <Text
+            style={[
+              styles.title,
+              { color: colors.text, fontFamily: FontFamily.headingBold },
+            ]}
+          >
+            Before you join the whānau
+          </Text>
+          <Text
+            style={[
+              styles.subtitle,
+              { color: colors.textSecondary, fontFamily: FontFamily.regular },
+            ]}
+          >
+            Please read and agree to our Terms of Use to access the Everybody
+            Eats volunteer community.
+          </Text>
+        </View>
+
+        {/* Terms content */}
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          <View
+            style={[
+              styles.termsBox,
+              {
+                backgroundColor: isDark ? "#1a1d21" : "#f8faf8",
+                borderColor: colors.border,
+              },
+            ]}
+          >
+            {TERMS_SECTIONS.map((section, i) => (
+              <View
+                key={section.title}
+                style={[
+                  styles.section,
+                  i < TERMS_SECTIONS.length - 1 && {
+                    borderBottomWidth: StyleSheet.hairlineWidth,
+                    borderBottomColor: colors.border,
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.sectionTitle,
+                    {
+                      color: colors.text,
+                      fontFamily: FontFamily.semiBold,
+                    },
+                  ]}
+                >
+                  {section.title}
+                </Text>
+                <Text
+                  style={[
+                    styles.sectionBody,
+                    {
+                      color: colors.textSecondary,
+                      fontFamily: FontFamily.regular,
+                    },
+                  ]}
+                >
+                  {section.body}
+                </Text>
+              </View>
+            ))}
+          </View>
+
+          <Text
+            style={[
+              styles.zeroTolerance,
+              { color: isDark ? "#fbbf24" : "#92400e", fontFamily: FontFamily.semiBold },
+            ]}
+          >
+            Zero tolerance for objectionable content or abusive behaviour.
+          </Text>
+        </ScrollView>
+
+        {/* Actions */}
+        <View style={styles.actions}>
+          <Pressable
+            onPress={handleAccept}
+            style={({ pressed }) => [
+              styles.acceptBtn,
+              { backgroundColor: Brand.green, opacity: pressed ? 0.85 : 1 },
+            ]}
+            accessibilityLabel="Agree to Terms of Use"
+            accessibilityRole="button"
+          >
+            <Text
+              style={[
+                styles.acceptBtnText,
+                { fontFamily: FontFamily.semiBold },
+              ]}
+            >
+              I Agree — Join the Whānau 💚
+            </Text>
+          </Pressable>
+
+          <Pressable
+            onPress={handleDecline}
+            style={({ pressed }) => [
+              styles.declineBtn,
+              { opacity: pressed ? 0.6 : 1 },
+            ]}
+            accessibilityLabel="Decline Terms of Use"
+            accessibilityRole="button"
+          >
+            <Text
+              style={[
+                styles.declineBtnText,
+                {
+                  color: colors.textSecondary,
+                  fontFamily: FontFamily.regular,
+                },
+              ]}
+            >
+              Not now
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  header: {
+    alignItems: "center",
+    paddingVertical: 20,
+    gap: 10,
+  },
+  logoCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 4,
+  },
+  logoEmoji: {
+    fontSize: 30,
+  },
+  title: {
+    fontSize: 22,
+    textAlign: "center",
+  },
+  subtitle: {
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: "center",
+    maxWidth: 300,
+  },
+  scroll: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 16,
+    gap: 12,
+  },
+  termsBox: {
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    overflow: "hidden",
+  },
+  section: {
+    padding: 14,
+    gap: 6,
+  },
+  sectionTitle: {
+    fontSize: 13,
+  },
+  sectionBody: {
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  zeroTolerance: {
+    textAlign: "center",
+    fontSize: 13,
+    paddingHorizontal: 16,
+    marginTop: 4,
+  },
+  actions: {
+    gap: 10,
+    paddingTop: 16,
+  },
+  acceptBtn: {
+    borderRadius: 14,
+    paddingVertical: 16,
+    alignItems: "center",
+  },
+  acceptBtnText: {
+    color: "#ffffff",
+    fontSize: 16,
+  },
+  declineBtn: {
+    alignItems: "center",
+    paddingVertical: 10,
+  },
+  declineBtnText: {
+    fontSize: 14,
+  },
+});

--- a/mobile/components/eula-modal.tsx
+++ b/mobile/components/eula-modal.tsx
@@ -3,7 +3,6 @@ import * as Haptics from "expo-haptics";
 import React, { useEffect, useState } from "react";
 import {
   Alert,
-  Linking,
   Modal,
   Platform,
   Pressable,

--- a/mobile/hooks/use-feed-interactions.ts
+++ b/mobile/hooks/use-feed-interactions.ts
@@ -38,6 +38,9 @@ type UseFeedInteractionsReturn = {
 
   /** Report a feed item as objectionable content. */
   reportItem: (targetType: string, targetId: string, reason: string) => Promise<boolean>;
+
+  /** Returns true if the user has already reported this targetId in this session. */
+  hasReported: (targetId: string) => boolean;
 };
 
 /**
@@ -51,6 +54,9 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
   const [commentStates, setCommentStates] = useState<
     Record<string, CommentState>
   >({});
+
+  // Track items reported this session so the UI can reflect the reported state
+  const [reportedIds, setReportedIds] = useState<Set<string>>(new Set());
 
   const toggleLike = useCallback(
     async (itemId: string): Promise<LikeResponse | null> => {
@@ -181,6 +187,7 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
           method: "POST",
           body: { targetType, targetId, reason },
         });
+        setReportedIds((prev) => new Set(prev).add(targetId));
         return true;
       } catch {
         return false;
@@ -189,5 +196,10 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
     []
   );
 
-  return { toggleLike, loadComments, addComment, getCommentState, reportItem };
+  const hasReported = useCallback(
+    (targetId: string) => reportedIds.has(targetId),
+    [reportedIds]
+  );
+
+  return { toggleLike, loadComments, addComment, getCommentState, reportItem, hasReported };
 }

--- a/mobile/hooks/use-feed-interactions.ts
+++ b/mobile/hooks/use-feed-interactions.ts
@@ -21,6 +21,8 @@ type CommentState = {
   error: string | null;
 };
 
+type ReportResponse = { ok: boolean };
+
 type UseFeedInteractionsReturn = {
   /** Toggle like on a feed item. Returns the new liked state and count. */
   toggleLike: (itemId: string) => Promise<LikeResponse | null>;
@@ -33,6 +35,9 @@ type UseFeedInteractionsReturn = {
 
   /** Get cached comment state for an item. */
   getCommentState: (itemId: string) => CommentState;
+
+  /** Report a feed item as objectionable content. */
+  reportItem: (targetType: string, targetId: string, reason: string) => Promise<boolean>;
 };
 
 /**
@@ -169,5 +174,20 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
     [commentStates]
   );
 
-  return { toggleLike, loadComments, addComment, getCommentState };
+  const reportItem = useCallback(
+    async (targetType: string, targetId: string, reason: string): Promise<boolean> => {
+      try {
+        await api<ReportResponse>("/api/mobile/report", {
+          method: "POST",
+          body: { targetType, targetId, reason },
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    []
+  );
+
+  return { toggleLike, loadComments, addComment, getCommentState, reportItem };
 }

--- a/web/.env.example
+++ b/web/.env.example
@@ -18,6 +18,9 @@ FACEBOOK_CLIENT_SECRET=""
 APPLE_CLIENT_ID=""
 APPLE_CLIENT_SECRET=""
 
+# Admin notifications (content reports and user blocks from mobile app)
+ADMIN_NOTIFICATION_EMAIL=""
+
 # Campaign Monitor Configuration
 CAMPAIGN_MONITOR_API_KEY=""
 CAMPAIGN_MONITOR_MIGRATION_EMAIL_ID=""

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,6 +42,7 @@
         "@vercel/speed-insights": "^1.3.1",
         "ai": "^6.0.158",
         "apexcharts": "^5.10.6",
+        "bad-words": "^4.0.0",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.3",
         "better-sse": "^0.16.1",
@@ -6707,6 +6708,24 @@
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
+    },
+    "node_modules/bad-words": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-4.0.0.tgz",
+      "integrity": "sha512-fLjG/I0N3I7xhurqGnGitSRD10UeEE63a7hyXtutQDpxo4+Eal+i7veWeZxZJPNtsl6X1mUIoWPwt8gQ7NMQUw==",
+      "license": "MIT",
+      "dependencies": {
+        "badwords-list": "^2.0.1-4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/badwords-list": {
+      "version": "2.0.1-4",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-2.0.1-4.tgz",
+      "integrity": "sha512-FxfZUp7B9yCnesNtFQS9v6PvZdxTYa14Q60JR6vhjdQdWI4naTjJIyx22JzoER8ooeT8SAAKoHLjKfCV7XgYUQ==",
+      "license": "MIT"
     },
     "node_modules/bail": {
       "version": "2.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -62,6 +62,7 @@
     "@vercel/speed-insights": "^1.3.1",
     "ai": "^6.0.158",
     "apexcharts": "^5.10.6",
+    "bad-words": "^4.0.0",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.3",
     "better-sse": "^0.16.1",

--- a/web/prisma/migrations/20260416000000_add_content_moderation/migration.sql
+++ b/web/prisma/migrations/20260416000000_add_content_moderation/migration.sql
@@ -1,0 +1,49 @@
+-- CreateTable
+CREATE TABLE "ContentReport" (
+    "id" TEXT NOT NULL,
+    "reporterId" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ContentReport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserBlock" (
+    "id" TEXT NOT NULL,
+    "blockerId" TEXT NOT NULL,
+    "blockedId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserBlock_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ContentReport_reporterId_idx" ON "ContentReport"("reporterId");
+
+-- CreateIndex
+CREATE INDEX "ContentReport_targetType_targetId_idx" ON "ContentReport"("targetType", "targetId");
+
+-- CreateIndex
+CREATE INDEX "ContentReport_status_idx" ON "ContentReport"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserBlock_blockerId_blockedId_key" ON "UserBlock"("blockerId", "blockedId");
+
+-- CreateIndex
+CREATE INDEX "UserBlock_blockerId_idx" ON "UserBlock"("blockerId");
+
+-- CreateIndex
+CREATE INDEX "UserBlock_blockedId_idx" ON "UserBlock"("blockedId");
+
+-- AddForeignKey
+ALTER TABLE "ContentReport" ADD CONSTRAINT "ContentReport_reporterId_fkey" FOREIGN KEY ("reporterId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserBlock" ADD CONSTRAINT "UserBlock_blockerId_fkey" FOREIGN KEY ("blockerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserBlock" ADD CONSTRAINT "UserBlock_blockedId_fkey" FOREIGN KEY ("blockedId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -127,6 +127,11 @@ model User {
 
   // Announcements authored by this user (admin)
   announcements Announcement[] @relation("AnnouncementAuthor")
+
+  // Content moderation
+  contentReports ContentReport[] @relation("ContentReporter")
+  blocksGiven    UserBlock[]     @relation("BlocksMade")
+  blocksReceived UserBlock[]     @relation("BlocksReceived")
 }
 
 model Passkey {
@@ -858,6 +863,40 @@ model DailyMenu {
   @@unique([date, location])
   @@index([location, date])
   @@index([date])
+}
+
+// ─── Content Moderation ────────────────────────────────────────────────────────
+
+/// A report of objectionable content or an abusive user, filed by a volunteer.
+model ContentReport {
+  id         String   @id @default(cuid())
+  reporterId String
+  targetType String   // 'comment' | 'post' | 'user'
+  targetId   String   // ID of the reported entity
+  reason     String   // Reporter-selected reason
+  status     String   @default("PENDING") // 'PENDING' | 'REVIEWED' | 'RESOLVED'
+  createdAt  DateTime @default(now())
+
+  reporter User @relation("ContentReporter", fields: [reporterId], references: [id], onDelete: Cascade)
+
+  @@index([reporterId])
+  @@index([targetType, targetId])
+  @@index([status])
+}
+
+/// A block between two users — blocker no longer sees blockedId content in feed/comments.
+model UserBlock {
+  id        String   @id @default(cuid())
+  blockerId String
+  blockedId String
+  createdAt DateTime @default(now())
+
+  blocker User @relation("BlocksMade", fields: [blockerId], references: [id], onDelete: Cascade)
+  blocked User @relation("BlocksReceived", fields: [blockedId], references: [id], onDelete: Cascade)
+
+  @@unique([blockerId, blockedId])
+  @@index([blockerId])
+  @@index([blockedId])
 }
 
 // ─── Announcements ────────────────────────────────────────────────────────────

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -60,7 +60,7 @@ export default async function AdminLayout({
 
   // Get pending parental consent count (volunteers requiring consent but not yet received)
   // Uses requiresParentalConsent flag for consistency with the table data
-  const [pendingParentalConsentCount, chatGuidesEnabled] = await Promise.all([
+  const [pendingParentalConsentCount, pendingReportCount, chatGuidesEnabled] = await Promise.all([
     prisma.user.count({
       where: {
         role: "VOLUNTEER",
@@ -68,6 +68,7 @@ export default async function AdminLayout({
         parentalConsentReceived: false,
       },
     }),
+    prisma.contentReport.count({ where: { status: "PENDING" } }),
     isFeatureEnabled(FeatureFlag.CHAT_GUIDES, session.user.id),
   ]);
 
@@ -85,6 +86,7 @@ export default async function AdminLayout({
           userProfile={userProfile}
           displayName={displayName}
           pendingParentalConsentCount={pendingParentalConsentCount}
+          pendingReportCount={pendingReportCount}
           hiddenNavItems={hiddenNavItems}
         />
         <SidebarInset>

--- a/web/src/app/admin/moderation/moderation-content.tsx
+++ b/web/src/app/admin/moderation/moderation-content.tsx
@@ -1,0 +1,377 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { Ban, Flag, RefreshCw, User } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+interface Reporter {
+  id: string;
+  firstName: string | null;
+  name: string | null;
+  email: string;
+}
+
+interface Report {
+  id: string;
+  reporterId: string;
+  targetType: string;
+  targetId: string;
+  reason: string;
+  status: string;
+  createdAt: string;
+  reporter: Reporter;
+}
+
+interface Block {
+  id: string;
+  blockerId: string;
+  blockedId: string;
+  createdAt: string;
+  blocker: Reporter;
+  blocked: Reporter;
+}
+
+function displayName(user: Reporter) {
+  return user.firstName ?? user.name ?? user.email;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === "PENDING")
+    return (
+      <Badge variant="outline" className="border-orange-400 text-orange-600">
+        Pending
+      </Badge>
+    );
+  if (status === "REVIEWED")
+    return (
+      <Badge variant="outline" className="border-blue-400 text-blue-600">
+        Reviewed
+      </Badge>
+    );
+  return (
+    <Badge variant="outline" className="border-green-500 text-green-600">
+      Resolved
+    </Badge>
+  );
+}
+
+function TargetTypeBadge({ type }: { type: string }) {
+  const map: Record<string, string> = {
+    post: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+    comment: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+    user: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${map[type] ?? "bg-muted text-muted-foreground"}`}
+    >
+      {type}
+    </span>
+  );
+}
+
+export function ModerationContent() {
+  const [reports, setReports] = useState<Report[]>([]);
+  const [blocks, setBlocks] = useState<Block[]>([]);
+  const [loadingReports, setLoadingReports] = useState(true);
+  const [loadingBlocks, setLoadingBlocks] = useState(true);
+  const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  const fetchReports = useCallback(async () => {
+    setLoadingReports(true);
+    try {
+      const res = await fetch("/api/admin/moderation/reports");
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      setReports(data.reports);
+    } catch {
+      toast({ title: "Error", description: "Failed to load reports", variant: "destructive" });
+    } finally {
+      setLoadingReports(false);
+    }
+  }, [toast]);
+
+  const fetchBlocks = useCallback(async () => {
+    setLoadingBlocks(true);
+    try {
+      const res = await fetch("/api/admin/moderation/blocks");
+      if (!res.ok) throw new Error();
+      const data = await res.json();
+      setBlocks(data.blocks);
+    } catch {
+      toast({ title: "Error", description: "Failed to load blocks", variant: "destructive" });
+    } finally {
+      setLoadingBlocks(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    fetchReports();
+    fetchBlocks();
+  }, [fetchReports, fetchBlocks]);
+
+  const updateStatus = useCallback(
+    async (id: string, status: "REVIEWED" | "RESOLVED") => {
+      setUpdatingId(id);
+      try {
+        const res = await fetch(`/api/admin/moderation/reports/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status }),
+        });
+        if (!res.ok) throw new Error();
+        setReports((prev) =>
+          prev.map((r) => (r.id === id ? { ...r, status } : r))
+        );
+        toast({ title: "Updated", description: `Report marked as ${status.toLowerCase()}.` });
+      } catch {
+        toast({ title: "Error", description: "Failed to update report", variant: "destructive" });
+      } finally {
+        setUpdatingId(null);
+      }
+    },
+    [toast]
+  );
+
+  const pendingCount = reports.filter((r) => r.status === "PENDING").length;
+
+  return (
+    <Tabs defaultValue="reports">
+      <TabsList>
+        <TabsTrigger value="reports" className="gap-2">
+          <Flag className="h-4 w-4" />
+          Reports
+          {pendingCount > 0 && (
+            <span className="ml-1 rounded-full bg-orange-500 text-white text-xs px-1.5 py-0.5 leading-none">
+              {pendingCount}
+            </span>
+          )}
+        </TabsTrigger>
+        <TabsTrigger value="blocks" className="gap-2">
+          <Ban className="h-4 w-4" />
+          Blocks
+          {blocks.length > 0 && (
+            <span className="ml-1 rounded-full bg-muted text-muted-foreground text-xs px-1.5 py-0.5 leading-none">
+              {blocks.length}
+            </span>
+          )}
+        </TabsTrigger>
+      </TabsList>
+
+      {/* ── Reports ── */}
+      <TabsContent value="reports" className="mt-4">
+        <div className="rounded-lg border">
+          <div className="flex items-center justify-between px-4 py-3 border-b">
+            <p className="text-sm text-muted-foreground">
+              {reports.length} total report{reports.length !== 1 ? "s" : ""}
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={fetchReports}
+              disabled={loadingReports}
+              className="gap-2"
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${loadingReports ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+          </div>
+
+          {loadingReports ? (
+            <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
+              Loading reports…
+            </div>
+          ) : reports.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 gap-2">
+              <Flag className="h-8 w-8 text-muted-foreground/40" />
+              <p className="text-sm text-muted-foreground">No reports yet</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Reporter</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead>Target ID</TableHead>
+                  <TableHead>Reason</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Received</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {reports.map((report) => (
+                  <TableRow key={report.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                        <div>
+                          <p className="text-sm font-medium leading-none">
+                            {displayName(report.reporter)}
+                          </p>
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {report.reporter.email}
+                          </p>
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <TargetTypeBadge type={report.targetType} />
+                    </TableCell>
+                    <TableCell>
+                      <code className="text-xs bg-muted px-1.5 py-0.5 rounded font-mono">
+                        {report.targetId.length > 24
+                          ? `${report.targetId.slice(0, 24)}…`
+                          : report.targetId}
+                      </code>
+                    </TableCell>
+                    <TableCell className="max-w-[180px]">
+                      <p className="text-sm truncate" title={report.reason}>
+                        {report.reason}
+                      </p>
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge status={report.status} />
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
+                      {formatDistanceToNow(new Date(report.createdAt), {
+                        addSuffix: true,
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {report.status === "PENDING" && (
+                        <div className="flex items-center justify-end gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={updatingId === report.id}
+                            onClick={() => updateStatus(report.id, "REVIEWED")}
+                          >
+                            Mark Reviewed
+                          </Button>
+                          <Button
+                            size="sm"
+                            disabled={updatingId === report.id}
+                            onClick={() => updateStatus(report.id, "RESOLVED")}
+                          >
+                            Resolve
+                          </Button>
+                        </div>
+                      )}
+                      {report.status === "REVIEWED" && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={updatingId === report.id}
+                          onClick={() => updateStatus(report.id, "RESOLVED")}
+                        >
+                          Resolve
+                        </Button>
+                      )}
+                      {report.status === "RESOLVED" && (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </TabsContent>
+
+      {/* ── Blocks ── */}
+      <TabsContent value="blocks" className="mt-4">
+        <div className="rounded-lg border">
+          <div className="flex items-center justify-between px-4 py-3 border-b">
+            <p className="text-sm text-muted-foreground">
+              {blocks.length} active block{blocks.length !== 1 ? "s" : ""}
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={fetchBlocks}
+              disabled={loadingBlocks}
+              className="gap-2"
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${loadingBlocks ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+          </div>
+
+          {loadingBlocks ? (
+            <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
+              Loading blocks…
+            </div>
+          ) : blocks.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 gap-2">
+              <Ban className="h-8 w-8 text-muted-foreground/40" />
+              <p className="text-sm text-muted-foreground">No blocks yet</p>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Blocked by</TableHead>
+                  <TableHead>Blocked user</TableHead>
+                  <TableHead>When</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {blocks.map((block) => (
+                  <TableRow key={block.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                        <div>
+                          <p className="text-sm font-medium leading-none">
+                            {displayName(block.blocker)}
+                          </p>
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {block.blocker.email}
+                          </p>
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Ban className="h-3.5 w-3.5 text-red-500 shrink-0" />
+                        <div>
+                          <p className="text-sm font-medium leading-none">
+                            {displayName(block.blocked)}
+                          </p>
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {block.blocked.email}
+                          </p>
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
+                      {formatDistanceToNow(new Date(block.createdAt), {
+                        addSuffix: true,
+                      })}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/web/src/app/admin/moderation/page.tsx
+++ b/web/src/app/admin/moderation/page.tsx
@@ -1,0 +1,101 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { AlertTriangle, Ban, CheckCircle, Clock } from "lucide-react";
+import type { Metadata } from "next";
+
+import { authOptions } from "@/lib/auth-options";
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { PageContainer } from "@/components/page-container";
+import { prisma } from "@/lib/prisma";
+import { ModerationContent } from "./moderation-content";
+
+export const metadata: Metadata = {
+  title: "Moderation | Admin",
+  robots: { index: false, follow: false },
+};
+
+export default async function ModerationPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) redirect("/login?callbackUrl=/admin/moderation");
+  if (session.user.role !== "ADMIN") redirect("/dashboard");
+
+  const [pendingReports, resolvedReports, activeBlocks] = await Promise.all([
+    prisma.contentReport.count({ where: { status: "PENDING" } }),
+    prisma.contentReport.count({ where: { status: "RESOLVED" } }),
+    prisma.userBlock.count(),
+  ]);
+
+  return (
+    <PageContainer>
+      <AdminPageWrapper
+        title="Content Moderation"
+        description="Review flagged content and user blocks — Apple Guideline 1.2 compliance"
+      >
+        <div className="space-y-6">
+          {/* Stats */}
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="rounded-lg border bg-card p-6">
+              <div className="flex items-center justify-between pb-2">
+                <h3 className="text-sm font-medium tracking-tight">
+                  Pending Reports
+                </h3>
+                <Clock className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <div className="text-2xl font-bold text-orange-600">
+                {pendingReports}
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                Requires review within 24 hours
+              </p>
+            </div>
+
+            <div className="rounded-lg border bg-card p-6">
+              <div className="flex items-center justify-between pb-2">
+                <h3 className="text-sm font-medium tracking-tight">
+                  Resolved Reports
+                </h3>
+                <CheckCircle className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <div className="text-2xl font-bold text-green-600">
+                {resolvedReports}
+              </div>
+            </div>
+
+            <div className="rounded-lg border bg-card p-6">
+              <div className="flex items-center justify-between pb-2">
+                <h3 className="text-sm font-medium tracking-tight">
+                  Active Blocks
+                </h3>
+                <Ban className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <div className="text-2xl font-bold">{activeBlocks}</div>
+              <p className="text-xs text-muted-foreground mt-1">
+                Users blocked by other users
+              </p>
+            </div>
+          </div>
+
+          {/* 24-hour reminder */}
+          {pendingReports > 0 && (
+            <div className="flex items-start gap-3 rounded-lg border border-orange-200 bg-orange-50 dark:bg-orange-950/20 dark:border-orange-800 p-4">
+              <AlertTriangle className="h-5 w-5 text-orange-600 dark:text-orange-400 mt-0.5 shrink-0" />
+              <div>
+                <p className="text-sm font-medium text-orange-800 dark:text-orange-200">
+                  {pendingReports} pending{" "}
+                  {pendingReports === 1 ? "report requires" : "reports require"}{" "}
+                  attention
+                </p>
+                <p className="text-sm text-orange-700 dark:text-orange-300 mt-0.5">
+                  Apple App Store Guideline 1.2 requires content reports to be
+                  reviewed and acted on within 24 hours.
+                </p>
+              </div>
+            </div>
+          )}
+
+          <ModerationContent />
+        </div>
+      </AdminPageWrapper>
+    </PageContainer>
+  );
+}

--- a/web/src/app/api/admin/moderation/blocks/route.ts
+++ b/web/src/app/api/admin/moderation/blocks/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/admin/moderation/blocks
+ * Returns all user blocks, newest first.
+ */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const blocks = await prisma.userBlock.findMany({
+    include: {
+      blocker: {
+        select: { id: true, firstName: true, name: true, email: true },
+      },
+      blocked: {
+        select: { id: true, firstName: true, name: true, email: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({ blocks });
+}

--- a/web/src/app/api/admin/moderation/reports/[id]/route.ts
+++ b/web/src/app/api/admin/moderation/reports/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * PATCH /api/admin/moderation/reports/[id]
+ * Updates the status of a content report.
+ * Body: { status: 'REVIEWED' | 'RESOLVED' }
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const body = await request.json().catch(() => null);
+  const status = body?.status;
+
+  if (!["REVIEWED", "RESOLVED"].includes(status)) {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  const report = await prisma.contentReport.update({
+    where: { id },
+    data: { status },
+  });
+
+  return NextResponse.json({ report });
+}

--- a/web/src/app/api/admin/moderation/reports/route.ts
+++ b/web/src/app/api/admin/moderation/reports/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/admin/moderation/reports
+ * Returns all content reports, newest first.
+ */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const reports = await prisma.contentReport.findMany({
+    include: {
+      reporter: {
+        select: { id: true, firstName: true, name: true, email: true },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({ reports });
+}

--- a/web/src/app/api/mobile/feed/[itemId]/comments/route.ts
+++ b/web/src/app/api/mobile/feed/[itemId]/comments/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireMobileUser } from "@/lib/mobile-auth";
+import { filterContent } from "@/lib/content-filter";
 
 /**
  * GET /api/mobile/feed/[itemId]/comments
@@ -22,8 +23,18 @@ export async function GET(
     return NextResponse.json({ error: "Invalid item ID" }, { status: 400 });
   }
 
+  // Get users that this person has blocked (hide their comments)
+  const blocks = await prisma.userBlock.findMany({
+    where: { blockerId: auth.userId },
+    select: { blockedId: true },
+  });
+  const blockedIds = blocks.map((b) => b.blockedId);
+
   const comments = await prisma.feedComment.findMany({
-    where: { feedItemId: itemId },
+    where: {
+      feedItemId: itemId,
+      ...(blockedIds.length > 0 ? { userId: { notIn: blockedIds } } : {}),
+    },
     include: {
       user: {
         select: { id: true, name: true, firstName: true, profilePhotoUrl: true },
@@ -74,6 +85,11 @@ export async function POST(
   }
   if (text.length > 1000) {
     return NextResponse.json({ error: "Comment too long (max 1000 characters)" }, { status: 400 });
+  }
+
+  const filterError = filterContent(text);
+  if (filterError) {
+    return NextResponse.json({ error: filterError }, { status: 422 });
   }
 
   const [comment, user] = await Promise.all([

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -28,8 +28,8 @@ export async function GET(request: Request) {
   since.setDate(since.getDate() - 14);
   const now = new Date();
 
-  // Get the user's profile for targeting checks
-  const [userProfile, friendships] = await Promise.all([
+  // Get the user's profile, friendships, and blocks in parallel
+  const [userProfile, friendships, blocks] = await Promise.all([
     prisma.user.findUnique({
       where: { id: userId },
       select: {
@@ -45,12 +45,22 @@ export async function GET(request: Request) {
       },
       select: { userId: true, friendId: true },
     }),
+    // Users this person has blocked
+    prisma.userBlock.findMany({
+      where: { blockerId: userId },
+      select: { blockedId: true },
+    }),
   ]);
 
-  const friendIds = friendships.map((f) =>
-    f.userId === userId ? f.friendId : f.userId
+  const blockedUserIds = new Set(blocks.map((b) => b.blockedId));
+
+  const friendIds = friendships
+    .map((f) => (f.userId === userId ? f.friendId : f.userId))
+    // Exclude blocked users from friend feed
+    .filter((id) => !blockedUserIds.has(id));
+  const visibleUserIds = [userId, ...friendIds].filter(
+    (id) => !blockedUserIds.has(id)
   );
-  const visibleUserIds = [userId, ...friendIds];
 
   const userLabelIds = (userProfile?.customLabels ?? []).map((l) => l.labelId);
   const userLocations = userProfile?.availableLocations

--- a/web/src/app/api/mobile/report/route.test.ts
+++ b/web/src/app/api/mobile/report/route.test.ts
@@ -1,0 +1,126 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    contentReport: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/mobile-auth", () => ({
+  requireMobileUser: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { requireMobileUser } from "@/lib/mobile-auth";
+import { prisma } from "@/lib/prisma";
+
+const mockAuth = requireMobileUser as ReturnType<typeof vi.fn>;
+const mockPrisma = prisma as unknown as {
+  contentReport: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+};
+
+function makeRequest(body?: unknown) {
+  return new Request("http://localhost/api/mobile/report", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer valid-token",
+      "Content-Type": "application/json",
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("POST /api/mobile/report", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockResolvedValue({ userId: "user-1" });
+    mockPrisma.contentReport.findFirst.mockResolvedValue(null);
+    mockPrisma.contentReport.create.mockResolvedValue({ id: "report-1" });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await POST(makeRequest({ targetType: "post", targetId: "abc", reason: "Spam" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for an invalid targetType", async () => {
+    const res = await POST(makeRequest({ targetType: "image", targetId: "abc", reason: "Spam" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when targetType is missing", async () => {
+    const res = await POST(makeRequest({ targetId: "abc", reason: "Spam" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when targetId is empty", async () => {
+    const res = await POST(makeRequest({ targetType: "post", targetId: "  ", reason: "Spam" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when reason is missing", async () => {
+    const res = await POST(makeRequest({ targetType: "post", targetId: "abc" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a report with a valid known reason", async () => {
+    const res = await POST(makeRequest({ targetType: "post", targetId: "abc", reason: "Spam" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(mockPrisma.contentReport.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ reason: "Spam", targetType: "post" }),
+      })
+    );
+  });
+
+  it("sanitises an unrecognised reason to 'Other'", async () => {
+    const res = await POST(makeRequest({ targetType: "comment", targetId: "xyz", reason: "I just don't like them" }));
+    expect(res.status).toBe(200);
+    expect(mockPrisma.contentReport.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ reason: "Other" }),
+      })
+    );
+  });
+
+  it("accepts all three valid targetTypes", async () => {
+    for (const targetType of ["comment", "post", "user"]) {
+      vi.clearAllMocks();
+      mockAuth.mockResolvedValue({ userId: "user-1" });
+      mockPrisma.contentReport.findFirst.mockResolvedValue(null);
+      mockPrisma.contentReport.create.mockResolvedValue({ id: "report-1" });
+
+      const res = await POST(makeRequest({ targetType, targetId: "abc", reason: "Spam" }));
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("returns 200 without creating a duplicate report", async () => {
+    mockPrisma.contentReport.findFirst.mockResolvedValue({ id: "existing-report" });
+
+    const res = await POST(makeRequest({ targetType: "post", targetId: "abc", reason: "Spam" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(mockPrisma.contentReport.create).not.toHaveBeenCalled();
+  });
+
+  it("trims whitespace from targetId", async () => {
+    const res = await POST(makeRequest({ targetType: "post", targetId: "  abc123  ", reason: "Spam" }));
+    expect(res.status).toBe(200);
+    expect(mockPrisma.contentReport.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ targetId: "abc123" }),
+      })
+    );
+  });
+});

--- a/web/src/app/api/mobile/report/route.ts
+++ b/web/src/app/api/mobile/report/route.ts
@@ -83,7 +83,7 @@ async function notifyAdmin(
 
   if (!adminEmail) {
     console.log(
-      `[report] Content report received (ADMIN_NOTIFICATION_EMAIL not set): ${targetType}/${targetId} — "${reason}" by user ${reporterId}`
+      `[report] Content report received (ADMIN_NOTIFICATION_EMAIL not set): ${targetType} — "${reason}"`
     );
     return;
   }

--- a/web/src/app/api/mobile/report/route.ts
+++ b/web/src/app/api/mobile/report/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireMobileUser } from "@/lib/mobile-auth";
+
+const VALID_TARGET_TYPES = ["comment", "post", "user"] as const;
+
+const VALID_REASONS = [
+  "Offensive or abusive content",
+  "Spam",
+  "Harassment",
+  "Hate speech",
+  "Other",
+] as const;
+
+/**
+ * POST /api/mobile/report
+ *
+ * Submits a content or user report. Satisfies Apple Guideline 1.2 requirement
+ * for a mechanism to flag objectionable content and abusive users.
+ *
+ * Body: { targetType: 'comment'|'post'|'user', targetId: string, reason: string }
+ */
+export async function POST(request: Request) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { userId } = auth;
+
+  const body = await request.json().catch(() => null);
+  const { targetType, targetId, reason } = body ?? {};
+
+  if (
+    !targetType ||
+    !VALID_TARGET_TYPES.includes(targetType) ||
+    typeof targetId !== "string" ||
+    !targetId.trim() ||
+    typeof reason !== "string" ||
+    !reason.trim()
+  ) {
+    return NextResponse.json({ error: "Invalid report data" }, { status: 400 });
+  }
+
+  const sanitizedReason = VALID_REASONS.includes(reason as (typeof VALID_REASONS)[number])
+    ? reason
+    : "Other";
+
+  // Prevent duplicate reports from the same user for the same item
+  const existing = await prisma.contentReport.findFirst({
+    where: { reporterId: userId, targetType, targetId },
+  });
+  if (existing) {
+    // Silently succeed — user already reported this, no need to double-report
+    return NextResponse.json({ ok: true });
+  }
+
+  await prisma.contentReport.create({
+    data: {
+      reporterId: userId,
+      targetType,
+      targetId: targetId.trim(),
+      reason: sanitizedReason,
+    },
+  });
+
+  // Notify admin asynchronously (don't block the response)
+  notifyAdmin(userId, targetType, targetId, sanitizedReason).catch((err) => {
+    console.error("[report] Admin notification failed:", err);
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+async function notifyAdmin(
+  reporterId: string,
+  targetType: string,
+  targetId: string,
+  reason: string
+) {
+  const adminEmail = process.env.ADMIN_NOTIFICATION_EMAIL;
+  const apiKey = process.env.CAMPAIGN_MONITOR_API_KEY;
+
+  if (!adminEmail) {
+    console.log(
+      `[report] Content report received (ADMIN_NOTIFICATION_EMAIL not set): ${targetType}/${targetId} — "${reason}" by user ${reporterId}`
+    );
+    return;
+  }
+
+  if (!apiKey || apiKey === "dummy-key-for-dev") {
+    console.log(
+      `[report] Would email ${adminEmail}: New ${targetType} report — "${reason}" (dev mode)`
+    );
+    return;
+  }
+
+  const subject = `[Everybody Eats] Content report: ${targetType}`;
+  const html = `
+    <p>A volunteer has reported ${targetType} content.</p>
+    <ul>
+      <li><strong>Type:</strong> ${targetType}</li>
+      <li><strong>Item ID:</strong> ${targetId}</li>
+      <li><strong>Reason:</strong> ${reason}</li>
+      <li><strong>Reporter ID:</strong> ${reporterId}</li>
+    </ul>
+    <p>Please review this within 24 hours and take appropriate action.</p>
+    <p>Log in to the admin panel to manage this report.</p>
+  `;
+
+  const response = await fetch(
+    "https://api.createsend.com/api/v3.3/transactional/classicemail/send",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${Buffer.from(`${apiKey}:x`).toString("base64")}`,
+      },
+      body: JSON.stringify({
+        To: adminEmail,
+        From: adminEmail,
+        Subject: subject,
+        Html: html,
+        ConsentToTrack: "Unchanged",
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Campaign Monitor error: ${response.status} ${text}`);
+  }
+}

--- a/web/src/app/api/mobile/users/[id]/block/route.ts
+++ b/web/src/app/api/mobile/users/[id]/block/route.ts
@@ -1,0 +1,138 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireMobileUser } from "@/lib/mobile-auth";
+
+/**
+ * POST /api/mobile/users/[id]/block
+ *
+ * Blocks a user. The blocked user's content is immediately hidden from the
+ * blocker's feed and comments. Notifies admin as required by Apple Guideline 1.2.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { userId } = auth;
+  const { id: blockedId } = await params;
+
+  if (!blockedId || blockedId === userId) {
+    return NextResponse.json({ error: "Invalid user ID" }, { status: 400 });
+  }
+
+  // Confirm target user exists
+  const target = await prisma.user.findUnique({
+    where: { id: blockedId },
+    select: { id: true, firstName: true, name: true, email: true },
+  });
+  if (!target) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  // Upsert block (idempotent)
+  await prisma.userBlock.upsert({
+    where: { blockerId_blockedId: { blockerId: userId, blockedId } },
+    update: {},
+    create: { blockerId: userId, blockedId },
+  });
+
+  // Notify admin asynchronously
+  notifyAdminOfBlock(userId, blockedId, target).catch((err) => {
+    console.error("[block] Admin notification failed:", err);
+  });
+
+  return NextResponse.json({ ok: true, blocked: true });
+}
+
+/**
+ * DELETE /api/mobile/users/[id]/block
+ *
+ * Unblocks a previously blocked user.
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { userId } = auth;
+  const { id: blockedId } = await params;
+
+  await prisma.userBlock
+    .delete({
+      where: { blockerId_blockedId: { blockerId: userId, blockedId } },
+    })
+    .catch(() => {
+      // Already unblocked — ignore
+    });
+
+  return NextResponse.json({ ok: true, blocked: false });
+}
+
+async function notifyAdminOfBlock(
+  blockerId: string,
+  blockedId: string,
+  blockedUser: { firstName: string | null; name: string | null; email: string }
+) {
+  const adminEmail = process.env.ADMIN_NOTIFICATION_EMAIL;
+  const apiKey = process.env.CAMPAIGN_MONITOR_API_KEY;
+
+  const blockedName =
+    blockedUser.firstName ?? blockedUser.name ?? blockedUser.email;
+
+  if (!adminEmail) {
+    console.log(
+      `[block] User ${blockerId} blocked ${blockedId} (${blockedName}). Set ADMIN_NOTIFICATION_EMAIL to receive alerts.`
+    );
+    return;
+  }
+
+  if (!apiKey || apiKey === "dummy-key-for-dev") {
+    console.log(
+      `[block] Would email ${adminEmail}: User block — ${blockerId} blocked ${blockedName} (dev mode)`
+    );
+    return;
+  }
+
+  const subject = `[Everybody Eats] User blocked — action may be required`;
+  const html = `
+    <p>A volunteer has blocked another user.</p>
+    <ul>
+      <li><strong>Blocked user:</strong> ${blockedName} (ID: ${blockedId})</li>
+      <li><strong>Blocked by:</strong> User ID ${blockerId}</li>
+      <li><strong>Time:</strong> ${new Date().toISOString()}</li>
+    </ul>
+    <p>If this is a result of abusive behaviour, please review and take action within 24 hours.</p>
+    <p>This block is in effect and the blocked user's content is already hidden from the reporter's feed.</p>
+  `;
+
+  const response = await fetch(
+    "https://api.createsend.com/api/v3.3/transactional/classicemail/send",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${Buffer.from(`${apiKey}:x`).toString("base64")}`,
+      },
+      body: JSON.stringify({
+        To: adminEmail,
+        From: adminEmail,
+        Subject: subject,
+        Html: html,
+        ConsentToTrack: "Unchanged",
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Campaign Monitor error: ${response.status} ${text}`);
+  }
+}

--- a/web/src/app/support/page.tsx
+++ b/web/src/app/support/page.tsx
@@ -1,0 +1,226 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  Mail,
+  MessageCircle,
+  Flag,
+  Shield,
+  HelpCircle,
+  ExternalLink,
+  Clock,
+  AlertTriangle,
+} from "lucide-react";
+
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Support",
+  description:
+    "Get help with your Everybody Eats volunteer account. Find answers to common questions, report issues, or contact our support team.",
+  path: "/support",
+});
+
+export default function SupportPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <div className="border-b bg-card">
+        <div className="max-w-4xl mx-auto px-6 py-12">
+          <Link
+            href="/"
+            className="text-sm text-muted-foreground hover:text-foreground mb-6 inline-flex items-center gap-1"
+          >
+            ← Back to portal
+          </Link>
+          <h1 className="text-3xl font-bold font-[Fraunces] mt-2">
+            Support & Help
+          </h1>
+          <p className="text-muted-foreground mt-2 text-lg">
+            We&apos;re here to help. Find answers below or reach out to our team.
+          </p>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-6 py-12 space-y-12">
+        {/* Contact */}
+        <section>
+          <h2 className="text-xl font-semibold mb-6 flex items-center gap-2">
+            <Mail className="h-5 w-5 text-primary" />
+            Contact Us
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-lg border bg-card p-6">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="h-9 w-9 rounded-full bg-primary/10 flex items-center justify-center">
+                  <Mail className="h-4 w-4 text-primary" />
+                </div>
+                <h3 className="font-medium">Email Support</h3>
+              </div>
+              <p className="text-sm text-muted-foreground mb-4">
+                For account help, shift questions, and general enquiries.
+              </p>
+              <a
+                href="mailto:hello@everybodyeats.nz"
+                className="text-sm font-medium text-primary hover:underline inline-flex items-center gap-1"
+              >
+                hello@everybodyeats.nz
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+
+            <div className="rounded-lg border bg-card p-6">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="h-9 w-9 rounded-full bg-primary/10 flex items-center justify-center">
+                  <Clock className="h-4 w-4 text-primary" />
+                </div>
+                <h3 className="font-medium">Response Times</h3>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                We aim to respond to all support enquiries within 24 hours
+                during business days (Monday–Friday, NZ time).
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Report Harmful Content */}
+        <section>
+          <h2 className="text-xl font-semibold mb-6 flex items-center gap-2">
+            <Shield className="h-5 w-5 text-red-500" />
+            Reporting & Safety
+          </h2>
+          <div className="rounded-lg border bg-card p-6 space-y-4">
+            <p className="text-sm text-muted-foreground">
+              The Everybody Eats Volunteer Portal is a community space. We take
+              reports of harmful, offensive, or inappropriate content seriously.
+            </p>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="rounded-md bg-muted/50 p-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <Flag className="h-4 w-4 text-orange-500" />
+                  <h3 className="text-sm font-medium">Report in the App</h3>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Use the &ldquo;⋯&rdquo; menu on any post or comment, or the Report button
+                  on a user&apos;s profile, to flag harmful content directly from the
+                  mobile app.
+                </p>
+              </div>
+
+              <div className="rounded-md bg-muted/50 p-4">
+                <div className="flex items-center gap-2 mb-2">
+                  <Mail className="h-4 w-4 text-orange-500" />
+                  <h3 className="text-sm font-medium">Report by Email</h3>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  If you can&apos;t report through the app, email us at{" "}
+                  <a
+                    href="mailto:hello@everybodyeats.nz"
+                    className="text-primary hover:underline"
+                  >
+                    hello@everybodyeats.nz
+                  </a>{" "}
+                  with details of the issue.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3 rounded-md border border-orange-200 bg-orange-50 dark:bg-orange-950/20 dark:border-orange-800 p-4">
+              <AlertTriangle className="h-4 w-4 text-orange-600 shrink-0 mt-0.5" />
+              <p className="text-xs text-orange-800 dark:text-orange-200">
+                <strong>24-hour commitment:</strong> We review all content
+                reports and take action within 24 hours in accordance with Apple
+                App Store Guideline 1.2.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section>
+          <h2 className="text-xl font-semibold mb-6 flex items-center gap-2">
+            <HelpCircle className="h-5 w-5 text-primary" />
+            Common Questions
+          </h2>
+          <div className="space-y-4">
+            {[
+              {
+                q: "How do I sign up for a shift?",
+                a: "Log in to the volunteer portal, go to Shifts, and select the date and shift type you'd like. Click Sign Up and you'll be added to the roster.",
+              },
+              {
+                q: "I can't log in to my account.",
+                a: "Try resetting your password via the Forgot Password link on the sign-in page. If you still can't access your account, email us and we'll help you recover it.",
+              },
+              {
+                q: "How do I cancel a shift I signed up for?",
+                a: "Open the shift in the portal or mobile app and select Cancel Sign-Up. Please cancel as early as possible so we can find a replacement volunteer.",
+              },
+              {
+                q: "How do I block another user?",
+                a: "On the mobile app, visit the user's profile and scroll to the bottom. Tap Block User. Blocked users cannot see your activity and you won't see theirs.",
+              },
+              {
+                q: "I received a notification I didn't expect.",
+                a: "Shift shortage notifications are sent when a shift is under-staffed. You can manage notification preferences in your Profile settings.",
+              },
+              {
+                q: "How do I delete my account?",
+                a: "Email hello@everybodyeats.nz with a request to delete your account. We'll process your request within 5 business days.",
+              },
+            ].map(({ q, a }) => (
+              <details
+                key={q}
+                className="group rounded-lg border bg-card px-5 py-4 cursor-pointer"
+              >
+                <summary className="flex items-center justify-between gap-4 text-sm font-medium list-none">
+                  {q}
+                  <span className="text-muted-foreground group-open:rotate-180 transition-transform shrink-0">
+                    ▾
+                  </span>
+                </summary>
+                <p className="mt-3 text-sm text-muted-foreground">{a}</p>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        {/* Feedback */}
+        <section className="rounded-lg border bg-card p-6">
+          <div className="flex items-start gap-4">
+            <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+              <MessageCircle className="h-5 w-5 text-primary" />
+            </div>
+            <div>
+              <h2 className="font-semibold mb-1">Give Us Feedback</h2>
+              <p className="text-sm text-muted-foreground mb-3">
+                Have a suggestion or noticed a bug? We&apos;d love to hear from you.
+                Your feedback helps us improve the portal for all volunteers.
+              </p>
+              <a
+                href="mailto:hello@everybodyeats.nz?subject=Volunteer Portal Feedback"
+                className="text-sm font-medium text-primary hover:underline inline-flex items-center gap-1"
+              >
+                Send feedback
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <p className="text-xs text-muted-foreground text-center pb-6">
+          Everybody Eats · Auckland, New Zealand ·{" "}
+          <a
+            href="https://everybodyeats.nz"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:underline"
+          >
+            everybodyeats.nz
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/admin-sidebar.tsx
+++ b/web/src/components/admin-sidebar.tsx
@@ -36,6 +36,7 @@ interface AdminSidebarProps {
   } | null;
   displayName: string;
   pendingParentalConsentCount: number;
+  pendingReportCount?: number;
   hiddenNavItems?: string[];
 }
 
@@ -44,6 +45,7 @@ export function AdminSidebar({
   userProfile,
   displayName,
   pendingParentalConsentCount,
+  pendingReportCount = 0,
   hiddenNavItems = [],
 }: AdminSidebarProps) {
   const pathname = usePathname();
@@ -139,6 +141,15 @@ export function AdminSidebar({
                             data-testid="parental-consent-badge"
                           >
                             {pendingParentalConsentCount}
+                          </SidebarMenuBadge>
+                        )}
+                      {item.href === "/admin/moderation" &&
+                        pendingReportCount > 0 && (
+                          <SidebarMenuBadge
+                            className="bg-red-500 text-white"
+                            data-testid="moderation-badge"
+                          >
+                            {pendingReportCount}
                           </SidebarMenuBadge>
                         )}
                     </SidebarMenuItem>

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -21,6 +21,7 @@ import {
   MessageSquare,
   Megaphone,
   UtensilsCrossed,
+  Shield,
 } from "lucide-react";
 
 export interface AdminNavItem {
@@ -213,6 +214,18 @@ export const adminNavCategories: AdminNavCategory[] = [
     ],
   },
   {
+    label: "Safety",
+    items: [
+      {
+        title: "Content Moderation",
+        href: "/admin/moderation",
+        icon: Shield,
+        description: "Review reports and user blocks",
+        commandKey: "moderation",
+      },
+    ],
+  },
+  {
     label: "User Migration",
     items: [
       {
@@ -301,6 +314,9 @@ export const getIconColor = (
     "Site Settings": "text-slate-600",
     "Chat Guides": "text-emerald-500",
     "Announcements": "text-orange-500",
+
+    // Safety
+    "Content Moderation": "text-red-600",
 
     // User Migration
     "Bulk Migration": "text-blue-600",

--- a/web/src/lib/content-filter.test.ts
+++ b/web/src/lib/content-filter.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { filterContent } from "./content-filter";
+
+describe("filterContent", () => {
+  it("returns null for clean text", () => {
+    expect(filterContent("Great shift tonight, ka pai everyone!")).toBeNull();
+    expect(filterContent("Looking forward to volunteering on Friday.")).toBeNull();
+    expect(filterContent("")).toBeNull();
+  });
+
+  it("rejects text containing profanity", () => {
+    expect(filterContent("what the fuck")).not.toBeNull();
+    expect(filterContent("you piece of shit")).not.toBeNull();
+    expect(filterContent("asshole")).not.toBeNull();
+  });
+
+  it("returns the user-facing error message string", () => {
+    const result = filterContent("fucking hell");
+    expect(typeof result).toBe("string");
+    expect(result).toContain("not allowed");
+  });
+
+  it("catches mixed-case variations", () => {
+    expect(filterContent("FUCK this")).not.toBeNull();
+    expect(filterContent("Shit")).not.toBeNull();
+  });
+
+  it("does not flag common words that contain filter substrings", () => {
+    // e.g. "classic", "cocktail", "assignment", "scrap" should be fine
+    expect(filterContent("classic cocktail evening")).toBeNull();
+    expect(filterContent("assignment completed")).toBeNull();
+  });
+});

--- a/web/src/lib/content-filter.ts
+++ b/web/src/lib/content-filter.ts
@@ -1,46 +1,20 @@
+import { Filter } from "bad-words";
+
 /**
- * Basic content filter for user-generated content.
+ * Content filter for user-generated content.
  * Satisfies Apple App Store Guideline 1.2 requirement for a filtering mechanism.
  *
- * This checks for a list of commonly objectionable terms. It is not exhaustive —
- * human review of ContentReport records is the primary moderation layer.
+ * Uses the `bad-words` library which handles leet-speak, mixed-case, and
+ * unicode variations that a hand-rolled regex list would miss.
+ * Human review of ContentReport records remains the primary moderation layer.
  */
-
-const BLOCKED_PATTERNS: RegExp[] = [
-  /\bf+u+c+k+\b/gi,
-  /\bs+h+i+t+\b/gi,
-  /\bc+u+n+t+\b/gi,
-  /\bn+i+g+g+e+r+\b/gi,
-  /\bn+i+g+g+a+\b/gi,
-  /\bf+a+g+g+o+t+\b/gi,
-  /\bc+h+i+n+k+\b/gi,
-  /\bk+i+k+e+\b/gi,
-  /\bs+p+i+c+\b/gi,
-  /\bc+o+o+n+\b/gi,
-  /\bw+h+o+r+e+\b/gi,
-  /\bs+l+u+t+\b/gi,
-  /\ba+s+s+h+o+l+e+\b/gi,
-  /\bb+i+t+c+h+\b/gi,
-  /\bd+i+c+k+\b/gi,
-  /\bc+o+c+k+\b/gi,
-  /\bp+u+s+s+y+\b/gi,
-  /\bt+w+a+t+\b/gi,
-  /\bc+r+a+c+k+e+r+\b/gi,
-  /\bm+o+t+h+e+r+f+u+c+k+e+r+\b/gi,
-];
-
-/**
- * Returns true if the text contains blocked content.
- */
-export function containsBlockedContent(text: string): boolean {
-  return BLOCKED_PATTERNS.some((pattern) => pattern.test(text));
-}
+const filter = new Filter();
 
 /**
  * Returns an error message if the text is rejected, or null if it passes.
  */
 export function filterContent(text: string): string | null {
-  if (containsBlockedContent(text)) {
+  if (filter.isProfane(text)) {
     return "Your message contains language that is not allowed. Please keep the conversation respectful.";
   }
   return null;

--- a/web/src/lib/content-filter.ts
+++ b/web/src/lib/content-filter.ts
@@ -1,0 +1,47 @@
+/**
+ * Basic content filter for user-generated content.
+ * Satisfies Apple App Store Guideline 1.2 requirement for a filtering mechanism.
+ *
+ * This checks for a list of commonly objectionable terms. It is not exhaustive —
+ * human review of ContentReport records is the primary moderation layer.
+ */
+
+const BLOCKED_PATTERNS: RegExp[] = [
+  /\bf+u+c+k+\b/gi,
+  /\bs+h+i+t+\b/gi,
+  /\bc+u+n+t+\b/gi,
+  /\bn+i+g+g+e+r+\b/gi,
+  /\bn+i+g+g+a+\b/gi,
+  /\bf+a+g+g+o+t+\b/gi,
+  /\bc+h+i+n+k+\b/gi,
+  /\bk+i+k+e+\b/gi,
+  /\bs+p+i+c+\b/gi,
+  /\bc+o+o+n+\b/gi,
+  /\bw+h+o+r+e+\b/gi,
+  /\bs+l+u+t+\b/gi,
+  /\ba+s+s+h+o+l+e+\b/gi,
+  /\bb+i+t+c+h+\b/gi,
+  /\bd+i+c+k+\b/gi,
+  /\bc+o+c+k+\b/gi,
+  /\bp+u+s+s+y+\b/gi,
+  /\bt+w+a+t+\b/gi,
+  /\bc+r+a+c+k+e+r+\b/gi,
+  /\bm+o+t+h+e+r+f+u+c+k+e+r+\b/gi,
+];
+
+/**
+ * Returns true if the text contains blocked content.
+ */
+export function containsBlockedContent(text: string): boolean {
+  return BLOCKED_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Returns an error message if the text is rejected, or null if it passes.
+ */
+export function filterContent(text: string): string | null {
+  if (containsBlockedContent(text)) {
+    return "Your message contains language that is not allowed. Please keep the conversation respectful.";
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Apple App Store rejection response — Guideline 1.2 (UGC Safety) and Guideline 1.5 (Support URL).

### Guideline 1.2 — User-Generated Content Safety

- **EULA modal**: shown to every user before they can access the app (persisted via `expo-secure-store`)
- **Content filter**: regex word-list filter applied on comment submission (returns 422 with user-friendly message)
- **Report mechanism**: "⋯" button on feed cards + "Report User" on friend profiles → Alert with reason selection → `POST /api/mobile/report`
- **Block mechanism**: "Block User" on friend profiles → `POST /api/mobile/users/[id]/block` + `DELETE` to unblock
- **Feed filtering**: blocked users excluded from feed, comments, and friend lists server-side
- **Admin moderation page** at `/admin/moderation` — tabs for Reports and Blocks with status management (Mark Reviewed / Resolve) and pending-count badge in sidebar
- **24-hour review commitment**: shown in EULA, admin page banner, and support page

### Guideline 1.5 — Support URL

- New public `/support` page with FAQ, email contact, reporting guide, and 24-hour review commitment
- Update the App Store support URL to `https://volunteers.everybodyeats.nz/support`

### Schema changes

Two new Prisma models: `ContentReport` and `UserBlock` with migration `20260416000000_add_content_moderation`.

## Test plan

- [ ] Fresh install: EULA modal appears before any content is visible
- [ ] "I Agree" dismisses modal and persists (doesn't reappear on restart)
- [ ] "Not now" shows alert with warning and keeps modal open
- [ ] Tap ⋯ on a feed card → report reasons appear → submission succeeds
- [ ] Block a user from their profile → they disappear from feed
- [ ] Unblock works (re-add endpoint)
- [ ] Type a blocked word in a comment → 422 returned, message shown
- [ ] `/admin/moderation` shows reports and blocks tables
- [ ] Mark Reviewed / Resolve updates status inline
- [ ] Sidebar shows red badge count when there are pending reports
- [ ] `/support` page renders correctly and is publicly accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)