### PR TITLE
feat: accept/decline friend requests on mobile + notification routing

### DIFF
--- a/mobile/app/notifications.tsx
+++ b/mobile/app/notifications.tsx
@@ -1,3 +1,4 @@
+import { useHeaderHeight } from '@react-navigation/elements';
 import { Ionicons } from '@expo/vector-icons';
 import {
   differenceInCalendarDays,
@@ -145,6 +146,7 @@ export default function NotificationsScreen() {
   const colors = Colors[colorScheme];
   const isDark = colorScheme === 'dark';
   const insets = useSafeAreaInsets();
+  const headerHeight = useHeaderHeight();
   const router = useRouter();
 
   const {
@@ -220,6 +222,7 @@ export default function NotificationsScreen() {
       <Stack.Screen
         options={{
           title: 'Notifications',
+          headerTransparent: true,
           headerTitleStyle: {
             fontFamily: FontFamily.heading,
             fontSize: 18,
@@ -296,7 +299,10 @@ export default function NotificationsScreen() {
           stickySectionHeadersEnabled={false}
           contentContainerStyle={[
             styles.listContent,
-            { paddingBottom: insets.bottom + 40 },
+            {
+              paddingTop: headerHeight,
+              paddingBottom: insets.bottom + 40,
+            },
             sections.length === 0 && styles.listContentEmpty,
           ]}
           ListHeaderComponent={

--- a/mobile/app/user/[id].tsx
+++ b/mobile/app/user/[id].tsx
@@ -35,6 +35,9 @@ export default function UserProfileScreen() {
   const { profile, isLoading, error, setProfile } = useUserProfile(id);
   const [isSendingRequest, setIsSendingRequest] = useState(false);
   const [isBlocking, setIsBlocking] = useState(false);
+  const [respondingTo, setRespondingTo] = useState<"accept" | "decline" | null>(
+    null
+  );
 
   const firstName = profile?.firstName ?? profile?.name.split(" ")[0] ?? "them";
 
@@ -72,6 +75,72 @@ export default function UserProfileScreen() {
     } finally {
       setIsSendingRequest(false);
     }
+  };
+
+  const handleAcceptRequest = async () => {
+    if (!profile?.friendRequestId || respondingTo) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    setRespondingTo("accept");
+    try {
+      await api(
+        `/api/mobile/friends/requests/${profile.friendRequestId}/accept`,
+        { method: "POST" }
+      );
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      setProfile((prev) =>
+        prev
+          ? { ...prev, friendshipStatus: "FRIENDS", friendRequestId: null }
+          : prev
+      );
+    } catch {
+      Alert.alert(
+        "Couldn't accept request",
+        "Please try again in a moment."
+      );
+    } finally {
+      setRespondingTo(null);
+    }
+  };
+
+  const handleDeclineRequest = () => {
+    if (!profile?.friendRequestId || respondingTo) return;
+    Alert.alert(
+      "Decline request?",
+      `${firstName} won't be notified — you can still send them a request later if you change your mind.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Decline",
+          style: "destructive",
+          onPress: async () => {
+            if (!profile?.friendRequestId) return;
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            setRespondingTo("decline");
+            try {
+              await api(
+                `/api/mobile/friends/requests/${profile.friendRequestId}/decline`,
+                { method: "POST" }
+              );
+              Haptics.notificationAsync(
+                Haptics.NotificationFeedbackType.Success
+              );
+              setProfile((prev) =>
+                prev
+                  ? { ...prev, friendshipStatus: "NONE", friendRequestId: null }
+                  : prev
+              );
+            } catch {
+              Alert.alert(
+                "Couldn't decline request",
+                "Please try again in a moment."
+              );
+            } finally {
+              setRespondingTo(null);
+            }
+          },
+        },
+      ]
+    );
   };
 
   const handleReport = () => {
@@ -360,7 +429,10 @@ export default function UserProfileScreen() {
             firstName={firstName}
             allowFriendRequests={profile.allowFriendRequests}
             isSending={isSendingRequest}
+            respondingTo={respondingTo}
             onAddFriend={handleAddFriend}
+            onAcceptRequest={handleAcceptRequest}
+            onDeclineRequest={handleDeclineRequest}
             onViewFullProfile={() =>
               router.replace({
                 pathname: "/friend/[id]",
@@ -473,7 +545,10 @@ function FriendshipAction({
   firstName,
   allowFriendRequests,
   isSending,
+  respondingTo,
   onAddFriend,
+  onAcceptRequest,
+  onDeclineRequest,
   onViewFullProfile,
   colors,
   isDark,
@@ -482,7 +557,10 @@ function FriendshipAction({
   firstName: string;
   allowFriendRequests: boolean;
   isSending: boolean;
+  respondingTo: "accept" | "decline" | null;
   onAddFriend: () => void;
+  onAcceptRequest: () => void;
+  onDeclineRequest: () => void;
   onViewFullProfile: () => void;
   colors: (typeof Colors)["light"];
   isDark: boolean;
@@ -541,14 +619,83 @@ function FriendshipAction({
   }
 
   if (status === "REQUEST_RECEIVED") {
+    const isAccepting = respondingTo === "accept";
+    const isDeclining = respondingTo === "decline";
+    const isBusy = respondingTo !== null;
+
     return (
-      <StatusCard
-        eyebrow="INCOMING"
-        title={`${firstName} sent you a request — check your friends tab 💌`}
-        ruleColor={isDark ? "#93c5fd" : "#1d4ed8"}
-        colors={colors}
-        isDark={isDark}
-      />
+      <View style={{ gap: 12 }}>
+        <StatusCard
+          eyebrow="INCOMING"
+          title={`Kia ora — ${firstName} wants to connect 💌`}
+          ruleColor={isDark ? "#93c5fd" : "#1d4ed8"}
+          colors={colors}
+          isDark={isDark}
+        />
+        <Pressable
+          onPress={onAcceptRequest}
+          disabled={isBusy}
+          style={({ pressed }) => [
+            styles.primaryBtn,
+            {
+              backgroundColor: isDark ? Brand.accent : Brand.green,
+              opacity: pressed || isBusy ? 0.9 : 1,
+              transform: [{ scale: pressed ? 0.985 : 1 }],
+            },
+          ]}
+          accessibilityLabel={`Accept friend request from ${firstName}`}
+          accessibilityRole="button"
+        >
+          {isAccepting ? (
+            <ActivityIndicator
+              size="small"
+              color={isDark ? Brand.green : "#fffdf7"}
+            />
+          ) : (
+            <Ionicons
+              name="checkmark-circle-outline"
+              size={18}
+              color={isDark ? Brand.green : "#fffdf7"}
+            />
+          )}
+          <Text
+            style={[
+              styles.primaryBtnText,
+              { color: isDark ? Brand.green : "#fffdf7" },
+            ]}
+          >
+            {isAccepting ? "Accepting…" : "Accept request"}
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={onDeclineRequest}
+          disabled={isBusy}
+          style={({ pressed }) => [
+            styles.declineBtn,
+            {
+              borderColor: colors.border,
+              opacity: pressed || isBusy ? 0.7 : 1,
+            },
+          ]}
+          accessibilityLabel={`Decline friend request from ${firstName}`}
+          accessibilityRole="button"
+        >
+          {isDeclining ? (
+            <ActivityIndicator size="small" color={colors.textSecondary} />
+          ) : (
+            <Ionicons
+              name="close-outline"
+              size={16}
+              color={colors.textSecondary}
+            />
+          )}
+          <Text
+            style={[styles.declineBtnText, { color: colors.textSecondary }]}
+          >
+            {isDeclining ? "Declining…" : "Decline"}
+          </Text>
+        </Pressable>
+      </View>
     );
   }
 
@@ -804,6 +951,20 @@ const styles = StyleSheet.create({
   },
   primaryBtnText: {
     fontSize: 15,
+    fontFamily: FontFamily.semiBold,
+    letterSpacing: 0.2,
+  },
+  declineBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    paddingVertical: 14,
+    borderRadius: 14,
+    borderWidth: 1.25,
+  },
+  declineBtnText: {
+    fontSize: 14,
     fontFamily: FontFamily.semiBold,
     letterSpacing: 0.2,
   },

--- a/mobile/hooks/use-user-profile.ts
+++ b/mobile/hooks/use-user-profile.ts
@@ -18,6 +18,7 @@ export type UserProfile = {
   totalShifts: number;
   hoursVolunteered: number;
   friendshipStatus: UserFriendshipStatus;
+  friendRequestId: string | null;
   allowFriendRequests: boolean;
   isBlocked: boolean;
   hasReported: boolean;

--- a/mobile/lib/notification-routing.ts
+++ b/mobile/lib/notification-routing.ts
@@ -1,4 +1,11 @@
 import { router } from 'expo-router';
+import {
+  openBrowserAsync,
+  WebBrowserPresentationStyle,
+} from 'expo-web-browser';
+
+const WEB_BASE_URL =
+  process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
 
 /**
  * Translate a web-app URL (from a notification's actionUrl) to a mobile
@@ -8,8 +15,18 @@ import { router } from 'expo-router';
 export function navigateToNotificationTarget(actionUrl: unknown) {
   if (typeof actionUrl !== 'string' || !actionUrl.startsWith('/')) return;
 
-  // Strip query string — we don't currently use it on mobile.
-  const pathname = actionUrl.split('?')[0];
+  const [pathname, queryString = ''] = actionUrl.split('?');
+  const query = new URLSearchParams(queryString);
+
+  // /surveys/:token -> open the web survey page in an in-app browser.
+  // Surveys aren't implemented natively on mobile, so we hand off to the
+  // web experience rather than no-op.
+  if (pathname.startsWith('/surveys/')) {
+    openBrowserAsync(`${WEB_BASE_URL}${actionUrl}`, {
+      presentationStyle: WebBrowserPresentationStyle.AUTOMATIC,
+    });
+    return;
+  }
 
   // /shifts/:id -> shift detail modal
   const shiftDetail = pathname.match(/^\/shifts\/([^/]+)$/);
@@ -24,7 +41,25 @@ export function navigateToNotificationTarget(actionUrl: unknown) {
     return;
   }
 
-  // /friends* -> profile tab (friends live under profile on mobile)
+  // Friend notifications — navigate to the other user's profile screen.
+  // FRIEND_REQUEST_ACCEPTED uses /friends/:userId (they're now a friend).
+  // FRIEND_REQUEST_RECEIVED uses /friends?fromUserId=:userId (not a friend
+  // yet, so the generic user screen handles the "send request" state).
+  const friendProfile = pathname.match(/^\/friends\/([^/]+)$/);
+  if (friendProfile) {
+    router.push({
+      pathname: '/user/[id]',
+      params: { id: friendProfile[1] },
+    });
+    return;
+  }
+  const fromUserId = query.get('fromUserId');
+  if (pathname === '/friends' && fromUserId) {
+    router.push({ pathname: '/user/[id]', params: { id: fromUserId } });
+    return;
+  }
+
+  // /friends* fallback -> profile tab (friends live under profile on mobile)
   if (pathname === '/friends' || pathname.startsWith('/friends/')) {
     router.push('/(tabs)/profile');
     return;

--- a/web/src/app/api/friends/requests/[requestId]/accept/route.ts
+++ b/web/src/app/api/friends/requests/[requestId]/accept/route.ts
@@ -122,7 +122,8 @@ export async function POST(
       await createFriendRequestAcceptedNotification(
         friendRequest.fromUserId,
         accepterName,
-        result.friendship1.id
+        result.friendship1.id,
+        user.id
       );
     } catch (notificationError) {
       // Don't fail the acceptance if notification creation fails

--- a/web/src/app/api/friends/route.ts
+++ b/web/src/app/api/friends/route.ts
@@ -274,7 +274,8 @@ export async function POST(req: NextRequest) {
       await createFriendRequestNotification(
         targetUser.id,
         senderName,
-        friendRequest.id
+        friendRequest.id,
+        user.id
       );
     } catch (notificationError) {
       // Don't fail the friend request if notification creation fails

--- a/web/src/app/api/mobile/friends/requests/[requestId]/accept/route.ts
+++ b/web/src/app/api/mobile/friends/requests/[requestId]/accept/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireMobileUser } from "@/lib/mobile-auth";
+import { createFriendRequestAcceptedNotification } from "@/lib/notifications";
+
+/**
+ * POST /api/mobile/friends/requests/[requestId]/accept
+ *
+ * Mobile equivalent of /api/friends/requests/[requestId]/accept. Authenticates
+ * via the mobile JWT, verifies the request belongs to the caller, creates the
+ * bidirectional friendship, and notifies the original requester.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ requestId: string }> }
+) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { userId } = auth;
+  const { requestId } = await params;
+
+  const me = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      firstName: true,
+      lastName: true,
+    },
+  });
+
+  if (!me) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const friendRequest = await prisma.friendRequest.findUnique({
+    where: { id: requestId },
+    select: {
+      id: true,
+      fromUserId: true,
+      toEmail: true,
+      status: true,
+      expiresAt: true,
+    },
+  });
+
+  if (!friendRequest) {
+    return NextResponse.json(
+      { error: "Friend request not found" },
+      { status: 404 }
+    );
+  }
+
+  if (friendRequest.toEmail !== me.email) {
+    return NextResponse.json(
+      { error: "Unauthorized to accept this request" },
+      { status: 403 }
+    );
+  }
+
+  if (
+    friendRequest.status !== "PENDING" ||
+    friendRequest.expiresAt < new Date()
+  ) {
+    return NextResponse.json(
+      { error: "Friend request is no longer valid" },
+      { status: 400 }
+    );
+  }
+
+  const existingFriendship = await prisma.friendship.findFirst({
+    where: {
+      OR: [
+        { userId: me.id, friendId: friendRequest.fromUserId },
+        { userId: friendRequest.fromUserId, friendId: me.id },
+      ],
+    },
+  });
+
+  if (existingFriendship) {
+    return NextResponse.json(
+      { error: "Friendship already exists" },
+      { status: 400 }
+    );
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    await tx.friendRequest.update({
+      where: { id: requestId },
+      data: { status: "ACCEPTED" },
+    });
+
+    const friendship1 = await tx.friendship.create({
+      data: {
+        userId: me.id,
+        friendId: friendRequest.fromUserId,
+        status: "ACCEPTED",
+        initiatedBy: friendRequest.fromUserId,
+      },
+    });
+
+    const friendship2 = await tx.friendship.create({
+      data: {
+        userId: friendRequest.fromUserId,
+        friendId: me.id,
+        status: "ACCEPTED",
+        initiatedBy: friendRequest.fromUserId,
+      },
+    });
+
+    return { friendship1, friendship2 };
+  });
+
+  try {
+    const accepterName =
+      me.name ??
+      ([me.firstName, me.lastName].filter(Boolean).join(" ") || me.email);
+    await createFriendRequestAcceptedNotification(
+      friendRequest.fromUserId,
+      accepterName,
+      result.friendship1.id,
+      me.id
+    );
+  } catch (err) {
+    console.error("[mobile/accept] Notification failed:", err);
+  }
+
+  return NextResponse.json({ ok: true, status: "FRIENDS" });
+}

--- a/web/src/app/api/mobile/friends/requests/[requestId]/decline/route.ts
+++ b/web/src/app/api/mobile/friends/requests/[requestId]/decline/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireMobileUser } from "@/lib/mobile-auth";
+
+/**
+ * POST /api/mobile/friends/requests/[requestId]/decline
+ *
+ * Mobile equivalent of /api/friends/requests/[requestId]/decline. Marks the
+ * pending FriendRequest as DECLINED after verifying it was addressed to the
+ * caller.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ requestId: string }> }
+) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { userId } = auth;
+  const { requestId } = await params;
+
+  const me = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { email: true },
+  });
+
+  if (!me) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const friendRequest = await prisma.friendRequest.findUnique({
+    where: { id: requestId },
+    select: { id: true, toEmail: true, status: true },
+  });
+
+  if (!friendRequest) {
+    return NextResponse.json(
+      { error: "Friend request not found" },
+      { status: 404 }
+    );
+  }
+
+  if (friendRequest.toEmail !== me.email) {
+    return NextResponse.json(
+      { error: "Unauthorized to decline this request" },
+      { status: 403 }
+    );
+  }
+
+  if (friendRequest.status !== "PENDING") {
+    return NextResponse.json(
+      { error: "Friend request is no longer pending" },
+      { status: 400 }
+    );
+  }
+
+  await prisma.friendRequest.update({
+    where: { id: requestId },
+    data: { status: "DECLINED" },
+  });
+
+  return NextResponse.json({ ok: true, status: "NONE" });
+}

--- a/web/src/app/api/mobile/users/[id]/friend-request/route.ts
+++ b/web/src/app/api/mobile/users/[id]/friend-request/route.ts
@@ -105,7 +105,12 @@ export async function POST(
     const senderName =
       me.name ??
       ([me.firstName, me.lastName].filter(Boolean).join(" ") || me.email);
-    await createFriendRequestNotification(target.id, senderName, friendRequest.id);
+    await createFriendRequestNotification(
+      target.id,
+      senderName,
+      friendRequest.id,
+      userId
+    );
   } catch (err) {
     console.error("[friend-request] Notification failed:", err);
   }

--- a/web/src/app/api/mobile/users/[id]/route.ts
+++ b/web/src/app/api/mobile/users/[id]/route.ts
@@ -54,8 +54,19 @@ export async function GET(
 
   const isSelf = target.id === userId;
 
-  // Friendship status
+  // Viewer's own email (needed to look up incoming FriendRequest rows, which
+  // are keyed by recipient email rather than user ID).
+  const viewer = isSelf
+    ? null
+    : await prisma.user.findUnique({
+        where: { id: userId },
+        select: { email: true },
+      });
+
+  // Friendship status + the FriendRequest id when the viewer has a pending
+  // incoming request — the mobile UI needs this id to accept or decline.
   let friendshipStatus: FriendshipStatus = "NONE";
+  let incomingRequestId: string | null = null;
   if (isSelf) {
     friendshipStatus = "SELF";
   } else {
@@ -75,8 +86,8 @@ export async function GET(
       friendshipStatus =
         friendship.initiatedBy === userId ? "REQUEST_SENT" : "REQUEST_RECEIVED";
     } else {
-      // Check for pending FriendRequest by email (used by the web flow)
-      const pendingRequest = await prisma.friendRequest.findFirst({
+      // Check the FriendRequest table used by both web and mobile send flows.
+      const outgoingRequest = await prisma.friendRequest.findFirst({
         where: {
           fromUserId: userId,
           toEmail: target.email,
@@ -85,7 +96,23 @@ export async function GET(
         },
         select: { id: true },
       });
-      if (pendingRequest) friendshipStatus = "REQUEST_SENT";
+      if (outgoingRequest) {
+        friendshipStatus = "REQUEST_SENT";
+      } else if (viewer?.email) {
+        const incomingRequest = await prisma.friendRequest.findFirst({
+          where: {
+            fromUserId: targetId,
+            toEmail: viewer.email,
+            status: "PENDING",
+            expiresAt: { gt: new Date() },
+          },
+          select: { id: true },
+        });
+        if (incomingRequest) {
+          friendshipStatus = "REQUEST_RECEIVED";
+          incomingRequestId = incomingRequest.id;
+        }
+      }
     }
   }
 
@@ -141,6 +168,7 @@ export async function GET(
       totalShifts,
       hoursVolunteered: Math.round(hoursResult[0].hours),
       friendshipStatus,
+      friendRequestId: incomingRequestId,
       allowFriendRequests: target.allowFriendRequests,
       isBlocked: Boolean(block),
       hasReported: Boolean(report),

--- a/web/src/lib/friends-actions.ts
+++ b/web/src/lib/friends-actions.ts
@@ -133,7 +133,8 @@ export async function sendFriendRequest(formData: FormData) {
       await createFriendRequestNotification(
         targetUser.id,
         senderName,
-        friendRequest.id
+        friendRequest.id,
+        user.id
       );
     } catch (notificationError) {
       // Don't fail the friend request if notification creation fails
@@ -235,7 +236,8 @@ export async function acceptFriendRequest(requestId: string) {
       await createFriendRequestAcceptedNotification(
         friendRequest.fromUserId,
         accepterName,
-        result.friendship1.id
+        result.friendship1.id,
+        user.id
       );
     } catch (notificationError) {
       // Don't fail the acceptance if notification creation fails
@@ -409,7 +411,8 @@ export async function sendFriendRequestByUserId(userId: string) {
       await createFriendRequestNotification(
         targetUser.id,
         senderName,
-        friendRequest.id
+        friendRequest.id,
+        user.id
       );
     } catch (notificationError) {
       // Don't fail the friend request if notification creation fails

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -244,14 +244,19 @@ export async function getUnreadNotificationCount(userId: string) {
 export async function createFriendRequestNotification(
   recipientUserId: string,
   senderName: string,
-  friendRequestId: string
+  friendRequestId: string,
+  senderUserId?: string
 ) {
+  const actionUrl = senderUserId
+    ? `/friends?tab=requests&fromUserId=${senderUserId}`
+    : "/friends?tab=requests";
+
   return createNotification({
     userId: recipientUserId,
     type: "FRIEND_REQUEST_RECEIVED",
     title: "New friend request",
     message: `${senderName} sent you a friend request`,
-    actionUrl: "/friends?tab=requests",
+    actionUrl,
     relatedId: friendRequestId,
   });
 }
@@ -262,14 +267,19 @@ export async function createFriendRequestNotification(
 export async function createFriendRequestAcceptedNotification(
   recipientUserId: string,
   accepterName: string,
-  friendshipId: string
+  friendshipId: string,
+  accepterUserId?: string
 ) {
+  const actionUrl = accepterUserId
+    ? `/friends/${accepterUserId}`
+    : "/friends";
+
   return createNotification({
     userId: recipientUserId,
     type: "FRIEND_REQUEST_ACCEPTED",
     title: "Friend request accepted",
     message: `${accepterName} accepted your friend request`,
-    actionUrl: "/friends",
+    actionUrl,
     relatedId: friendshipId,
   });
 }


### PR DESCRIPTION
## Summary

- Mobile volunteers can now **accept or decline incoming friend requests** directly from the user profile screen — no more bouncing to the web app.
- **Friend notifications** (sent / accepted) deep-link to the relevant user profile, where the new Accept/Decline buttons live.
- **Survey notifications** open the web survey inside an in-app browser (expo-web-browser) since surveys aren't implemented natively.
- Notifications screen gets a **transparent header** for a cleaner look.

### Backend

- `api/mobile/users/[id]` now detects `REQUEST_RECEIVED` via the `FriendRequest` table (previously only checked `Friendship.PENDING`) and returns `friendRequestId` so the mobile UI can act on it.
- New mobile-auth endpoints:
  - `POST /api/mobile/friends/requests/[requestId]/accept` — creates bidirectional friendship, notifies requester.
  - `POST /api/mobile/friends/requests/[requestId]/decline` — marks `FriendRequest` as `DECLINED`.
- `createFriendRequest*Notification` helpers now accept the sender / accepter user ID and embed it in `actionUrl` (e.g. `/friends/:id` for accepted, `/friends?fromUserId=:id` for received) so both web and mobile can route sensibly. All 4 call sites updated.

### Mobile

- `notification-routing` parses query strings, routes friend URLs to `user/[id]`, routes `/surveys/:token` to the in-app browser via `expo-web-browser`.
- `user/[id]` renders an Accept / Decline pair when `friendshipStatus === 'REQUEST_RECEIVED'`:
  - Primary Accept button (brand green) with spinner + haptics + optimistic state update.
  - Outlined Decline button gated behind a destructive `Alert.alert` confirmation.
- Notifications screen: `headerTransparent: true` + `useHeaderHeight()` offset so the hero doesn't render under the bar.

## Test plan

- [ ] On web, send a friend request to a test volunteer → they receive a mobile push notification.
- [ ] Tap the notification → mobile routes to the sender's user profile (not the home tab).
- [ ] Tap **Accept request** → button shows spinner, friendship is created, the sender receives a "request accepted" notification, UI flips to "You're friends 💚".
- [ ] Repeat with **Decline** → confirmation alert shows, request marks as `DECLINED`, UI flips to the generic "Add friend" CTA.
- [ ] From the sender's side, tap the acceptance notification → routes to the new friend's profile screen.
- [ ] Assign a survey trigger → tap the survey notification on mobile → web survey opens in an in-app browser.
- [ ] Open the mobile notifications screen → header is transparent, list doesn't clip under it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)