### PR TITLE
fix: friend notification routing fallthrough + backfill old URLs

### DIFF
--- a/mobile/lib/notification-routing.ts
+++ b/mobile/lib/notification-routing.ts
@@ -13,10 +13,12 @@ const WEB_BASE_URL =
  * screen for — better than crashing the app on an unmapped path.
  */
 export function navigateToNotificationTarget(actionUrl: unknown) {
+  console.log('[notification-routing] actionUrl:', actionUrl);
   if (typeof actionUrl !== 'string' || !actionUrl.startsWith('/')) return;
 
   const [pathname, queryString = ''] = actionUrl.split('?');
   const query = new URLSearchParams(queryString);
+  console.log('[notification-routing] pathname:', pathname, 'query:', queryString);
 
   // /surveys/:token -> open the web survey page in an in-app browser.
   // Surveys aren't implemented natively on mobile, so we hand off to the

--- a/web/src/app/api/mobile/notifications/route.ts
+++ b/web/src/app/api/mobile/notifications/route.ts
@@ -1,10 +1,90 @@
 import { NextResponse } from "next/server";
 import { requireMobileUser } from "@/lib/mobile-auth";
+import { prisma } from "@/lib/prisma";
 import {
   getNotifications,
   getUnreadNotificationCount,
   markAllNotificationsAsRead,
 } from "@/lib/notifications";
+
+/**
+ * Rewrite friend-notification actionUrls to include the other user's id, so
+ * the mobile app can route straight to their profile. Handles notifications
+ * created before we started embedding the id in the URL — we resolve it from
+ * `relatedId` (a FriendRequest or Friendship id) at read time.
+ */
+async function enrichFriendActionUrls(
+  notifications: {
+    id: string;
+    type: string;
+    actionUrl: string | null;
+    relatedId: string | null;
+  }[],
+  viewerId: string
+): Promise<Map<string, string>> {
+  const patched = new Map<string, string>();
+
+  const requestIds = notifications
+    .filter(
+      (n) =>
+        n.type === "FRIEND_REQUEST_RECEIVED" &&
+        n.relatedId &&
+        !n.actionUrl?.includes("fromUserId=")
+    )
+    .map((n) => n.relatedId!);
+
+  const friendshipIds = notifications
+    .filter(
+      (n) =>
+        n.type === "FRIEND_REQUEST_ACCEPTED" &&
+        n.relatedId &&
+        !/^\/friends\/[^?]+/.test(n.actionUrl ?? "")
+    )
+    .map((n) => n.relatedId!);
+
+  const [requests, friendships] = await Promise.all([
+    requestIds.length
+      ? prisma.friendRequest.findMany({
+          where: { id: { in: requestIds } },
+          select: { id: true, fromUserId: true },
+        })
+      : Promise.resolve([]),
+    friendshipIds.length
+      ? prisma.friendship.findMany({
+          where: { id: { in: friendshipIds } },
+          select: { id: true, userId: true, friendId: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const requestById = new Map(requests.map((r) => [r.id, r.fromUserId]));
+  const otherUserByFriendship = new Map(
+    friendships.map((f) => [
+      f.id,
+      f.userId === viewerId ? f.friendId : f.userId,
+    ])
+  );
+
+  for (const n of notifications) {
+    if (!n.relatedId) continue;
+    if (n.type === "FRIEND_REQUEST_RECEIVED") {
+      const fromUserId = requestById.get(n.relatedId);
+      if (fromUserId) {
+        patched.set(
+          n.id,
+          `/friends?tab=requests&fromUserId=${fromUserId}`
+        );
+      }
+    } else if (n.type === "FRIEND_REQUEST_ACCEPTED") {
+      const otherUserId = otherUserByFriendship.get(n.relatedId);
+      if (otherUserId) {
+        patched.set(n.id, `/friends/${otherUserId}`);
+      }
+    }
+  }
+
+  return patched;
+}
 
 /**
  * GET /api/mobile/notifications?limit=20&offset=0
@@ -34,6 +114,11 @@ export async function GET(request: Request) {
       getUnreadNotificationCount(auth.userId),
     ]);
 
+    const patchedUrls = await enrichFriendActionUrls(
+      list.notifications,
+      auth.userId
+    );
+
     return NextResponse.json({
       notifications: list.notifications.map((n) => ({
         id: n.id,
@@ -41,7 +126,7 @@ export async function GET(request: Request) {
         title: n.title,
         message: n.message,
         isRead: n.isRead,
-        actionUrl: n.actionUrl,
+        actionUrl: patchedUrls.get(n.id) ?? n.actionUrl,
         relatedId: n.relatedId,
         createdAt: n.createdAt.toISOString(),
       })),


### PR DESCRIPTION
## Summary
- Backend: enrich the mobile notifications endpoint so old friend-request notifications (without \`fromUserId\` in the URL) get rewritten at read time using \`relatedId\` → route to the other user's profile.
- Mobile: add a diagnostic \`console.log\` in \`navigateToNotificationTarget\` so we can see the exact actionUrl any reported fallthrough is coming from.

## Why
After #784 merged, tapping a friend-request notification was still landing on the Profile tab instead of the user profile screen. Most likely causes: stale notifications created before the URL format changed, or a fresh one whose URL format isn't what we expect. The backend enrichment handles the first case; the log helps us pin down the second.

## Test plan
- [ ] Tap a freshly-received friend request notification on mobile → lands on the other user's profile screen (previously landed on Profile tab)
- [ ] Tap an older friend-request notification (created before #784) → also lands on the correct profile (enriched server-side)
- [ ] Tap a FRIEND_REQUEST_ACCEPTED notification → lands on the accepter's profile
- [ ] Metro console shows \`[notification-routing] actionUrl: /friends?...\` when a notification is tapped