### PR TITLE
feat(web): milestone analytics — recent achievers + stack by restaurant

### DIFF
--- a/web/src/app/admin/analytics/milestones/milestone-analytics-client.tsx
+++ b/web/src/app/admin/analytics/milestones/milestone-analytics-client.tsx
@@ -43,6 +43,7 @@ import {
 } from "@/components/ui/dialog";
 import Link from "next/link";
 import type { MilestoneData } from "@/lib/milestone-analytics";
+import { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
 
 const Chart = dynamic(() => import("react-apexcharts"), { ssr: false });
 
@@ -70,6 +71,33 @@ const MILESTONE_COLORS: Record<number, string> = {
   200: "#10b981",
   500: "#3b82f6",
 };
+
+// Stable per-restaurant colour palette. Matches the recruitment analytics
+// section so stacks line up across pages. "Unspecified" is muted on purpose
+// so it doesn't dominate the visual.
+const LOCATION_COLORS: Record<string, string> = {
+  Wellington: "#3b82f6",
+  "Glen Innes": "#8b5cf6",
+  Onehunga: "#10b981",
+  "Special Event Venue": "#f59e0b",
+  [UNSPECIFIED_LOCATION]: "#94a3b8",
+};
+
+const FALLBACK_LOCATION_COLORS = [
+  "#ec4899",
+  "#14b8a6",
+  "#fb923c",
+  "#6366f1",
+  "#f43f5e",
+  "#22c55e",
+];
+
+function colorForLocation(location: string, index: number): string {
+  return (
+    LOCATION_COLORS[location] ??
+    FALLBACK_LOCATION_COLORS[index % FALLBACK_LOCATION_COLORS.length]
+  );
+}
 
 function MilestoneCard({
   threshold,
@@ -145,19 +173,42 @@ export function MilestoneAnalyticsClient({
     (p) => p.threshold === selectedMilestone
   );
 
-  // Distribution chart data (sorted by minShifts)
+  const restaurantList = data.locations;
+  const hasMultipleRestaurants = restaurantList.length > 1;
+  const locationColors = restaurantList.map((loc, i) =>
+    colorForLocation(loc, i)
+  );
+
+  // Distribution chart — horizontal bars, stacked by restaurant
   const distCategories = data.distribution.map((b) => b.label);
   const distCounts = data.distribution.map((b) => b.count);
+  const distSeriesByLocation = restaurantList.map((loc) => ({
+    name: loc,
+    data: data.distribution.map((b) => b.byLocation[loc] ?? 0),
+  }));
 
-  // Milestone hits chart
+  // Milestone hits chart — vertical bars showing "hit in period", stacked by
+  // restaurant. All-time totals remain visible on the summary cards above.
   const hitsCategories = data.milestoneHits.map((m) => `${m.threshold}`);
-  const hitsInPeriod = data.milestoneHits.map((m) => m.hitInPeriod);
-  const hitsAllTime = data.milestoneHits.map((m) => m.allTimeTotal);
+  const hitsSeriesByLocation = restaurantList.map((loc) => ({
+    name: loc,
+    data: data.milestoneHits.map((m) => m.byLocation[loc]?.hitInPeriod ?? 0),
+  }));
+  const hitsAnyValue = data.milestoneHits.some((m) => m.hitInPeriod > 0);
 
-  // Projection chart
+  // Projection chart — bars per threshold showing "projected in next 12
+  // months", stacked by primary restaurant. All-time totals per threshold are
+  // already visible on the summary cards at the top of the page.
   const projCategories = data.projections.map((p) => `${p.threshold} shifts`);
-  const projAlready = data.projections.map((p) => p.alreadyHit);
-  const projAdditional = data.projections.map((p) => p.projectedAdditional);
+  const projProjectedSeries = restaurantList.map((loc) => ({
+    name: loc,
+    data: data.projections.map(
+      (p) => p.byLocation[loc]?.projectedAdditional ?? 0
+    ),
+  }));
+  const projHasAdditional = data.projections.some(
+    (p) => p.projectedAdditional > 0
+  );
 
   // Recent achievements (filtered by threshold)
   const filteredRecentAchievements =
@@ -282,9 +333,12 @@ export function MilestoneAnalyticsClient({
                           crossed the threshold for the first time.
                         </p>
                         <p>
-                          The darker bars show all-time totals (everyone who has
-                          ever reached that milestone). The bright bars show how
-                          many crossed it during the selected period.
+                          Each bar shows milestone crossings in the selected
+                          period, split by the volunteer&rsquo;s primary
+                          restaurant (their default location). Volunteers
+                          without a primary restaurant set are grouped as
+                          &ldquo;{UNSPECIFIED_LOCATION}&rdquo;. All-time totals
+                          remain visible on the summary cards above.
                         </p>
                       </div>
                     </DialogContent>
@@ -292,11 +346,12 @@ export function MilestoneAnalyticsClient({
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                {hitsAllTime.some((v) => v > 0) ? (
+                {hitsAnyValue ? (
                   <Chart
                     options={{
                       chart: {
                         type: "bar" as const,
+                        stacked: true,
                         toolbar: { show: false },
                         background: "transparent",
                       },
@@ -328,17 +383,10 @@ export function MilestoneAnalyticsClient({
                           },
                         },
                       },
-                      colors: ["#f59e0b", "#f59e0b33"],
-                      dataLabels: {
-                        enabled: true,
-                        formatter: (val: number) =>
-                          val > 0 ? String(val) : "",
-                        style: {
-                          fontSize: "11px",
-                          fontFamily: "var(--font-libre-franklin), sans-serif",
-                          fontWeight: 600,
-                        },
-                      },
+                      colors: locationColors.length
+                        ? locationColors
+                        : ["#f59e0b"],
+                      dataLabels: { enabled: false },
                       grid: {
                         borderColor: "#e5e7eb",
                         strokeDashArray: 4,
@@ -353,26 +401,33 @@ export function MilestoneAnalyticsClient({
                         },
                       },
                       legend: {
-                        position: "top" as const,
+                        show: hasMultipleRestaurants,
+                        position: "bottom" as const,
                         fontSize: "12px",
                         fontFamily: "var(--font-libre-franklin), sans-serif",
                         markers: { size: 6, offsetX: -2 },
+                        itemMargin: { horizontal: 8, vertical: 4 },
                       },
                       theme: { mode: chartThemeMode },
                     }}
-                    series={[
-                      {
-                        name: `Hit in last ${periodLabel}`,
-                        data: hitsInPeriod,
-                      },
-                      { name: "All-time total", data: hitsAllTime },
-                    ]}
+                    series={
+                      hitsSeriesByLocation.length > 0
+                        ? hitsSeriesByLocation
+                        : [
+                            {
+                              name: `Hit in last ${periodLabel}`,
+                              data: data.milestoneHits.map(
+                                (m) => m.hitInPeriod
+                              ),
+                            },
+                          ]
+                    }
                     type="bar"
                     height={300}
                   />
                 ) : (
                   <div className="flex items-center justify-center h-[300px] text-muted-foreground text-sm">
-                    No milestone data available
+                    No milestones crossed in the last {periodLabel}
                   </div>
                 )}
               </CardContent>
@@ -394,7 +449,7 @@ export function MilestoneAnalyticsClient({
                     </TooltipTrigger>
                     <TooltipContent side="top" className="w-auto max-w-56">
                       How many volunteers currently sit in each shift-count band
-                      (all-time completed shifts)
+                      (all-time completed shifts), stacked by primary restaurant
                     </TooltipContent>
                   </Tooltip>
                 </CardTitle>
@@ -405,6 +460,7 @@ export function MilestoneAnalyticsClient({
                     options={{
                       chart: {
                         type: "bar" as const,
+                        stacked: true,
                         toolbar: { show: false },
                         background: "transparent",
                       },
@@ -446,32 +502,38 @@ export function MilestoneAnalyticsClient({
                           },
                         },
                       },
-                      colors: ["#3b82f6"],
-                      dataLabels: {
-                        enabled: true,
-                        formatter: (val: number) =>
-                          val > 0 ? String(val) : "",
-                        style: {
-                          fontSize: "11px",
-                          fontFamily: "var(--font-libre-franklin), sans-serif",
-                          fontWeight: 600,
-                        },
-                      },
+                      colors: locationColors.length
+                        ? locationColors
+                        : ["#3b82f6"],
+                      dataLabels: { enabled: false },
                       grid: {
                         borderColor: "#e5e7eb",
                         strokeDashArray: 4,
                         yaxis: { lines: { show: false } },
                       },
                       tooltip: {
+                        shared: true,
+                        intersect: false,
                         y: {
                           formatter: (val: number) =>
                             `${val} volunteer${val !== 1 ? "s" : ""}`,
                         },
                       },
-                      legend: { show: false },
+                      legend: {
+                        show: hasMultipleRestaurants,
+                        position: "bottom" as const,
+                        fontSize: "12px",
+                        fontFamily: "var(--font-libre-franklin), sans-serif",
+                        markers: { size: 6, offsetX: -2 },
+                        itemMargin: { horizontal: 8, vertical: 4 },
+                      },
                       theme: { mode: chartThemeMode },
                     }}
-                    series={[{ name: "Volunteers", data: distCounts }]}
+                    series={
+                      distSeriesByLocation.length > 0
+                        ? distSeriesByLocation
+                        : [{ name: "Volunteers", data: distCounts }]
+                    }
                     type="bar"
                     height={300}
                   />
@@ -519,10 +581,17 @@ export function MilestoneAnalyticsClient({
                         counted in the &ldquo;Projected&rdquo; total.
                       </p>
                       <p>
+                        Each bar is stacked by the volunteer&rsquo;s primary
+                        restaurant, so you can see which locations are
+                        trending toward each level of recognition. All-time
+                        totals (who has already crossed each threshold) live
+                        on the summary cards at the top of the page.
+                      </p>
+                      <p>
                         Volunteers with no shifts in the past 6 months are not
                         projected — they&rsquo;re considered inactive. Use the
-                        approaching volunteers list below to view everyone close
-                        to a milestone regardless of recent activity.
+                        approaching volunteers list below to view everyone
+                        close to a milestone regardless of recent activity.
                       </p>
                       <p>
                         These projections are useful for planning recognition
@@ -535,8 +604,7 @@ export function MilestoneAnalyticsClient({
               </CardTitle>
             </CardHeader>
             <CardContent>
-              {projAlready.some((v) => v > 0) ||
-              projAdditional.some((v) => v > 0) ? (
+              {projHasAdditional ? (
                 <Chart
                   options={{
                     chart: {
@@ -566,7 +634,7 @@ export function MilestoneAnalyticsClient({
                     },
                     yaxis: {
                       title: {
-                        text: "Volunteers",
+                        text: "Volunteers projected",
                         style: {
                           fontFamily: "var(--font-libre-franklin), sans-serif",
                           fontSize: "11px",
@@ -580,16 +648,10 @@ export function MilestoneAnalyticsClient({
                         },
                       },
                     },
-                    colors: ["#10b981", "#6366f1"],
-                    dataLabels: {
-                      enabled: true,
-                      formatter: (val: number) => (val > 0 ? String(val) : ""),
-                      style: {
-                        fontSize: "11px",
-                        fontFamily: "var(--font-libre-franklin), sans-serif",
-                        fontWeight: 600,
-                      },
-                    },
+                    colors: locationColors.length
+                      ? locationColors
+                      : ["#6366f1"],
+                    dataLabels: { enabled: false },
                     grid: {
                       borderColor: "#e5e7eb",
                       strokeDashArray: 4,
@@ -604,26 +666,34 @@ export function MilestoneAnalyticsClient({
                       },
                     },
                     legend: {
-                      position: "top" as const,
+                      show: hasMultipleRestaurants,
+                      position: "bottom" as const,
                       fontSize: "12px",
                       fontFamily: "var(--font-libre-franklin), sans-serif",
                       markers: { size: 6, offsetX: -2 },
+                      itemMargin: { horizontal: 8, vertical: 4 },
                     },
                     theme: { mode: chartThemeMode },
                   }}
-                  series={[
-                    { name: "Already achieved", data: projAlready },
-                    {
-                      name: "Projected in next 12 months",
-                      data: projAdditional,
-                    },
-                  ]}
+                  series={
+                    projProjectedSeries.length > 0
+                      ? projProjectedSeries
+                      : [
+                          {
+                            name: "Projected in next 12 months",
+                            data: data.projections.map(
+                              (p) => p.projectedAdditional
+                            ),
+                          },
+                        ]
+                  }
                   type="bar"
                   height={300}
                 />
               ) : (
                 <div className="flex items-center justify-center h-[300px] text-muted-foreground text-sm">
-                  No projection data available
+                  No volunteers are projected to cross a milestone in the next
+                  12 months
                 </div>
               )}
             </CardContent>
@@ -701,9 +771,14 @@ export function MilestoneAnalyticsClient({
                         className="flex items-center gap-4 py-2 border-b last:border-0"
                       >
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium truncate">
-                            {v.name}
-                          </p>
+                          <div className="flex items-baseline gap-2 min-w-0">
+                            <p className="text-sm font-medium truncate">
+                              {v.name}
+                            </p>
+                            <span className="text-xs text-muted-foreground truncate">
+                              · {v.location}
+                            </span>
+                          </div>
                           <div className="mt-1 h-1.5 rounded-full bg-muted overflow-hidden">
                             <div
                               className="h-full rounded-full transition-all"
@@ -843,9 +918,14 @@ export function MilestoneAnalyticsClient({
                         className="flex items-center gap-4 py-2 border-b last:border-0"
                       >
                         <div className="flex-1 min-w-0">
-                          <p className="text-sm font-medium truncate">
-                            {a.name}
-                          </p>
+                          <div className="flex items-baseline gap-2 min-w-0">
+                            <p className="text-sm font-medium truncate">
+                              {a.name}
+                            </p>
+                            <span className="text-xs text-muted-foreground truncate">
+                              · {a.location}
+                            </span>
+                          </div>
                         </div>
                         <span className="w-28">
                           <span

--- a/web/src/app/admin/analytics/milestones/milestone-analytics-client.tsx
+++ b/web/src/app/admin/analytics/milestones/milestone-analytics-client.tsx
@@ -23,7 +23,10 @@ import {
   Loader2,
   Info,
   ExternalLink,
+  Sparkles,
 } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { formatInNZT } from "@/lib/timezone";
 import dynamic from "next/dynamic";
 import {
   Tooltip,
@@ -122,6 +125,8 @@ export function MilestoneAnalyticsClient({
   const [months, setMonths] = useState(initialMonths);
   const [location, setLocation] = useState(initialLocation);
   const [selectedMilestone, setSelectedMilestone] = useState<number>(100);
+  const [recentThresholdFilter, setRecentThresholdFilter] =
+    useState<string>("all");
   const chartThemeMode = (resolvedTheme === "dark" ? "dark" : "light") as
     | "dark"
     | "light";
@@ -153,6 +158,14 @@ export function MilestoneAnalyticsClient({
   const projCategories = data.projections.map((p) => `${p.threshold} shifts`);
   const projAlready = data.projections.map((p) => p.alreadyHit);
   const projAdditional = data.projections.map((p) => p.projectedAdditional);
+
+  // Recent achievements (filtered by threshold)
+  const filteredRecentAchievements =
+    recentThresholdFilter === "all"
+      ? data.recentAchievements
+      : data.recentAchievements.filter(
+          (a) => String(a.threshold) === recentThresholdFilter
+        );
 
   return (
     <div className="space-y-6">
@@ -745,6 +758,135 @@ export function MilestoneAnalyticsClient({
                   {selectedProjection
                     ? `No volunteers are currently approaching the ${selectedMilestone}-shift milestone`
                     : "Select a milestone to view approaching volunteers"}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </motion.div>
+
+        {/* Recent Milestone Achievements */}
+        <motion.div variants={staggerItem}>
+          <Card>
+            <CardHeader className="pb-4">
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                <CardTitle className="text-base font-semibold flex items-center gap-2">
+                  <Sparkles className="h-4 w-4 text-muted-foreground" />
+                  Recent Milestone Achievements
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button className="text-muted-foreground hover:text-foreground transition-colors">
+                        <Info className="h-3.5 w-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" className="w-auto max-w-64">
+                      Volunteers whose Nth completed shift landed inside the
+                      selected time period. Newest achievements first. Useful
+                      for recognition — reach out while it&rsquo;s still fresh.
+                    </TooltipContent>
+                  </Tooltip>
+                </CardTitle>
+                <div className="flex items-center gap-2">
+                  <Label
+                    htmlFor="recent-threshold-select"
+                    className="text-sm shrink-0"
+                  >
+                    Milestone:
+                  </Label>
+                  <Select
+                    value={recentThresholdFilter}
+                    onValueChange={setRecentThresholdFilter}
+                  >
+                    <SelectTrigger
+                      id="recent-threshold-select"
+                      className="w-36"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All milestones</SelectItem>
+                      {data.projections.map((p) => (
+                        <SelectItem
+                          key={p.threshold}
+                          value={String(p.threshold)}
+                        >
+                          {p.threshold} shifts
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {filteredRecentAchievements.length > 0 ? (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-4 text-xs text-muted-foreground pb-1">
+                    <span className="flex-1">Volunteer</span>
+                    <span className="w-28">Milestone</span>
+                    <span className="w-20 text-right">Total</span>
+                    <span className="w-32 text-right">Achieved</span>
+                    <span className="w-8" />
+                  </div>
+                  {filteredRecentAchievements.map((a) => {
+                    const color = MILESTONE_COLORS[a.threshold] ?? "#6b7280";
+                    const absoluteDate = formatInNZT(
+                      a.achievedAt,
+                      "d MMM yyyy"
+                    );
+                    const relative = formatDistanceToNow(
+                      new Date(a.achievedAt),
+                      { addSuffix: true }
+                    );
+                    return (
+                      <div
+                        key={`${a.userId}-${a.threshold}`}
+                        className="flex items-center gap-4 py-2 border-b last:border-0"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium truncate">
+                            {a.name}
+                          </p>
+                        </div>
+                        <span className="w-28">
+                          <span
+                            className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold"
+                            style={{
+                              backgroundColor: color + "20",
+                              color,
+                            }}
+                          >
+                            <Trophy className="h-3 w-3" />
+                            {a.threshold} shifts
+                          </span>
+                        </span>
+                        <span className="w-20 text-right text-sm tabular-nums font-medium">
+                          {a.totalShifts}
+                        </span>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="w-32 text-right text-sm text-muted-foreground tabular-nums cursor-default">
+                              {relative}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent side="top">
+                            {absoluteDate}
+                          </TooltipContent>
+                        </Tooltip>
+                        <Link
+                          href={`/admin/volunteers/${a.userId}`}
+                          className="w-8 flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </Link>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="flex items-center justify-center h-24 text-muted-foreground text-sm">
+                  {data.recentAchievements.length === 0
+                    ? `No volunteers crossed a milestone in the last ${periodLabel}`
+                    : `No ${recentThresholdFilter}-shift milestones were crossed in the last ${periodLabel}`}
                 </div>
               )}
             </CardContent>

--- a/web/src/lib/milestone-analytics.ts
+++ b/web/src/lib/milestone-analytics.ts
@@ -1,6 +1,9 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@/generated/client";
 import { nowInNZT } from "@/lib/timezone";
+import { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
+
+export { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
 
 export const MILESTONE_THRESHOLDS = [10, 25, 50, 100, 200, 500] as const;
 export type MilestoneThreshold = (typeof MILESTONE_THRESHOLDS)[number];
@@ -9,6 +12,7 @@ export interface MilestoneHit {
   threshold: number;
   hitInPeriod: number;
   allTimeTotal: number;
+  byLocation: Record<string, { hitInPeriod: number; allTimeTotal: number }>;
 }
 
 export interface DistributionBucket {
@@ -16,11 +20,13 @@ export interface DistributionBucket {
   minShifts: number;
   maxShifts: number | null;
   count: number;
+  byLocation: Record<string, number>;
 }
 
 export interface ApproachingVolunteer {
   userId: string;
   name: string;
+  location: string;
   totalShifts: number;
   shiftsNeeded: number;
   monthlyRate: number;
@@ -32,11 +38,16 @@ export interface MilestoneProjection {
   alreadyHit: number;
   projectedAdditional: number;
   approaching: ApproachingVolunteer[];
+  byLocation: Record<
+    string,
+    { alreadyHit: number; projectedAdditional: number }
+  >;
 }
 
 export interface RecentMilestoneAchievement {
   userId: string;
   name: string;
+  location: string;
   threshold: number;
   achievedAt: string;
   totalShifts: number;
@@ -47,6 +58,17 @@ export interface MilestoneData {
   distribution: DistributionBucket[];
   projections: MilestoneProjection[];
   recentAchievements: RecentMilestoneAchievement[];
+  locations: string[];
+}
+
+function sortLocations(names: Iterable<string>): string[] {
+  const list = Array.from(new Set(names)).filter(Boolean);
+  list.sort((a, b) => {
+    if (a === UNSPECIFIED_LOCATION && b !== UNSPECIFIED_LOCATION) return 1;
+    if (b === UNSPECIFIED_LOCATION && a !== UNSPECIFIED_LOCATION) return -1;
+    return a.localeCompare(b);
+  });
+  return list;
 }
 
 export async function getMilestoneData(
@@ -75,92 +97,60 @@ export async function getMilestoneData(
     volunteerStatsResult,
     recentAchievementsResult,
   ] = await Promise.all([
-      // How many volunteers crossed each milestone threshold in the selected period
-      prisma.$queryRaw<Array<{ milestone: bigint; count: bigint }>>`
-        WITH ranked AS (
-          SELECT
-            sg."userId",
-            sh."end" AS shift_end,
-            ROW_NUMBER() OVER (PARTITION BY sg."userId" ORDER BY sh."end") AS rn
-          FROM "Signup" sg
-          JOIN "Shift"  sh ON sh.id = sg."shiftId"
-          JOIN "User"   u  ON u.id  = sg."userId"
-          WHERE sg.status = 'CONFIRMED'::"SignupStatus"
-            AND sh."end" < ${now}
-            AND u.role   = 'VOLUNTEER'::"Role"
-            ${locationCond}
-        )
-        SELECT
-          rn::bigint AS milestone,
-          COUNT(*)::bigint AS count
-        FROM ranked
-        WHERE shift_end >= ${periodStart}
-          AND shift_end <  ${now}
-          AND rn IN (10, 25, 50, 100, 200, 500)
-        GROUP BY rn
-        ORDER BY rn
-      `,
-
-      // All-time totals per milestone + current distribution buckets
-      prisma.$queryRaw<
-        Array<{
-          ten: bigint;
-          twentyfive: bigint;
-          fifty: bigint;
-          hundred: bigint;
-          twohundred: bigint;
-          fivehundred: bigint;
-          d_1_9: bigint;
-          d_10_24: bigint;
-          d_25_49: bigint;
-          d_50_99: bigint;
-          d_100_199: bigint;
-          d_200_499: bigint;
-          d_500_plus: bigint;
-        }>
-      >`
-        WITH user_totals AS (
-          SELECT sg."userId", COUNT(*) AS n
-          FROM "Signup" sg
-          JOIN "Shift" sh ON sh.id = sg."shiftId"
-          JOIN "User"  u  ON u.id  = sg."userId"
-          WHERE sg.status = 'CONFIRMED'::"SignupStatus"
-            AND sh."end" < ${now}
-            AND u.role   = 'VOLUNTEER'::"Role"
-            ${locationCond}
-          GROUP BY sg."userId"
-        )
-        SELECT
-          COUNT(*) FILTER (WHERE n >= 10)::bigint   AS ten,
-          COUNT(*) FILTER (WHERE n >= 25)::bigint   AS twentyfive,
-          COUNT(*) FILTER (WHERE n >= 50)::bigint   AS fifty,
-          COUNT(*) FILTER (WHERE n >= 100)::bigint  AS hundred,
-          COUNT(*) FILTER (WHERE n >= 200)::bigint  AS twohundred,
-          COUNT(*) FILTER (WHERE n >= 500)::bigint  AS fivehundred,
-          COUNT(*) FILTER (WHERE n BETWEEN 1   AND 9)   ::bigint AS d_1_9,
-          COUNT(*) FILTER (WHERE n BETWEEN 10  AND 24)  ::bigint AS d_10_24,
-          COUNT(*) FILTER (WHERE n BETWEEN 25  AND 49)  ::bigint AS d_25_49,
-          COUNT(*) FILTER (WHERE n BETWEEN 50  AND 99)  ::bigint AS d_50_99,
-          COUNT(*) FILTER (WHERE n BETWEEN 100 AND 199) ::bigint AS d_100_199,
-          COUNT(*) FILTER (WHERE n BETWEEN 200 AND 499) ::bigint AS d_200_499,
-          COUNT(*) FILTER (WHERE n >= 500)              ::bigint AS d_500_plus
-        FROM user_totals
-      `,
-
-      // Per-volunteer stats for projections and approaching lists
-      prisma.$queryRaw<
-        Array<{
-          userId: string;
-          name: string | null;
-          total_shifts: bigint;
-          recent_shifts: bigint;
-        }>
-      >`
+    // Milestone crossings in the selected period, grouped by threshold & location
+    prisma.$queryRaw<
+      Array<{ milestone: bigint; location: string; count: bigint }>
+    >`
+      WITH ranked AS (
         SELECT
           sg."userId",
-          u.name,
-          COUNT(*)::bigint AS total_shifts,
-          COUNT(*) FILTER (WHERE sh."end" >= ${sixMonthsAgo})::bigint AS recent_shifts
+          sh."end" AS shift_end,
+          ROW_NUMBER() OVER (PARTITION BY sg."userId" ORDER BY sh."end") AS rn,
+          COALESCE(NULLIF(u."defaultLocation", ''), ${UNSPECIFIED_LOCATION}) AS location
+        FROM "Signup" sg
+        JOIN "Shift"  sh ON sh.id = sg."shiftId"
+        JOIN "User"   u  ON u.id  = sg."userId"
+        WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+          AND sh."end" < ${now}
+          AND u.role   = 'VOLUNTEER'::"Role"
+          ${locationCond}
+      )
+      SELECT
+        rn::bigint       AS milestone,
+        location,
+        COUNT(*)::bigint AS count
+      FROM ranked
+      WHERE shift_end >= ${periodStart}
+        AND shift_end <  ${now}
+        AND rn IN (10, 25, 50, 100, 200, 500)
+      GROUP BY rn, location
+      ORDER BY rn, location
+    `,
+
+    // All-time totals per milestone + distribution buckets, one row per location
+    prisma.$queryRaw<
+      Array<{
+        location: string;
+        ten: bigint;
+        twentyfive: bigint;
+        fifty: bigint;
+        hundred: bigint;
+        twohundred: bigint;
+        fivehundred: bigint;
+        d_1_9: bigint;
+        d_10_24: bigint;
+        d_25_49: bigint;
+        d_50_99: bigint;
+        d_100_199: bigint;
+        d_200_499: bigint;
+        d_500_plus: bigint;
+      }>
+    >`
+      WITH user_totals AS (
+        SELECT
+          sg."userId",
+          COALESCE(NULLIF(u."defaultLocation", ''), ${UNSPECIFIED_LOCATION}) AS location,
+          COUNT(*) AS n
         FROM "Signup" sg
         JOIN "Shift" sh ON sh.id = sg."shiftId"
         JOIN "User"  u  ON u.id  = sg."userId"
@@ -168,125 +158,208 @@ export async function getMilestoneData(
           AND sh."end" < ${now}
           AND u.role   = 'VOLUNTEER'::"Role"
           ${locationCond}
-        GROUP BY sg."userId", u.name
-        HAVING COUNT(*) > 0
-        ORDER BY COUNT(*) DESC
-      `,
+        GROUP BY sg."userId", u."defaultLocation"
+      )
+      SELECT
+        location,
+        COUNT(*) FILTER (WHERE n >= 10)::bigint                 AS ten,
+        COUNT(*) FILTER (WHERE n >= 25)::bigint                 AS twentyfive,
+        COUNT(*) FILTER (WHERE n >= 50)::bigint                 AS fifty,
+        COUNT(*) FILTER (WHERE n >= 100)::bigint                AS hundred,
+        COUNT(*) FILTER (WHERE n >= 200)::bigint                AS twohundred,
+        COUNT(*) FILTER (WHERE n >= 500)::bigint                AS fivehundred,
+        COUNT(*) FILTER (WHERE n BETWEEN 1   AND 9)::bigint     AS d_1_9,
+        COUNT(*) FILTER (WHERE n BETWEEN 10  AND 24)::bigint    AS d_10_24,
+        COUNT(*) FILTER (WHERE n BETWEEN 25  AND 49)::bigint    AS d_25_49,
+        COUNT(*) FILTER (WHERE n BETWEEN 50  AND 99)::bigint    AS d_50_99,
+        COUNT(*) FILTER (WHERE n BETWEEN 100 AND 199)::bigint   AS d_100_199,
+        COUNT(*) FILTER (WHERE n BETWEEN 200 AND 499)::bigint   AS d_200_499,
+        COUNT(*) FILTER (WHERE n >= 500)::bigint                AS d_500_plus
+      FROM user_totals
+      GROUP BY location
+      ORDER BY location
+    `,
 
-      // Volunteers who crossed a milestone during the selected period,
-      // along with the shift that tipped them over and their current total.
-      prisma.$queryRaw<
-        Array<{
-          userId: string;
-          name: string | null;
-          threshold: bigint;
-          achieved_at: Date;
-          total_shifts: bigint;
-        }>
-      >`
-        WITH ranked AS (
-          SELECT
-            sg."userId",
-            u.name,
-            sh."end" AS shift_end,
-            ROW_NUMBER() OVER (PARTITION BY sg."userId" ORDER BY sh."end") AS rn,
-            COUNT(*) OVER (PARTITION BY sg."userId") AS total_shifts
-          FROM "Signup" sg
-          JOIN "Shift" sh ON sh.id = sg."shiftId"
-          JOIN "User"  u  ON u.id  = sg."userId"
-          WHERE sg.status = 'CONFIRMED'::"SignupStatus"
-            AND sh."end" < ${now}
-            AND u.role   = 'VOLUNTEER'::"Role"
-            ${locationCond}
-        )
+    // Per-volunteer stats (with primary restaurant) for projections and approaching lists
+    prisma.$queryRaw<
+      Array<{
+        userId: string;
+        name: string | null;
+        location: string;
+        total_shifts: bigint;
+        recent_shifts: bigint;
+      }>
+    >`
+      SELECT
+        sg."userId",
+        u.name,
+        COALESCE(NULLIF(u."defaultLocation", ''), ${UNSPECIFIED_LOCATION}) AS location,
+        COUNT(*)::bigint AS total_shifts,
+        COUNT(*) FILTER (WHERE sh."end" >= ${sixMonthsAgo})::bigint AS recent_shifts
+      FROM "Signup" sg
+      JOIN "Shift" sh ON sh.id = sg."shiftId"
+      JOIN "User"  u  ON u.id  = sg."userId"
+      WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+        AND sh."end" < ${now}
+        AND u.role   = 'VOLUNTEER'::"Role"
+        ${locationCond}
+      GROUP BY sg."userId", u.name, u."defaultLocation"
+      HAVING COUNT(*) > 0
+      ORDER BY COUNT(*) DESC
+    `,
+
+    // Volunteers who crossed a milestone during the selected period,
+    // along with the shift that tipped them over and their current total.
+    prisma.$queryRaw<
+      Array<{
+        userId: string;
+        name: string | null;
+        location: string;
+        threshold: bigint;
+        achieved_at: Date;
+        total_shifts: bigint;
+      }>
+    >`
+      WITH ranked AS (
         SELECT
-          "userId",
-          name,
-          rn::bigint        AS threshold,
-          shift_end         AS achieved_at,
-          total_shifts::bigint AS total_shifts
-        FROM ranked
-        WHERE shift_end >= ${periodStart}
-          AND shift_end <  ${now}
-          AND rn IN (10, 25, 50, 100, 200, 500)
-        ORDER BY shift_end DESC
-      `,
-    ]);
+          sg."userId",
+          u.name,
+          COALESCE(NULLIF(u."defaultLocation", ''), ${UNSPECIFIED_LOCATION}) AS location,
+          sh."end" AS shift_end,
+          ROW_NUMBER() OVER (PARTITION BY sg."userId" ORDER BY sh."end") AS rn,
+          COUNT(*) OVER (PARTITION BY sg."userId") AS total_shifts
+        FROM "Signup" sg
+        JOIN "Shift" sh ON sh.id = sg."shiftId"
+        JOIN "User"  u  ON u.id  = sg."userId"
+        WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+          AND sh."end" < ${now}
+          AND u.role   = 'VOLUNTEER'::"Role"
+          ${locationCond}
+      )
+      SELECT
+        "userId",
+        name,
+        location,
+        rn::bigint        AS threshold,
+        shift_end         AS achieved_at,
+        total_shifts::bigint AS total_shifts
+      FROM ranked
+      WHERE shift_end >= ${periodStart}
+        AND shift_end <  ${now}
+        AND rn IN (10, 25, 50, 100, 200, 500)
+      ORDER BY shift_end DESC
+    `,
+  ]);
+
+  // Collect every location name we've seen across all result sets so the UI
+  // can render a consistent, sorted series list.
+  const locationSet = new Set<string>();
+  for (const r of hitsInPeriodResult) locationSet.add(r.location);
+  for (const r of totalsResult) locationSet.add(r.location);
+  for (const r of volunteerStatsResult) locationSet.add(r.location);
+  for (const r of recentAchievementsResult) locationSet.add(r.location);
+  const locations = sortLocations(locationSet);
 
   // ── Milestone hits in period ───────────────────────────────────────────────
-  const hitsMap = new Map(
-    hitsInPeriodResult.map((r) => [Number(r.milestone), Number(r.count)])
-  );
+  // hits[threshold][location] = count
+  const hitsByThresholdLocation: Record<number, Record<string, number>> = {};
+  for (const r of hitsInPeriodResult) {
+    const threshold = Number(r.milestone);
+    if (!hitsByThresholdLocation[threshold])
+      hitsByThresholdLocation[threshold] = {};
+    hitsByThresholdLocation[threshold][r.location] = Number(r.count);
+  }
 
-  const t = totalsResult[0];
-  const allTimeTotals: Record<number, number> = {
-    10: Number(t?.ten ?? 0),
-    25: Number(t?.twentyfive ?? 0),
-    50: Number(t?.fifty ?? 0),
-    100: Number(t?.hundred ?? 0),
-    200: Number(t?.twohundred ?? 0),
-    500: Number(t?.fivehundred ?? 0),
-  };
+  // allTimeByThresholdLocation[threshold][location]
+  const allTimeByThresholdLocation: Record<
+    number,
+    Record<string, number>
+  > = {};
+  for (const t of MILESTONE_THRESHOLDS) allTimeByThresholdLocation[t] = {};
 
-  const milestoneHits: MilestoneHit[] = MILESTONE_THRESHOLDS.map(
-    (threshold) => ({
+  for (const row of totalsResult) {
+    allTimeByThresholdLocation[10][row.location] = Number(row.ten);
+    allTimeByThresholdLocation[25][row.location] = Number(row.twentyfive);
+    allTimeByThresholdLocation[50][row.location] = Number(row.fifty);
+    allTimeByThresholdLocation[100][row.location] = Number(row.hundred);
+    allTimeByThresholdLocation[200][row.location] = Number(row.twohundred);
+    allTimeByThresholdLocation[500][row.location] = Number(row.fivehundred);
+  }
+
+  const milestoneHits: MilestoneHit[] = MILESTONE_THRESHOLDS.map((threshold) => {
+    const hitsMap = hitsByThresholdLocation[threshold] ?? {};
+    const allMap = allTimeByThresholdLocation[threshold] ?? {};
+    const byLocation: Record<
+      string,
+      { hitInPeriod: number; allTimeTotal: number }
+    > = {};
+    for (const loc of locations) {
+      byLocation[loc] = {
+        hitInPeriod: hitsMap[loc] ?? 0,
+        allTimeTotal: allMap[loc] ?? 0,
+      };
+    }
+    return {
       threshold,
-      hitInPeriod: hitsMap.get(threshold) ?? 0,
-      allTimeTotal: allTimeTotals[threshold] ?? 0,
-    })
-  );
+      hitInPeriod: Object.values(byLocation).reduce(
+        (a, b) => a + b.hitInPeriod,
+        0
+      ),
+      allTimeTotal: Object.values(byLocation).reduce(
+        (a, b) => a + b.allTimeTotal,
+        0
+      ),
+      byLocation,
+    };
+  });
 
   // ── Distribution buckets ──────────────────────────────────────────────────
-  const distribution: DistributionBucket[] = [
-    {
-      label: "1–9",
-      minShifts: 1,
-      maxShifts: 9,
-      count: Number(t?.d_1_9 ?? 0),
-    },
-    {
-      label: "10–24",
-      minShifts: 10,
-      maxShifts: 24,
-      count: Number(t?.d_10_24 ?? 0),
-    },
-    {
-      label: "25–49",
-      minShifts: 25,
-      maxShifts: 49,
-      count: Number(t?.d_25_49 ?? 0),
-    },
-    {
-      label: "50–99",
-      minShifts: 50,
-      maxShifts: 99,
-      count: Number(t?.d_50_99 ?? 0),
-    },
-    {
-      label: "100–199",
-      minShifts: 100,
-      maxShifts: 199,
-      count: Number(t?.d_100_199 ?? 0),
-    },
-    {
-      label: "200–499",
-      minShifts: 200,
-      maxShifts: 499,
-      count: Number(t?.d_200_499 ?? 0),
-    },
-    {
-      label: "500+",
-      minShifts: 500,
-      maxShifts: null,
-      count: Number(t?.d_500_plus ?? 0),
-    },
+  type TotalsRow = (typeof totalsResult)[number];
+  type BucketKey =
+    | "d_1_9"
+    | "d_10_24"
+    | "d_25_49"
+    | "d_50_99"
+    | "d_100_199"
+    | "d_200_499"
+    | "d_500_plus";
+  const bucketDefs: Array<{
+    label: string;
+    minShifts: number;
+    maxShifts: number | null;
+    key: BucketKey;
+  }> = [
+    { label: "1–9", minShifts: 1, maxShifts: 9, key: "d_1_9" },
+    { label: "10–24", minShifts: 10, maxShifts: 24, key: "d_10_24" },
+    { label: "25–49", minShifts: 25, maxShifts: 49, key: "d_25_49" },
+    { label: "50–99", minShifts: 50, maxShifts: 99, key: "d_50_99" },
+    { label: "100–199", minShifts: 100, maxShifts: 199, key: "d_100_199" },
+    { label: "200–499", minShifts: 200, maxShifts: 499, key: "d_200_499" },
+    { label: "500+", minShifts: 500, maxShifts: null, key: "d_500_plus" },
   ];
+
+  const distribution: DistributionBucket[] = bucketDefs.map(
+    ({ label, minShifts, maxShifts, key }) => {
+      const byLocation: Record<string, number> = {};
+      let total = 0;
+      for (const row of totalsResult) {
+        const n = Number((row as TotalsRow)[key] ?? 0);
+        byLocation[row.location] = n;
+        total += n;
+      }
+      for (const loc of locations) {
+        if (!(loc in byLocation)) byLocation[loc] = 0;
+      }
+      return { label, minShifts, maxShifts, count: total, byLocation };
+    }
+  );
 
   // ── Projections ───────────────────────────────────────────────────────────
   const PROJECTION_MONTHS = 12;
   const volunteers = volunteerStatsResult.map((v) => ({
     userId: v.userId,
     name: v.name ?? "Unknown",
+    location: v.location,
     totalShifts: Number(v.total_shifts),
     recentShifts: Number(v.recent_shifts),
     // Average shifts per month over the last 6 months
@@ -295,21 +368,44 @@ export async function getMilestoneData(
 
   const projections: MilestoneProjection[] = MILESTONE_THRESHOLDS.map(
     (threshold) => {
-      const alreadyHit = allTimeTotals[threshold] ?? 0;
+      const allMap = allTimeByThresholdLocation[threshold] ?? {};
 
       // Volunteers who haven't yet hit this milestone
-      const notYetHit = volunteers.filter(
-        (v) => v.totalShifts < threshold
-      );
+      const notYetHit = volunteers.filter((v) => v.totalShifts < threshold);
 
-      // Among those, project who will hit it in the next 12 months
-      // Only project for volunteers with a positive recent rate
-      const projectedAdditional = notYetHit.filter((v) => {
-        if (v.monthlyRate <= 0) return false;
+      // Per-location projected counts
+      const projectedByLocation: Record<string, number> = {};
+      for (const loc of locations) projectedByLocation[loc] = 0;
+
+      for (const v of notYetHit) {
+        if (v.monthlyRate <= 0) continue;
         const shiftsNeeded = threshold - v.totalShifts;
         const monthsNeeded = shiftsNeeded / v.monthlyRate;
-        return monthsNeeded <= PROJECTION_MONTHS;
-      }).length;
+        if (monthsNeeded <= PROJECTION_MONTHS) {
+          projectedByLocation[v.location] =
+            (projectedByLocation[v.location] ?? 0) + 1;
+        }
+      }
+
+      const byLocation: Record<
+        string,
+        { alreadyHit: number; projectedAdditional: number }
+      > = {};
+      for (const loc of locations) {
+        byLocation[loc] = {
+          alreadyHit: allMap[loc] ?? 0,
+          projectedAdditional: projectedByLocation[loc] ?? 0,
+        };
+      }
+
+      const alreadyHit = Object.values(byLocation).reduce(
+        (a, b) => a + b.alreadyHit,
+        0
+      );
+      const projectedAdditional = Object.values(byLocation).reduce(
+        (a, b) => a + b.projectedAdditional,
+        0
+      );
 
       // Approaching: within 20% of the milestone (below it)
       const approachingMinShifts = Math.floor(threshold * 0.8);
@@ -324,6 +420,7 @@ export async function getMilestoneData(
           return {
             userId: v.userId,
             name: v.name,
+            location: v.location,
             totalShifts: v.totalShifts,
             shiftsNeeded,
             monthlyRate: Math.round(v.monthlyRate * 10) / 10,
@@ -332,7 +429,13 @@ export async function getMilestoneData(
         })
         .sort((a, b) => a.shiftsNeeded - b.shiftsNeeded);
 
-      return { threshold, alreadyHit, projectedAdditional, approaching };
+      return {
+        threshold,
+        alreadyHit,
+        projectedAdditional,
+        approaching,
+        byLocation,
+      };
     }
   );
 
@@ -341,10 +444,17 @@ export async function getMilestoneData(
     recentAchievementsResult.map((r) => ({
       userId: r.userId,
       name: r.name ?? "Unknown",
+      location: r.location,
       threshold: Number(r.threshold),
       achievedAt: r.achieved_at.toISOString(),
       totalShifts: Number(r.total_shifts),
     }));
 
-  return { milestoneHits, distribution, projections, recentAchievements };
+  return {
+    milestoneHits,
+    distribution,
+    projections,
+    recentAchievements,
+    locations,
+  };
 }

--- a/web/src/lib/milestone-analytics.ts
+++ b/web/src/lib/milestone-analytics.ts
@@ -34,10 +34,19 @@ export interface MilestoneProjection {
   approaching: ApproachingVolunteer[];
 }
 
+export interface RecentMilestoneAchievement {
+  userId: string;
+  name: string;
+  threshold: number;
+  achievedAt: string;
+  totalShifts: number;
+}
+
 export interface MilestoneData {
   milestoneHits: MilestoneHit[];
   distribution: DistributionBucket[];
   projections: MilestoneProjection[];
+  recentAchievements: RecentMilestoneAchievement[];
 }
 
 export async function getMilestoneData(
@@ -60,8 +69,12 @@ export async function getMilestoneData(
     ? Prisma.sql`AND u."availableLocations" LIKE ${`%"${location}"%`}`
     : Prisma.empty;
 
-  const [hitsInPeriodResult, totalsResult, volunteerStatsResult] =
-    await Promise.all([
+  const [
+    hitsInPeriodResult,
+    totalsResult,
+    volunteerStatsResult,
+    recentAchievementsResult,
+  ] = await Promise.all([
       // How many volunteers crossed each milestone threshold in the selected period
       prisma.$queryRaw<Array<{ milestone: bigint; count: bigint }>>`
         WITH ranked AS (
@@ -158,6 +171,45 @@ export async function getMilestoneData(
         GROUP BY sg."userId", u.name
         HAVING COUNT(*) > 0
         ORDER BY COUNT(*) DESC
+      `,
+
+      // Volunteers who crossed a milestone during the selected period,
+      // along with the shift that tipped them over and their current total.
+      prisma.$queryRaw<
+        Array<{
+          userId: string;
+          name: string | null;
+          threshold: bigint;
+          achieved_at: Date;
+          total_shifts: bigint;
+        }>
+      >`
+        WITH ranked AS (
+          SELECT
+            sg."userId",
+            u.name,
+            sh."end" AS shift_end,
+            ROW_NUMBER() OVER (PARTITION BY sg."userId" ORDER BY sh."end") AS rn,
+            COUNT(*) OVER (PARTITION BY sg."userId") AS total_shifts
+          FROM "Signup" sg
+          JOIN "Shift" sh ON sh.id = sg."shiftId"
+          JOIN "User"  u  ON u.id  = sg."userId"
+          WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+            AND sh."end" < ${now}
+            AND u.role   = 'VOLUNTEER'::"Role"
+            ${locationCond}
+        )
+        SELECT
+          "userId",
+          name,
+          rn::bigint        AS threshold,
+          shift_end         AS achieved_at,
+          total_shifts::bigint AS total_shifts
+        FROM ranked
+        WHERE shift_end >= ${periodStart}
+          AND shift_end <  ${now}
+          AND rn IN (10, 25, 50, 100, 200, 500)
+        ORDER BY shift_end DESC
       `,
     ]);
 
@@ -284,5 +336,15 @@ export async function getMilestoneData(
     }
   );
 
-  return { milestoneHits, distribution, projections };
+  // ── Recent milestone achievements ─────────────────────────────────────────
+  const recentAchievements: RecentMilestoneAchievement[] =
+    recentAchievementsResult.map((r) => ({
+      userId: r.userId,
+      name: r.name ?? "Unknown",
+      threshold: Number(r.threshold),
+      achievedAt: r.achieved_at.toISOString(),
+      totalShifts: Number(r.total_shifts),
+    }));
+
+  return { milestoneHits, distribution, projections, recentAchievements };
 }


### PR DESCRIPTION
## Summary

Extends the admin Milestone Analytics page with two related improvements:

- **Recent Milestone Achievements** — a new card lists volunteers who actually crossed 10 / 25 / 50 / 100 / 200 / 500 shifts inside the selected period, newest first. Supports per-threshold filtering and links each volunteer to their admin profile for timely follow-up. Closes #799.
- **Stack by restaurant** — Milestones Hit, Volunteer Distribution, and 12-Month Projections now stack by the volunteer's primary restaurant (their `defaultLocation`). Volunteers with no primary restaurant fall into an "Unspecified" bucket, consistent with how the recruitment analytics page already splits. Closes #796.

The 12-month projections chart drops its "already achieved" series — those totals are already visible on the summary cards at the top of the page, so the chart now focuses purely on the forward-looking projection.

## Test plan

- [ ] Admin → Analytics → Milestones renders without errors at default filters
- [ ] "Recent Milestone Achievements" lists volunteers with correct thresholds, totals, relative dates (absolute date on hover), and working profile links
- [ ] Filtering Recent Achievements by each milestone threshold works; empty state shows when none match
- [ ] Milestones Hit chart stacks by restaurant; legend shows only when >1 restaurant present
- [ ] Volunteer Distribution chart stacks by restaurant
- [ ] 12-Month Projections chart shows only projected counts, stacked by restaurant
- [ ] Approaching Volunteers and Recent Achievements rows each display the volunteer's primary restaurant next to the name
- [ ] Location dropdown (Wellington / Glen Innes / Onehunga / Special Event Venue) still filters the whole page correctly
- [ ] Time period dropdown (1 / 3 / 6 / 12 / 24 months) still filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)