### PR TITLE
feat: push + in-app notifications for shift shortage blasts

### DIFF
--- a/web/prisma/migrations/20260421000001_add_shift_shortage_notification_type/migration.sql
+++ b/web/prisma/migrations/20260421000001_add_shift_shortage_notification_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'SHIFT_SHORTAGE';

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -449,6 +449,7 @@ enum NotificationType {
   FLEXIBLE_PLACEMENT // Deprecated - kept for backwards compatibility
   UNDERAGE_USER_REGISTERED // Underage user registered - notify admins for parental consent
   SURVEY_ASSIGNED // A new survey has been assigned to you
+  SHIFT_SHORTAGE // Admin sent shortage alert for shifts that need more volunteers
 }
 
 model RestaurantManager {

--- a/web/src/app/api/admin/notifications/send-shortage/route.ts
+++ b/web/src/app/api/admin/notifications/send-shortage/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { getEmailService } from "@/lib/email-service";
 import { formatInNZT } from "@/lib/timezone";
+import { createNotificationsForUsers } from "@/lib/notifications";
 
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
@@ -156,6 +157,34 @@ export async function POST(request: Request) {
     if (logEntries.length > 0) {
       await prisma.shortageNotificationLog.createMany({
         data: logEntries,
+      });
+    }
+
+    // Fan out in-app + push notifications to every volunteer the email
+    // reached. One createMany + one batched Expo call handles the whole
+    // group instead of N per-user requests.
+    const notifiedUserIds = allResults
+      .filter((r) => r.success && r.recipientId)
+      .map((r) => r.recipientId);
+
+    if (notifiedUserIds.length > 0) {
+      const firstShift = shiftsForEmail[0];
+      const pushTitle =
+        shifts.length === 1
+          ? `Shift needs volunteers: ${firstShift.shiftName}`
+          : `${shifts.length} shifts need volunteers`;
+      const pushMessage =
+        shifts.length === 1
+          ? `${firstShift.shiftName} on ${firstShift.shiftDate} at ${firstShift.location} — ${firstShift.neededVolunteers} more needed.`
+          : `Tap to see ${shifts.length} shifts across our locations that still need cover.`;
+
+      await createNotificationsForUsers({
+        userIds: notifiedUserIds,
+        type: "SHIFT_SHORTAGE",
+        title: pushTitle,
+        message: pushMessage,
+        actionUrl:
+          shifts.length === 1 ? `/shifts/${firstShift.shiftId}` : "/shifts",
       });
     }
 

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -4,7 +4,7 @@ import {
   sendNotificationToUser,
   updateUnreadCount,
 } from "./notification-helpers";
-import { sendPushToUser } from "./services/expo-push";
+import { sendPushToUser, sendPushToUsers } from "./services/expo-push";
 
 export interface CreateNotificationParams {
   userId: string;
@@ -73,6 +73,89 @@ export async function createNotification(params: CreateNotificationParams) {
     return notification;
   } catch (error) {
     console.error("Error creating notification:", error);
+    throw error;
+  }
+}
+
+export interface CreateNotificationsForUsersParams {
+  userIds: string[];
+  type: NotificationType;
+  title: string;
+  message: string;
+  actionUrl?: string;
+  relatedId?: string;
+}
+
+/**
+ * Create the same notification for many users in one go. Uses a single
+ * `createMany` for the database inserts, a single batched Expo push call
+ * (with per-user badge counts), and per-user SSE fan-out in parallel.
+ *
+ * Caller is responsible for filtering `userIds` by any per-user opt-in flags.
+ */
+export async function createNotificationsForUsers(
+  params: CreateNotificationsForUsersParams
+) {
+  const userIds = Array.from(new Set(params.userIds));
+  if (userIds.length === 0) return { count: 0 };
+
+  try {
+    const result = await prisma.notification.createMany({
+      data: userIds.map((userId) => ({
+        userId,
+        type: params.type,
+        title: params.title,
+        message: params.message,
+        actionUrl: params.actionUrl,
+        relatedId: params.relatedId,
+      })),
+    });
+
+    // Fan out SSE + push. All fire-and-forget so the admin request returns
+    // quickly even if a subset of SSE writers hang on backpressure.
+    const unreadCounts = await prisma.notification.groupBy({
+      by: ["userId"],
+      where: { userId: { in: userIds }, isRead: false },
+      _count: { _all: true },
+    });
+    const badgeByUserId = new Map(
+      unreadCounts.map((row) => [row.userId, row._count._all])
+    );
+
+    for (const userId of userIds) {
+      const unreadCount = badgeByUserId.get(userId) ?? 0;
+      sendNotificationToUser(userId, {
+        title: params.title,
+        message: params.message,
+        type: "info",
+        actionUrl: params.actionUrl,
+        metadata: {
+          type: params.type,
+          relatedId: params.relatedId,
+        },
+      }).catch((err) => console.error("Error sending SSE notification:", err));
+      updateUnreadCount(userId, unreadCount).catch((err) =>
+        console.error("Error sending SSE unread count update:", err)
+      );
+    }
+
+    sendPushToUsers(
+      userIds,
+      {
+        title: params.title,
+        body: params.message,
+        data: {
+          type: params.type,
+          relatedId: params.relatedId,
+          actionUrl: params.actionUrl,
+        },
+      },
+      badgeByUserId
+    ).catch((err) => console.error("Error sending batched push:", err));
+
+    return result;
+  } catch (error) {
+    console.error("Error creating batched notifications:", error);
     throw error;
   }
 }

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { NotificationType } from "@/generated/client";
 import {
+  isUserConnected,
   sendNotificationToUser,
   updateUnreadCount,
 } from "./notification-helpers";
@@ -122,7 +123,11 @@ export async function createNotificationsForUsers(
       unreadCounts.map((row) => [row.userId, row._count._all])
     );
 
+    // Skip SSE for users with no active connection — this is a cheap
+    // in-memory check that avoids per-user log spam when most recipients
+    // aren't online (e.g. an admin sending a shortage blast at 2am).
     for (const userId of userIds) {
+      if (!isUserConnected(userId)) continue;
       const unreadCount = badgeByUserId.get(userId) ?? 0;
       sendNotificationToUser(userId, {
         title: params.title,

--- a/web/src/lib/services/expo-push.ts
+++ b/web/src/lib/services/expo-push.ts
@@ -50,6 +50,40 @@ export async function sendPushToUser(
 }
 
 /**
+ * Send a push notification to every registered device across a set of users,
+ * in one batched Expo request (chunked to the 100-message limit).
+ *
+ * `badgeByUserId` lets callers set a per-user badge value (each recipient's
+ * own unread count) while sharing a single payload. Falls back to
+ * `payload.badge` when a user isn't in the map.
+ */
+export async function sendPushToUsers(
+  userIds: string[],
+  payload: ExpoPushPayload,
+  badgeByUserId?: Map<string, number>
+): Promise<void> {
+  if (userIds.length === 0) return;
+
+  const tokens = await prisma.pushToken.findMany({
+    where: { userId: { in: userIds } },
+    select: { token: true, userId: true },
+  });
+
+  if (tokens.length === 0) return;
+
+  const messages = tokens
+    .filter((t) => isExpoPushToken(t.token))
+    .map((t) =>
+      buildMessage(t.token, {
+        ...payload,
+        badge: badgeByUserId?.get(t.userId) ?? payload.badge,
+      })
+    );
+
+  await dispatchMessages(messages);
+}
+
+/**
  * Send a push notification to a raw list of Expo tokens.
  * Handles chunking, Expo ticket errors, and invalid-token cleanup.
  */
@@ -60,7 +94,18 @@ export async function sendPushToTokens(
   const valid = tokens.filter(isExpoPushToken);
   if (valid.length === 0) return;
 
-  const messages: ExpoPushMessage[] = valid.map((token) => ({
+  const messages: ExpoPushMessage[] = valid.map((token) =>
+    buildMessage(token, payload)
+  );
+
+  await dispatchMessages(messages);
+}
+
+function buildMessage(
+  token: string,
+  payload: ExpoPushPayload
+): ExpoPushMessage {
+  return {
     to: token,
     title: payload.title,
     body: payload.body,
@@ -69,7 +114,11 @@ export async function sendPushToTokens(
     badge: payload.badge,
     // Android notification channel (configured on the client side)
     channelId: payload.channelId ?? "default",
-  }));
+  };
+}
+
+async function dispatchMessages(messages: ExpoPushMessage[]): Promise<void> {
+  if (messages.length === 0) return;
 
   const invalidTokens: string[] = [];
 


### PR DESCRIPTION
## Summary
- Admins sending shortage emails now also dispatch an in-app notification (bell + SSE) and a mobile push to every volunteer the email reached.
- New `createNotificationsForUsers` helper batches the work into one `createMany`, one `groupBy` for per-user unread counts, parallel SSE fan-out, and a single chunked Expo call — no per-volunteer request fan-out.
- Adds `SHIFT_SHORTAGE` to the `NotificationType` enum (with a Prisma migration) and wires the helper into `/api/admin/notifications/send-shortage`.

## Notes
- Push title/body adapts to 1 vs. many shifts; `actionUrl` is `/shifts/:id` for a single shift (opens the shift detail modal on mobile) or `/shifts` for a multi-shift blast (goes to the Shifts tab). Existing `navigateToNotificationTarget` handles both.
- Re-uses the existing `receiveShortageNotifications` opt-in — only volunteers whose email was sent successfully get notified.
- Badge stays in sync: each user's push payload carries their own post-insert unread count.

## Test plan
- [ ] Run `npm run prisma:migrate` locally and verify `SHIFT_SHORTAGE` is added to the enum.
- [ ] Send a single-shift shortage blast as admin → confirm bell notification appears, push arrives on mobile, and tapping it deep-links to the shift detail.
- [ ] Send a multi-shift shortage blast → confirm notification copy summarises the count and tap goes to the Shifts tab.
- [ ] Volunteer with `receiveShortageNotifications = false` receives neither email nor notification.
- [ ] Push badge increments by 1 for recipients who had unread notifications already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)