### PR TITLE
feat: Volunteer Recruitment analytics page

### DIFF
--- a/web/prisma/migrations/20260417000000_add_analytics_indexes/migration.sql
+++ b/web/prisma/migrations/20260417000000_add_analytics_indexes/migration.sql
@@ -1,0 +1,9 @@
+-- Analytics performance indexes
+-- User: composite index on (role, createdAt) — recruitment/engagement queries filter on role='VOLUNTEER' and date range
+CREATE INDEX "User_role_createdAt_idx" ON "User"("role", "createdAt");
+
+-- Shift: index on end — analytics filter confirmed shifts where end < now
+CREATE INDEX "Shift_end_idx" ON "Shift"("end");
+
+-- Signup: index on shiftId — reverse join from Shift → Signup used in analytics CTEs
+CREATE INDEX "Signup_shiftId_idx" ON "Signup"("shiftId");

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -132,6 +132,9 @@ model User {
   contentReports ContentReport[] @relation("ContentReporter")
   blocksGiven    UserBlock[]     @relation("BlocksMade")
   blocksReceived UserBlock[]     @relation("BlocksReceived")
+
+  // Analytics queries filter heavily on role + createdAt
+  @@index([role, createdAt])
 }
 
 model Passkey {
@@ -217,6 +220,9 @@ model Shift {
   updatedAt        DateTime       @updatedAt
   shiftType        ShiftType      @relation(fields: [shiftTypeId], references: [id])
   signups          Signup[]
+
+  // Analytics queries filter and sort on shift end date
+  @@index([end])
 }
 
 model Signup {
@@ -252,6 +258,8 @@ model Signup {
   @@unique([userId, shiftId])
   @@index([status, canceledAt])
   @@index([userId, canceledAt])
+  // shiftId-only index for reverse joins (Shift → Signup lookups in analytics)
+  @@index([shiftId])
 }
 
 model Achievement {

--- a/web/src/app/admin/analytics/engagement/recruitment-section.tsx
+++ b/web/src/app/admin/analytics/engagement/recruitment-section.tsx
@@ -1,0 +1,582 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { motion } from "motion/react";
+import { staggerContainer, staggerItem } from "@/lib/motion";
+import {
+  UserPlus,
+  Clock,
+  TrendingUp,
+  Users,
+  Info,
+  UserX,
+  CalendarCheck,
+} from "lucide-react";
+import dynamic from "next/dynamic";
+import { useTheme } from "next-themes";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { RecruitmentData } from "@/lib/recruitment";
+
+const Chart = dynamic(() => import("react-apexcharts"), { ssr: false });
+
+const MONTHS_LABELS: Record<string, string> = {
+  "1": "1 month",
+  "3": "3 months",
+  "6": "6 months",
+  "12": "12 months",
+};
+
+function pct(num: number, total: number) {
+  if (total === 0) return 0;
+  return Math.round((num / total) * 100);
+}
+
+interface InfoDialogProps {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+function InfoDialog({ title, description, children }: InfoDialogProps) {
+  return (
+    <Dialog>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <button className="text-muted-foreground hover:text-foreground transition-colors">
+              <Info className="h-3.5 w-3.5" />
+            </button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top">More info</TooltipContent>
+      </Tooltip>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 text-sm">{children}</div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface Props {
+  data: RecruitmentData;
+  months: string;
+  location: string;
+}
+
+export function RecruitmentSection({ data, months, location }: Props) {
+  const { resolvedTheme } = useTheme();
+  const chartMode = (resolvedTheme === "dark" ? "dark" : "light") as
+    | "dark"
+    | "light";
+
+  const { funnel, registrationTrend } = data;
+  const total = funnel.totalRegistrations;
+  const periodLabel = MONTHS_LABELS[months] ?? `${months} months`;
+
+  // Funnel stages — strictly decreasing from total → first shift
+  const profileComplete = total - funnel.incompleteProfiles;
+  const signedUp = funnel.signedUpNoShift + funnel.completedShift;
+  const funnelStages = [
+    {
+      name: "Registered",
+      value: total,
+      color: "#3b82f6",
+      desc: "Created an account",
+    },
+    {
+      name: "Profile Complete",
+      value: profileComplete,
+      color: "#8b5cf6",
+      desc: "Finished profile setup",
+    },
+    {
+      name: "Signed Up for a Shift",
+      value: signedUp,
+      color: "#f59e0b",
+      desc: "At least one shift signup",
+    },
+    {
+      name: "Completed First Shift",
+      value: funnel.completedShift,
+      color: "#10b981",
+      desc: "First confirmed shift done",
+    },
+  ];
+
+  const hasDistribution = funnel.completedShift > 0;
+
+  const statCards = [
+    {
+      label: "New Registrations",
+      value: String(total),
+      sub: `Last ${periodLabel}`,
+      icon: UserPlus,
+      bg: "bg-blue-50 dark:bg-blue-950/20",
+      iconBg: "bg-blue-100 dark:bg-blue-900/30",
+      iconColor: "text-blue-600 dark:text-blue-400",
+      tooltip: "Total new volunteer accounts created during the selected period",
+    },
+    {
+      label: "Profile Incomplete",
+      value: String(funnel.incompleteProfiles),
+      sub:
+        total > 0
+          ? `${pct(funnel.incompleteProfiles, total)}% of registrations`
+          : "no registrations yet",
+      icon: UserX,
+      bg: "bg-orange-50 dark:bg-orange-950/20",
+      iconBg: "bg-orange-100 dark:bg-orange-900/30",
+      iconColor: "text-orange-600 dark:text-orange-400",
+      tooltip:
+        "Registered in this period but never completed their profile setup",
+    },
+    {
+      label: "No Shift Signup",
+      value: String(funnel.completedProfileNoSignup),
+      sub:
+        total > 0
+          ? `${pct(funnel.completedProfileNoSignup, total)}% completed profile, no shifts`
+          : "no registrations yet",
+      icon: CalendarCheck,
+      bg: "bg-amber-50 dark:bg-amber-950/20",
+      iconBg: "bg-amber-100 dark:bg-amber-900/30",
+      iconColor: "text-amber-600 dark:text-amber-400",
+      tooltip:
+        "Completed their profile but haven't signed up for any shifts yet",
+    },
+    {
+      label: "Avg. Days to First Shift",
+      value:
+        funnel.avgDaysToFirstShift != null
+          ? String(funnel.avgDaysToFirstShift)
+          : "—",
+      sub:
+        funnel.avgDaysToFirstShift != null
+          ? "registration → first completed shift"
+          : "no completed first shifts yet",
+      icon: Clock,
+      bg: "bg-emerald-50 dark:bg-emerald-950/20",
+      iconBg: "bg-emerald-100 dark:bg-emerald-900/30",
+      iconColor: "text-emerald-600 dark:text-emerald-400",
+      tooltip:
+        "Average number of days between a volunteer registering and completing their very first shift, among those registered in this period",
+    },
+  ];
+
+  return (
+    <motion.div
+      variants={staggerContainer}
+      initial="hidden"
+      animate="visible"
+      className="space-y-6"
+    >
+      {/* Stat cards */}
+      <motion.div
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+      >
+        {statCards.map((card) => {
+          const Icon = card.icon;
+          return (
+            <motion.div key={card.label} variants={staggerItem}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Card className={`${card.bg} border-0 cursor-help`}>
+                    <CardContent className="flex items-center gap-4 py-5">
+                      <div
+                        className={`p-2.5 rounded-full shrink-0 ${card.iconBg}`}
+                      >
+                        <Icon className={`h-5 w-5 ${card.iconColor}`} />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                          {card.label}
+                        </p>
+                        <p className="text-2xl font-bold tracking-tight tabular-nums">
+                          {card.value}
+                        </p>
+                        <p className="text-xs text-muted-foreground truncate">
+                          {card.sub}
+                        </p>
+                      </div>
+                    </CardContent>
+                  </Card>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-56">
+                  {card.tooltip}
+                </TooltipContent>
+              </Tooltip>
+            </motion.div>
+          );
+        })}
+      </motion.div>
+
+      {/* Charts row */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Registrations over time */}
+        <motion.div variants={staggerItem}>
+          <Card className="h-full">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base font-semibold flex items-center gap-2">
+                <TrendingUp className="h-4 w-4 text-blue-500" />
+                New Registrations
+                <InfoDialog
+                  title="New Registrations Over Time"
+                  description="Monthly volunteer sign-ups over the past 12 months"
+                >
+                  <p>
+                    Shows how many new volunteer accounts were created each
+                    month over the past 12 months.
+                  </p>
+                  {location && location !== "all" && (
+                    <p>
+                      Filtered to volunteers who selected{" "}
+                      <strong>{location}</strong> as a preferred location.
+                    </p>
+                  )}
+                  <p className="text-muted-foreground">
+                    The chart always shows 12 months for context — the time
+                    period filter above affects the stat cards only.
+                  </p>
+                </InfoDialog>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {registrationTrend.some((t) => t.count > 0) ? (
+                <Chart
+                  options={{
+                    chart: {
+                      type: "bar" as const,
+                      toolbar: { show: false },
+                      background: "transparent",
+                    },
+                    plotOptions: {
+                      bar: {
+                        borderRadius: 4,
+                        borderRadiusApplication: "end" as const,
+                        columnWidth: "65%",
+                      },
+                    },
+                    xaxis: {
+                      categories: registrationTrend.map((t) => t.month),
+                      labels: {
+                        style: {
+                          fontFamily:
+                            "var(--font-libre-franklin), sans-serif",
+                          fontSize: "11px",
+                        },
+                        rotate: -45,
+                        rotateAlways: false,
+                        hideOverlappingLabels: true,
+                      },
+                      axisBorder: { show: false },
+                      axisTicks: { show: false },
+                    },
+                    yaxis: {
+                      min: 0,
+                      labels: {
+                        style: {
+                          fontFamily:
+                            "var(--font-libre-franklin), sans-serif",
+                          fontSize: "11px",
+                        },
+                        formatter: (v: number) => String(Math.round(v)),
+                      },
+                    },
+                    colors: ["#3b82f6"],
+                    dataLabels: { enabled: false },
+                    grid: {
+                      borderColor: "#e5e7eb",
+                      strokeDashArray: 4,
+                      xaxis: { lines: { show: false } },
+                    },
+                    tooltip: {
+                      y: {
+                        formatter: (val: number) =>
+                          `${val} volunteer${val !== 1 ? "s" : ""}`,
+                      },
+                    },
+                    theme: { mode: chartMode },
+                  }}
+                  series={[
+                    {
+                      name: "New Registrations",
+                      data: registrationTrend.map((t) => t.count),
+                    },
+                  ]}
+                  type="bar"
+                  height={320}
+                />
+              ) : (
+                <div className="flex items-center justify-center h-[320px] text-muted-foreground text-sm">
+                  No registration data available
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </motion.div>
+
+        {/* Onboarding funnel */}
+        <motion.div variants={staggerItem}>
+          <Card className="h-full">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base font-semibold flex items-center gap-2">
+                <Users className="h-4 w-4 text-violet-500" />
+                Onboarding Funnel
+                <InfoDialog
+                  title="Onboarding Funnel"
+                  description="How new volunteers progress through onboarding"
+                >
+                  <p>
+                    Shows how many volunteers registered in the selected period
+                    progressed through each stage of their onboarding journey.
+                  </p>
+                  <div className="space-y-2 pt-1">
+                    {funnelStages.map((s) => (
+                      <div key={s.name} className="flex gap-2">
+                        <span
+                          className="inline-block w-2 h-2 rounded-full mt-1.5 shrink-0"
+                          style={{ background: s.color }}
+                        />
+                        <p>
+                          <span className="font-medium">{s.name}</span> —{" "}
+                          {s.desc}.
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                  <p className="text-muted-foreground pt-1">
+                    Drop-off numbers show how many people stopped at each
+                    stage, helping identify where to focus your onboarding
+                    efforts.
+                  </p>
+                </InfoDialog>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {total > 0 ? (
+                <div className="space-y-4 py-2">
+                  {funnelStages.map((stage, i) => {
+                    const stagePct = pct(stage.value, total);
+                    const nextStage = funnelStages[i + 1];
+                    const dropOff =
+                      nextStage != null
+                        ? stage.value - nextStage.value
+                        : null;
+                    const dropOffPct =
+                      dropOff != null && stage.value > 0
+                        ? pct(dropOff, stage.value)
+                        : null;
+
+                    return (
+                      <div key={stage.name} className="space-y-1.5">
+                        <div className="flex items-center justify-between text-sm gap-2">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <span
+                              className="inline-block w-2 h-2 rounded-full shrink-0"
+                              style={{ background: stage.color }}
+                            />
+                            <span className="font-medium truncate">
+                              {stage.name}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-3 shrink-0">
+                            <span className="text-muted-foreground tabular-nums text-xs">
+                              {stage.value.toLocaleString()}
+                            </span>
+                            <span
+                              className="font-semibold tabular-nums w-9 text-right text-sm"
+                              style={{ color: stage.color }}
+                            >
+                              {stagePct}%
+                            </span>
+                          </div>
+                        </div>
+                        <div className="h-5 bg-muted/30 rounded overflow-hidden">
+                          <motion.div
+                            className="h-full rounded"
+                            style={{ background: stage.color }}
+                            initial={{ width: 0 }}
+                            animate={{ width: `${stagePct}%` }}
+                            transition={{
+                              duration: 0.6,
+                              delay: 0.1 + i * 0.12,
+                              ease: [0.4, 0, 0.2, 1],
+                            }}
+                          />
+                        </div>
+                        {dropOff != null && dropOff > 0 && (
+                          <p className="text-xs text-muted-foreground pl-4">
+                            ↓ {dropOff.toLocaleString()} dropped off
+                            {dropOffPct != null ? ` (${dropOffPct}%)` : ""}
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="flex items-center justify-center h-[280px] text-muted-foreground text-sm">
+                  No registrations in this period
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </motion.div>
+      </div>
+
+      {/* Time-to-first-shift distribution */}
+      {hasDistribution && (
+        <motion.div variants={staggerItem}>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base font-semibold flex items-center gap-2">
+                <Clock className="h-4 w-4 text-emerald-500" />
+                Time to First Shift Distribution
+                <InfoDialog
+                  title="Time to First Shift"
+                  description="How quickly new volunteers complete their first shift"
+                >
+                  <p>
+                    Among volunteers registered in the selected period who have
+                    completed at least one confirmed shift, this shows how many
+                    days elapsed between their registration date and their first
+                    completed shift.
+                  </p>
+                  <p>
+                    A large proportion in the first bar (≤ 7 days) suggests
+                    strong onboarding momentum. A spread toward 90+ days may
+                    indicate friction in the signup or scheduling process.
+                  </p>
+                </InfoDialog>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Chart
+                options={{
+                  chart: {
+                    type: "bar" as const,
+                    toolbar: { show: false },
+                    background: "transparent",
+                  },
+                  plotOptions: {
+                    bar: {
+                      horizontal: true,
+                      borderRadius: 4,
+                      borderRadiusApplication: "end" as const,
+                      barHeight: "55%",
+                      distributed: true,
+                    },
+                  },
+                  xaxis: {
+                    categories: [
+                      "Same day",
+                      "1–3 days",
+                      "4–7 days",
+                      "8–14 days",
+                      "15–30 days",
+                      "31–60 days",
+                      "61–90 days",
+                      "> 90 days",
+                    ],
+                    labels: {
+                      style: {
+                        fontFamily: "var(--font-libre-franklin), sans-serif",
+                        fontSize: "12px",
+                      },
+                    },
+                    axisBorder: { show: false },
+                    axisTicks: { show: false },
+                    title: {
+                      text: "Volunteers",
+                      style: {
+                        fontFamily: "var(--font-libre-franklin), sans-serif",
+                        fontSize: "11px",
+                        fontWeight: 400,
+                      },
+                    },
+                  },
+                  yaxis: {
+                    labels: {
+                      style: {
+                        fontFamily: "var(--font-libre-franklin), sans-serif",
+                        fontSize: "12px",
+                      },
+                    },
+                  },
+                  colors: [
+                    "#10b981", // same day
+                    "#34d399", // 1–3 days
+                    "#3b82f6", // 4–7 days
+                    "#60a5fa", // 8–14 days
+                    "#f59e0b", // 15–30 days
+                    "#fb923c", // 31–60 days
+                    "#ef4444", // 61–90 days
+                    "#dc2626", // >90 days
+                  ],
+                  dataLabels: {
+                    enabled: true,
+                    formatter: (val: number) => (val > 0 ? String(val) : ""),
+                    style: {
+                      fontFamily: "var(--font-libre-franklin), sans-serif",
+                      fontSize: "12px",
+                      fontWeight: 600,
+                    },
+                  },
+                  legend: { show: false },
+                  grid: {
+                    borderColor: "#e5e7eb",
+                    strokeDashArray: 4,
+                    yaxis: { lines: { show: false } },
+                  },
+                  tooltip: {
+                    y: {
+                      formatter: (val: number) =>
+                        `${val} volunteer${val !== 1 ? "s" : ""}`,
+                    },
+                  },
+                  theme: { mode: chartMode },
+                }}
+                series={[
+                  {
+                    name: "Volunteers",
+                    data: [
+                      funnel.sameDay,
+                      funnel.within3Days,
+                      funnel.within7Days,
+                      funnel.within14Days,
+                      funnel.within30Days,
+                      funnel.within60Days,
+                      funnel.within90Days,
+                      funnel.over90Days,
+                    ],
+                  },
+                ]}
+                type="bar"
+                height={300}
+              />
+            </CardContent>
+          </Card>
+        </motion.div>
+      )}
+    </motion.div>
+  );
+}

--- a/web/src/app/admin/analytics/recruitment/page.tsx
+++ b/web/src/app/admin/analytics/recruitment/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { PageContainer } from "@/components/page-container";
+import { RecruitmentAnalyticsClient } from "./recruitment-analytics-client";
+import { LOCATIONS } from "@/lib/locations";
+import { getRecruitmentData } from "@/lib/recruitment";
+
+export default async function RecruitmentAnalyticsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect("/login?callbackUrl=/admin/analytics/recruitment");
+  }
+
+  if (session.user.role !== "ADMIN") {
+    redirect("/dashboard");
+  }
+
+  const params = await searchParams;
+  const months = (params.months as string) || "3";
+  const location = (params.location as string) || "all";
+
+  const data = await getRecruitmentData(parseInt(months, 10), location);
+
+  const locationOptions = LOCATIONS.map((loc) => ({
+    value: loc,
+    label: loc,
+  }));
+
+  return (
+    <AdminPageWrapper
+      title="Volunteer Recruitment"
+      description="New registrations, onboarding conversion, and time-to-first-shift metrics"
+    >
+      <PageContainer testid="recruitment-analytics-page">
+        <RecruitmentAnalyticsClient
+          data={data}
+          months={months}
+          location={location}
+          locations={locationOptions}
+        />
+      </PageContainer>
+    </AdminPageWrapper>
+  );
+}

--- a/web/src/app/admin/analytics/recruitment/recruitment-analytics-client.tsx
+++ b/web/src/app/admin/analytics/recruitment/recruitment-analytics-client.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+import { motion } from "motion/react";
+import { staggerContainer, staggerItem } from "@/lib/motion";
+import { RecruitmentSection } from "../engagement/recruitment-section";
+import type { RecruitmentData } from "@/lib/recruitment";
+
+interface Props {
+  data: RecruitmentData;
+  months: string;
+  location: string;
+  locations: Array<{ value: string; label: string }>;
+}
+
+export function RecruitmentAnalyticsClient({
+  data,
+  months: initialMonths,
+  location: initialLocation,
+  locations,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [months, setMonths] = useState(initialMonths);
+  const [location, setLocation] = useState(initialLocation);
+
+  const handleApplyFilters = () => {
+    const params = new URLSearchParams({ months, location });
+    startTransition(() => {
+      router.push(`/admin/analytics/recruitment?${params}`);
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Filters */}
+      <Card>
+        <CardContent className="py-4">
+          <div className="flex flex-col sm:flex-row items-end gap-4">
+            <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="months">Time Period</Label>
+                <Select value={months} onValueChange={setMonths}>
+                  <SelectTrigger id="months">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="1">Last 1 month</SelectItem>
+                    <SelectItem value="3">Last 3 months</SelectItem>
+                    <SelectItem value="6">Last 6 months</SelectItem>
+                    <SelectItem value="12">Last 12 months</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="location">Location</Label>
+                <Select value={location} onValueChange={setLocation}>
+                  <SelectTrigger id="location">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Locations</SelectItem>
+                    {locations.map((loc) => (
+                      <SelectItem key={loc.value} value={loc.value}>
+                        {loc.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <Button
+              onClick={handleApplyFilters}
+              className="sm:w-auto w-full"
+              disabled={isPending}
+            >
+              {isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              Apply Filters
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Content */}
+      <motion.div
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+        className={`space-y-6 transition-opacity ${isPending ? "opacity-50 pointer-events-none" : ""}`}
+      >
+        <motion.div variants={staggerItem}>
+          <RecruitmentSection
+            data={data}
+            months={initialMonths}
+            location={initialLocation}
+          />
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+}

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -22,6 +22,7 @@ import {
   Megaphone,
   UtensilsCrossed,
   Shield,
+  UserPlus,
 } from "lucide-react";
 
 export interface AdminNavItem {
@@ -51,19 +52,31 @@ export const adminNavCategories: AdminNavCategory[] = [
         description: "Overview and statistics",
         commandKey: "dashboard",
       },
+    ],
+  },
+  {
+    label: "Analytics",
+    items: [
       {
         title: "Restaurant Analytics",
         href: "/admin/analytics",
         icon: BarChart3,
-        description: "Restaurant analytics and metrics",
+        description: "Meals served and year-over-year comparisons",
         commandKey: "analytics",
       },
       {
         title: "Volunteer Engagement",
         href: "/admin/analytics/engagement",
         icon: Activity,
-        description: "Volunteer activity and retention metrics",
+        description: "Activity levels, retention, and cohort analysis",
         commandKey: "engagement",
+      },
+      {
+        title: "Volunteer Recruitment",
+        href: "/admin/analytics/recruitment",
+        icon: UserPlus,
+        description: "New registrations, onboarding funnel, and conversion",
+        commandKey: "recruitment",
       },
     ],
   },
@@ -141,7 +154,7 @@ export const adminNavCategories: AdminNavCategory[] = [
     ],
   },
   {
-    label: "Restaraunt Management",
+    label: "Restaurant Management",
     items: [
       {
         title: "Daily Menus",
@@ -289,6 +302,7 @@ export const getIconColor = (
     Dashboard: "text-blue-600",
     "Restaurant Analytics": "text-purple-600",
     "Volunteer Engagement": "text-emerald-600",
+    "Volunteer Recruitment": "text-violet-600",
 
     // Volunteer Management
     "All Users": "text-purple-600",

--- a/web/src/lib/recruitment.ts
+++ b/web/src/lib/recruitment.ts
@@ -1,0 +1,215 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/client";
+import { nowInNZT, toNZT } from "@/lib/timezone";
+
+export interface RecruitmentFunnel {
+  totalRegistrations: number;
+  /** Registered but profileCompleted = false */
+  incompleteProfiles: number;
+  /** profileCompleted = true, zero signups ever */
+  completedProfileNoSignup: number;
+  /** Has at least one signup record, but zero confirmed shifts */
+  signedUpNoShift: number;
+  /** Has at least one confirmed completed shift */
+  completedShift: number;
+  /** Average days from registration to first completed shift (null if no data) */
+  avgDaysToFirstShift: number | null;
+  sameDay: number;     // 0 days
+  within3Days: number; // 1–3 days
+  within7Days: number; // 4–7 days
+  within14Days: number; // 8–14 days
+  within30Days: number; // 15–30 days
+  within60Days: number; // 31–60 days
+  within90Days: number; // 61–90 days
+  over90Days: number;   // 91+ days
+}
+
+export interface RecruitmentData {
+  funnel: RecruitmentFunnel;
+  /** 12-month rolling monthly registration counts (filled with 0 for empty months) */
+  registrationTrend: Array<{ month: string; count: number }>;
+}
+
+export async function getRecruitmentData(
+  months: number,
+  location: string | null
+): Promise<RecruitmentData> {
+  // All date boundaries are anchored to NZ time so that monthly groupings
+  // and period filters reflect NZ calendar dates, not UTC. Vercel runs in UTC,
+  // so without this a registration at 11 pm NZT would shift to the next UTC day.
+  const nzNow = nowInNZT();
+  const now = new Date(nzNow.getTime());
+
+  const nzPeriodStart = nowInNZT();
+  nzPeriodStart.setMonth(nzPeriodStart.getMonth() - months);
+  const periodStart = new Date(nzPeriodStart.getTime());
+
+  // Always show 12 months in the trend chart regardless of the period filter
+  const nzTrendStart = nowInNZT();
+  nzTrendStart.setMonth(nzTrendStart.getMonth() - 12);
+  const trendStart = new Date(nzTrendStart.getTime());
+
+  const isLocationFiltered = !!location && location !== "all";
+  // Filter by preferred location stored as a JSON string array in availableLocations
+  const locationCond = isLocationFiltered
+    ? Prisma.sql`AND u."availableLocations" LIKE ${`%"${location}"%`}`
+    : Prisma.empty;
+
+  const [funnelResult, trendResult] = await Promise.all([
+    // ── Funnel query (scoped to the selected period) ──────────────────────────
+    prisma.$queryRaw<
+      Array<{
+        totalRegistrations: bigint;
+        incompleteProfiles: bigint;
+        completedProfileNoSignup: bigint;
+        signedUpNoShift: bigint;
+        completedShift: bigint;
+        avgDaysToFirstShift: number | null;
+        sameDay: bigint;
+        within3Days: bigint;
+        within7Days: bigint;
+        within14Days: bigint;
+        within30Days: bigint;
+        within60Days: bigint;
+        within90Days: bigint;
+        over90Days: bigint;
+      }>
+    >`
+      WITH user_base AS (
+        SELECT u.id, u."profileCompleted", u."createdAt"
+        FROM "User" u
+        WHERE u.role = 'VOLUNTEER'::"Role"
+          AND u."createdAt" >= ${periodStart}
+          AND u."createdAt" < ${now}
+          ${locationCond}
+      ),
+      user_stats AS (
+        SELECT
+          ub.id,
+          ub."profileCompleted",
+          ub."createdAt",
+          COUNT(sg.id)                                                                  AS total_signups,
+          COUNT(sg.id) FILTER (
+            WHERE sg.status = 'CONFIRMED'::"SignupStatus" AND sh."end" < ${now}
+          )                                                                             AS confirmed_shifts,
+          MIN(sh."end") FILTER (
+            WHERE sg.status = 'CONFIRMED'::"SignupStatus" AND sh."end" < ${now}
+          )                                                                             AS first_shift_date
+        FROM user_base ub
+        LEFT JOIN "Signup" sg ON sg."userId" = ub.id
+        LEFT JOIN "Shift"  sh ON sh.id = sg."shiftId"
+        GROUP BY ub.id, ub."profileCompleted", ub."createdAt"
+      )
+      SELECT
+        COUNT(*)::bigint                                                               AS "totalRegistrations",
+        COUNT(*) FILTER (WHERE NOT "profileCompleted")::bigint                        AS "incompleteProfiles",
+        COUNT(*) FILTER (WHERE "profileCompleted" AND total_signups = 0)::bigint      AS "completedProfileNoSignup",
+        COUNT(*) FILTER (WHERE total_signups > 0 AND confirmed_shifts = 0)::bigint    AS "signedUpNoShift",
+        COUNT(*) FILTER (WHERE confirmed_shifts > 0)::bigint                          AS "completedShift",
+        AVG(
+          EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0
+        ) FILTER (WHERE first_shift_date IS NOT NULL)::float                          AS "avgDaysToFirstShift",
+        COUNT(*) FILTER (
+          WHERE first_shift_date IS NOT NULL
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 < 1
+        )::bigint                                                                      AS "sameDay",
+        COUNT(*) FILTER (
+          WHERE first_shift_date IS NOT NULL
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 >= 1
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 <= 3
+        )::bigint                                                                      AS "within3Days",
+        COUNT(*) FILTER (
+          WHERE first_shift_date IS NOT NULL
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 > 3
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 <= 7
+        )::bigint                                                                      AS "within7Days",
+        COUNT(*) FILTER (
+          WHERE first_shift_date IS NOT NULL
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 > 7
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 <= 14
+        )::bigint                                                                      AS "within14Days",
+        COUNT(*) FILTER (
+          WHERE first_shift_date IS NOT NULL
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 > 14
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 <= 30
+        )::bigint                                                                      AS "within30Days",
+        COUNT(*) FILTER (
+          WHERE first_shift_date IS NOT NULL
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 > 30
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 <= 60
+        )::bigint                                                                      AS "within60Days",
+        COUNT(*) FILTER (
+          WHERE first_shift_date IS NOT NULL
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 > 60
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 <= 90
+        )::bigint                                                                      AS "within90Days",
+        COUNT(*) FILTER (
+          WHERE first_shift_date IS NOT NULL
+            AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 > 90
+        )::bigint                                                                      AS "over90Days"
+      FROM user_stats
+    `,
+
+    // ── 12-month trend (always full year for chart context) ───────────────────
+    // Convert createdAt from UTC to NZ time before truncating to month so that
+    // registrations are grouped into the NZ calendar month they actually occurred in.
+    prisma.$queryRaw<Array<{ month: string; count: bigint }>>`
+      SELECT
+        to_char(
+          date_trunc('month', (u."createdAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Pacific/Auckland'),
+          'YYYY-MM'
+        )                AS month,
+        COUNT(*)::bigint AS count
+      FROM "User" u
+      WHERE u.role = 'VOLUNTEER'::"Role"
+        AND u."createdAt" >= ${trendStart}
+        AND u."createdAt" < ${now}
+        ${locationCond}
+      GROUP BY date_trunc('month', (u."createdAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Pacific/Auckland')
+      ORDER BY month
+    `,
+  ]);
+
+  const f = funnelResult[0];
+  const trendMap = new Map(trendResult.map((r) => [r.month, Number(r.count)]));
+
+  // Iterate NZ months so that keys match the NZ-grouped SQL output.
+  // toNZT() returns a TZDate whose getMonth()/setMonth() operate in NZ timezone.
+  const registrationTrend: Array<{ month: string; count: number }> = [];
+  const nzCursor = toNZT(trendStart);
+  nzCursor.setDate(1);
+  while (nzCursor.getTime() < now.getTime()) {
+    const key = `${nzCursor.getFullYear()}-${String(nzCursor.getMonth() + 1).padStart(2, "0")}`;
+    registrationTrend.push({
+      month: nzCursor.toLocaleDateString("en-NZ", {
+        month: "short",
+        year: "2-digit",
+      }),
+      count: trendMap.get(key) ?? 0,
+    });
+    nzCursor.setMonth(nzCursor.getMonth() + 1);
+  }
+
+  const rawAvg = f?.avgDaysToFirstShift;
+
+  return {
+    funnel: {
+      totalRegistrations:        Number(f?.totalRegistrations        ?? 0),
+      incompleteProfiles:        Number(f?.incompleteProfiles        ?? 0),
+      completedProfileNoSignup:  Number(f?.completedProfileNoSignup  ?? 0),
+      signedUpNoShift:           Number(f?.signedUpNoShift           ?? 0),
+      completedShift:            Number(f?.completedShift            ?? 0),
+      avgDaysToFirstShift:
+        rawAvg != null ? Math.round(Number(rawAvg) * 10) / 10 : null,
+      sameDay:       Number(f?.sameDay      ?? 0),
+      within3Days:   Number(f?.within3Days  ?? 0),
+      within7Days:   Number(f?.within7Days  ?? 0),
+      within14Days:  Number(f?.within14Days ?? 0),
+      within30Days:  Number(f?.within30Days ?? 0),
+      within60Days:  Number(f?.within60Days ?? 0),
+      within90Days:  Number(f?.within90Days ?? 0),
+      over90Days:    Number(f?.over90Days   ?? 0),
+    },
+    registrationTrend,
+  };
+}


### PR DESCRIPTION
## Summary

- New standalone admin page at `/admin/analytics/recruitment` tracking how well new registrations convert into active volunteers
- Admin sidebar nav restructured: "Overview" and "Analytics" are now separate groups, with all three analytics pages (Restaurant, Engagement, Recruitment) clearly grouped together
- Fixed longstanding "Restaraunt Management" typo in the nav

## What's in the Recruitment page

**Stat cards (filtered by location + time period)**
- New Registrations — total accounts created in the period
- Profile Incomplete — registered but never finished profile setup
- No Shift Signup — completed profile but never signed up for a shift
- Avg. Days to First Shift — mean time from registration to first confirmed shift

**New Registrations Over Time** — 12-month bar chart (always shows full year for trend context regardless of period filter)

**Onboarding Funnel** — animated horizontal bars showing drop-off at each stage: Registered → Profile Complete → Signed Up for Shift → Completed First Shift, with explicit drop-off counts between stages

**Time to First Shift Distribution** — 8-bucket horizontal bar chart colour-coded green→red (fast→slow): Same day / 1–3 / 4–7 / 8–14 / 15–30 / 31–60 / 61–90 / 90+ days

## Timezone handling

All date boundaries and SQL month groupings use NZ timezone (`nowInNZT` / `toNZT` from `@/lib/timezone`, `AT TIME ZONE 'Pacific/Auckland'` in raw SQL) so results are correct on Vercel (UTC).

## Test plan
- [ ] Visit `/admin/analytics/recruitment` — page renders with stat cards, trend chart, funnel, and distribution chart
- [ ] Apply location filter — all stat cards and registration trend update
- [ ] Apply time period filter — stat cards update; trend chart stays at 12 months
- [ ] Verify sidebar shows "Analytics" group with all three pages listed
- [ ] Verify "Restaurant Management" label is no longer misspelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)