### PR TITLE
feat: log mobile AI chat conversations + admin viewer

### DIFF
--- a/web/prisma/migrations/20260421000000_add_chat_log/migration.sql
+++ b/web/prisma/migrations/20260421000000_add_chat_log/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "ChatLog" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "userMessage" TEXT NOT NULL,
+    "assistantResponse" TEXT NOT NULL,
+    "conversation" JSONB NOT NULL,
+    "model" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ChatLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ChatLog_createdAt_idx" ON "ChatLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "ChatLog_userId_createdAt_idx" ON "ChatLog"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ChatLog" ADD CONSTRAINT "ChatLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -151,6 +151,9 @@ model User {
   // Archive activity performed by this user (admin)
   archiveActions ArchiveLog[] @relation("ArchiveActor")
 
+  // Mobile chat assistant conversations
+  chatLogs ChatLog[]
+
   // Analytics queries filter heavily on role + createdAt
   @@index([role, createdAt])
   // Archive filters and scheduled job queries
@@ -987,6 +990,23 @@ enum ArchiveTriggerSource {
   CRON
   SELF_EXTENSION
   SELF_REACTIVATION
+}
+
+// Mobile AI chat assistant conversation log.
+// One row per user message + assistant reply pair. Pruned after 30 days by cron.
+model ChatLog {
+  id                String   @id @default(cuid())
+  userId            String
+  userMessage       String   // The latest user message in the turn
+  assistantResponse String   // The full assistant reply text
+  conversation      Json     // Full message history at time of request: [{role, content}, ...]
+  model             String   // OpenRouter model id used
+  createdAt         DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([createdAt])
+  @@index([userId, createdAt])
 }
 
 model ArchiveLog {

--- a/web/src/app/admin/chat-guides/logs/chat-logs-search.tsx
+++ b/web/src/app/admin/chat-guides/logs/chat-logs-search.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Search, X } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+interface ChatLogsSearchProps {
+  initialQuery: string;
+}
+
+export function ChatLogsSearch({ initialQuery }: ChatLogsSearchProps) {
+  const router = useRouter();
+  const [value, setValue] = useState(initialQuery);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const sp = new URLSearchParams();
+      if (value.trim()) sp.set("q", value.trim());
+      const qs = sp.toString();
+      router.replace(`/admin/chat-guides/logs${qs ? `?${qs}` : ""}`);
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [value, router]);
+
+  return (
+    <div className="relative max-w-md">
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Search by volunteer name or email..."
+        className="pl-9 pr-9"
+      />
+      {value && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2"
+          onClick={() => setValue("")}
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/admin/chat-guides/logs/page.tsx
+++ b/web/src/app/admin/chat-guides/logs/page.tsx
@@ -1,0 +1,267 @@
+import Link from "next/link";
+import { getServerSession } from "next-auth";
+import { notFound, redirect } from "next/navigation";
+import { subDays } from "date-fns";
+import { ArrowLeft, Bot, MessageSquare, User as UserIcon } from "lucide-react";
+
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+import { isFeatureEnabled, FeatureFlag } from "@/lib/posthog-server";
+import { formatInNZT } from "@/lib/timezone";
+
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ChatLogsSearch } from "./chat-logs-search";
+
+const PAGE_SIZE = 50;
+
+interface ChatLogsPageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function ChatLogsPage({ searchParams }: ChatLogsPageProps) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) redirect("/login?callbackUrl=/admin/chat-guides/logs");
+  if (session.user.role !== "ADMIN") redirect("/dashboard");
+
+  const enabled = await isFeatureEnabled(FeatureFlag.CHAT_GUIDES, session.user.id);
+  if (!enabled) notFound();
+
+  const params = await searchParams;
+  const page = Math.max(1, parseInt((params.page as string) ?? "1", 10) || 1);
+  const q = ((params.q as string) ?? "").trim();
+
+  const userFilter = q
+    ? {
+        user: {
+          OR: [
+            { email: { contains: q, mode: "insensitive" as const } },
+            { name: { contains: q, mode: "insensitive" as const } },
+            { firstName: { contains: q, mode: "insensitive" as const } },
+            { lastName: { contains: q, mode: "insensitive" as const } },
+          ],
+        },
+      }
+    : {};
+
+  const now = new Date();
+  const sevenDaysAgo = subDays(now, 7);
+  const thirtyDaysAgo = subDays(now, 30);
+
+  const [logs, totalCount, last7Count, last30Count, uniqueUsers30] = await Promise.all([
+    prisma.chatLog.findMany({
+      where: userFilter,
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * PAGE_SIZE,
+      take: PAGE_SIZE,
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            firstName: true,
+            lastName: true,
+            profilePhotoUrl: true,
+          },
+        },
+      },
+    }),
+    prisma.chatLog.count({ where: userFilter }),
+    prisma.chatLog.count({ where: { createdAt: { gte: sevenDaysAgo } } }),
+    prisma.chatLog.count({ where: { createdAt: { gte: thirtyDaysAgo } } }),
+    prisma.chatLog.findMany({
+      where: { createdAt: { gte: thirtyDaysAgo } },
+      distinct: ["userId"],
+      select: { userId: true },
+    }),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+
+  const buildPageHref = (p: number) => {
+    const sp = new URLSearchParams();
+    if (p > 1) sp.set("page", String(p));
+    if (q) sp.set("q", q);
+    const qs = sp.toString();
+    return `/admin/chat-guides/logs${qs ? `?${qs}` : ""}`;
+  };
+
+  return (
+    <AdminPageWrapper
+      title="Chat Logs"
+      description="Conversations volunteers have had with the AI assistant. Logs are kept for 30 days."
+    >
+      <div className="space-y-6">
+        {/* Back link */}
+        <div>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/admin/chat-guides">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Chat Guides
+            </Link>
+          </Button>
+        </div>
+
+        {/* Stats */}
+        <div className="grid gap-4 md:grid-cols-3">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Last 7 days</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold">{last7Count.toLocaleString()}</div>
+              <p className="mt-1 text-xs text-muted-foreground">conversation turns</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Last 30 days</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold">{last30Count.toLocaleString()}</div>
+              <p className="mt-1 text-xs text-muted-foreground">conversation turns</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Unique users (30d)</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="text-3xl font-bold">{uniqueUsers30.length.toLocaleString()}</div>
+              <p className="mt-1 text-xs text-muted-foreground">volunteers chatted with the assistant</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Filter */}
+        <ChatLogsSearch initialQuery={q} />
+
+        {/* Result summary */}
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>
+            {totalCount === 0
+              ? "No logs found"
+              : `Showing ${(safePage - 1) * PAGE_SIZE + 1}–${Math.min(safePage * PAGE_SIZE, totalCount)} of ${totalCount.toLocaleString()}`}
+            {q && (
+              <>
+                {" "}
+                for <span className="font-medium text-foreground">&ldquo;{q}&rdquo;</span>
+              </>
+            )}
+          </span>
+          {q && (
+            <Button variant="ghost" size="sm" asChild>
+              <Link href="/admin/chat-guides/logs">Clear filter</Link>
+            </Button>
+          )}
+        </div>
+
+        {/* Logs */}
+        {logs.length === 0 ? (
+          <Card>
+            <CardContent className="flex flex-col items-center justify-center py-12">
+              <MessageSquare className="h-12 w-12 text-muted-foreground/50" />
+              <p className="mt-4 text-lg font-medium">No conversations yet</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {q
+                  ? "Try a different search term"
+                  : "Once volunteers chat with the assistant, their conversations will appear here."}
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {logs.map((log) => {
+              const displayName =
+                log.user.firstName && log.user.lastName
+                  ? `${log.user.firstName} ${log.user.lastName}`
+                  : log.user.name || log.user.firstName || log.user.email;
+              return (
+                <details
+                  key={log.id}
+                  className="group rounded-lg border bg-card transition-colors hover:bg-muted/30 open:bg-muted/30"
+                >
+                  <summary className="flex cursor-pointer list-none items-start gap-3 p-4">
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                      <UserIcon className="h-4 w-4 text-primary" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                        <Link
+                          href={`/admin/volunteers/${log.user.id}`}
+                          className="font-medium hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {displayName}
+                        </Link>
+                        <span className="text-xs text-muted-foreground">{log.user.email}</span>
+                        <Badge variant="secondary" className="ml-auto text-xs font-normal">
+                          {formatInNZT(log.createdAt, "d MMM yyyy, h:mm a")}
+                        </Badge>
+                      </div>
+                      <p className="mt-1.5 line-clamp-2 text-sm text-foreground">
+                        {log.userMessage || <span className="italic text-muted-foreground">(empty message)</span>}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Click to view assistant reply · model: <code className="text-[10px]">{log.model}</code>
+                      </p>
+                    </div>
+                  </summary>
+                  <div className="space-y-3 border-t px-4 py-4">
+                    <div>
+                      <div className="mb-1.5 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        <UserIcon className="h-3 w-3" />
+                        Volunteer
+                      </div>
+                      <div className="whitespace-pre-wrap rounded-md bg-background p-3 text-sm leading-relaxed">
+                        {log.userMessage}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="mb-1.5 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        <Bot className="h-3 w-3" />
+                        Assistant
+                      </div>
+                      <div className="whitespace-pre-wrap rounded-md bg-background p-3 text-sm leading-relaxed">
+                        {log.assistantResponse || (
+                          <span className="italic text-muted-foreground">(no reply recorded)</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </details>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2 pt-2">
+            <Button variant="outline" size="sm" asChild disabled={safePage <= 1}>
+              {safePage <= 1 ? (
+                <span aria-disabled="true">Previous</span>
+              ) : (
+                <Link href={buildPageHref(safePage - 1)}>Previous</Link>
+              )}
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              Page {safePage} of {totalPages}
+            </span>
+            <Button variant="outline" size="sm" asChild disabled={safePage >= totalPages}>
+              {safePage >= totalPages ? (
+                <span aria-disabled="true">Next</span>
+              ) : (
+                <Link href={buildPageHref(safePage + 1)}>Next</Link>
+              )}
+            </Button>
+          </div>
+        )}
+      </div>
+    </AdminPageWrapper>
+  );
+}

--- a/web/src/app/admin/chat-guides/page.tsx
+++ b/web/src/app/admin/chat-guides/page.tsx
@@ -1,11 +1,14 @@
+import Link from "next/link";
 import { getServerSession } from "next-auth";
 import { notFound, redirect } from "next/navigation";
+import { ScrollText } from "lucide-react";
 
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { isFeatureEnabled, FeatureFlag } from "@/lib/posthog-server";
 
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { Button } from "@/components/ui/button";
 import { ChatGuidesContent } from "./chat-guides-content";
 
 export default async function ChatGuidesPage() {
@@ -69,6 +72,14 @@ export default async function ChatGuidesPage() {
     <AdminPageWrapper
       title="Chat Guides"
       description="Manage which resources are included as context for the mobile AI chat assistant. Volunteers can ask the assistant questions and it will answer based on these resources."
+      actions={
+        <Button variant="outline" asChild>
+          <Link href="/admin/chat-guides/logs">
+            <ScrollText className="mr-2 h-4 w-4" />
+            View Logs
+          </Link>
+        </Button>
+      }
     >
       <ChatGuidesContent
         initialChatResources={chatResources}

--- a/web/src/app/api/cron/prune-chat-logs/route.ts
+++ b/web/src/app/api/cron/prune-chat-logs/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const RETENTION_DAYS = 30;
+
+/**
+ * GET /api/cron/prune-chat-logs
+ *
+ * Deletes ChatLog rows older than 30 days. Runs daily.
+ * Secured via CRON_SECRET (automatically set by Vercel).
+ */
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000);
+
+  const { count } = await prisma.chatLog.deleteMany({
+    where: { createdAt: { lt: cutoff } },
+  });
+
+  console.log(`[cron] Pruned ${count} ChatLog rows older than ${RETENTION_DAYS} days`);
+
+  return NextResponse.json({ pruned: count, cutoff: cutoff.toISOString() });
+}

--- a/web/src/app/api/mobile/chat/route.ts
+++ b/web/src/app/api/mobile/chat/route.ts
@@ -377,6 +377,9 @@ export async function POST(request: Request) {
       systemPromptLength: systemPrompt.length,
     });
 
+    const lastUserMessage =
+      [...messages].reverse().find((m) => m.role === "user")?.content ?? "";
+
     const result = streamText({
       model: openrouter(modelId),
       system: systemPrompt,
@@ -386,6 +389,21 @@ export async function POST(request: Request) {
       })),
       onError: ({ error }) => {
         console.error("[mobile-chat] streamText error:", error);
+      },
+      onFinish: async ({ text }) => {
+        try {
+          await prisma.chatLog.create({
+            data: {
+              userId: auth.userId,
+              userMessage: lastUserMessage,
+              assistantResponse: text,
+              conversation: messages,
+              model: modelId,
+            },
+          });
+        } catch (err) {
+          console.error("[mobile-chat] Failed to write ChatLog:", err);
+        }
       },
     });
 

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -25,6 +25,7 @@ import {
   UserPlus,
   Award,
   Archive,
+  ScrollText,
 } from "lucide-react";
 
 export interface AdminNavItem {
@@ -234,6 +235,13 @@ export const adminNavCategories: AdminNavCategory[] = [
         commandKey: "chat-guides",
       },
       {
+        title: "Chat Logs",
+        href: "/admin/chat-guides/logs",
+        icon: ScrollText,
+        description: "View volunteer conversations with the AI assistant",
+        commandKey: "chat-logs",
+      },
+      {
         title: "Announcements",
         href: "/admin/announcements",
         icon: Megaphone,
@@ -345,6 +353,7 @@ export const getIconColor = (
     "Resource Hub": "text-blue-500",
     "Site Settings": "text-slate-600",
     "Chat Guides": "text-emerald-500",
+    "Chat Logs": "text-emerald-600",
     "Announcements": "text-orange-500",
 
     // Safety

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/refresh-website-content",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/prune-chat-logs",
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- New `ChatLog` Prisma model captures each volunteer ↔ assistant turn (user message, full assistant reply, conversation history, model used).
- `/api/mobile/chat` writes a log row via `streamText`'s `onFinish` callback — non-blocking, doesn't affect the user-facing stream.
- New admin page at `/admin/chat-guides/logs` lists conversations with stats (7d/30d/unique users), volunteer search, pagination (50/page), and expandable rows showing both sides of the conversation.
- Sidebar nav entry "Chat Logs" added under Resources.
- 30-day retention enforced via new daily cron `/api/cron/prune-chat-logs` (registered in `vercel.json`, runs at 03:00 UTC).

## Why

Volunteers reported the AI chat "wasn't working" but the team had no visibility into actual usage to debug. This gives admins a way to see what people are asking and how the assistant is replying.

## Test plan

- [ ] Run `npm run prisma:migrate` locally → confirm `ChatLog` table created
- [ ] Send a chat message from the mobile app → confirm a row appears in `ChatLog`
- [ ] Visit `/admin/chat-guides/logs` → confirm stats, list, expand interaction, search, and pagination all work
- [ ] Click "View Logs" button on `/admin/chat-guides` → navigates to logs page
- [ ] Confirm "Chat Logs" appears in admin sidebar under Resources
- [ ] Manually hit `/api/cron/prune-chat-logs` with `Authorization: Bearer $CRON_SECRET` → confirm it runs (no rows to prune yet)
- [ ] After deploy: check Vercel cron is registered

## Notes

- Retention chosen as 30 days to avoid indefinite accumulation of volunteer messages.
- `onFinish` errors are caught and logged but do not break the chat response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)