### PR TITLE
refactor: switch admin location targeting to defaultLocation

### DIFF
--- a/mobile/hooks/use-shifts.ts
+++ b/mobile/hooks/use-shifts.ts
@@ -15,7 +15,6 @@ type ShiftsResponse = {
   available: Shift[];
   past: Shift[];
   pastNextCursor: string | null;
-  userPreferredLocations: string[];
   userDefaultLocation: string | null;
   periodFriends: Record<string, PeriodFriend[]>;
   shiftFriends?: Record<string, PeriodFriend[]>;
@@ -31,7 +30,6 @@ type UseShiftsReturn = {
   loadMorePast: () => Promise<void>;
   hasMorePast: boolean;
   isLoadingMore: boolean;
-  userPreferredLocations: string[];
   userDefaultLocation: string | null;
   /** Friends keyed by "YYYY-MM-DD-DAY" or "YYYY-MM-DD-EVE" */
   periodFriends: Record<string, PeriodFriend[]>;
@@ -46,7 +44,6 @@ export function useShifts(): UseShiftsReturn {
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [userPreferredLocations, setUserPreferredLocations] = useState<string[]>([]);
   const [userDefaultLocation, setUserDefaultLocation] = useState<string | null>(null);
   const [periodFriends, setPeriodFriends] = useState<Record<string, PeriodFriend[]>>({});
   const [shiftFriends, setShiftFriends] = useState<Record<string, PeriodFriend[]>>({});
@@ -61,7 +58,6 @@ export function useShifts(): UseShiftsReturn {
       setMyShifts(result.myShifts);
       setAvailable(result.available);
       setPast(result.past);
-      setUserPreferredLocations(result.userPreferredLocations ?? []);
       setUserDefaultLocation(result.userDefaultLocation ?? null);
       setPeriodFriends(result.periodFriends ?? {});
       setShiftFriends(result.shiftFriends ?? {});
@@ -119,7 +115,6 @@ export function useShifts(): UseShiftsReturn {
     loadMorePast,
     hasMorePast: pastCursorRef.current !== null,
     isLoadingMore,
-    userPreferredLocations,
     userDefaultLocation,
     periodFriends,
     shiftFriends,

--- a/web/prisma/migrations/20260422000001_backfill_default_location_from_preferences/migration.sql
+++ b/web/prisma/migrations/20260422000001_backfill_default_location_from_preferences/migration.sql
@@ -1,0 +1,23 @@
+-- Follow-up backfill for users the original defaultLocation migration missed.
+-- The previous migration's fallback only parsed availableLocations when it was
+-- a JSON array. Legacy rows also store it as a plain string ("Onehunga") or a
+-- comma-separated list ("Wellington,Special event venue"). For each user with
+-- a null defaultLocation, split availableLocations on commas and pick the
+-- first entry that matches an active Location. Rows that can't be resolved
+-- (bad data like "Glen,Innes" or empty "[]") stay NULL.
+
+UPDATE "User"
+SET "defaultLocation" = picked.loc
+FROM (
+  SELECT DISTINCT ON (u.id) u.id, loc.name AS loc
+  FROM "User" u
+  CROSS JOIN LATERAL unnest(string_to_array(u."availableLocations", ',')) WITH ORDINALITY AS entry(val, ord)
+  JOIN "Location" loc
+    ON lower(TRIM(loc.name)) = lower(TRIM(entry.val))
+   AND loc."isActive" = true
+  WHERE u."defaultLocation" IS NULL
+    AND u."availableLocations" IS NOT NULL
+    AND u."availableLocations" <> ''
+  ORDER BY u.id, entry.ord
+) picked
+WHERE "User".id = picked.id;

--- a/web/src/app/admin/admin-dashboard-content.tsx
+++ b/web/src/app/admin/admin-dashboard-content.tsx
@@ -271,7 +271,7 @@ export async function AdminDashboardContent({
         where: {
           createdAt: { gte: startOfWeek, lt: endOfWeek },
           ...(selectedLocation
-            ? { availableLocations: { contains: selectedLocation } }
+            ? { defaultLocation: selectedLocation }
             : {}),
         },
       }),

--- a/web/src/app/admin/notifications/notifications-content.tsx
+++ b/web/src/app/admin/notifications/notifications-content.tsx
@@ -314,11 +314,7 @@ export function NotificationsContent({
 
     // Filter by location
     if (filterLocation !== "all") {
-      filtered = filtered.filter(
-        (v) =>
-          Array.isArray(v.availableLocations) &&
-          v.availableLocations.includes(filterLocation)
-      );
+      filtered = filtered.filter((v) => v.defaultLocation === filterLocation);
     }
 
     // Filter by shift type preference

--- a/web/src/app/admin/surveys/[id]/responses/page.tsx
+++ b/web/src/app/admin/surveys/[id]/responses/page.tsx
@@ -41,7 +41,7 @@ export default async function SurveyResponsesPage({
   // Build user filter from query params
   const userWhere: Record<string, unknown> = {};
   if (location) {
-    userWhere.availableLocations = { contains: location, mode: "insensitive" };
+    userWhere.defaultLocation = location;
   }
   if (grade) {
     userWhere.volunteerGrade = grade;
@@ -86,7 +86,7 @@ export default async function SurveyResponsesPage({
               id: true,
               name: true,
               email: true,
-              availableLocations: true,
+              defaultLocation: true,
               createdAt: true,
               volunteerGrade: true,
               completedShiftAdjustment: true,
@@ -237,7 +237,7 @@ export default async function SurveyResponsesPage({
               id: a.user.id,
               name: a.user.name,
               email: a.user.email,
-              availableLocations: a.user.availableLocations,
+              defaultLocation: a.user.defaultLocation,
               createdAt: a.user.createdAt,
               volunteerGrade: a.user.volunteerGrade,
               completedShifts:
@@ -262,7 +262,7 @@ export default async function SurveyResponsesPage({
               id: a.user.id,
               name: a.user.name,
               email: a.user.email,
-              availableLocations: a.user.availableLocations,
+              defaultLocation: a.user.defaultLocation,
               createdAt: a.user.createdAt,
               volunteerGrade: a.user.volunteerGrade,
               completedShifts:

--- a/web/src/app/admin/surveys/[id]/responses/responses-content.tsx
+++ b/web/src/app/admin/surveys/[id]/responses/responses-content.tsx
@@ -44,7 +44,6 @@ import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
 import type { SurveyQuestion } from "@/types/survey";
 import { formatDistanceToNow } from "date-fns";
-import { safeParseAvailability } from "@/lib/parse-availability";
 
 type SortDirection = "asc" | "desc";
 type SortConfig<T extends string> = { key: T; direction: SortDirection } | null;
@@ -107,7 +106,7 @@ interface UserData {
   id: string;
   name: string | null;
   email: string;
-  availableLocations?: string | null;
+  defaultLocation?: string | null;
   createdAt: Date | string;
   volunteerGrade?: string;
   completedShifts?: number;
@@ -184,8 +183,8 @@ export function ResponsesContent({
       if (key === "name") {
         cmp = (a.user.name || "").localeCompare(b.user.name || "");
       } else if (key === "location") {
-        cmp = (a.user.availableLocations || "").localeCompare(
-          b.user.availableLocations || ""
+        cmp = (a.user.defaultLocation || "").localeCompare(
+          b.user.defaultLocation || ""
         );
       } else if (key === "shifts") {
         cmp = (a.user.completedShifts || 0) - (b.user.completedShifts || 0);
@@ -211,8 +210,8 @@ export function ResponsesContent({
       if (key === "name") {
         cmp = (a.user.name || "").localeCompare(b.user.name || "");
       } else if (key === "location") {
-        cmp = (a.user.availableLocations || "").localeCompare(
-          b.user.availableLocations || ""
+        cmp = (a.user.defaultLocation || "").localeCompare(
+          b.user.defaultLocation || ""
         );
       } else if (key === "shifts") {
         cmp = (a.user.completedShifts || 0) - (b.user.completedShifts || 0);
@@ -712,7 +711,7 @@ export function ResponsesContent({
                       </TableCell>
                       <TableCell>
                         <span className="text-sm text-muted-foreground">
-                          {safeParseAvailability(response.user.availableLocations).join(", ") || "-"}
+                          {response.user.defaultLocation || "-"}
                         </span>
                       </TableCell>
                       <TableCell>
@@ -870,7 +869,7 @@ export function ResponsesContent({
                       </TableCell>
                       <TableCell>
                         <span className="text-sm text-muted-foreground">
-                          {safeParseAvailability(assignment.user.availableLocations).join(", ") || "-"}
+                          {assignment.user.defaultLocation || "-"}
                         </span>
                       </TableCell>
                       <TableCell>

--- a/web/src/app/admin/users/page.tsx
+++ b/web/src/app/admin/users/page.tsx
@@ -82,7 +82,7 @@ export default async function AdminUsersPage({
   }
 
   if (locationFilter) {
-    whereClause.availableLocations = { contains: locationFilter };
+    whereClause.defaultLocation = locationFilter;
   }
 
   if (archivedFilter === "active") {
@@ -161,8 +161,7 @@ export default async function AdminUsersPage({
     }
 
     if (locationFilter) {
-      const locationPattern = `%"${locationFilter}"%`;
-      conditions.push(Prisma.sql`u."availableLocations" LIKE ${locationPattern}`);
+      conditions.push(Prisma.sql`u."defaultLocation" = ${locationFilter}`);
     }
 
     if (archivedFilter === "active") {

--- a/web/src/app/api/admin/announcements/recipient-count/route.ts
+++ b/web/src/app/api/admin/announcements/recipient-count/route.ts
@@ -24,10 +24,8 @@ export async function POST(request: Request) {
   const conditions: Prisma.Sql[] = [Prisma.sql`role = 'VOLUNTEER'`];
 
   if (Array.isArray(targetLocations) && targetLocations.length > 0) {
-    // Split availableLocations on commas (trimming spaces) and check for exact overlap.
-    // Prisma's `contains` would do substring matching and false-match partial location names.
     conditions.push(
-      Prisma.sql`string_to_array(regexp_replace(COALESCE("availableLocations", ''), '\\s*,\\s*', ',', 'g'), ',') && ARRAY[${Prisma.join(targetLocations as string[])}]::text[]`
+      Prisma.sql`"defaultLocation" = ANY(ARRAY[${Prisma.join(targetLocations as string[])}]::text[])`
     );
   }
 

--- a/web/src/app/api/admin/announcements/route.ts
+++ b/web/src/app/api/admin/announcements/route.ts
@@ -115,11 +115,6 @@ export async function POST(request: Request) {
 /**
  * Count how many volunteers will receive an announcement based on targeting filters.
  * Each filter dimension is OR-within, AND-across. Empty = "all" for that dimension.
- *
- * Uses $queryRaw for location matching because availableLocations is a comma-separated
- * string field — Prisma's `contains` would do substring matching and false-match
- * (e.g. targeting "land" would match users with "Auckland"). string_to_array splits
- * on commas (normalising surrounding whitespace) and && checks array overlap.
  */
 async function countRecipients(
   targetLocations: string[],
@@ -129,9 +124,8 @@ async function countRecipients(
   const conditions: Prisma.Sql[] = [Prisma.sql`role = 'VOLUNTEER'`];
 
   if (targetLocations.length > 0) {
-    // Split availableLocations on commas (trimming spaces) and check for exact overlap
     conditions.push(
-      Prisma.sql`string_to_array(regexp_replace(COALESCE("availableLocations", ''), '\\s*,\\s*', ',', 'g'), ',') && ARRAY[${Prisma.join(targetLocations)}]::text[]`
+      Prisma.sql`"defaultLocation" = ANY(ARRAY[${Prisma.join(targetLocations)}]::text[])`
     );
   }
 

--- a/web/src/app/api/admin/chat-guides/preview/route.ts
+++ b/web/src/app/api/admin/chat-guides/preview/route.ts
@@ -69,7 +69,7 @@ export async function POST(request: Request) {
             name: true,
             volunteerGrade: true,
             availableDays: true,
-            availableLocations: true,
+            defaultLocation: true,
           },
         }),
         prisma.signup.findMany({

--- a/web/src/app/api/admin/volunteers/route.ts
+++ b/web/src/app/api/admin/volunteers/route.ts
@@ -33,7 +33,7 @@ export async function GET(request: Request) {
         firstName: true,
         lastName: true,
         volunteerGrade: true,
-        availableLocations: true,
+        defaultLocation: true,
         availableDays: true,
         receiveShortageNotifications: true,
         excludedShortageNotificationTypes: true,
@@ -83,7 +83,6 @@ export async function GET(request: Request) {
       return {
         ...volunteerWithoutSignups,
         availableDays: safeParseAvailability(volunteer.availableDays),
-        availableLocations: safeParseAvailability(volunteer.availableLocations),
         ...(includeStats && { completedShifts }),
       };
     });

--- a/web/src/app/api/mobile/chat/route.ts
+++ b/web/src/app/api/mobile/chat/route.ts
@@ -146,7 +146,7 @@ async function getUserContext(userId: string) {
         name: true,
         volunteerGrade: true,
         availableDays: true,
-        availableLocations: true,
+        defaultLocation: true,
         completedShiftAdjustment: true,
         profileCompleted: true,
         volunteerAgreementAccepted: true,
@@ -229,8 +229,8 @@ async function getUserContext(userId: string) {
     `Name: ${volunteerName}`,
     `Grade: ${volunteer?.volunteerGrade ?? "GREEN"} (GREEN = new, YELLOW = experienced, PINK = shift leader)`,
     `Completed shifts: ${totalShifts}`,
-    volunteer?.availableLocations
-      ? `Preferred locations: ${volunteer.availableLocations}`
+    volunteer?.defaultLocation
+      ? `Default location: ${volunteer.defaultLocation}`
       : null,
     volunteer?.availableDays ? `Available days: ${volunteer.availableDays}` : null,
     nudges.length > 0

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: Request) {
       where: { id: userId },
       select: {
         volunteerGrade: true,
-        availableLocations: true,
+        defaultLocation: true,
         customLabels: { select: { labelId: true } },
       },
     }),
@@ -74,9 +74,7 @@ export async function GET(request: Request) {
   );
 
   const userLabelIds = (userProfile?.customLabels ?? []).map((l) => l.labelId);
-  const userLocations = userProfile?.availableLocations
-    ? userProfile.availableLocations.split(",").map((l) => l.trim()).filter(Boolean)
-    : [];
+  const userDefaultLocation = userProfile?.defaultLocation ?? null;
   const userGrade = userProfile?.volunteerGrade ?? "GREEN";
 
   // Run all data queries in parallel
@@ -192,8 +190,7 @@ export async function GET(request: Request) {
 
     // Announcements: fetch all non-expired ones from the window, then filter by
     // user targeting in app code. Grade and label are pre-filtered at DB level;
-    // location targeting uses in-memory exact matching (availableLocations is a
-    // comma-separated string so we can't safely do it in Prisma without raw SQL).
+    // location targeting is matched against the user's defaultLocation.
     prisma.announcement.findMany({
       where: {
         createdAt: { gte: since },
@@ -238,7 +235,8 @@ export async function GET(request: Request) {
     // Location targeting: empty = all locations
     const locationMatch =
       ann.targetLocations.length === 0 ||
-      ann.targetLocations.some((loc) => userLocations.includes(loc));
+      (userDefaultLocation !== null &&
+        ann.targetLocations.includes(userDefaultLocation));
 
     // Grade targeting: empty = all grades
     const gradeMatch =

--- a/web/src/app/api/mobile/shifts/route.ts
+++ b/web/src/app/api/mobile/shifts/route.ts
@@ -29,24 +29,11 @@ export async function GET(request: Request) {
   const now = new Date();
   const { userId } = auth;
 
-  // Fetch user's locations for the client to default the filter
+  // Fetch user's default location for the client to default the filter
   const userRecord = await prisma.user.findUnique({
     where: { id: userId },
-    select: { availableLocations: true, defaultLocation: true },
+    select: { defaultLocation: true },
   });
-  let userPreferredLocations: string[] = [];
-  if (userRecord?.availableLocations) {
-    try {
-      const parsed = JSON.parse(userRecord.availableLocations);
-      if (Array.isArray(parsed)) {
-        userPreferredLocations = parsed.filter(
-          (item: unknown) => typeof item === "string" && (item as string).trim()
-        );
-      }
-    } catch {
-      // Not valid JSON — ignore
-    }
-  }
   const userDefaultLocation = userRecord?.defaultLocation ?? null;
 
   const url = new URL(request.url);
@@ -254,7 +241,6 @@ export async function GET(request: Request) {
     pastNextCursor: hasMorePast
       ? pastSignups[pastSignups.length - 1]?.id ?? null
       : null,
-    userPreferredLocations,
     userDefaultLocation,
     periodFriends,
     shiftFriends,

--- a/web/src/app/shifts/details/shift-details-content.tsx
+++ b/web/src/app/shifts/details/shift-details-content.tsx
@@ -343,7 +343,7 @@ export async function ShiftDetailsContent({
   if (session?.user?.email) {
     currentUser = await prisma.user.findUnique({
       where: { email: session.user.email },
-      select: { id: true, availableLocations: true },
+      select: { id: true },
     });
 
     if (currentUser?.id) {

--- a/web/src/components/volunteers-data-table.tsx
+++ b/web/src/components/volunteers-data-table.tsx
@@ -44,7 +44,7 @@ export interface Volunteer {
   name: string | null;
   firstName: string | null;
   lastName: string | null;
-  availableLocations: string[];
+  defaultLocation: string | null;
   availableDays: string[];
   receiveShortageNotifications: boolean;
   excludedShortageNotificationTypes: string[];
@@ -128,23 +128,17 @@ export const columns: ColumnDef<Volunteer>[] = [
     },
   },
   {
-    accessorKey: "availableLocations",
-    header: "Locations",
+    accessorKey: "defaultLocation",
+    header: "Default Location",
     cell: ({ row }) => {
-      const locations = row.getValue("availableLocations") as string[];
+      const location = row.getValue("defaultLocation") as string | null;
+      if (!location) {
+        return <span className="text-xs text-muted-foreground">—</span>;
+      }
       return (
-        <div className="flex gap-1 flex-wrap">
-          {locations?.slice(0, 2).map((location) => (
-            <Badge key={location} variant="outline" className="text-xs">
-              {location}
-            </Badge>
-          ))}
-          {locations?.length > 2 && (
-            <Badge variant="outline" className="text-xs">
-              +{locations.length - 2}
-            </Badge>
-          )}
-        </div>
+        <Badge variant="outline" className="text-xs">
+          {location}
+        </Badge>
       );
     },
   },

--- a/web/src/lib/engagement.ts
+++ b/web/src/lib/engagement.ts
@@ -69,12 +69,12 @@ export async function getEngagementSummary(
     ? Prisma.sql`AND EXTRACT(DOW FROM ${shiftStartNZ()})::int IN (${Prisma.join(daysFilter)})`
     : Prisma.empty;
   // When location-filtered, include volunteers with shifts at this location
-  // OR who selected this location in preferences (for "never volunteered")
+  // OR who selected this location as their default (for "never volunteered")
   const excludeCond = isLocationFiltered
-    ? Prisma.sql`(total_shifts > 0 OR (all_completed = 0 AND has_preferred_location))`
+    ? Prisma.sql`(total_shifts > 0 OR (all_completed = 0 AND has_default_location))`
     : Prisma.sql`TRUE`;
   const neverCond = isLocationFiltered
-    ? Prisma.sql`all_completed = 0 AND has_preferred_location`
+    ? Prisma.sql`all_completed = 0 AND has_default_location`
     : Prisma.sql`all_completed = 0`;
 
   const safeMonths = Math.max(months, 1);
@@ -107,15 +107,15 @@ export async function getEngagementSummary(
           BOOL_OR(sh."end" >= ${priorStart} AND sh."end" < ${periodStart} AND ${locationCond} ${daysCond}) as in_prior_period,
           BOOL_OR(sh."end" >= ${periodStart} AND sh."end" < ${now} AND ${locationCond} ${daysCond}) as in_current_period,
           CASE
-            WHEN u."availableLocations" LIKE ${`%"${location || ''}"%`}
+            WHEN u."defaultLocation" = ${location || ''}
             THEN TRUE
             ELSE FALSE
-          END as has_preferred_location
+          END as has_default_location
         FROM "User" u
         LEFT JOIN "Signup" sg ON sg."userId" = u.id AND sg.status = 'CONFIRMED'
         LEFT JOIN "Shift" sh ON sh.id = sg."shiftId"
         WHERE u.role = 'VOLUNTEER'::"Role"
-        GROUP BY u.id, u."availableLocations"
+        GROUP BY u.id, u."defaultLocation"
       )
       SELECT
         COUNT(*) FILTER (WHERE ${excludeCond})::bigint as "totalVolunteers",
@@ -497,9 +497,9 @@ export async function getEngagementVolunteers(params: {
     : Prisma.empty;
 
   // When location-filtered, skip volunteers with no association to this location
-  // (no shifts there AND didn't select it as a preferred location)
+  // (no shifts there AND this isn't their default location)
   const skipCond = isLocationFiltered
-    ? Prisma.sql`total_shifts = 0 AND NOT has_preferred_location`
+    ? Prisma.sql`total_shifts = 0 AND NOT has_default_location`
     : Prisma.sql`FALSE`;
 
   const statusCond =
@@ -531,10 +531,10 @@ export async function getEngagementVolunteers(params: {
         COALESCE(COUNT(sg.id) FILTER (WHERE sh."end" >= ${periodStart} AND sh."end" < ${now} AND ${locationCond} ${daysCond}), 0) as shifts_in_period,
         MAX(sh."end") FILTER (WHERE sh."end" < ${now} AND ${locationCond} ${daysCond}) as last_shift_date,
         CASE
-          WHEN u."availableLocations" LIKE ${`%"${location || ''}"%`}
+          WHEN u."defaultLocation" = ${location || ''}
           THEN TRUE
           ELSE FALSE
-        END as has_preferred_location
+        END as has_default_location
       FROM "User" u
       LEFT JOIN "Signup" sg ON sg."userId" = u.id AND sg.status = 'CONFIRMED'
       LEFT JOIN "Shift" sh ON sh.id = sg."shiftId"
@@ -542,7 +542,7 @@ export async function getEngagementVolunteers(params: {
         ${searchCond}
       GROUP BY u.id, u.name, u."firstName", u."lastName", u.email,
         u."profilePhotoUrl", u."volunteerGrade", u."createdAt",
-        u."availableLocations"
+        u."defaultLocation"
     ),
     volunteer_stats AS (
       SELECT *,


### PR DESCRIPTION
## Summary

Follow-up to #797. The original PR moved shift browsing onto the new `defaultLocation` field but intentionally left admin targeting paths on `availableLocations`. This PR consolidates everything onto `defaultLocation` so location matching is driven by one consistent signal everywhere, drops some dead plumbing, and backfills the last legacy rows the original migration couldn't parse.

### Admin targeting — switched to `defaultLocation`

- Admin dashboard new-users count
- Admin users page location filter (Prisma + raw-SQL branches)
- Survey responses filter, table column, and sort
- Notifications audience filter + `VolunteersDataTable` column (now shows a single Default Location badge)
- Announcement targeting + recipient count (raw SQL rewritten to `"defaultLocation" = ANY(...)`)
- Recruitment engagement analytics (`has_default_location` replaces the preferences LIKE)
- Mobile feed announcement targeting
- Mobile chat + admin chat-guides preview volunteer context

### Dead code

- `shift-details-content.tsx` selected `availableLocations` but never read it
- `/api/mobile/shifts` returned `userPreferredLocations` that the mobile app never consumed — dropped from the route, `useShifts` hook, and response type

### Migration

`20260422000001_backfill_default_location_from_preferences` backfills legacy users missed by the original migration's JSON-only fallback (plain strings like `"Onehunga"`, comma-separated lists like `"Wellington,Special event venue"`). Splits on comma and picks the first entry that joins to an active Location — skips unresolvable cases like `"Glen,Innes"` and `"[]"`.

## Test plan

- [ ] `npm run typecheck` + `npm run lint` pass
- [ ] Admin dashboard: new-users count changes when switching location filter
- [ ] Admin users page: location filter returns the right users
- [ ] Survey responses: location filter and location column show defaultLocation
- [ ] Notifications page: audience filter works; VolunteersDataTable shows Default Location column
- [ ] Announcement preview: recipient count reflects defaultLocation targeting
- [ ] Engagement analytics: "never volunteered at X" cohort uses defaultLocation
- [ ] Mobile feed: location-targeted announcements reach users with matching defaultLocation
- [ ] Mobile chat: system prompt shows "Default location: …"
- [ ] Run the preview SQL against production to confirm backfill updates ~7 users

🤖 Generated with [Claude Code](https://claude.com/claude-code)