### PR TITLE
feat(profile): visual refresh on the view page

### DIFF
--- a/web/src/app/profile/profile-content.tsx
+++ b/web/src/app/profile/profile-content.tsx
@@ -1,14 +1,29 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
-import { CardContent } from "@/components/ui/card";
+import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import Link from "next/link";
 import { MotionCard } from "@/components/motion-card";
+import { MotionContentCard } from "@/components/motion-content-card";
 import { ContentGrid } from "@/components/dashboard-animated";
 import { safeParseAvailability } from "@/lib/parse-availability";
+import {
+  Bell,
+  CalendarDays,
+  CalendarPlus,
+  HeartPulse,
+  Info,
+  Mail,
+  MapPin,
+  Pencil,
+  Phone,
+  Sparkles,
+  User as UserIcon,
+  UserCircle,
+} from "lucide-react";
 
 export async function ProfileContent() {
   const session = await getServerSession(authOptions);
@@ -55,44 +70,31 @@ export async function ProfileContent() {
         },
       }),
       prisma.shiftType.findMany({
-        select: {
-          id: true,
-          name: true,
-        },
-        orderBy: {
-          name: "asc",
-        },
+        select: { id: true, name: true },
+        orderBy: { name: "asc" },
       }),
       prisma.newsletterList.findMany({
         where: { active: true },
-        select: {
-          id: true,
-          name: true,
-          campaignMonitorId: true,
-        },
-        orderBy: {
-          displayOrder: "asc",
-        },
+        select: { id: true, name: true, campaignMonitorId: true },
+        orderBy: { displayOrder: "asc" },
       }),
     ]);
   }
 
-  const userInitials =
-    userProfile?.name || session?.user?.name
-      ? (userProfile?.name || session?.user?.name)!
-          .split(" ")
-          .map((name: string) => name.charAt(0))
-          .join("")
-          .substring(0, 2)
-          .toUpperCase()
-      : "U";
+  const displayName =
+    userProfile?.name || session?.user?.name || "Volunteer";
+  const userInitials = displayName
+    .split(" ")
+    .map((n: string) => n.charAt(0))
+    .join("")
+    .substring(0, 2)
+    .toUpperCase();
 
   const availableDays = safeParseAvailability(userProfile?.availableDays);
   const availableLocations = safeParseAvailability(
     userProfile?.availableLocations
   );
 
-  // Check if profile is incomplete based on required fields
   const isProfileIncomplete =
     !userProfile?.phone ||
     !userProfile?.dateOfBirth ||
