### PR TITLE
fix(web): allow notes-only meals served records

### DIFF
--- a/web/prisma/migrations/20260423000000_meals_served_nullable_count/migration.sql
+++ b/web/prisma/migrations/20260423000000_meals_served_nullable_count/migration.sql
@@ -1,0 +1,2 @@
+-- Allow MealsServed rows with notes but no recorded count.
+ALTER TABLE "MealsServed" ALTER COLUMN "mealsServed" DROP NOT NULL;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -735,7 +735,7 @@ model MealsServed {
   id          String   @id @default(cuid())
   date        DateTime // Date for this record (stored as start of day in UTC)
   location    String // Location name (Wellington, Glen Innes, Onehunga)
-  mealsServed Int // Actual number of meals served that day
+  mealsServed Int? // Actual number of meals served that day (nullable — admins may save notes without a count)
   notes       String? // Optional notes about the day
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt

--- a/web/src/app/admin/admin-dashboard-content.tsx
+++ b/web/src/app/admin/admin-dashboard-content.tsx
@@ -320,6 +320,7 @@ export async function AdminDashboardContent({
   // Calculate meals served with fallback to location defaults
   const actualMealsMap = new Map<string, number>();
   for (const record of weekMealsRecords) {
+    if (record.mealsServed === null) continue;
     const key = `${record.date.toISOString()}-${record.location}`;
     actualMealsMap.set(key, record.mealsServed);
   }

--- a/web/src/app/api/admin/analytics/meals-served/route.ts
+++ b/web/src/app/api/admin/analytics/meals-served/route.ts
@@ -96,9 +96,10 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Create a map of recorded meals by date/location
+    // Create a map of recorded meals by date/location (skip note-only rows)
     const recordedMeals = new Map<string, number>();
     mealsServedRecords.forEach((record) => {
+      if (record.mealsServed === null) return;
       const dateKey = new Date(record.date).toISOString().substring(0, 10);
       const key = `${dateKey}|${record.location}`;
       recordedMeals.set(key, record.mealsServed);
@@ -218,6 +219,7 @@ export async function GET(request: NextRequest) {
     > = {};
 
     mealsServedRecords.forEach((record) => {
+      if (record.mealsServed === null) return;
       const monthKey = new Date(record.date).toISOString().substring(0, 7); // YYYY-MM
 
       if (!monthlyTrends[record.location]) {
@@ -250,7 +252,8 @@ export async function GET(request: NextRequest) {
       daysInRange,
       chartData,
       monthlyTrends,
-      recordCount: mealsServedRecords.length,
+      recordCount: mealsServedRecords.filter((r) => r.mealsServed !== null)
+        .length,
     });
   } catch (error) {
     console.error("Error fetching meals served analytics:", error);

--- a/web/src/app/api/admin/chat-guides/preview/route.ts
+++ b/web/src/app/api/admin/chat-guides/preview/route.ts
@@ -109,7 +109,10 @@ export async function POST(request: Request) {
         }),
         prisma.user.count({ where: { role: "VOLUNTEER" } }),
         prisma.mealsServed.aggregate({
-          where: { date: { gte: thirtyDaysAgo } },
+          where: {
+            date: { gte: thirtyDaysAgo },
+            mealsServed: { not: null },
+          },
           _sum: { mealsServed: true },
           _count: true,
         }),

--- a/web/src/app/api/admin/meals-served/route.ts
+++ b/web/src/app/api/admin/meals-served/route.ts
@@ -78,9 +78,28 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { date, location, mealsServed, notes } = body;
 
-    if (!date || !location || mealsServed === undefined) {
+    if (!date || !location) {
       return NextResponse.json(
-        { error: "Date, location, and mealsServed are required" },
+        { error: "Date and location are required" },
+        { status: 400 }
+      );
+    }
+
+    const hasMealsCount =
+      mealsServed !== undefined && mealsServed !== null && mealsServed !== "";
+    const trimmedNotes = typeof notes === "string" ? notes.trim() : "";
+
+    if (!hasMealsCount && !trimmedNotes) {
+      return NextResponse.json(
+        { error: "Enter a meals count, a note, or both" },
+        { status: 400 }
+      );
+    }
+
+    const parsedMeals = hasMealsCount ? parseInt(mealsServed, 10) : null;
+    if (hasMealsCount && (parsedMeals === null || Number.isNaN(parsedMeals))) {
+      return NextResponse.json(
+        { error: "Meals count must be a number" },
         { status: 400 }
       );
     }
@@ -99,15 +118,15 @@ export async function POST(request: NextRequest) {
         },
       },
       update: {
-        mealsServed: parseInt(mealsServed),
-        notes: notes || null,
+        mealsServed: parsedMeals,
+        notes: trimmedNotes || null,
         createdBy: session.user.id,
       },
       create: {
         date: startOfDayUTC,
         location,
-        mealsServed: parseInt(mealsServed),
-        notes: notes || null,
+        mealsServed: parsedMeals,
+        notes: trimmedNotes || null,
         createdBy: session.user.id,
       },
     });

--- a/web/src/app/api/mobile/chat/route.ts
+++ b/web/src/app/api/mobile/chat/route.ts
@@ -60,11 +60,15 @@ async function getStaticContext(): Promise<StaticContext> {
       }),
       prisma.user.count({ where: { role: "VOLUNTEER" } }),
       prisma.mealsServed.aggregate({
-        where: { date: { gte: thirtyDaysAgo } },
+        where: {
+          date: { gte: thirtyDaysAgo },
+          mealsServed: { not: null },
+        },
         _sum: { mealsServed: true },
         _count: true,
       }),
       prisma.mealsServed.aggregate({
+        where: { mealsServed: { not: null } },
         _sum: { mealsServed: true },
       }),
       // Count recent shifts for fallback estimate

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -582,9 +582,10 @@ export async function GET(request: Request) {
     ]);
 
     // Only emit recaps for (location, day) pairs with an explicit MealsServed
-    // record — otherwise we'd be making up numbers from the location default.
+    // count — notes-only rows don't give us a number to share.
     const mealsMap = new Map<string, number>();
     for (const record of mealsServedRecords) {
+      if (record.mealsServed === null) continue;
       const key = `${record.location}-${record.date.toISOString()}`;
       mealsMap.set(key, record.mealsServed);
     }

--- a/web/src/app/shifts/mine/shift-details-dialog.tsx
+++ b/web/src/app/shifts/mine/shift-details-dialog.tsx
@@ -38,7 +38,7 @@ export async function ShiftDetailsDialog({
     const startOfDayUTC = getStartOfDayUTC(shift.shift.start);
 
     // First try to get actual meals served
-    mealsServedData = await prisma.mealsServed.findUnique({
+    const record = await prisma.mealsServed.findUnique({
       where: {
         date_location: {
           date: startOfDayUTC,
@@ -47,8 +47,11 @@ export async function ShiftDetailsDialog({
       },
     });
 
-    // If no actual data, get the location's default
-    if (!mealsServedData) {
+    // Treat note-only records (mealsServed === null) the same as "no data"
+    // — we still need a number to display, so fall back to the location default.
+    if (record && record.mealsServed !== null) {
+      mealsServedData = record;
+    } else {
       const locationData = await prisma.location.findUnique({
         where: { name: shift.shift.location },
         select: { defaultMealsServed: true },

--- a/web/src/components/dashboard-impact-stats.tsx
+++ b/web/src/components/dashboard-impact-stats.tsx
@@ -76,10 +76,11 @@ export async function DashboardImpactStats({
     },
   });
 
-  // Create a map of actual meals served by date-location key
+  // Create a map of actual meals served by date-location key (skip note-only rows)
   const actualMealsMap = new Map<string, number>();
   mealsServedRecords.forEach(
-    (record: { date: Date; location: string; mealsServed: number }) => {
+    (record: { date: Date; location: string; mealsServed: number | null }) => {
+      if (record.mealsServed === null) return;
       const dateKey = `${record.date.toISOString()}-${record.location}`;
       actualMealsMap.set(dateKey, record.mealsServed);
     }

--- a/web/src/components/meals-served-input.tsx
+++ b/web/src/components/meals-served-input.tsx
@@ -34,15 +34,22 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
         );
         if (response.ok) {
           const data = await response.json();
-          if (data.mealsServed !== null) {
-            setMealsServed(data.mealsServed.toString());
+          const hasRecord =
+            data.mealsServed !== null ||
+            (typeof data.notes === "string" && data.notes.length > 0);
+          if (hasRecord) {
+            setMealsServed(
+              data.mealsServed !== null ? data.mealsServed.toString() : ""
+            );
             setNotes(data.notes || "");
             setHasExistingRecord(true);
           } else {
-            setDefaultValue(data.defaultMealsServed);
             setMealsServed("");
             setNotes("");
             setHasExistingRecord(false);
+          }
+          if (typeof data.defaultMealsServed === "number") {
+            setDefaultValue(data.defaultMealsServed);
           }
         }
       } catch (error) {
@@ -55,9 +62,14 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
     fetchData();
   }, [date, location]);
 
+  const trimmedNotes = notes.trim();
+  const hasMealsCount = mealsServed !== "";
+  const canSave = hasMealsCount || trimmedNotes.length > 0;
+  const hasRecordedCount = hasExistingRecord && hasMealsCount;
+
   const handleSave = async () => {
-    if (!mealsServed || mealsServed === "") {
-      toast.error("Please enter the number of meals served");
+    if (!canSave) {
+      toast.error("Enter a meals count, a note, or both");
       return;
     }
 
@@ -71,14 +83,18 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
         body: JSON.stringify({
           date,
           location,
-          mealsServed: parseInt(mealsServed),
-          notes,
+          mealsServed: hasMealsCount ? parseInt(mealsServed, 10) : null,
+          notes: trimmedNotes,
         }),
       });
 
       if (response.ok) {
         setHasExistingRecord(true);
-        toast.success("Meals served recorded successfully!");
+        toast.success(
+          hasMealsCount
+            ? "Meals served recorded successfully!"
+            : "Note saved — add the meals count when you have it"
+        );
       } else {
         const error = await response.json();
         toast.error(error.error || "Failed to save meals served");
@@ -111,7 +127,7 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
           Meals Served
           {hasExistingRecord && (
             <span className="text-sm font-normal text-muted-foreground ml-2">
-              (Recorded)
+              ({hasRecordedCount ? "Recorded" : "Note saved"})
             </span>
           )}
         </CardTitle>
@@ -121,40 +137,21 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
           <div>
             <Label htmlFor="mealsServed">
               Number of people served{" "}
-              {!hasExistingRecord && (
+              {!hasRecordedCount && (
                 <span className="text-xs text-muted-foreground">
                   (Default: {defaultValue})
                 </span>
               )}
             </Label>
-            <div className="flex gap-2 mt-1.5">
-              <Input
-                id="mealsServed"
-                type="number"
-                min="0"
-                value={mealsServed}
-                onChange={(e) => setMealsServed(e.target.value)}
-                placeholder={`e.g., ${defaultValue}`}
-                className="max-w-xs"
-              />
-              <Button
-                onClick={handleSave}
-                disabled={loading}
-                className="bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800"
-              >
-                {loading ? (
-                  <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    Saving...
-                  </>
-                ) : (
-                  <>
-                    <Save className="h-4 w-4 mr-2" />
-                    {hasExistingRecord ? "Update" : "Save"}
-                  </>
-                )}
-              </Button>
-            </div>
+            <Input
+              id="mealsServed"
+              type="number"
+              min="0"
+              value={mealsServed}
+              onChange={(e) => setMealsServed(e.target.value)}
+              placeholder={`e.g., ${defaultValue}`}
+              className="max-w-xs mt-1.5"
+            />
           </div>
 
           <div>
@@ -167,6 +164,29 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
               className="mt-1.5"
               rows={2}
             />
+          </div>
+
+          <div className="flex items-center justify-between gap-3 pt-1">
+            <p className="text-xs text-muted-foreground">
+              Leave a note now — you can add the count later.
+            </p>
+            <Button
+              onClick={handleSave}
+              disabled={loading || !canSave}
+              className="bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800"
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                <>
+                  <Save className="h-4 w-4 mr-2" />
+                  {hasExistingRecord ? "Update" : "Save"}
+                </>
+              )}
+            </Button>
           </div>
         </div>
       </CardContent>

--- a/web/src/lib/achievements.ts
+++ b/web/src/lib/achievements.ts
@@ -374,10 +374,11 @@ export async function calculateUserProgress(
     },
   });
 
-  // Create a map of actual meals served by date-location key
+  // Create a map of actual meals served by date-location key (skip note-only rows)
   const actualMealsMap = new Map<string, number>();
   mealsServedRecords.forEach(
-    (record: { date: Date; location: string; mealsServed: number }) => {
+    (record: { date: Date; location: string; mealsServed: number | null }) => {
+      if (record.mealsServed === null) return;
       const dateKey = `${record.date.toISOString()}-${record.location}`;
       actualMealsMap.set(dateKey, record.mealsServed);
     }

--- a/web/src/lib/restaurant-analytics.ts
+++ b/web/src/lib/restaurant-analytics.ts
@@ -43,7 +43,11 @@ interface PeriodResult {
 
 function processPeriod(
   shifts: Array<{ start: Date; location: string | null }>,
-  mealsRecords: Array<{ date: Date; location: string; mealsServed: number }>,
+  mealsRecords: Array<{
+    date: Date;
+    location: string;
+    mealsServed: number | null;
+  }>,
   locationDefaults: Record<string, number>,
   daysFilter: number[] | null
 ): PeriodResult {
@@ -62,6 +66,7 @@ function processPeriod(
 
   const recordedMeals = new Map<string, number>();
   mealsRecords.forEach((r) => {
+    if (r.mealsServed === null) return;
     const key = `${r.date.toISOString().substring(0, 10)}|${r.location}`;
     recordedMeals.set(key, r.mealsServed);
   });


### PR DESCRIPTION
## Summary
- `MealsServed.mealsServed` is now nullable so admins can save a note for a service day without entering a count yet.
- Updated the admin input card: the number field is no longer required — the Save button enables as soon as either a count or a note is filled in. Copy hints that a note can be saved first and the count added later.
- Updated consumers (admin dashboard, analytics API, shift recap feed, chat/aggregate routes, shift details dialog, achievement stats, restaurant analytics) to skip note-only rows so averages and displayed totals ignore records without a count.

Closes #800

## Test plan
- [ ] Run `npm run prisma:migrate` in web/ against a local DB and confirm the migration applies cleanly
- [ ] In the admin shifts page for a date + location, save with **note only** (number blank) → record persists, toast says "Note saved — add the meals count when you have it", card shows "(Note saved)" badge
- [ ] Re-open the same day → note prefills, number field stays empty with default hint
- [ ] Enter a count + note, save → "(Recorded)" badge, update works as before
- [ ] Try to save with both fields blank → blocked with the "Enter a meals count, a note, or both" toast
- [ ] Admin dashboard "meals served this week" still computes (uses location default for note-only days)
- [ ] Admin meals-served analytics chart + averages match pre-change values when no note-only rows exist
- [ ] Volunteer "My Shifts" dialog for a past shift where the only record is note-only → falls back to "estimated" default, not empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)