### PR TITLE
feat(web): stack recruitment analytics charts by restaurant

### DIFF
--- a/web/src/app/admin/analytics/engagement/recruitment-section.tsx
+++ b/web/src/app/admin/analytics/engagement/recruitment-section.tsx
@@ -27,7 +27,11 @@ import {
   DialogDescription,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import type { RecruitmentData } from "@/lib/recruitment";
+import type {
+  RecruitmentData,
+  RecruitmentFunnelBreakdown,
+} from "@/lib/recruitment-types";
+import { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
 
 const Chart = dynamic(() => import("react-apexcharts"), { ssr: false });
 
@@ -37,6 +41,33 @@ const MONTHS_LABELS: Record<string, string> = {
   "6": "6 months",
   "12": "12 months",
 };
+
+// Stable per-location color palette. Well-known locations get fixed colors so
+// the stacking stays consistent across pages; anything else cycles through
+// `FALLBACK_COLORS`. "Unspecified" is muted so it doesn't dominate.
+const LOCATION_COLORS: Record<string, string> = {
+  Wellington: "#3b82f6",
+  "Glen Innes": "#8b5cf6",
+  Onehunga: "#10b981",
+  "Special Event Venue": "#f59e0b",
+  [UNSPECIFIED_LOCATION]: "#94a3b8",
+};
+
+const FALLBACK_COLORS = [
+  "#ec4899",
+  "#14b8a6",
+  "#fb923c",
+  "#6366f1",
+  "#f43f5e",
+  "#22c55e",
+];
+
+function colorForLocation(location: string, index: number): string {
+  return (
+    LOCATION_COLORS[location] ??
+    FALLBACK_COLORS[index % FALLBACK_COLORS.length]
+  );
+}
 
 function pct(num: number, total: number) {
   if (total === 0) return 0;
@@ -79,42 +110,71 @@ interface Props {
   location: string;
 }
 
+type FunnelStageKey =
+  | "totalRegistrations"
+  | "profileComplete"
+  | "signedUp"
+  | "completedShift";
+
+function stageValue(
+  row: RecruitmentFunnelBreakdown,
+  key: FunnelStageKey
+): number {
+  switch (key) {
+    case "totalRegistrations":
+      return row.totalRegistrations;
+    case "profileComplete":
+      return row.totalRegistrations - row.incompleteProfiles;
+    case "signedUp":
+      return row.signedUpNoShift + row.completedShift;
+    case "completedShift":
+      return row.completedShift;
+  }
+}
+
 export function RecruitmentSection({ data, months, location }: Props) {
   const { resolvedTheme } = useTheme();
   const chartMode = (resolvedTheme === "dark" ? "dark" : "light") as
     | "dark"
     | "light";
 
-  const { funnel, registrationTrend } = data;
+  const { funnel, registrationTrend, locations } = data;
   const total = funnel.totalRegistrations;
   const periodLabel = MONTHS_LABELS[months] ?? `${months} months`;
+
+  const locationColors = locations.map((loc, i) => colorForLocation(loc, i));
 
   // Funnel stages — strictly decreasing from total → first shift
   const profileComplete = total - funnel.incompleteProfiles;
   const signedUp = funnel.signedUpNoShift + funnel.completedShift;
-  const funnelStages = [
+  const funnelStages: Array<{
+    name: string;
+    key: FunnelStageKey;
+    value: number;
+    desc: string;
+  }> = [
     {
       name: "Registered",
+      key: "totalRegistrations",
       value: total,
-      color: "#3b82f6",
       desc: "Created an account",
     },
     {
       name: "Profile Complete",
+      key: "profileComplete",
       value: profileComplete,
-      color: "#8b5cf6",
       desc: "Finished profile setup",
     },
     {
       name: "Signed Up for a Shift",
+      key: "signedUp",
       value: signedUp,
-      color: "#f59e0b",
       desc: "At least one shift signup",
     },
     {
       name: "Completed First Shift",
+      key: "completedShift",
       value: funnel.completedShift,
-      color: "#10b981",
       desc: "First confirmed shift done",
     },
   ];
@@ -130,7 +190,8 @@ export function RecruitmentSection({ data, months, location }: Props) {
       bg: "bg-blue-50 dark:bg-blue-950/20",
       iconBg: "bg-blue-100 dark:bg-blue-900/30",
       iconColor: "text-blue-600 dark:text-blue-400",
-      tooltip: "Total new volunteer accounts created during the selected period",
+      tooltip:
+        "Total new volunteer accounts created during the selected period",
     },
     {
       label: "Profile Incomplete",
@@ -178,6 +239,55 @@ export function RecruitmentSection({ data, months, location }: Props) {
         "Average number of days between a volunteer registering and completing their very first shift, among those registered in this period",
     },
   ];
+
+  // One ApexCharts series per location so all three bar charts stack by
+  // restaurant. `locations` is sorted so colours line up consistently.
+  const registrationSeries =
+    locations.length > 0
+      ? locations.map((loc) => ({
+          name: loc,
+          data: registrationTrend.map((t) => t.byLocation[loc] ?? 0),
+        }))
+      : [
+          {
+            name: "New Registrations",
+            data: registrationTrend.map((t) => t.count),
+          },
+        ];
+
+  const timeToFirstShiftBuckets: Array<
+    [
+      label: string,
+      key: keyof Pick<
+        RecruitmentFunnelBreakdown,
+        | "sameDay"
+        | "within3Days"
+        | "within7Days"
+        | "within14Days"
+        | "within30Days"
+        | "within60Days"
+        | "within90Days"
+        | "over90Days"
+      >,
+    ]
+  > = [
+    ["Same day", "sameDay"],
+    ["1–3 days", "within3Days"],
+    ["4–7 days", "within7Days"],
+    ["8–14 days", "within14Days"],
+    ["15–30 days", "within30Days"],
+    ["31–60 days", "within60Days"],
+    ["61–90 days", "within90Days"],
+    ["> 90 days", "over90Days"],
+  ];
+
+  const timeToFirstShiftSeries = locations.map((loc) => {
+    const row = funnel.byLocation.find((b) => b.location === loc);
+    return {
+      name: loc,
+      data: timeToFirstShiftBuckets.map(([, key]) => (row ? row[key] : 0)),
+    };
+  });
 
   return (
     <motion.div
@@ -240,11 +350,12 @@ export function RecruitmentSection({ data, months, location }: Props) {
                 New Registrations
                 <InfoDialog
                   title="New Registrations Over Time"
-                  description="Monthly volunteer sign-ups over the past 12 months"
+                  description="Monthly volunteer sign-ups over the past 12 months, stacked by restaurant"
                 >
                   <p>
                     Shows how many new volunteer accounts were created each
-                    month over the past 12 months.
+                    month over the past 12 months, split by the volunteer&rsquo;s
+                    primary restaurant (their default location).
                   </p>
                   {location && location !== "all" && (
                     <p>
@@ -253,8 +364,10 @@ export function RecruitmentSection({ data, months, location }: Props) {
                     </p>
                   )}
                   <p className="text-muted-foreground">
-                    The chart always shows 12 months for context — the time
-                    period filter above affects the stat cards only.
+                    Volunteers without a primary restaurant set are grouped as
+                    &ldquo;{UNSPECIFIED_LOCATION}&rdquo;. The chart always shows
+                    12 months for context — the time period filter above affects
+                    the stat cards only.
                   </p>
                 </InfoDialog>
               </CardTitle>
@@ -265,6 +378,7 @@ export function RecruitmentSection({ data, months, location }: Props) {
                   options={{
                     chart: {
                       type: "bar" as const,
+                      stacked: true,
                       toolbar: { show: false },
                       background: "transparent",
                     },
@@ -301,8 +415,16 @@ export function RecruitmentSection({ data, months, location }: Props) {
                         formatter: (v: number) => String(Math.round(v)),
                       },
                     },
-                    colors: ["#3b82f6"],
+                    colors: locationColors.length ? locationColors : ["#3b82f6"],
                     dataLabels: { enabled: false },
+                    legend: {
+                      show: locations.length > 1,
+                      position: "bottom",
+                      fontFamily: "var(--font-libre-franklin), sans-serif",
+                      fontSize: "12px",
+                      markers: { size: 6 },
+                      itemMargin: { horizontal: 8, vertical: 4 },
+                    },
                     grid: {
                       borderColor: "#e5e7eb",
                       strokeDashArray: 4,
@@ -316,12 +438,7 @@ export function RecruitmentSection({ data, months, location }: Props) {
                     },
                     theme: { mode: chartMode },
                   }}
-                  series={[
-                    {
-                      name: "New Registrations",
-                      data: registrationTrend.map((t) => t.count),
-                    },
-                  ]}
+                  series={registrationSeries}
                   type="bar"
                   height={320}
                 />
@@ -343,19 +460,18 @@ export function RecruitmentSection({ data, months, location }: Props) {
                 Onboarding Funnel
                 <InfoDialog
                   title="Onboarding Funnel"
-                  description="How new volunteers progress through onboarding"
+                  description="How new volunteers progress through onboarding, stacked by restaurant"
                 >
                   <p>
                     Shows how many volunteers registered in the selected period
                     progressed through each stage of their onboarding journey.
+                    Each bar is split by the volunteer&rsquo;s primary
+                    restaurant.
                   </p>
                   <div className="space-y-2 pt-1">
                     {funnelStages.map((s) => (
                       <div key={s.name} className="flex gap-2">
-                        <span
-                          className="inline-block w-2 h-2 rounded-full mt-1.5 shrink-0"
-                          style={{ background: s.color }}
-                        />
+                        <span className="inline-block w-2 h-2 rounded-full mt-1.5 shrink-0 bg-muted-foreground" />
                         <p>
                           <span className="font-medium">{s.name}</span> —{" "}
                           {s.desc}.
@@ -374,6 +490,23 @@ export function RecruitmentSection({ data, months, location }: Props) {
             <CardContent>
               {total > 0 ? (
                 <div className="space-y-4 py-2">
+                  {locations.length > 1 && (
+                    <div className="flex flex-wrap gap-3 pb-1">
+                      {locations.map((loc, i) => (
+                        <div
+                          key={loc}
+                          className="flex items-center gap-1.5 text-xs"
+                        >
+                          <span
+                            className="inline-block w-2.5 h-2.5 rounded-full"
+                            style={{ background: locationColors[i] }}
+                          />
+                          <span className="text-muted-foreground">{loc}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
                   {funnelStages.map((stage, i) => {
                     const stagePct = pct(stage.value, total);
                     const nextStage = funnelStages[i + 1];
@@ -386,14 +519,28 @@ export function RecruitmentSection({ data, months, location }: Props) {
                         ? pct(dropOff, stage.value)
                         : null;
 
+                    // Segment widths are relative to `total` so all bars share
+                    // the same scale, and a location's segment reflects its
+                    // share of the whole registered cohort — not just the stage.
+                    const segments = locations
+                      .map((loc, li) => {
+                        const row = funnel.byLocation.find(
+                          (b) => b.location === loc
+                        );
+                        const value = row ? stageValue(row, stage.key) : 0;
+                        return {
+                          loc,
+                          value,
+                          color: locationColors[li],
+                          widthPct: total > 0 ? (value / total) * 100 : 0,
+                        };
+                      })
+                      .filter((s) => s.value > 0);
+
                     return (
                       <div key={stage.name} className="space-y-1.5">
                         <div className="flex items-center justify-between text-sm gap-2">
                           <div className="flex items-center gap-2 min-w-0">
-                            <span
-                              className="inline-block w-2 h-2 rounded-full shrink-0"
-                              style={{ background: stage.color }}
-                            />
                             <span className="font-medium truncate">
                               {stage.name}
                             </span>
@@ -402,26 +549,34 @@ export function RecruitmentSection({ data, months, location }: Props) {
                             <span className="text-muted-foreground tabular-nums text-xs">
                               {stage.value.toLocaleString()}
                             </span>
-                            <span
-                              className="font-semibold tabular-nums w-9 text-right text-sm"
-                              style={{ color: stage.color }}
-                            >
+                            <span className="font-semibold tabular-nums w-9 text-right text-sm">
                               {stagePct}%
                             </span>
                           </div>
                         </div>
-                        <div className="h-5 bg-muted/30 rounded overflow-hidden">
-                          <motion.div
-                            className="h-full rounded"
-                            style={{ background: stage.color }}
-                            initial={{ width: 0 }}
-                            animate={{ width: `${stagePct}%` }}
-                            transition={{
-                              duration: 0.6,
-                              delay: 0.1 + i * 0.12,
-                              ease: [0.4, 0, 0.2, 1],
-                            }}
-                          />
+                        <div className="h-5 bg-muted/30 rounded overflow-hidden flex">
+                          {segments.map((seg, si) => (
+                            <Tooltip key={seg.loc}>
+                              <TooltipTrigger asChild>
+                                <motion.div
+                                  className="h-full"
+                                  style={{ background: seg.color }}
+                                  initial={{ width: 0 }}
+                                  animate={{ width: `${seg.widthPct}%` }}
+                                  transition={{
+                                    duration: 0.6,
+                                    delay: 0.1 + i * 0.12 + si * 0.04,
+                                    ease: [0.4, 0, 0.2, 1],
+                                  }}
+                                />
+                              </TooltipTrigger>
+                              <TooltipContent side="top">
+                                <span className="font-medium">{seg.loc}</span>:{" "}
+                                {seg.value.toLocaleString()} (
+                                {pct(seg.value, stage.value)}% of stage)
+                              </TooltipContent>
+                            </Tooltip>
+                          ))}
                         </div>
                         {dropOff != null && dropOff > 0 && (
                           <p className="text-xs text-muted-foreground pl-4">
@@ -453,13 +608,14 @@ export function RecruitmentSection({ data, months, location }: Props) {
                 Time to First Shift Distribution
                 <InfoDialog
                   title="Time to First Shift"
-                  description="How quickly new volunteers complete their first shift"
+                  description="How quickly new volunteers complete their first shift, stacked by restaurant"
                 >
                   <p>
                     Among volunteers registered in the selected period who have
                     completed at least one confirmed shift, this shows how many
                     days elapsed between their registration date and their first
-                    completed shift.
+                    completed shift. Bars are stacked by the volunteer&rsquo;s
+                    primary restaurant.
                   </p>
                   <p>
                     A large proportion in the first bar (≤ 7 days) suggests
@@ -474,6 +630,7 @@ export function RecruitmentSection({ data, months, location }: Props) {
                 options={{
                   chart: {
                     type: "bar" as const,
+                    stacked: true,
                     toolbar: { show: false },
                     background: "transparent",
                   },
@@ -483,20 +640,10 @@ export function RecruitmentSection({ data, months, location }: Props) {
                       borderRadius: 4,
                       borderRadiusApplication: "end" as const,
                       barHeight: "55%",
-                      distributed: true,
                     },
                   },
                   xaxis: {
-                    categories: [
-                      "Same day",
-                      "1–3 days",
-                      "4–7 days",
-                      "8–14 days",
-                      "15–30 days",
-                      "31–60 days",
-                      "61–90 days",
-                      "> 90 days",
-                    ],
+                    categories: timeToFirstShiftBuckets.map(([label]) => label),
                     labels: {
                       style: {
                         fontFamily: "var(--font-libre-franklin), sans-serif",
@@ -522,16 +669,7 @@ export function RecruitmentSection({ data, months, location }: Props) {
                       },
                     },
                   },
-                  colors: [
-                    "#10b981", // same day
-                    "#34d399", // 1–3 days
-                    "#3b82f6", // 4–7 days
-                    "#60a5fa", // 8–14 days
-                    "#f59e0b", // 15–30 days
-                    "#fb923c", // 31–60 days
-                    "#ef4444", // 61–90 days
-                    "#dc2626", // >90 days
-                  ],
+                  colors: locationColors.length ? locationColors : ["#10b981"],
                   dataLabels: {
                     enabled: true,
                     formatter: (val: number) => (val > 0 ? String(val) : ""),
@@ -541,7 +679,14 @@ export function RecruitmentSection({ data, months, location }: Props) {
                       fontWeight: 600,
                     },
                   },
-                  legend: { show: false },
+                  legend: {
+                    show: locations.length > 1,
+                    position: "bottom",
+                    fontFamily: "var(--font-libre-franklin), sans-serif",
+                    fontSize: "12px",
+                    markers: { size: 6 },
+                    itemMargin: { horizontal: 8, vertical: 4 },
+                  },
                   grid: {
                     borderColor: "#e5e7eb",
                     strokeDashArray: 4,
@@ -555,21 +700,18 @@ export function RecruitmentSection({ data, months, location }: Props) {
                   },
                   theme: { mode: chartMode },
                 }}
-                series={[
-                  {
-                    name: "Volunteers",
-                    data: [
-                      funnel.sameDay,
-                      funnel.within3Days,
-                      funnel.within7Days,
-                      funnel.within14Days,
-                      funnel.within30Days,
-                      funnel.within60Days,
-                      funnel.within90Days,
-                      funnel.over90Days,
-                    ],
-                  },
-                ]}
+                series={
+                  timeToFirstShiftSeries.length > 0
+                    ? timeToFirstShiftSeries
+                    : [
+                        {
+                          name: "Volunteers",
+                          data: timeToFirstShiftBuckets.map(
+                            ([, key]) => funnel[key]
+                          ),
+                        },
+                      ]
+                }
                 type="bar"
                 height={300}
               />

--- a/web/src/lib/recruitment-types.ts
+++ b/web/src/lib/recruitment-types.ts
@@ -1,0 +1,67 @@
+// Client-safe recruitment analytics types. Kept in a separate module from
+// `@/lib/recruitment` so client components can import these without pulling
+// Prisma (and its transitive `pg` dependency) into the client bundle.
+
+// "Unspecified" bucket for users with no defaultLocation set.
+export const UNSPECIFIED_LOCATION = "Unspecified";
+
+export interface RecruitmentFunnelBreakdown {
+  location: string;
+  totalRegistrations: number;
+  incompleteProfiles: number;
+  completedProfileNoSignup: number;
+  signedUpNoShift: number;
+  completedShift: number;
+  sameDay: number;
+  within3Days: number;
+  within7Days: number;
+  within14Days: number;
+  within30Days: number;
+  within60Days: number;
+  within90Days: number;
+  over90Days: number;
+}
+
+export interface RecruitmentFunnel {
+  totalRegistrations: number;
+  /** Registered but profileCompleted = false */
+  incompleteProfiles: number;
+  /** profileCompleted = true, zero signups ever */
+  completedProfileNoSignup: number;
+  /** Has at least one signup record, but zero confirmed shifts */
+  signedUpNoShift: number;
+  /** Has at least one confirmed completed shift */
+  completedShift: number;
+  /** Average days from registration to first completed shift (null if no data) */
+  avgDaysToFirstShift: number | null;
+  sameDay: number; // 0 days
+  within3Days: number; // 1–3 days
+  within7Days: number; // 4–7 days
+  within14Days: number; // 8–14 days
+  within30Days: number; // 15–30 days
+  within60Days: number; // 31–60 days
+  within90Days: number; // 61–90 days
+  over90Days: number; // 91+ days
+  /** Per-location breakdown of all funnel/time-to-first-shift counts. */
+  byLocation: RecruitmentFunnelBreakdown[];
+}
+
+export interface RecruitmentTrendPoint {
+  month: string;
+  /** Total across all locations for this month */
+  count: number;
+  /** Location name → count for that month */
+  byLocation: Record<string, number>;
+}
+
+export interface RecruitmentData {
+  funnel: RecruitmentFunnel;
+  /** 12-month rolling monthly registration counts (filled with 0 for empty months) */
+  registrationTrend: RecruitmentTrendPoint[];
+  /**
+   * Distinct location names seen anywhere in the returned data, in stable
+   * alphabetical order with "Unspecified" pinned last. Used by the UI to render
+   * one chart series per restaurant.
+   */
+  locations: string[];
+}

--- a/web/src/lib/recruitment.ts
+++ b/web/src/lib/recruitment.ts
@@ -1,33 +1,29 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@/generated/client";
 import { nowInNZT, toNZT } from "@/lib/timezone";
+import {
+  UNSPECIFIED_LOCATION,
+  type RecruitmentData,
+  type RecruitmentFunnelBreakdown,
+  type RecruitmentTrendPoint,
+} from "@/lib/recruitment-types";
 
-export interface RecruitmentFunnel {
-  totalRegistrations: number;
-  /** Registered but profileCompleted = false */
-  incompleteProfiles: number;
-  /** profileCompleted = true, zero signups ever */
-  completedProfileNoSignup: number;
-  /** Has at least one signup record, but zero confirmed shifts */
-  signedUpNoShift: number;
-  /** Has at least one confirmed completed shift */
-  completedShift: number;
-  /** Average days from registration to first completed shift (null if no data) */
-  avgDaysToFirstShift: number | null;
-  sameDay: number;     // 0 days
-  within3Days: number; // 1–3 days
-  within7Days: number; // 4–7 days
-  within14Days: number; // 8–14 days
-  within30Days: number; // 15–30 days
-  within60Days: number; // 31–60 days
-  within90Days: number; // 61–90 days
-  over90Days: number;   // 91+ days
-}
+export {
+  UNSPECIFIED_LOCATION,
+  type RecruitmentData,
+  type RecruitmentFunnel,
+  type RecruitmentFunnelBreakdown,
+  type RecruitmentTrendPoint,
+} from "@/lib/recruitment-types";
 
-export interface RecruitmentData {
-  funnel: RecruitmentFunnel;
-  /** 12-month rolling monthly registration counts (filled with 0 for empty months) */
-  registrationTrend: Array<{ month: string; count: number }>;
+function sortLocations(names: Iterable<string>): string[] {
+  const list = Array.from(new Set(names)).filter(Boolean);
+  list.sort((a, b) => {
+    if (a === UNSPECIFIED_LOCATION && b !== UNSPECIFIED_LOCATION) return 1;
+    if (b === UNSPECIFIED_LOCATION && a !== UNSPECIFIED_LOCATION) return -1;
+    return a.localeCompare(b);
+  });
+  return list;
 }
 
 export async function getRecruitmentData(
@@ -55,16 +51,16 @@ export async function getRecruitmentData(
     ? Prisma.sql`AND u."availableLocations" LIKE ${`%"${location}"%`}`
     : Prisma.empty;
 
-  const [funnelResult, trendResult] = await Promise.all([
-    // ── Funnel query (scoped to the selected period) ──────────────────────────
+  const [funnelRows, avgResult, trendResult] = await Promise.all([
+    // ── Funnel query: one row per defaultLocation bucket ─────────────────────
     prisma.$queryRaw<
       Array<{
+        location: string;
         totalRegistrations: bigint;
         incompleteProfiles: bigint;
         completedProfileNoSignup: bigint;
         signedUpNoShift: bigint;
         completedShift: bigint;
-        avgDaysToFirstShift: number | null;
         sameDay: bigint;
         within3Days: bigint;
         within7Days: bigint;
@@ -76,7 +72,11 @@ export async function getRecruitmentData(
       }>
     >`
       WITH user_base AS (
-        SELECT u.id, u."profileCompleted", u."createdAt"
+        SELECT
+          u.id,
+          u."profileCompleted",
+          u."createdAt",
+          COALESCE(NULLIF(u."defaultLocation", ''), ${UNSPECIFIED_LOCATION}) AS location
         FROM "User" u
         WHERE u.role = 'VOLUNTEER'::"Role"
           AND u."createdAt" >= ${periodStart}
@@ -86,6 +86,7 @@ export async function getRecruitmentData(
       user_stats AS (
         SELECT
           ub.id,
+          ub.location,
           ub."profileCompleted",
           ub."createdAt",
           COUNT(sg.id)                                                                  AS total_signups,
@@ -98,17 +99,15 @@ export async function getRecruitmentData(
         FROM user_base ub
         LEFT JOIN "Signup" sg ON sg."userId" = ub.id
         LEFT JOIN "Shift"  sh ON sh.id = sg."shiftId"
-        GROUP BY ub.id, ub."profileCompleted", ub."createdAt"
+        GROUP BY ub.id, ub.location, ub."profileCompleted", ub."createdAt"
       )
       SELECT
+        location                                                                       AS "location",
         COUNT(*)::bigint                                                               AS "totalRegistrations",
-        COUNT(*) FILTER (WHERE NOT "profileCompleted")::bigint                        AS "incompleteProfiles",
-        COUNT(*) FILTER (WHERE "profileCompleted" AND total_signups = 0)::bigint      AS "completedProfileNoSignup",
-        COUNT(*) FILTER (WHERE total_signups > 0 AND confirmed_shifts = 0)::bigint    AS "signedUpNoShift",
-        COUNT(*) FILTER (WHERE confirmed_shifts > 0)::bigint                          AS "completedShift",
-        AVG(
-          EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0
-        ) FILTER (WHERE first_shift_date IS NOT NULL)::float                          AS "avgDaysToFirstShift",
+        COUNT(*) FILTER (WHERE NOT "profileCompleted")::bigint                         AS "incompleteProfiles",
+        COUNT(*) FILTER (WHERE "profileCompleted" AND total_signups = 0)::bigint       AS "completedProfileNoSignup",
+        COUNT(*) FILTER (WHERE total_signups > 0 AND confirmed_shifts = 0)::bigint     AS "signedUpNoShift",
+        COUNT(*) FILTER (WHERE confirmed_shifts > 0)::bigint                           AS "completedShift",
         COUNT(*) FILTER (
           WHERE first_shift_date IS NOT NULL
             AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 < 1
@@ -148,68 +147,145 @@ export async function getRecruitmentData(
             AND EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0 > 90
         )::bigint                                                                      AS "over90Days"
       FROM user_stats
+      GROUP BY location
+      ORDER BY location
     `,
 
-    // ── 12-month trend (always full year for chart context) ───────────────────
+    // ── Overall average days to first shift (one number across all locations) ─
+    prisma.$queryRaw<Array<{ avgDaysToFirstShift: number | null }>>`
+      WITH user_base AS (
+        SELECT u.id, u."createdAt"
+        FROM "User" u
+        WHERE u.role = 'VOLUNTEER'::"Role"
+          AND u."createdAt" >= ${periodStart}
+          AND u."createdAt" < ${now}
+          ${locationCond}
+      ),
+      first_shift AS (
+        SELECT
+          ub.id,
+          ub."createdAt",
+          MIN(sh."end") FILTER (
+            WHERE sg.status = 'CONFIRMED'::"SignupStatus" AND sh."end" < ${now}
+          ) AS first_shift_date
+        FROM user_base ub
+        LEFT JOIN "Signup" sg ON sg."userId" = ub.id
+        LEFT JOIN "Shift"  sh ON sh.id = sg."shiftId"
+        GROUP BY ub.id, ub."createdAt"
+      )
+      SELECT
+        AVG(
+          EXTRACT(EPOCH FROM (first_shift_date - "createdAt")) / 86400.0
+        ) FILTER (WHERE first_shift_date IS NOT NULL)::float AS "avgDaysToFirstShift"
+      FROM first_shift
+    `,
+
+    // ── 12-month trend grouped by month AND defaultLocation ──────────────────
     // Convert createdAt from UTC to NZ time before truncating to month so that
     // registrations are grouped into the NZ calendar month they actually occurred in.
-    prisma.$queryRaw<Array<{ month: string; count: bigint }>>`
+    prisma.$queryRaw<
+      Array<{ month: string; location: string; count: bigint }>
+    >`
       SELECT
         to_char(
           date_trunc('month', (u."createdAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Pacific/Auckland'),
           'YYYY-MM'
-        )                AS month,
-        COUNT(*)::bigint AS count
+        )                                                                      AS month,
+        COALESCE(NULLIF(u."defaultLocation", ''), ${UNSPECIFIED_LOCATION})     AS location,
+        COUNT(*)::bigint                                                        AS count
       FROM "User" u
       WHERE u.role = 'VOLUNTEER'::"Role"
         AND u."createdAt" >= ${trendStart}
         AND u."createdAt" < ${now}
         ${locationCond}
-      GROUP BY date_trunc('month', (u."createdAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Pacific/Auckland')
+      GROUP BY month, location
       ORDER BY month
     `,
   ]);
 
-  const f = funnelResult[0];
-  const trendMap = new Map(trendResult.map((r) => [r.month, Number(r.count)]));
+  // Build per-location funnel rows and aggregate totals.
+  const byLocation: RecruitmentFunnelBreakdown[] = funnelRows.map((r) => ({
+    location: r.location ?? UNSPECIFIED_LOCATION,
+    totalRegistrations: Number(r.totalRegistrations ?? 0),
+    incompleteProfiles: Number(r.incompleteProfiles ?? 0),
+    completedProfileNoSignup: Number(r.completedProfileNoSignup ?? 0),
+    signedUpNoShift: Number(r.signedUpNoShift ?? 0),
+    completedShift: Number(r.completedShift ?? 0),
+    sameDay: Number(r.sameDay ?? 0),
+    within3Days: Number(r.within3Days ?? 0),
+    within7Days: Number(r.within7Days ?? 0),
+    within14Days: Number(r.within14Days ?? 0),
+    within30Days: Number(r.within30Days ?? 0),
+    within60Days: Number(r.within60Days ?? 0),
+    within90Days: Number(r.within90Days ?? 0),
+    over90Days: Number(r.over90Days ?? 0),
+  }));
+
+  const sumKey = (
+    key: keyof Omit<RecruitmentFunnelBreakdown, "location">
+  ): number => byLocation.reduce((acc, row) => acc + row[key], 0);
+
+  const rawAvg = avgResult[0]?.avgDaysToFirstShift;
+
+  // Build 12-month trend with per-location buckets.
+  type MonthBuckets = { count: number; byLocation: Record<string, number> };
+  const trendMap = new Map<string, MonthBuckets>();
+  for (const row of trendResult) {
+    const key = row.month;
+    const loc = row.location ?? UNSPECIFIED_LOCATION;
+    const add = Number(row.count);
+    const bucket = trendMap.get(key) ?? { count: 0, byLocation: {} };
+    bucket.count += add;
+    bucket.byLocation[loc] = (bucket.byLocation[loc] ?? 0) + add;
+    trendMap.set(key, bucket);
+  }
 
   // Iterate NZ months so that keys match the NZ-grouped SQL output.
   // toNZT() returns a TZDate whose getMonth()/setMonth() operate in NZ timezone.
-  const registrationTrend: Array<{ month: string; count: number }> = [];
+  const registrationTrend: RecruitmentTrendPoint[] = [];
   const nzCursor = toNZT(trendStart);
   nzCursor.setDate(1);
   while (nzCursor.getTime() < now.getTime()) {
-    const key = `${nzCursor.getFullYear()}-${String(nzCursor.getMonth() + 1).padStart(2, "0")}`;
+    const key = `${nzCursor.getFullYear()}-${String(
+      nzCursor.getMonth() + 1
+    ).padStart(2, "0")}`;
+    const bucket = trendMap.get(key);
     registrationTrend.push({
       month: nzCursor.toLocaleDateString("en-NZ", {
         month: "short",
         year: "2-digit",
       }),
-      count: trendMap.get(key) ?? 0,
+      count: bucket?.count ?? 0,
+      byLocation: bucket?.byLocation ?? {},
     });
     nzCursor.setMonth(nzCursor.getMonth() + 1);
   }
 
-  const rawAvg = f?.avgDaysToFirstShift;
+  const locations = sortLocations([
+    ...byLocation.map((b) => b.location),
+    ...registrationTrend.flatMap((t) => Object.keys(t.byLocation)),
+  ]);
 
   return {
     funnel: {
-      totalRegistrations:        Number(f?.totalRegistrations        ?? 0),
-      incompleteProfiles:        Number(f?.incompleteProfiles        ?? 0),
-      completedProfileNoSignup:  Number(f?.completedProfileNoSignup  ?? 0),
-      signedUpNoShift:           Number(f?.signedUpNoShift           ?? 0),
-      completedShift:            Number(f?.completedShift            ?? 0),
+      totalRegistrations: sumKey("totalRegistrations"),
+      incompleteProfiles: sumKey("incompleteProfiles"),
+      completedProfileNoSignup: sumKey("completedProfileNoSignup"),
+      signedUpNoShift: sumKey("signedUpNoShift"),
+      completedShift: sumKey("completedShift"),
       avgDaysToFirstShift:
         rawAvg != null ? Math.round(Number(rawAvg) * 10) / 10 : null,
-      sameDay:       Number(f?.sameDay      ?? 0),
-      within3Days:   Number(f?.within3Days  ?? 0),
-      within7Days:   Number(f?.within7Days  ?? 0),
-      within14Days:  Number(f?.within14Days ?? 0),
-      within30Days:  Number(f?.within30Days ?? 0),
-      within60Days:  Number(f?.within60Days ?? 0),
-      within90Days:  Number(f?.within90Days ?? 0),
-      over90Days:    Number(f?.over90Days   ?? 0),
+      sameDay: sumKey("sameDay"),
+      within3Days: sumKey("within3Days"),
+      within7Days: sumKey("within7Days"),
+      within14Days: sumKey("within14Days"),
+      within30Days: sumKey("within30Days"),
+      within60Days: sumKey("within60Days"),
+      within90Days: sumKey("within90Days"),
+      over90Days: sumKey("over90Days"),
+      byLocation,
     },
     registrationTrend,
+    locations,
   };
 }


### PR DESCRIPTION
## Summary
- Registrations over time, the onboarding funnel, and the time-to-first-shift distribution are now stacked by restaurant (`defaultLocation`).
- Volunteers without a primary restaurant fall into an "Unspecified" bucket; existing location dropdown still filters by `availableLocations` (unchanged behaviour).
- Client-safe types extracted to `src/lib/recruitment-types.ts` so the client section component doesn't pull Prisma/`pg` into the browser bundle.

Closes #794

## Test plan
- [ ] Visit `/admin/analytics/recruitment` with "All Locations" selected — confirm each chart shows one segment/series per restaurant with a legend.
- [ ] Pick a specific location in the filter — charts still render (may collapse to a single stack) and totals match the stat cards.
- [ ] Hover each funnel bar segment — tooltip shows location name, volunteer count, and share of stage.
- [ ] Verify colours stay consistent across the three charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)