@@ -104,21 +106,9 @@ export async function ProfileContent() {
   if (!session?.user) {
     return (
       <MotionCard>
-        <CardContent className="p-8 text-center">
+        <CardContent className="p-10 text-center">
           <div className="w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-            <svg
-              className="w-8 h-8 text-primary/60"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-              />
-            </svg>
+            <UserCircle className="w-8 h-8 text-primary/70" />
           </div>
           <h3 className="text-xl font-semibold mb-2">Sign in required</h3>
           <p className="text-muted-foreground mb-4">
@@ -134,313 +124,259 @@ export async function ProfileContent() {
 
   return (
     <div className="space-y-8">
-      {/* Profile Header */}
+      {/* Hero */}
       <MotionCard>
-        <CardContent className="p-8">
-          <div className="flex flex-col md:flex-row items-center md:items-start gap-6">
-            <div className="relative">
-              <Avatar className="w-36 h-36 shadow-lg">
-                <AvatarImage
-                  src={userProfile?.profilePhotoUrl || undefined}
-                  alt="Profile"
-                  className="object-cover"
-                />
-                <AvatarFallback className="text-2xl font-bold bg-gradient-to-br from-primary to-primary-700 text-white">
-                  {userInitials}
-                </AvatarFallback>
-              </Avatar>
-            </div>
+        <CardContent className="p-8 md:p-10">
+          <div className="flex flex-col md:flex-row items-center md:items-start gap-8">
+            <Avatar className="w-32 h-32 md:w-36 md:h-36 ring-4 ring-primary/10 dark:ring-primary/20 shadow-lg">
+              <AvatarImage
+                src={userProfile?.profilePhotoUrl || undefined}
+                alt={displayName}
+                className="object-cover"
+              />
+              <AvatarFallback className="text-3xl font-bold bg-gradient-to-br from-primary to-primary-700 text-white">
+                {userInitials}
+              </AvatarFallback>
+            </Avatar>
 
-            <div className="flex-1 text-center md:text-left">
-              <h2 className="text-2xl font-bold mb-2">
-                {userProfile?.name || session.user.name || "Volunteer"}
+            <div className="flex-1 min-w-0 text-center md:text-left">
+              <h2
+                className="font-accent text-4xl md:text-5xl font-bold tracking-tight text-foreground"
+                style={{ fontVariationSettings: '"SOFT" 50' }}
+              >
+                {displayName}
               </h2>
-              <p className="text-muted-foreground mb-4">
-                {userProfile?.email || session.user.email}
-              </p>
-              {userProfile?.pronouns && (
-                <p className="text-sm text-muted-foreground mb-4">
-                  Pronouns: {userProfile.pronouns}
-                </p>
-              )}
+              <div className="mt-3 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 text-sm text-muted-foreground justify-center md:justify-start">
+                <span className="inline-flex items-center gap-1.5">
+                  <Mail className="w-4 h-4" />
+                  {userProfile?.email || session.user.email}
+                </span>
+                {userProfile?.pronouns && (
+                  <span className="hidden sm:inline text-border">•</span>
+                )}
+                {userProfile?.pronouns && (
+                  <span>{userProfile.pronouns}</span>
+                )}
+              </div>
 
-              <div className="flex flex-wrap gap-2 justify-center md:justify-start">
+              <div className="mt-5 flex flex-wrap gap-2 justify-center md:justify-start">
                 <Badge className="badge-primary" data-testid="user-role">
                   {userProfile?.role === "ADMIN"
                     ? "Administrator"
                     : "Volunteer"}
                 </Badge>
-                <Badge variant="outline" className="badge-accent">
-                  Active Member
-                </Badge>
+                {userProfile?.defaultLocation && (
+                  <Badge variant="outline" className="gap-1.5">
+                    <MapPin className="w-3 h-3" />
+                    {userProfile.defaultLocation}
+                  </Badge>
+                )}
                 {userProfile?.volunteerAgreementAccepted && (
                   <Badge
                     variant="outline"
-                    className="text-green-600 border-green-200 dark:text-green-400 dark:border-green-800"
+                    className="text-green-700 border-green-200 bg-green-50/60 dark:text-green-400 dark:border-green-900/60 dark:bg-green-950/30"
                   >
-                    Agreement Signed
+                    Agreement signed
                   </Badge>
                 )}
               </div>
             </div>
 
-            <div className="flex gap-2">
-              <Button variant="outline" size="sm" asChild>
-                <Link
-                  href="/profile/edit"
-                  className="flex items-center gap-2"
-                >
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                    />
-                  </svg>
-                  Edit Profile
-                </Link>
-              </Button>
-            </div>
+            <Button asChild variant="outline" className="self-stretch md:self-start">
+              <Link href="/profile/edit" className="flex items-center gap-2">
+                <Pencil className="w-4 h-4" />
+                Edit profile
+              </Link>
+            </Button>
           </div>
         </CardContent>
       </MotionCard>
 
-      {/* Profile Details Grid */}
+      {/* Incomplete profile nudge */}
+      {isProfileIncomplete && (
+        <MotionCard>
+          <CardContent className="flex items-start gap-4 p-5 md:p-6">
+            <div className="shrink-0 w-10 h-10 rounded-full bg-primary/10 dark:bg-primary/20 flex items-center justify-center">
+              <Info className="w-5 h-5 text-primary dark:text-emerald-400" />
+            </div>
+            <div className="flex-1">
+              <h3 className="font-semibold">Finish setting up your profile</h3>
+              <p className="text-sm text-muted-foreground mt-1">
+                Add your emergency contact, availability, and preferences so we
+                can match you to the right shifts.
+              </p>
+            </div>
+            <Button asChild size="sm">
+              <Link href="/profile/edit">Complete profile</Link>
+            </Button>
+          </CardContent>
+        </MotionCard>
+      )}
+
+      {/* Details grid */}
       <ContentGrid>
         {/* Personal Information */}
-        <MotionCard>
-          <CardContent className="px-6">
-            <div className="flex items-center gap-4 mb-6">
-              <div className="w-12 h-12 bg-blue-100 dark:bg-blue-900/50 rounded-lg flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-blue-600 dark:text-blue-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                  />
-                </svg>
-              </div>
-              <div>
-                <h2
-                  className="text-xl font-semibold"
-                  data-testid="personal-info-heading"
-                >
-                  Personal Information
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  Your account details
-                </p>
-              </div>
-            </div>
+        <MotionContentCard delay={0.05}>
+          <CardHeader>
+            <CardTitle
+              className="flex items-center gap-2 text-xl"
+              data-testid="personal-info-heading"
+            >
+              <UserIcon className="w-5 h-5 text-primary dark:text-emerald-400" />
+              Personal Information
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl
+              className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-3 text-sm"
+              data-testid="personal-info-section"
+            >
+              <dt
+                className="text-muted-foreground"
+                data-testid="personal-info-name-label"
+              >
+                Name
+              </dt>
+              <dd className="font-medium text-right">
+                {userProfile?.name || "—"}
+              </dd>
 
-            <div className="space-y-4" data-testid="personal-info-section">
-              <div className="flex justify-between items-center py-3 border-b border-border">
-                <span
-                  className="text-sm font-medium text-muted-foreground"
-                  data-testid="personal-info-name-label"
-                >
-                  Name
-                </span>
-                <span className="font-medium">
-                  {userProfile?.name || "\u2014"}
-                </span>
-              </div>
-              <div className="flex justify-between items-center py-3 border-b border-border">
-                <span
-                  className="text-sm font-medium text-muted-foreground"
-                  data-testid="personal-info-email-label"
-                >
-                  Email
-                </span>
-                <span className="font-medium">
-                  {userProfile?.email || "\u2014"}
-                </span>
-              </div>
+              <dt
+                className="text-muted-foreground"
+                data-testid="personal-info-email-label"
+              >
+                Email
+              </dt>
+              <dd className="font-medium text-right break-all">
+                {userProfile?.email || "—"}
+              </dd>
+
               {userProfile?.phone && (
-                <div className="flex justify-between items-center py-3 border-b border-border">
-                  <span className="text-sm font-medium text-muted-foreground">
-                    Phone
-                  </span>
-                  <span className="font-medium">{userProfile.phone}</span>
-                </div>
+                <>
+                  <dt className="text-muted-foreground">Phone</dt>
+                  <dd className="font-medium text-right">
+                    {userProfile.phone}
+                  </dd>
+                </>
               )}
+
               {userProfile?.dateOfBirth && (
-                <div className="flex justify-between items-center py-3 border-b border-border">
-                  <span className="text-sm font-medium text-muted-foreground">
-                    Date of Birth
-                  </span>
-                  <span className="font-medium">
+                <>
+                  <dt className="text-muted-foreground">Date of birth</dt>
+                  <dd className="font-medium text-right">
                     {new Date(userProfile.dateOfBirth).toLocaleDateString(
                       "en-NZ"
                     )}
-                  </span>
-                </div>
-              )}
-              <div className="flex justify-between items-center py-3">
-                <span
-                  className="text-sm font-medium text-muted-foreground"
-                  data-testid="personal-info-account-type-label"
-                >
-                  Account Type
-                </span>
-                <span className="font-medium">
-                  {userProfile?.role === "ADMIN"
-                    ? "Administrator"
-                    : "Volunteer"}
-                </span>
-              </div>
-            </div>
-          </CardContent>
-        </MotionCard>
-
-        {/* Emergency Contact & Availability */}
-        <MotionCard>
-          <CardContent className="px-6">
-            <div className="flex items-center gap-4 mb-6">
-              <div className="w-12 h-12 bg-green-100 dark:bg-green-900/50 rounded-lg flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-green-600 dark:text-green-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
-                  />
-                </svg>
-              </div>
-              <div>
-                <h2
-                  className="text-xl font-semibold"
-                  data-testid="emergency-contact-heading"
-                >
-                  Emergency Contact
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  Emergency contact information
-                </p>
-              </div>
-            </div>
-
-            <div
-              className="space-y-4"
-              data-testid="emergency-contact-section"
-            >
-              {userProfile?.emergencyContactName ? (
-                <>
-                  <div className="flex justify-between items-center py-3 border-b border-border">
-                    <span
-                      className="text-sm font-medium text-muted-foreground"
-                      data-testid="emergency-contact-name-label"
-                    >
-                      Name
-                    </span>
-                    <span className="font-medium">
-                      {userProfile.emergencyContactName}
-                    </span>
-                  </div>
-                  {userProfile.emergencyContactRelationship && (
-                    <div className="flex justify-between items-center py-3 border-b border-border">
-                      <span className="text-sm font-medium text-muted-foreground">
-                        Relationship
-                      </span>
-                      <span className="font-medium">
-                        {userProfile.emergencyContactRelationship}
-                      </span>
-                    </div>
-                  )}
-                  {userProfile.emergencyContactPhone && (
-                    <div className="flex justify-between items-center py-3">
-                      <span className="text-sm font-medium text-muted-foreground">
-                        Phone
-                      </span>
-                      <span className="font-medium">
-                        {userProfile.emergencyContactPhone}
-                      </span>
-                    </div>
-                  )}
+                  </dd>
                 </>
+              )}
+
+              <dt
+                className="text-muted-foreground"
+                data-testid="personal-info-account-type-label"
+              >
+                Account type
+              </dt>
+              <dd className="font-medium text-right">
+                {userProfile?.role === "ADMIN" ? "Administrator" : "Volunteer"}
+              </dd>
+            </dl>
+          </CardContent>
+        </MotionContentCard>
+
+        {/* Emergency Contact */}
+        <MotionContentCard delay={0.1}>
+          <CardHeader>
+            <CardTitle
+              className="flex items-center gap-2 text-xl"
+              data-testid="emergency-contact-heading"
+            >
+              <HeartPulse className="w-5 h-5 text-primary dark:text-emerald-400" />
+              Emergency Contact
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div data-testid="emergency-contact-section">
+              {userProfile?.emergencyContactName ? (
+                <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-3 text-sm">
+                  <dt
+                    className="text-muted-foreground"
+                    data-testid="emergency-contact-name-label"
+                  >
+                    Name
+                  </dt>
+                  <dd className="font-medium text-right">
+                    {userProfile.emergencyContactName}
+                  </dd>
+
+                  {userProfile.emergencyContactRelationship && (
+                    <>
+                      <dt className="text-muted-foreground">Relationship</dt>
+                      <dd className="font-medium text-right">
+                        {userProfile.emergencyContactRelationship}
+                      </dd>
+                    </>
+                  )}
+
+                  {userProfile.emergencyContactPhone && (
+                    <>
+                      <dt className="text-muted-foreground">Phone</dt>
+                      <dd className="font-medium text-right">
+                        {userProfile.emergencyContactPhone}
+                      </dd>
+                    </>
+                  )}
+                </dl>
               ) : (
-                <p className="text-muted-foreground text-center py-4">
-                  No emergency contact information provided
-                </p>
+                <EmptyState
+                  icon={Phone}
+                  message="No emergency contact on file yet."
+                />
               )}
             </div>
           </CardContent>
-        </MotionCard>
+        </MotionContentCard>
 
-        {/* Availability Information */}
-        <MotionCard>
-          <CardContent className="px-6">
-            <div className="flex items-center gap-4 mb-6">
-              <div className="w-12 h-12 bg-purple-100 dark:bg-purple-900/50 rounded-lg flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-purple-600 dark:text-purple-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  />
-                </svg>
-              </div>
-              <div>
-                <h2
-                  className="text-xl font-semibold"
-                  data-testid="availability-heading"
-                >
-                  Availability
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  When and where you can volunteer
-                </p>
-              </div>
-            </div>
+        {/* Availability */}
+        <MotionContentCard delay={0.15}>
+          <CardHeader>
+            <CardTitle
+              className="flex items-center gap-2 text-xl"
+              data-testid="availability-heading"
+            >
+              <CalendarDays className="w-5 h-5 text-primary dark:text-emerald-400" />
+              Availability
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div
+              className="space-y-5 text-sm"
+              data-testid="availability-section"
+            >
+              {userProfile?.defaultLocation && (
+                <Field label="Default location">
+                  <Badge variant="outline" className="gap-1.5">
+                    <MapPin className="w-3 h-3" />
+                    {userProfile.defaultLocation}
+                  </Badge>
+                </Field>
+              )}
 
-            <div className="space-y-4" data-testid="availability-section">
               {availableDays.length > 0 && (
-                <div>
-                  <span className="text-sm font-medium text-muted-foreground">
-                    Available Days:
-                  </span>
-                  <div className="flex flex-wrap gap-1 mt-2">
+                <Field label="Available days">
+                  <div className="flex flex-wrap gap-1.5">
                     {availableDays.map((day: string) => (
-                      <Badge
-                        key={day}
-                        variant="outline"
-                        className="text-xs"
-                      >
+                      <Badge key={day} variant="outline" className="text-xs">
                         {day.charAt(0).toUpperCase() + day.slice(1)}
                       </Badge>
                     ))}
                   </div>
-                </div>
+                </Field>
               )}
+
               {availableLocations.length > 0 && (
-                <div>
-                  <span className="text-sm font-medium text-muted-foreground">
-                    Available Locations:
-                  </span>
-                  <div className="flex flex-wrap gap-1 mt-2">
+                <Field label="Preferred locations">
+                  <div className="flex flex-wrap gap-1.5">
                     {availableLocations.map((location: string) => (
                       <Badge
                         key={location}
@@ -451,74 +387,43 @@ export async function ProfileContent() {
                       </Badge>
                     ))}
                   </div>
-                </div>
+                </Field>
               )}
-              {userProfile?.defaultLocation && (
-                <div>
-                  <span className="text-sm font-medium text-muted-foreground">
-                    Default Location:
-                  </span>
-                  <div className="flex flex-wrap gap-1 mt-2">
-                    <Badge variant="outline" className="text-xs">
-                      {userProfile.defaultLocation}
-                    </Badge>
-                  </div>
-                </div>
-              )}
+
               {availableDays.length === 0 &&
-                availableLocations.length === 0 && (
-                  <p className="text-muted-foreground text-center py-4">
-                    No availability preferences set
-                  </p>
+                availableLocations.length === 0 &&
+                !userProfile?.defaultLocation && (
+                  <EmptyState
+                    icon={CalendarDays}
+                    message="No availability preferences set yet."
+                  />
                 )}
             </div>
           </CardContent>
-        </MotionCard>
+        </MotionContentCard>
 
-        {/* Notification Preferences */}
-        <MotionCard>
-          <CardContent className="px-6">
-            <div className="flex items-center gap-4 mb-6">
-              <div className="w-12 h-12 bg-orange-100 dark:bg-orange-900/50 rounded-lg flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-orange-600 dark:text-orange-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0"
-                  />
-                </svg>
-              </div>
-              <div>
-                <h2 className="text-xl font-semibold">
-                  Shift Shortage Notifications
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  Control your notification preferences
-                </p>
-              </div>
-            </div>
-
+        {/* Notifications */}
+        <MotionContentCard delay={0.2}>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-xl">
+              <Bell className="w-5 h-5 text-primary dark:text-emerald-400" />
+              Notifications
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
             <div
-              className="space-y-4"
+              className="space-y-5 text-sm"
               data-testid="notification-preferences-section"
             >
-              <div className="flex justify-between items-center py-3 border-b border-border">
-                <span className="text-sm font-medium text-muted-foreground">
-                  Receive Notifications
-                </span>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Shortage alerts</span>
                 <Badge
                   variant="outline"
                   data-testid="receive-notifications-toggle"
                   className={
                     userProfile?.receiveShortageNotifications
-                      ? "text-green-600 border-green-200 dark:text-green-400 dark:border-green-800"
-                      : "text-muted-foreground border-border"
+                      ? "text-green-700 border-green-200 bg-green-50/60 dark:text-green-400 dark:border-green-900/60 dark:bg-green-950/30"
+                      : "text-muted-foreground"
                   }
                 >
                   {userProfile?.receiveShortageNotifications
@@ -529,11 +434,8 @@ export async function ProfileContent() {
 
               {userProfile?.receiveShortageNotifications && (
                 <>
-                  <div>
-                    <span className="text-sm font-medium text-muted-foreground">
-                      Shift types you&apos;d like notifications for:
-                    </span>
-                    <div className="flex flex-wrap gap-1 mt-2">
+                  <Field label="Receiving alerts for">
+                    <div className="flex flex-wrap gap-1.5">
                       {shiftTypes
                         .filter(
                           (type) =>
@@ -551,15 +453,12 @@ export async function ProfileContent() {
                           </Badge>
                         ))}
                     </div>
-                  </div>
+                  </Field>
 
                   {userProfile?.excludedShortageNotificationTypes?.length >
                     0 && (
-                    <div>
-                      <span className="text-sm font-medium text-muted-foreground">
-                        Excluded shift types:
-                      </span>
-                      <div className="flex flex-wrap gap-1 mt-2">
+                    <Field label="Muted shift types">
+                      <div className="flex flex-wrap gap-1.5">
                         {shiftTypes
                           .filter((type) =>
                             userProfile?.excludedShortageNotificationTypes?.includes(
@@ -576,22 +475,20 @@ export async function ProfileContent() {
                             </Badge>
                           ))}
                       </div>
-                    </div>
+                    </Field>
                   )}
                 </>
               )}
 
-              <div className="mt-6 pt-4 border-t border-border">
-                <div className="flex justify-between items-center py-3">
-                  <span className="text-sm font-medium text-muted-foreground">
-                    Newsletter Subscription
-                  </span>
+              <div className="border-t pt-5 space-y-5">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-muted-foreground">Newsletter</span>
                   <Badge
                     variant="outline"
                     className={
                       userProfile?.emailNewsletterSubscription
-                        ? "text-green-600 border-green-200 dark:text-green-400 dark:border-green-800"
-                        : "text-muted-foreground border-border"
+                        ? "text-green-700 border-green-200 bg-green-50/60 dark:text-green-400 dark:border-green-900/60 dark:bg-green-950/30"
+                        : "text-muted-foreground"
                     }
                   >
                     {userProfile?.emailNewsletterSubscription
@@ -601,88 +498,60 @@ export async function ProfileContent() {
                 </div>
 
                 {userProfile?.emailNewsletterSubscription &&
-                  userProfile?.newsletterLists &&
-                  userProfile.newsletterLists.length > 0 && (
-                    <div className="mt-2">
-                      <span className="text-sm font-medium text-muted-foreground">
-                        Subscribed to:
-                      </span>
-                      <div className="flex flex-wrap gap-1 mt-2">
-                        {userProfile.newsletterLists.map(
-                          (listId: string) => {
-                            const list = newsletterLists.find(
-                              (l) => l.campaignMonitorId === listId
-                            );
-                            return (
-                              <Badge
-                                key={listId}
-                                variant="outline"
-                                className="text-xs"
-                              >
-                                {list?.name || listId}
-                              </Badge>
-                            );
-                          }
-                        )}
+                  userProfile?.newsletterLists?.length > 0 && (
+                    <Field label="Subscribed to">
+                      <div className="flex flex-wrap gap-1.5">
+                        {userProfile.newsletterLists.map((listId: string) => {
+                          const list = newsletterLists.find(
+                            (l) => l.campaignMonitorId === listId
+                          );
+                          return (
+                            <Badge
+                              key={listId}
+                              variant="outline"
+                              className="text-xs"
+                            >
+                              {list?.name || listId}
+                            </Badge>
+                          );
+                        })}
                       </div>
-                    </div>
+                    </Field>
                   )}
               </div>
 
-              <div className="pt-4 border-t border-border">
+              <div className="border-t pt-5">
                 <Button
                   variant="outline"
                   size="sm"
                   data-testid="edit-notification-preferences"
                   asChild
                 >
-                  <Link href="/profile/edit?step=communication">
-                    Edit Preferences
+                  <Link
+                    href="/profile/edit?step=communication"
+                    className="flex items-center gap-2"
+                  >
+                    <Pencil className="w-3.5 h-3.5" />
+                    Edit preferences
                   </Link>
                 </Button>
               </div>
             </div>
           </CardContent>
-        </MotionCard>
+        </MotionContentCard>
 
         {/* Quick Actions */}
-        <MotionCard>
-          <CardContent className="p-6">
-            <div className="flex items-center gap-4 mb-6">
-              <div className="w-12 h-12 bg-amber-100 dark:bg-amber-900/50 rounded-lg flex items-center justify-center">
-                <svg
-                  className="w-6 h-6 text-amber-600 dark:text-amber-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                </svg>
-              </div>
-              <div>
-                <h2
-                  className="text-xl font-semibold"
-                  data-testid="quick-actions-heading"
-                >
-                  Quick Actions
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  Manage your volunteer experience
-                </p>
-              </div>
-            </div>
-
+        <MotionContentCard delay={0.25}>
+          <CardHeader>
+            <CardTitle
+              className="flex items-center gap-2 text-xl"
+              data-testid="quick-actions-heading"
+            >
+              <Sparkles className="w-5 h-5 text-primary dark:text-emerald-400" />
+              Quick Actions
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
             <div className="space-y-3" data-testid="quick-actions-section">
               <Button
                 asChild
@@ -691,20 +560,8 @@ export async function ProfileContent() {
                 data-testid="browse-shifts-button"
               >
                 <Link href="/shifts" className="flex items-center gap-3">
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-                    />
-                  </svg>
-                  Browse Available Shifts
+                  <CalendarPlus className="w-4 h-4" />
+                  Browse available shifts
                 </Link>
               </Button>
 
@@ -714,62 +571,45 @@ export async function ProfileContent() {
                 className="w-full justify-start"
                 data-testid="view-schedule-button"
               >
-                <Link
-                  href="/shifts/mine"
-                  className="flex items-center gap-3"
-                >
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 5H7a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                    />
-                  </svg>
-                  View My Schedule
+                <Link href="/shifts/mine" className="flex items-center gap-3">
+                  <CalendarDays className="w-4 h-4" />
+                  View my schedule
                 </Link>
               </Button>
-
-              {isProfileIncomplete && (
-                <div className="pt-4 border-t border-border">
-                  <div className="bg-primary/5 dark:bg-primary/10 rounded-lg p-4 border border-primary/20 dark:border-primary/30">
-                    <div className="flex items-start gap-3">
-                      <svg
-                        className="w-5 h-5 text-primary mt-0.5"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
-                      <div>
-                        <p className="font-medium text-primary">
-                          Complete your profile!
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          Add your emergency contact, availability, and
-                          preferences to get the most out of your volunteer
-                          experience.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
             </div>
           </CardContent>
-        </MotionCard>
+        </MotionContentCard>
       </ContentGrid>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="text-muted-foreground mb-2">{label}</div>
+      {children}
+    </div>
+  );
+}
+
+function EmptyState({
+  icon: Icon,
+  message,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  message: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center text-center py-6 text-muted-foreground">
+      <Icon className="w-6 h-6 mb-2 opacity-60" />
+      <p className="text-sm">{message}</p>
     </div>
   );
 }

--- a/web/tests/e2e/profile.spec.ts
+++ b/web/tests/e2e/profile.spec.ts
@@ -26,9 +26,9 @@ test.describe("Profile Page", () => {
     );
     await expect(description.first()).toBeVisible();
 
-    // Check profile header card is visible by finding the "Active Member" badge
-    const activeMemberBadge = page.getByText("Active Member");
-    await expect(activeMemberBadge.first()).toBeVisible();
+    // Check profile header card is visible via the role badge
+    const roleBadge = page.getByTestId("user-role");
+    await expect(roleBadge).toBeVisible();
 
     // Check edit profile button
     const editButton = page.getByRole("link", { name: /edit profile/i });
@@ -58,20 +58,12 @@ test.describe("Profile Page", () => {
     // Check role badge
     const roleBadge = page.getByTestId("user-role");
     await expect(roleBadge).toBeVisible();
-
-    // Check active member badge
-    const activeBadge = page.getByText("Active Member");
-    await expect(activeBadge.first()).toBeVisible();
   });
 
   test("should display personal information section", async ({ page }) => {
     // Check personal information heading
     const personalInfoHeading = page.getByTestId("personal-info-heading");
     await expect(personalInfoHeading).toBeVisible();
-
-    // Check account details subheading
-    const accountDetails = page.getByText("Your account details");
-    await expect(accountDetails.first()).toBeVisible();
 
     // Check common fields that should always be present
     const nameLabel = page.getByTestId("personal-info-name-label");
@@ -91,17 +83,9 @@ test.describe("Profile Page", () => {
     const emergencyHeading = page.getByTestId("emergency-contact-heading");
     await expect(emergencyHeading).toBeVisible();
 
-    // Check section description
-    const emergencyDescription = page.getByText(
-      "Emergency contact information"
-    );
-    await expect(emergencyDescription.first()).toBeVisible();
-
     // Check either emergency contact info or empty state message
-    const hasEmergencyContact =
-      (await page
-        .getByText("No emergency contact information provided")
-        .count()) === 0;
+    const emptyState = page.getByText("No emergency contact on file yet.");
+    const hasEmergencyContact = (await emptyState.count()) === 0;
 
     if (hasEmergencyContact) {
       // If emergency contact exists, check for name field
@@ -109,43 +93,33 @@ test.describe("Profile Page", () => {
       await expect(contactNameLabel).toBeVisible();
     } else {
       // If no emergency contact, check for empty state message
-      const noContactMessage = page.getByText(
-        "No emergency contact information provided"
-      );
-      await expect(noContactMessage.first()).toBeVisible();
+      await expect(emptyState.first()).toBeVisible();
     }
   });
 
   test("should display availability section", async ({ page }) => {
     // Check availability heading
     const availabilityHeading = page.getByTestId("availability-heading");
-    await expect(availabilityHeading).toBeVisible();
-
-    // Check section description
-    const availabilityDescription = page.getByText(
-      "When and where you can volunteer"
-    );
-    await expect(availabilityDescription.first()).toBeVisible();
+    await expect(availabilityHeading.first()).toBeVisible();
 
     // Check either availability info or empty state
-    const hasAvailability =
-      (await page.getByText("No availability preferences set").count()) === 0;
+    const emptyState = page.getByText("No availability preferences set yet.");
+    const hasAvailability = (await emptyState.count()) === 0;
 
     if (hasAvailability) {
-      // If availability exists, check for available days or locations
-      const availableDaysLabel = page.getByText("Available Days:");
-      const availableLocationsLabel = page.getByText("Available Locations:");
+      // If availability exists, check for at least one of the populated fields
+      const availableDaysLabel = page.getByText("Available days");
+      const preferredLocationsLabel = page.getByText("Preferred locations");
+      const defaultLocationLabel = page.getByText("Default location");
 
       const hasDays = (await availableDaysLabel.count()) > 0;
-      const hasLocations = (await availableLocationsLabel.count()) > 0;
+      const hasLocations = (await preferredLocationsLabel.count()) > 0;
+      const hasDefault = (await defaultLocationLabel.count()) > 0;
 
-      expect(hasDays || hasLocations).toBe(true);
+      expect(hasDays || hasLocations || hasDefault).toBe(true);
     } else {
       // If no availability, check for empty state message
-      const noAvailabilityMessage = page.getByText(
-        "No availability preferences set"
-      );
-      await expect(noAvailabilityMessage.first()).toBeVisible();
+      await expect(emptyState.first()).toBeVisible();
     }
   });
 
@@ -154,20 +128,14 @@ test.describe("Profile Page", () => {
     const quickActionsHeading = page.getByTestId("quick-actions-heading");
     await expect(quickActionsHeading).toBeVisible();
 
-    // Check section description
-    const quickActionsDescription = page.getByText(
-      "Manage your volunteer experience"
-    );
-    await expect(quickActionsDescription.first()).toBeVisible();
-
     // Check action buttons exist
     const browseShiftsButton = page.getByTestId("browse-shifts-button");
     await expect(browseShiftsButton).toBeVisible();
-    await expect(browseShiftsButton).toContainText("Browse Available Shifts");
+    await expect(browseShiftsButton).toContainText(/browse available shifts/i);
 
     const viewScheduleButton = page.getByTestId("view-schedule-button");
     await expect(viewScheduleButton).toBeVisible();
-    await expect(viewScheduleButton).toContainText("View My Schedule");
+    await expect(viewScheduleButton).toContainText(/view my schedule/i);
   });
 
   test("should navigate to edit profile page", async ({ page }) => {
@@ -183,7 +151,7 @@ test.describe("Profile Page", () => {
     // Check that the link exists and is clickable
     const browseShiftsLink = page
       .locator('a[href="/shifts"]')
-      .filter({ hasText: "Browse Available Shifts" });
+      .filter({ hasText: /browse available shifts/i });
     await expect(browseShiftsLink.first()).toBeVisible();
 
     await browseShiftsLink.click();
@@ -198,7 +166,7 @@ test.describe("Profile Page", () => {
     // Check that the link exists and is clickable
     const viewScheduleLink = page
       .locator('a[href="/shifts/mine"]')
-      .filter({ hasText: "View My Schedule" });
+      .filter({ hasText: /view my schedule/i });
     await expect(viewScheduleLink.first()).toBeVisible();
 
     await viewScheduleLink.click();
@@ -258,19 +226,13 @@ test.describe("Profile Page", () => {
   });
 
   test("should display badges correctly", async ({ page }) => {
-    // Check role badge
-    const badges = page
-      .locator('[class*="badge"]')
-      .or(page.getByText("Administrator").or(page.getByText("Volunteer")));
-    const badgeCount = await badges.count();
-    expect(badgeCount).toBeGreaterThan(0);
+    // Role badge always rendered via data-testid
+    const roleBadge = page.getByTestId("user-role");
+    await expect(roleBadge).toBeVisible();
+    await expect(roleBadge).toContainText(/administrator|volunteer/i);
 
-    // Check active member badge
-    const activeBadge = page.getByText("Active Member");
-    await expect(activeBadge.first()).toBeVisible();
-
-    // Check for agreement signed badge if present
-    const agreementBadge = page.getByText("Agreement Signed");
+    // Agreement signed badge if profile has it accepted
+    const agreementBadge = page.getByText(/agreement signed/i);
     if ((await agreementBadge.count()) > 0) {
       await expect(agreementBadge.first()).toBeVisible();
     }
@@ -356,13 +318,15 @@ test.describe("Profile Page", () => {
       "personal-info-account-type-label"
     );
     await expect(accountTypeLabel).toBeVisible();
-    await expect(accountTypeLabel).toContainText("Account Type");
+    await expect(accountTypeLabel).toContainText(/account type/i);
   });
 
   test("should show complete profile reminder only for incomplete profiles", async ({ page }) => {
-    // The "Complete your profile!" reminder only shows when profile is incomplete
-    // (missing phone, date of birth, emergency contact, or agreements)
-    const completeProfileMessage = page.getByText("Complete your profile!");
+    // The "Finish setting up your profile" reminder only shows when profile is
+    // incomplete (missing phone, date of birth, emergency contact, or agreements)
+    const completeProfileMessage = page.getByText(
+      /finish setting up your profile/i
+    );
 
     // Check if reminder exists - it should only appear for incomplete profiles
     const reminderCount = await completeProfileMessage.count();


### PR DESCRIPTION
## Summary
Polishes the read-only \`/profile\` page to match the dashboard's visual language. No functional changes — every data-testid and the underlying data are unchanged.

**What changed**
- Replaced inline SVGs with lucide-react icons, matching \`dashboard-next-shift\`, \`dashboard-impact-stats\`, etc.
- Dropped the colored icon squares on each card header; icons now sit inline with CardTitle (\`w-5 h-5 text-primary dark:text-emerald-400\`).
- Switched the row pattern from \`justify-between border-b\` to a cleaner definition-list grid.
- Hero: Fraunces display name (\`font-accent\`), \`ring-primary/10\` on the avatar, mail/pronouns row, trimmed the meaningless \"Active Member\" badge, surfaced the user's default location as a map-pin badge.
- Incomplete-profile nudge promoted to a top-level banner with an Info icon, out of the Quick Actions card.
- Empty states use inline lucide icon + short message rather than bare text.
- Converted the five detail cards to \`MotionContentCard\` with staggered \`delay\` — same pattern the dashboard uses.
- Copy cleanup: sentence case on buttons/fields, friendlier empty-state copy.

**Preserved**
- Every data-testid on the page (user-role, personal-info-*, emergency-contact-*, availability-*, notification-preferences-section, quick-actions-*, browse-shifts-button, view-schedule-button, edit-notification-preferences).
- Auth-gated sign-in fallback.
- Dark-mode styling.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean (only pre-existing warnings)
- [x] \`npx playwright test tests/e2e/profile.spec.ts --project=chromium\` — 17/17 passing after copy updates
- [ ] Visual review on \`/profile\` in light + dark mode at mobile and desktop viewports
- [ ] Incomplete-profile banner renders for an unfinished profile
- [ ] Edit-profile CTA still links to \`/profile/edit\` and notification CTA to \`/profile/edit?step=communication\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)