### PR TITLE
feat(mobile): default location picker on profile edit

### DIFF
--- a/mobile/app/profile/edit.tsx
+++ b/mobile/app/profile/edit.tsx
@@ -47,6 +47,7 @@ type FormData = {
   excludedShortageNotificationTypes: string[];
   emailNewsletterSubscription: boolean;
   newsletterLists: string[];
+  defaultLocation: string;
 };
 
 type ShiftType = { id: string; name: string };
@@ -110,7 +111,7 @@ export default function EditProfileScreen() {
   const isDark = colorScheme === "dark";
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { profile, refresh } = useProfile();
+  const { profile, availableLocations, refresh } = useProfile();
 
   const [form, setForm] = useState<FormData>({
     firstName: "",
@@ -126,6 +127,7 @@ export default function EditProfileScreen() {
     excludedShortageNotificationTypes: [],
     emailNewsletterSubscription: true,
     newsletterLists: [],
+    defaultLocation: "",
   });
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
@@ -228,6 +230,7 @@ export default function EditProfileScreen() {
           profile.excludedShortageNotificationTypes,
         emailNewsletterSubscription: profile.emailNewsletterSubscription,
         newsletterLists: profile.newsletterLists,
+        defaultLocation: profile.defaultLocation ?? "",
       });
       setLocalImage(profile.image ?? null);
       setInitialized(true);
@@ -393,6 +396,7 @@ export default function EditProfileScreen() {
           newsletterLists: form.emailNewsletterSubscription
             ? form.newsletterLists
             : [],
+          defaultLocation: form.defaultLocation || null,
         },
       });
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
@@ -557,6 +561,85 @@ export default function EditProfileScreen() {
             isDark={isDark}
           />
         </View>
+
+        {/* ── Default Location ── */}
+        {availableLocations.length > 0 && (
+          <View style={s.section}>
+            <Text style={[s.sectionTitle, { color: colors.text }]}>
+              Default Location
+            </Text>
+            <Text style={[s.sectionHint, { color: colors.textSecondary }]}>
+              Your usual restaurant — we&apos;ll show shifts here first when you
+              browse.
+            </Text>
+
+            <View
+              style={[
+                s.nestedSection,
+                {
+                  backgroundColor: isDark
+                    ? "rgba(255,255,255,0.04)"
+                    : "#f8fafc",
+                },
+              ]}
+            >
+              {availableLocations.map((location) => {
+                const selected = form.defaultLocation === location;
+                return (
+                  <Pressable
+                    key={location}
+                    onPress={() => {
+                      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                      updateField(
+                        "defaultLocation",
+                        selected ? "" : location
+                      );
+                    }}
+                    style={s.checkRow}
+                  >
+                    <Ionicons
+                      name={selected ? "radio-button-on" : "radio-button-off"}
+                      size={22}
+                      color={
+                        selected
+                          ? isDark
+                            ? "#86efac"
+                            : Brand.green
+                          : colors.textSecondary
+                      }
+                    />
+                    <Text style={[s.checkLabel, { color: colors.text }]}>
+                      {location}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+              {form.defaultLocation !== "" && (
+                <Pressable
+                  onPress={() => {
+                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                    updateField("defaultLocation", "");
+                  }}
+                  style={[s.checkRow, { marginTop: 4 }]}
+                >
+                  <Ionicons
+                    name="close-circle-outline"
+                    size={22}
+                    color={colors.textSecondary}
+                  />
+                  <Text
+                    style={[
+                      s.checkLabel,
+                      { color: colors.textSecondary },
+                    ]}
+                  >
+                    Clear default
+                  </Text>
+                </Pressable>
+              )}
+            </View>
+          </View>
+        )}
 
         {/* ── Emergency Contact ── */}
         <View style={s.section}>

--- a/mobile/hooks/use-profile.ts
+++ b/mobile/hooks/use-profile.ts
@@ -26,7 +26,9 @@ type ProfileResponse = {
     excludedShortageNotificationTypes: string[];
     emailNewsletterSubscription: boolean;
     newsletterLists: string[];
+    defaultLocation: string | null;
   };
+  availableLocations: string[];
   stats: ProfileStats;
   achievements: Achievement[];
   totalPoints: number;
@@ -35,6 +37,7 @@ type ProfileResponse = {
 
 type UseProfileReturn = {
   profile: UserProfile | null;
+  availableLocations: string[];
   stats: ProfileStats | null;
   achievements: Achievement[];
   totalPoints: number;
@@ -93,6 +96,7 @@ export function useProfile(): UseProfileReturn {
         excludedShortageNotificationTypes: data.profile.excludedShortageNotificationTypes,
         emailNewsletterSubscription: data.profile.emailNewsletterSubscription,
         newsletterLists: data.profile.newsletterLists,
+        defaultLocation: data.profile.defaultLocation,
         totalShifts: data.stats.shiftsCompleted,
         memberSince: data.profile.memberSince,
       }
@@ -100,6 +104,7 @@ export function useProfile(): UseProfileReturn {
 
   return {
     profile,
+    availableLocations: data?.availableLocations ?? [],
     stats: data?.stats ?? null,
     achievements: data?.achievements ?? [],
     totalPoints: data?.totalPoints ?? 0,

--- a/mobile/lib/dummy-data.ts
+++ b/mobile/lib/dummy-data.ts
@@ -29,6 +29,7 @@ export type UserProfile = User & {
   excludedShortageNotificationTypes: string[];
   emailNewsletterSubscription: boolean;
   newsletterLists: string[];
+  defaultLocation: string | null;
   totalShifts: number;
   memberSince: string;
 };
@@ -49,6 +50,7 @@ export const DUMMY_PROFILE: UserProfile = {
   excludedShortageNotificationTypes: [],
   emailNewsletterSubscription: true,
   newsletterLists: [],
+  defaultLocation: null,
   totalShifts: 23,
   memberSince: '2025-06-15',
 };

--- a/web/src/app/api/mobile/profile/route.test.ts
+++ b/web/src/app/api/mobile/profile/route.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/prisma", () => ({
     signup: { count: vi.fn(), findMany: vi.fn() },
     friendship: { findMany: vi.fn() },
     userAchievement: { groupBy: vi.fn(), findMany: vi.fn() },
+    location: { findMany: vi.fn() },
   },
 }));
 
@@ -47,6 +48,7 @@ const mockPrisma = prisma as unknown as {
     groupBy: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
   };
+  location: { findMany: ReturnType<typeof vi.fn> };
 };
 
 const MOCK_USER = {
@@ -132,6 +134,10 @@ describe("GET /api/mobile/profile", () => {
     mockPrisma.user.count.mockResolvedValue(10);
     mockPrisma.friendship.findMany.mockResolvedValue([]);
     mockPrisma.userAchievement.groupBy.mockResolvedValue([]);
+    mockPrisma.location.findMany.mockResolvedValue([
+      { name: "Wellington" },
+      { name: "Auckland" },
+    ]);
 
     const response = await GET(makeRequest());
     expect(response.status).toBe(200);
@@ -165,6 +171,7 @@ describe("GET /api/mobile/profile", () => {
     mockPrisma.user.count.mockResolvedValue(5);
     mockPrisma.friendship.findMany.mockResolvedValue([]);
     mockPrisma.userAchievement.groupBy.mockResolvedValue([]);
+    mockPrisma.location.findMany.mockResolvedValue([]);
 
     const response = await GET(makeRequest());
     const json = await response.json();

--- a/web/src/app/api/mobile/profile/route.ts
+++ b/web/src/app/api/mobile/profile/route.ts
@@ -50,6 +50,7 @@ export async function GET(request: Request) {
         excludedShortageNotificationTypes: true,
         emailNewsletterSubscription: true,
         newsletterLists: true,
+        defaultLocation: true,
         createdAt: true,
         customLabels: {
           select: {
@@ -106,7 +107,7 @@ export async function GET(request: Request) {
 
     // Fetch achievements
     await checkAndUnlockAchievements(userId);
-    const [userAchievements, availableAchievements, totalVolunteers] =
+    const [userAchievements, availableAchievements, totalVolunteers, locationRows] =
       await Promise.all([
         getUserAchievements(userId),
         getAvailableAchievements(userId),
@@ -115,7 +116,18 @@ export async function GET(request: Request) {
             signups: { some: { status: "CONFIRMED" } },
           },
         }),
+        prisma.location.findMany({
+          where: { isActive: true },
+          select: { name: true },
+          orderBy: { name: "asc" },
+        }),
       ]);
+
+    // Exclude "Special Event Venue" — it isn't a regular working location
+    // and we don't want it offered as a default.
+    const availableLocations = locationRows
+      .map((l) => l.name)
+      .filter((n) => n !== "Special Event Venue");
 
     // Count how many users have unlocked each achievement
     const allAchievementIds = [
@@ -252,7 +264,9 @@ export async function GET(request: Request) {
         excludedShortageNotificationTypes: user.excludedShortageNotificationTypes,
         emailNewsletterSubscription: user.emailNewsletterSubscription,
         newsletterLists: user.newsletterLists,
+        defaultLocation: user.defaultLocation,
       },
+      availableLocations,
       stats: {
         shiftsCompleted: completedSignups,
         hoursContributed: Math.round(hoursContributed),
@@ -316,6 +330,7 @@ const updateMobileProfileSchema = z.object({
   excludedShortageNotificationTypes: z.array(z.string()).optional(),
   emailNewsletterSubscription: z.boolean().optional(),
   newsletterLists: z.array(z.string()).optional(),
+  defaultLocation: z.string().nullable().optional(),
 });
 
 export async function PUT(request: Request) {
@@ -338,6 +353,11 @@ export async function PUT(request: Request) {
     const profileFields = parsed.data;
 
     const data: Record<string, unknown> = { ...profileFields };
+
+    // Normalize empty string to null so "no default" clears the column.
+    if (profileFields.defaultLocation !== undefined) {
+      data.defaultLocation = profileFields.defaultLocation || null;
+    }
 
     // Update name field for display consistency
     if (profileFields.firstName || profileFields.lastName) {


### PR DESCRIPTION
## Summary
- Adds a Default Location section to the mobile profile edit screen with a radio-style picker and a Clear option — follow-up to #804 which only exposed the field on the shifts filter
- `/api/mobile/profile` GET now returns `defaultLocation` and the list of selectable locations (active Locations minus "Special Event Venue")
- `/api/mobile/profile` PUT accepts `defaultLocation` (nullable)

## Test plan
- [ ] Open the mobile app → Profile → Edit profile
- [ ] Default Location section renders with one row per active restaurant location
- [ ] Tapping a location selects it (haptic feedback, radio-on icon)
- [ ] Clear default hides when no selection, appears otherwise
- [ ] Saving persists the choice; reopening the edit screen shows it selected
- [ ] Shifts tab opens with the newly-chosen location pre-filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)