### PR TITLE
feat: Milestone Analytics admin page

### DIFF
--- a/web/src/app/admin/analytics/milestones/milestone-analytics-client.tsx
+++ b/web/src/app/admin/analytics/milestones/milestone-analytics-client.tsx
@@ -1,0 +1,764 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useTheme } from "next-themes";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { motion } from "motion/react";
+import { staggerContainer, staggerItem } from "@/lib/motion";
+import {
+  Trophy,
+  TrendingUp,
+  Users,
+  Loader2,
+  Info,
+  ExternalLink,
+} from "lucide-react";
+import dynamic from "next/dynamic";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import Link from "next/link";
+import type { MilestoneData } from "@/lib/milestone-analytics";
+
+const Chart = dynamic(() => import("react-apexcharts"), { ssr: false });
+
+interface Props {
+  data: MilestoneData;
+  months: string;
+  location: string;
+  locations: Array<{ value: string; label: string }>;
+}
+
+const MONTHS_LABELS: Record<string, string> = {
+  "1": "1 month",
+  "3": "3 months",
+  "6": "6 months",
+  "12": "12 months",
+  "24": "24 months",
+};
+
+// Milestone colour palette — one per threshold
+const MILESTONE_COLORS: Record<number, string> = {
+  10: "#6366f1",
+  25: "#8b5cf6",
+  50: "#ec4899",
+  100: "#f59e0b",
+  200: "#10b981",
+  500: "#3b82f6",
+};
+
+function MilestoneCard({
+  threshold,
+  hitInPeriod,
+  allTimeTotal,
+  periodLabel,
+}: {
+  threshold: number;
+  hitInPeriod: number;
+  allTimeTotal: number;
+  periodLabel: string;
+}) {
+  const color = MILESTONE_COLORS[threshold] ?? "#6b7280";
+  return (
+    <Card className="border-0 overflow-hidden">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between mb-3">
+          <div
+            className="rounded-lg p-2"
+            style={{ backgroundColor: color + "20" }}
+          >
+            <Trophy className="h-4 w-4" style={{ color }} />
+          </div>
+          <span
+            className="text-xs font-semibold rounded-full px-2 py-0.5"
+            style={{ backgroundColor: color + "20", color }}
+          >
+            {threshold} shifts
+          </span>
+        </div>
+        <p className="text-3xl font-bold tracking-tight">{hitInPeriod}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          hit in last {periodLabel}
+        </p>
+        <div className="mt-3 pt-3 border-t flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">All-time total</span>
+          <span className="text-sm font-semibold">{allTimeTotal}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function MilestoneAnalyticsClient({
+  data,
+  months: initialMonths,
+  location: initialLocation,
+  locations,
+}: Props) {
+  const router = useRouter();
+  const { resolvedTheme } = useTheme();
+  const [isPending, startTransition] = useTransition();
+  const [months, setMonths] = useState(initialMonths);
+  const [location, setLocation] = useState(initialLocation);
+  const [selectedMilestone, setSelectedMilestone] = useState<number>(100);
+  const chartThemeMode = (
+    resolvedTheme === "dark" ? "dark" : "light"
+  ) as "dark" | "light";
+
+  const handleApplyFilters = () => {
+    const params = new URLSearchParams({ months, location });
+    startTransition(() => {
+      router.push(`/admin/analytics/milestones?${params}`);
+    });
+  };
+
+  const periodLabel = MONTHS_LABELS[initialMonths] ?? `${initialMonths} months`;
+
+  // Projection for selected milestone
+  const selectedProjection = data.projections.find(
+    (p) => p.threshold === selectedMilestone
+  );
+
+  // Distribution chart data (sorted by minShifts)
+  const distCategories = data.distribution.map((b) => b.label);
+  const distCounts = data.distribution.map((b) => b.count);
+
+  // Milestone hits chart
+  const hitsCategories = data.milestoneHits.map((m) => `${m.threshold}`);
+  const hitsInPeriod = data.milestoneHits.map((m) => m.hitInPeriod);
+  const hitsAllTime = data.milestoneHits.map((m) => m.allTimeTotal);
+
+  // Projection chart
+  const projCategories = data.projections.map((p) => `${p.threshold} shifts`);
+  const projAlready = data.projections.map((p) => p.alreadyHit);
+  const projAdditional = data.projections.map((p) => p.projectedAdditional);
+
+  return (
+    <div className="space-y-6">
+      {/* Filters */}
+      <Card>
+        <CardContent className="py-4">
+          <div className="flex flex-col sm:flex-row items-end gap-4">
+            <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="months">Time Period</Label>
+                <Select value={months} onValueChange={setMonths}>
+                  <SelectTrigger id="months">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="1">Last 1 month</SelectItem>
+                    <SelectItem value="3">Last 3 months</SelectItem>
+                    <SelectItem value="6">Last 6 months</SelectItem>
+                    <SelectItem value="12">Last 12 months</SelectItem>
+                    <SelectItem value="24">Last 24 months</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="location">Location</Label>
+                <Select value={location} onValueChange={setLocation}>
+                  <SelectTrigger id="location">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Locations</SelectItem>
+                    {locations.map((loc) => (
+                      <SelectItem key={loc.value} value={loc.value}>
+                        {loc.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <Button
+              onClick={handleApplyFilters}
+              className="sm:w-auto w-full"
+              disabled={isPending}
+            >
+              {isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              Apply Filters
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Content */}
+      <motion.div
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+        className={`space-y-6 transition-opacity ${isPending ? "opacity-50 pointer-events-none" : ""}`}
+      >
+        {/* Milestone Summary Cards */}
+        <motion.div
+          className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3"
+          variants={staggerContainer}
+          initial="hidden"
+          animate="visible"
+        >
+          {data.milestoneHits.map((m) => (
+            <motion.div key={m.threshold} variants={staggerItem}>
+              <MilestoneCard
+                threshold={m.threshold}
+                hitInPeriod={m.hitInPeriod}
+                allTimeTotal={m.allTimeTotal}
+                periodLabel={periodLabel}
+              />
+            </motion.div>
+          ))}
+        </motion.div>
+
+        {/* Charts Row: Hits in period + Distribution */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Milestone Hits in Period */}
+          <motion.div variants={staggerItem}>
+            <Card className="h-full">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base font-semibold flex items-center gap-2">
+                  <Trophy className="h-4 w-4 text-amber-500" />
+                  Milestones Hit
+                  <Dialog>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <DialogTrigger asChild>
+                          <button className="text-muted-foreground hover:text-foreground transition-colors">
+                            <Info className="h-3.5 w-3.5" />
+                          </button>
+                        </DialogTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">More info</TooltipContent>
+                    </Tooltip>
+                    <DialogContent>
+                      <DialogHeader>
+                        <DialogTitle>Milestones Hit</DialogTitle>
+                        <DialogDescription>
+                          How milestone crossings are counted
+                        </DialogDescription>
+                      </DialogHeader>
+                      <div className="space-y-3 text-sm">
+                        <p>
+                          A volunteer &ldquo;hits&rdquo; a milestone when their
+                          Nth completed shift (e.g. their 100th) falls within
+                          the selected time period. Each volunteer is counted at
+                          most once per milestone — this tracks the moment they
+                          crossed the threshold for the first time.
+                        </p>
+                        <p>
+                          The darker bars show all-time totals (everyone who has
+                          ever reached that milestone). The bright bars show how
+                          many crossed it during the selected period.
+                        </p>
+                      </div>
+                    </DialogContent>
+                  </Dialog>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {hitsAllTime.some((v) => v > 0) ? (
+                  <Chart
+                    options={{
+                      chart: {
+                        type: "bar" as const,
+                        toolbar: { show: false },
+                        background: "transparent",
+                      },
+                      plotOptions: {
+                        bar: {
+                          borderRadius: 4,
+                          columnWidth: "55%",
+                          borderRadiusApplication: "end" as const,
+                        },
+                      },
+                      xaxis: {
+                        categories: hitsCategories.map((c) => `${c} shifts`),
+                        labels: {
+                          style: {
+                            fontFamily:
+                              "var(--font-libre-franklin), sans-serif",
+                            fontSize: "11px",
+                          },
+                        },
+                        axisBorder: { show: false },
+                        axisTicks: { show: false },
+                      },
+                      yaxis: {
+                        labels: {
+                          style: {
+                            fontFamily:
+                              "var(--font-libre-franklin), sans-serif",
+                            fontSize: "11px",
+                          },
+                        },
+                      },
+                      colors: ["#f59e0b", "#f59e0b33"],
+                      dataLabels: {
+                        enabled: true,
+                        formatter: (val: number) =>
+                          val > 0 ? String(val) : "",
+                        style: {
+                          fontSize: "11px",
+                          fontFamily:
+                            "var(--font-libre-franklin), sans-serif",
+                          fontWeight: 600,
+                        },
+                      },
+                      grid: {
+                        borderColor: "#e5e7eb",
+                        strokeDashArray: 4,
+                        xaxis: { lines: { show: false } },
+                      },
+                      tooltip: {
+                        shared: true,
+                        intersect: false,
+                        y: {
+                          formatter: (val: number) =>
+                            `${val} volunteer${val !== 1 ? "s" : ""}`,
+                        },
+                      },
+                      legend: {
+                        position: "top" as const,
+                        fontSize: "12px",
+                        fontFamily:
+                          "var(--font-libre-franklin), sans-serif",
+                        markers: { size: 6, offsetX: -2 },
+                      },
+                      theme: { mode: chartThemeMode },
+                    }}
+                    series={[
+                      { name: `Hit in last ${periodLabel}`, data: hitsInPeriod },
+                      { name: "All-time total", data: hitsAllTime },
+                    ]}
+                    type="bar"
+                    height={300}
+                  />
+                ) : (
+                  <div className="flex items-center justify-center h-[300px] text-muted-foreground text-sm">
+                    No milestone data available
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </motion.div>
+
+          {/* Volunteer Distribution */}
+          <motion.div variants={staggerItem}>
+            <Card className="h-full">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base font-semibold flex items-center gap-2">
+                  <Users className="h-4 w-4 text-blue-500" />
+                  Volunteer Distribution
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button className="text-muted-foreground hover:text-foreground transition-colors">
+                        <Info className="h-3.5 w-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="top"
+                      className="w-auto max-w-56"
+                    >
+                      How many volunteers currently sit in each shift-count
+                      band (all-time completed shifts)
+                    </TooltipContent>
+                  </Tooltip>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {distCounts.some((v) => v > 0) ? (
+                  <Chart
+                    options={{
+                      chart: {
+                        type: "bar" as const,
+                        toolbar: { show: false },
+                        background: "transparent",
+                      },
+                      plotOptions: {
+                        bar: {
+                          horizontal: true,
+                          borderRadius: 4,
+                          borderRadiusApplication: "end" as const,
+                          barHeight: "60%",
+                        },
+                      },
+                      xaxis: {
+                        categories: distCategories,
+                        title: {
+                          text: "Volunteers",
+                          style: {
+                            fontFamily:
+                              "var(--font-libre-franklin), sans-serif",
+                            fontSize: "11px",
+                            fontWeight: 400,
+                          },
+                        },
+                        labels: {
+                          style: {
+                            fontFamily:
+                              "var(--font-libre-franklin), sans-serif",
+                            fontSize: "11px",
+                          },
+                        },
+                        axisBorder: { show: false },
+                        axisTicks: { show: false },
+                      },
+                      yaxis: {
+                        labels: {
+                          style: {
+                            fontFamily:
+                              "var(--font-libre-franklin), sans-serif",
+                            fontSize: "12px",
+                          },
+                        },
+                      },
+                      colors: ["#3b82f6"],
+                      dataLabels: {
+                        enabled: true,
+                        formatter: (val: number) =>
+                          val > 0 ? String(val) : "",
+                        style: {
+                          fontSize: "11px",
+                          fontFamily:
+                            "var(--font-libre-franklin), sans-serif",
+                          fontWeight: 600,
+                        },
+                      },
+                      grid: {
+                        borderColor: "#e5e7eb",
+                        strokeDashArray: 4,
+                        yaxis: { lines: { show: false } },
+                      },
+                      tooltip: {
+                        y: {
+                          formatter: (val: number) =>
+                            `${val} volunteer${val !== 1 ? "s" : ""}`,
+                        },
+                      },
+                      legend: { show: false },
+                      theme: { mode: chartThemeMode },
+                    }}
+                    series={[{ name: "Volunteers", data: distCounts }]}
+                    type="bar"
+                    height={300}
+                  />
+                ) : (
+                  <div className="flex items-center justify-center h-[300px] text-muted-foreground text-sm">
+                    No distribution data available
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </motion.div>
+        </div>
+
+        {/* 12-Month Projections */}
+        <motion.div variants={staggerItem}>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base font-semibold flex items-center gap-2">
+                <TrendingUp className="h-4 w-4 text-emerald-500" />
+                12-Month Milestone Projections
+                <Dialog>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DialogTrigger asChild>
+                        <button className="text-muted-foreground hover:text-foreground transition-colors">
+                          <Info className="h-3.5 w-3.5" />
+                        </button>
+                      </DialogTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">More info</TooltipContent>
+                  </Tooltip>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>12-Month Milestone Projections</DialogTitle>
+                      <DialogDescription>
+                        How projections are calculated
+                      </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-3 text-sm">
+                      <p>
+                        For each volunteer who hasn&rsquo;t yet hit a milestone,
+                        we calculate their average shift rate over the last 6
+                        months. If their projected rate means they&rsquo;ll
+                        reach the threshold within 12 months, they&rsquo;re
+                        counted in the &ldquo;Projected&rdquo; total.
+                      </p>
+                      <p>
+                        Volunteers with no shifts in the past 6 months are not
+                        projected — they&rsquo;re considered inactive. Use the
+                        approaching volunteers list below to view everyone close
+                        to a milestone regardless of recent activity.
+                      </p>
+                      <p>
+                        These projections are useful for planning recognition
+                        budgets — for example, estimating how many volunteers
+                        will hit 100 shifts in the next year.
+                      </p>
+                    </div>
+                  </DialogContent>
+                </Dialog>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {projAlready.some((v) => v > 0) ||
+              projAdditional.some((v) => v > 0) ? (
+                <Chart
+                  options={{
+                    chart: {
+                      type: "bar" as const,
+                      stacked: true,
+                      toolbar: { show: false },
+                      background: "transparent",
+                    },
+                    plotOptions: {
+                      bar: {
+                        horizontal: false,
+                        borderRadius: 4,
+                        borderRadiusApplication: "end" as const,
+                        columnWidth: "50%",
+                      },
+                    },
+                    xaxis: {
+                      categories: projCategories,
+                      labels: {
+                        style: {
+                          fontFamily:
+                            "var(--font-libre-franklin), sans-serif",
+                          fontSize: "11px",
+                        },
+                      },
+                      axisBorder: { show: false },
+                      axisTicks: { show: false },
+                    },
+                    yaxis: {
+                      title: {
+                        text: "Volunteers",
+                        style: {
+                          fontFamily:
+                            "var(--font-libre-franklin), sans-serif",
+                          fontSize: "11px",
+                          fontWeight: 400,
+                        },
+                      },
+                      labels: {
+                        style: {
+                          fontFamily:
+                            "var(--font-libre-franklin), sans-serif",
+                          fontSize: "11px",
+                        },
+                      },
+                    },
+                    colors: ["#10b981", "#6366f1"],
+                    dataLabels: {
+                      enabled: true,
+                      formatter: (val: number) =>
+                        val > 0 ? String(val) : "",
+                      style: {
+                        fontSize: "11px",
+                        fontFamily:
+                          "var(--font-libre-franklin), sans-serif",
+                        fontWeight: 600,
+                      },
+                    },
+                    grid: {
+                      borderColor: "#e5e7eb",
+                      strokeDashArray: 4,
+                      xaxis: { lines: { show: false } },
+                    },
+                    tooltip: {
+                      shared: true,
+                      intersect: false,
+                      y: {
+                        formatter: (val: number) =>
+                          `${val} volunteer${val !== 1 ? "s" : ""}`,
+                      },
+                    },
+                    legend: {
+                      position: "top" as const,
+                      fontSize: "12px",
+                      fontFamily: "var(--font-libre-franklin), sans-serif",
+                      markers: { size: 6, offsetX: -2 },
+                    },
+                    theme: { mode: chartThemeMode },
+                  }}
+                  series={[
+                    { name: "Already achieved", data: projAlready },
+                    {
+                      name: "Projected in next 12 months",
+                      data: projAdditional,
+                    },
+                  ]}
+                  type="bar"
+                  height={300}
+                />
+              ) : (
+                <div className="flex items-center justify-center h-[300px] text-muted-foreground text-sm">
+                  No projection data available
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </motion.div>
+
+        {/* Approaching Volunteers */}
+        <motion.div variants={staggerItem}>
+          <Card>
+            <CardHeader className="pb-4">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                <CardTitle className="text-base font-semibold flex items-center gap-2">
+                  <Trophy className="h-4 w-4 text-muted-foreground" />
+                  Approaching Volunteers
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button className="text-muted-foreground hover:text-foreground transition-colors">
+                        <Info className="h-3.5 w-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="w-auto max-w-64">
+                      Volunteers within 20% of the selected milestone
+                      threshold. Projected months is based on their average
+                      shift rate over the last 6 months.
+                    </TooltipContent>
+                  </Tooltip>
+                </CardTitle>
+                <div className="flex items-center gap-2">
+                  <Label
+                    htmlFor="milestone-select"
+                    className="text-sm shrink-0"
+                  >
+                    Milestone:
+                  </Label>
+                  <Select
+                    value={String(selectedMilestone)}
+                    onValueChange={(v) => setSelectedMilestone(Number(v))}
+                  >
+                    <SelectTrigger
+                      id="milestone-select"
+                      className="w-36"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {data.projections.map((p) => (
+                        <SelectItem key={p.threshold} value={String(p.threshold)}>
+                          {p.threshold} shifts
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {selectedProjection && selectedProjection.approaching.length > 0 ? (
+                <div className="space-y-3">
+                  <div className="flex items-center gap-4 text-xs text-muted-foreground pb-1">
+                    <span className="flex-1">Volunteer</span>
+                    <span className="w-24 text-right">Shifts</span>
+                    <span className="w-24 text-right">Still needed</span>
+                    <span className="w-28 text-right">Rate / month</span>
+                    <span className="w-28 text-right">Est. arrival</span>
+                    <span className="w-8" />
+                  </div>
+                  {selectedProjection.approaching.map((v) => {
+                    const color =
+                      MILESTONE_COLORS[selectedMilestone] ?? "#6b7280";
+                    const pctDone =
+                      (v.totalShifts / selectedMilestone) * 100;
+                    return (
+                      <div
+                        key={v.userId}
+                        className="flex items-center gap-4 py-2 border-b last:border-0"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium truncate">
+                            {v.name}
+                          </p>
+                          <div className="mt-1 h-1.5 rounded-full bg-muted overflow-hidden">
+                            <div
+                              className="h-full rounded-full transition-all"
+                              style={{
+                                width: `${pctDone}%`,
+                                backgroundColor: color,
+                              }}
+                            />
+                          </div>
+                        </div>
+                        <span className="w-24 text-right text-sm tabular-nums font-medium">
+                          {v.totalShifts}
+                        </span>
+                        <span className="w-24 text-right text-sm tabular-nums text-muted-foreground">
+                          {v.shiftsNeeded}
+                        </span>
+                        <span className="w-28 text-right text-sm tabular-nums text-muted-foreground">
+                          {v.monthlyRate > 0
+                            ? `${v.monthlyRate}/mo`
+                            : "—"}
+                        </span>
+                        <span className="w-28 text-right text-sm">
+                          {v.projectedMonths != null ? (
+                            <Badge
+                              variant={
+                                v.projectedMonths <= 3
+                                  ? "default"
+                                  : v.projectedMonths <= 6
+                                    ? "secondary"
+                                    : "outline"
+                              }
+                              className="text-xs"
+                            >
+                              ~{v.projectedMonths} mo
+                            </Badge>
+                          ) : (
+                            <span className="text-muted-foreground text-xs">
+                              inactive
+                            </span>
+                          )}
+                        </span>
+                        <Link
+                          href={`/admin/users/${v.userId}`}
+                          className="w-8 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </Link>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="flex items-center justify-center h-24 text-muted-foreground text-sm">
+                  {selectedProjection
+                    ? `No volunteers are currently approaching the ${selectedMilestone}-shift milestone`
+                    : "Select a milestone to view approaching volunteers"}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+}

--- a/web/src/app/admin/analytics/milestones/page.tsx
+++ b/web/src/app/admin/analytics/milestones/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { PageContainer } from "@/components/page-container";
+import { MilestoneAnalyticsClient } from "./milestone-analytics-client";
+import { LOCATIONS } from "@/lib/locations";
+import { getMilestoneData } from "@/lib/milestone-analytics";
+
+export default async function MilestoneAnalyticsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect("/login?callbackUrl=/admin/analytics/milestones");
+  }
+
+  if (session.user.role !== "ADMIN") {
+    redirect("/dashboard");
+  }
+
+  const params = await searchParams;
+  const months = (params.months as string) || "12";
+  const location = (params.location as string) || "all";
+
+  const data = await getMilestoneData(parseInt(months, 10), location);
+
+  const locationOptions = LOCATIONS.map((loc) => ({
+    value: loc,
+    label: loc,
+  }));
+
+  return (
+    <AdminPageWrapper
+      title="Milestone Analytics"
+      description="Track when volunteers hit key shift milestones and project future recognition opportunities"
+    >
+      <PageContainer testid="milestone-analytics-page">
+        <MilestoneAnalyticsClient
+          data={data}
+          months={months}
+          location={location}
+          locations={locationOptions}
+        />
+      </PageContainer>
+    </AdminPageWrapper>
+  );
+}

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -23,6 +23,7 @@ import {
   UtensilsCrossed,
   Shield,
   UserPlus,
+  Award,
 } from "lucide-react";
 
 export interface AdminNavItem {
@@ -77,6 +78,13 @@ export const adminNavCategories: AdminNavCategory[] = [
         icon: UserPlus,
         description: "New registrations, onboarding funnel, and conversion",
         commandKey: "recruitment",
+      },
+      {
+        title: "Milestone Analytics",
+        href: "/admin/analytics/milestones",
+        icon: Award,
+        description: "Shift milestones, volunteer recognition, and 12-month projections",
+        commandKey: "milestones",
       },
     ],
   },
@@ -303,6 +311,7 @@ export const getIconColor = (
     "Restaurant Analytics": "text-purple-600",
     "Volunteer Engagement": "text-emerald-600",
     "Volunteer Recruitment": "text-violet-600",
+    "Milestone Analytics": "text-amber-600",
 
     // Volunteer Management
     "All Users": "text-purple-600",

--- a/web/src/lib/milestone-analytics.ts
+++ b/web/src/lib/milestone-analytics.ts
@@ -1,0 +1,288 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/client";
+import { nowInNZT } from "@/lib/timezone";
+
+export const MILESTONE_THRESHOLDS = [10, 25, 50, 100, 200, 500] as const;
+export type MilestoneThreshold = (typeof MILESTONE_THRESHOLDS)[number];
+
+export interface MilestoneHit {
+  threshold: number;
+  hitInPeriod: number;
+  allTimeTotal: number;
+}
+
+export interface DistributionBucket {
+  label: string;
+  minShifts: number;
+  maxShifts: number | null;
+  count: number;
+}
+
+export interface ApproachingVolunteer {
+  userId: string;
+  name: string;
+  totalShifts: number;
+  shiftsNeeded: number;
+  monthlyRate: number;
+  projectedMonths: number | null;
+}
+
+export interface MilestoneProjection {
+  threshold: number;
+  alreadyHit: number;
+  projectedAdditional: number;
+  approaching: ApproachingVolunteer[];
+}
+
+export interface MilestoneData {
+  milestoneHits: MilestoneHit[];
+  distribution: DistributionBucket[];
+  projections: MilestoneProjection[];
+}
+
+export async function getMilestoneData(
+  months: number,
+  location: string | null
+): Promise<MilestoneData> {
+  const nzNow = nowInNZT();
+  const now = new Date(nzNow.getTime());
+
+  const nzPeriodStart = nowInNZT();
+  nzPeriodStart.setMonth(nzPeriodStart.getMonth() - months);
+  const periodStart = new Date(nzPeriodStart.getTime());
+
+  const nzSixMonthsAgo = nowInNZT();
+  nzSixMonthsAgo.setMonth(nzSixMonthsAgo.getMonth() - 6);
+  const sixMonthsAgo = new Date(nzSixMonthsAgo.getTime());
+
+  const isLocationFiltered = !!location && location !== "all";
+  const locationCond = isLocationFiltered
+    ? Prisma.sql`AND u."availableLocations" LIKE ${`%"${location}"%`}`
+    : Prisma.empty;
+
+  const [hitsInPeriodResult, totalsResult, volunteerStatsResult] =
+    await Promise.all([
+      // How many volunteers crossed each milestone threshold in the selected period
+      prisma.$queryRaw<Array<{ milestone: bigint; count: bigint }>>`
+        WITH ranked AS (
+          SELECT
+            sg."userId",
+            sh."end" AS shift_end,
+            ROW_NUMBER() OVER (PARTITION BY sg."userId" ORDER BY sh."end") AS rn
+          FROM "Signup" sg
+          JOIN "Shift"  sh ON sh.id = sg."shiftId"
+          JOIN "User"   u  ON u.id  = sg."userId"
+          WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+            AND sh."end" < ${now}
+            AND u.role   = 'VOLUNTEER'::"Role"
+            ${locationCond}
+        )
+        SELECT
+          rn::bigint AS milestone,
+          COUNT(*)::bigint AS count
+        FROM ranked
+        WHERE shift_end >= ${periodStart}
+          AND shift_end <  ${now}
+          AND rn IN (10, 25, 50, 100, 200, 500)
+        GROUP BY rn
+        ORDER BY rn
+      `,
+
+      // All-time totals per milestone + current distribution buckets
+      prisma.$queryRaw<
+        Array<{
+          ten: bigint;
+          twentyfive: bigint;
+          fifty: bigint;
+          hundred: bigint;
+          twohundred: bigint;
+          fivehundred: bigint;
+          d_1_9: bigint;
+          d_10_24: bigint;
+          d_25_49: bigint;
+          d_50_99: bigint;
+          d_100_199: bigint;
+          d_200_499: bigint;
+          d_500_plus: bigint;
+        }>
+      >`
+        WITH user_totals AS (
+          SELECT sg."userId", COUNT(*) AS n
+          FROM "Signup" sg
+          JOIN "Shift" sh ON sh.id = sg."shiftId"
+          JOIN "User"  u  ON u.id  = sg."userId"
+          WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+            AND sh."end" < ${now}
+            AND u.role   = 'VOLUNTEER'::"Role"
+            ${locationCond}
+          GROUP BY sg."userId"
+        )
+        SELECT
+          COUNT(*) FILTER (WHERE n >= 10)::bigint   AS ten,
+          COUNT(*) FILTER (WHERE n >= 25)::bigint   AS twentyfive,
+          COUNT(*) FILTER (WHERE n >= 50)::bigint   AS fifty,
+          COUNT(*) FILTER (WHERE n >= 100)::bigint  AS hundred,
+          COUNT(*) FILTER (WHERE n >= 200)::bigint  AS twohundred,
+          COUNT(*) FILTER (WHERE n >= 500)::bigint  AS fivehundred,
+          COUNT(*) FILTER (WHERE n BETWEEN 1   AND 9)   ::bigint AS d_1_9,
+          COUNT(*) FILTER (WHERE n BETWEEN 10  AND 24)  ::bigint AS d_10_24,
+          COUNT(*) FILTER (WHERE n BETWEEN 25  AND 49)  ::bigint AS d_25_49,
+          COUNT(*) FILTER (WHERE n BETWEEN 50  AND 99)  ::bigint AS d_50_99,
+          COUNT(*) FILTER (WHERE n BETWEEN 100 AND 199) ::bigint AS d_100_199,
+          COUNT(*) FILTER (WHERE n BETWEEN 200 AND 499) ::bigint AS d_200_499,
+          COUNT(*) FILTER (WHERE n >= 500)              ::bigint AS d_500_plus
+        FROM user_totals
+      `,
+
+      // Per-volunteer stats for projections and approaching lists
+      prisma.$queryRaw<
+        Array<{
+          userId: string;
+          name: string | null;
+          total_shifts: bigint;
+          recent_shifts: bigint;
+        }>
+      >`
+        SELECT
+          sg."userId",
+          u.name,
+          COUNT(*)::bigint AS total_shifts,
+          COUNT(*) FILTER (WHERE sh."end" >= ${sixMonthsAgo})::bigint AS recent_shifts
+        FROM "Signup" sg
+        JOIN "Shift" sh ON sh.id = sg."shiftId"
+        JOIN "User"  u  ON u.id  = sg."userId"
+        WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+          AND sh."end" < ${now}
+          AND u.role   = 'VOLUNTEER'::"Role"
+          ${locationCond}
+        GROUP BY sg."userId", u.name
+        HAVING COUNT(*) > 0
+        ORDER BY COUNT(*) DESC
+      `,
+    ]);
+
+  // ── Milestone hits in period ───────────────────────────────────────────────
+  const hitsMap = new Map(
+    hitsInPeriodResult.map((r) => [Number(r.milestone), Number(r.count)])
+  );
+
+  const t = totalsResult[0];
+  const allTimeTotals: Record<number, number> = {
+    10: Number(t?.ten ?? 0),
+    25: Number(t?.twentyfive ?? 0),
+    50: Number(t?.fifty ?? 0),
+    100: Number(t?.hundred ?? 0),
+    200: Number(t?.twohundred ?? 0),
+    500: Number(t?.fivehundred ?? 0),
+  };
+
+  const milestoneHits: MilestoneHit[] = MILESTONE_THRESHOLDS.map(
+    (threshold) => ({
+      threshold,
+      hitInPeriod: hitsMap.get(threshold) ?? 0,
+      allTimeTotal: allTimeTotals[threshold] ?? 0,
+    })
+  );
+
+  // ── Distribution buckets ──────────────────────────────────────────────────
+  const distribution: DistributionBucket[] = [
+    {
+      label: "1–9",
+      minShifts: 1,
+      maxShifts: 9,
+      count: Number(t?.d_1_9 ?? 0),
+    },
+    {
+      label: "10–24",
+      minShifts: 10,
+      maxShifts: 24,
+      count: Number(t?.d_10_24 ?? 0),
+    },
+    {
+      label: "25–49",
+      minShifts: 25,
+      maxShifts: 49,
+      count: Number(t?.d_25_49 ?? 0),
+    },
+    {
+      label: "50–99",
+      minShifts: 50,
+      maxShifts: 99,
+      count: Number(t?.d_50_99 ?? 0),
+    },
+    {
+      label: "100–199",
+      minShifts: 100,
+      maxShifts: 199,
+      count: Number(t?.d_100_199 ?? 0),
+    },
+    {
+      label: "200–499",
+      minShifts: 200,
+      maxShifts: 499,
+      count: Number(t?.d_200_499 ?? 0),
+    },
+    {
+      label: "500+",
+      minShifts: 500,
+      maxShifts: null,
+      count: Number(t?.d_500_plus ?? 0),
+    },
+  ];
+
+  // ── Projections ───────────────────────────────────────────────────────────
+  const PROJECTION_MONTHS = 12;
+  const volunteers = volunteerStatsResult.map((v) => ({
+    userId: v.userId,
+    name: v.name ?? "Unknown",
+    totalShifts: Number(v.total_shifts),
+    recentShifts: Number(v.recent_shifts),
+    // Average shifts per month over the last 6 months
+    monthlyRate: Number(v.recent_shifts) / 6,
+  }));
+
+  const projections: MilestoneProjection[] = MILESTONE_THRESHOLDS.map(
+    (threshold) => {
+      const alreadyHit = allTimeTotals[threshold] ?? 0;
+
+      // Volunteers who haven't yet hit this milestone
+      const notYetHit = volunteers.filter(
+        (v) => v.totalShifts < threshold
+      );
+
+      // Among those, project who will hit it in the next 12 months
+      // Only project for volunteers with a positive recent rate
+      const projectedAdditional = notYetHit.filter((v) => {
+        if (v.monthlyRate <= 0) return false;
+        const shiftsNeeded = threshold - v.totalShifts;
+        const monthsNeeded = shiftsNeeded / v.monthlyRate;
+        return monthsNeeded <= PROJECTION_MONTHS;
+      }).length;
+
+      // Approaching: within 20% of the milestone (below it)
+      const approachingMinShifts = Math.floor(threshold * 0.8);
+      const approaching: ApproachingVolunteer[] = notYetHit
+        .filter((v) => v.totalShifts >= approachingMinShifts)
+        .map((v) => {
+          const shiftsNeeded = threshold - v.totalShifts;
+          const projectedMonths =
+            v.monthlyRate > 0
+              ? Math.ceil(shiftsNeeded / v.monthlyRate)
+              : null;
+          return {
+            userId: v.userId,
+            name: v.name,
+            totalShifts: v.totalShifts,
+            shiftsNeeded,
+            monthlyRate: Math.round(v.monthlyRate * 10) / 10,
+            projectedMonths,
+          };
+        })
+        .sort((a, b) => a.shiftsNeeded - b.shiftsNeeded);
+
+      return { threshold, alreadyHit, projectedAdditional, approaching };
+    }
+  );
+
+  return { milestoneHits, distribution, projections };
+}


### PR DESCRIPTION
## Summary

- Adds a new **Milestone Analytics** page at `/admin/analytics/milestones` to track volunteer recognition milestones and project future recognition opportunities
- New nav item in the Analytics section of the admin sidebar

## What's included

**Milestone summary cards** — one per threshold (10, 25, 50, 100, 200, 500 shifts), showing how many volunteers crossed it in the selected period and the all-time total

**Milestone hits chart** — bar chart comparing crossings in the selected period vs all-time totals for each threshold

**Volunteer distribution chart** — horizontal bar chart showing how the entire volunteer base is distributed across shift-count buckets (1–9, 10–24, 25–49, 50–99, 100–199, 200–499, 500+)

**12-month projections** — stacked bar chart showing already-achieved counts plus projected additional milestone hits within the next 12 months (based on each volunteer's shift rate over the past 6 months)

**Approaching volunteers table** — filterable by milestone; shows volunteers within 20% of a threshold with their current count, shifts needed, monthly rate, and estimated arrival time

## How projections work

For each volunteer below a threshold with at least one shift in the last 6 months, we calculate their average rate (shifts/month over 6 months) and project whether they'll hit the threshold within 12 months. Inactive volunteers (no recent shifts) are excluded from projections but appear in the approaching table.

## Test plan

- [ ] Visit `/admin/analytics/milestones`
- [ ] Verify all summary cards display correct counts
- [ ] Change time period and location filters — data should update
- [ ] Check milestone hits chart reflects the filter period
- [ ] Verify distribution chart matches expected volunteer counts
- [ ] Verify projection chart shows plausible 12-month estimates
- [ ] Select different milestones in the approaching volunteers dropdown
- [ ] Click volunteer profile link (external link icon) — should open `/admin/users/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)