### PR TITLE
Add admin reactivate UI and protect manual/regular volunteers from archive

### DIFF
--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -24,6 +24,8 @@ import {
   PauseCircle,
   CheckCircle,
   FileText,
+  Archive,
+  ArchiveRestore,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
@@ -45,6 +47,14 @@ import { ShiftHistoryPaginated } from "@/components/shift-history-paginated";
 import { LocationFilterTabs } from "@/components/location-filter-tabs";
 import { ShiftCountAdjustment } from "@/components/shift-count-adjustment";
 import { VolunteerSurveyHistory } from "@/components/volunteer-survey-history";
+import { ReactivateUserDialog } from "@/components/reactivate-user-dialog";
+
+const ARCHIVE_REASON_LABELS: Record<string, string> = {
+  INACTIVE_12_MONTHS: "Inactive for 12+ months",
+  NEVER_ACTIVATED: "Never activated",
+  NEVER_MIGRATED: "Never migrated",
+  MANUAL: "Manually archived",
+};
 
 interface AdminVolunteerPageProps {
   params: Promise<{ id: string }>;
@@ -111,6 +121,8 @@ export default async function AdminVolunteerPage({
       completedShiftAdjustmentBy: true,
       completedShiftAdjustmentAt: true,
       createdAt: true,
+      archivedAt: true,
+      archiveReason: true,
       regularVolunteers: {
         include: {
           shiftType: true,
@@ -292,6 +304,50 @@ export default async function AdminVolunteerPage({
         testid="admin-volunteer-profile-page"
         className="bg-background"
       >
+        {volunteer.archivedAt && (
+          <div
+            className="mb-6 rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-800/60 dark:bg-amber-950/40"
+            data-testid="volunteer-archived-banner"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-3">
+                <Archive className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-700 dark:text-amber-300" />
+                <div className="space-y-1">
+                  <p className="font-semibold text-amber-900 dark:text-amber-100">
+                    This volunteer is archived
+                  </p>
+                  <p className="text-sm text-amber-800 dark:text-amber-200">
+                    {volunteer.archiveReason
+                      ? `${ARCHIVE_REASON_LABELS[volunteer.archiveReason] ?? volunteer.archiveReason} · `
+                      : ""}
+                    Archived{" "}
+                    {formatInNZT(volunteer.archivedAt, "d MMM yyyy")}.
+                    They cannot sign in until reactivated.
+                  </p>
+                </div>
+              </div>
+              <ReactivateUserDialog
+                user={{
+                  id: volunteer.id,
+                  email: volunteer.email,
+                  name: volunteer.name,
+                  firstName: volunteer.firstName,
+                  lastName: volunteer.lastName,
+                  archiveReason: volunteer.archiveReason,
+                }}
+              >
+                <Button
+                  size="sm"
+                  className="gap-2 bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-500 dark:hover:bg-emerald-600 sm:flex-shrink-0"
+                  data-testid="volunteer-reactivate-button"
+                >
+                  <ArchiveRestore className="h-4 w-4" />
+                  Reactivate
+                </Button>
+              </ReactivateUserDialog>
+            </div>
+          </div>
+        )}
         <div
           className="grid grid-cols-1 lg:grid-cols-3 gap-6"
           data-testid="volunteer-profile-layout"

--- a/web/src/app/api/auth/mobile/oauth/route.ts
+++ b/web/src/app/api/auth/mobile/oauth/route.ts
@@ -101,6 +101,7 @@ export async function POST(request: Request) {
         await unarchiveUser({
           userId: user.id,
           triggerSource: ArchiveTriggerSource.SELF_REACTIVATION,
+          actorId: user.id,
         });
         user = await prisma.user.findUnique({ where: { id: user.id } }) ?? user;
       }

--- a/web/src/app/api/passkey/authenticate/verify-authentication/route.ts
+++ b/web/src/app/api/passkey/authenticate/verify-authentication/route.ts
@@ -20,6 +20,8 @@ import {
   bufferToBase64URL,
 } from "@/lib/webauthn-utils";
 import { rpID, expectedOrigin } from "@/lib/webauthn-config";
+import { unarchiveUser } from "@/lib/archive-service";
+import { ArchiveTriggerSource } from "@/generated/client";
 
 export async function POST(req: NextRequest) {
   try {
@@ -55,6 +57,7 @@ export async function POST(req: NextRequest) {
             role: true,
             phone: true,
             emailVerified: true,
+            archivedAt: true,
           },
         },
       },
@@ -149,6 +152,16 @@ export async function POST(req: NextRequest) {
         lastUsedAt: new Date(),
       },
     });
+
+    // Auto-reactivate archived users — successful passkey assertion is
+    // cryptographic proof of identity, same standard as OAuth re-auth.
+    if (passkey.user.archivedAt) {
+      await unarchiveUser({
+        userId: passkey.user.id,
+        triggerSource: ArchiveTriggerSource.SELF_REACTIVATION,
+        actorId: passkey.user.id,
+      });
+    }
 
     // Return user info for NextAuth session
     return NextResponse.json(

--- a/web/src/components/reactivate-user-dialog.tsx
+++ b/web/src/components/reactivate-user-dialog.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import { ArchiveRestore, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { type ArchiveReason } from "@/generated/client";
+
+const ARCHIVE_REASON_LABELS: Record<ArchiveReason, string> = {
+  INACTIVE_12_MONTHS: "Inactive for 12+ months",
+  NEVER_ACTIVATED: "Never activated",
+  NEVER_MIGRATED: "Never migrated",
+  MANUAL: "Manually archived",
+};
+
+interface ReactivateUserDialogProps {
+  user: {
+    id: string;
+    email: string;
+    name: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    archiveReason?: ArchiveReason | null;
+  };
+  children: React.ReactNode;
+}
+
+const NOTE_MAX_LENGTH = 500;
+
+export function ReactivateUserDialog({
+  user,
+  children,
+}: ReactivateUserDialogProps) {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [note, setNote] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const displayName =
+    user.name ||
+    `${user.firstName || ""} ${user.lastName || ""}`.trim() ||
+    user.email;
+
+  const handleReactivate = async () => {
+    setIsSubmitting(true);
+    setError("");
+
+    try {
+      const trimmed = note.trim();
+      const response = await fetch(
+        `/api/admin/users/${user.id}/unarchive`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(trimmed ? { note: trimmed } : {}),
+        }
+      );
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to reactivate user");
+      }
+
+      toast.success(`${displayName} has been reactivated`);
+      setIsOpen(false);
+      setNote("");
+      router.refresh();
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "An error occurred while reactivating the user"
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (isSubmitting) return;
+    setIsOpen(open);
+    if (!open) {
+      setNote("");
+      setError("");
+    }
+  };
+
+  const reasonLabel = user.archiveReason
+    ? ARCHIVE_REASON_LABELS[user.archiveReason]
+    : null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent
+        className="sm:max-w-md"
+        data-testid="reactivate-user-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-emerald-700 dark:text-emerald-400">
+            <ArchiveRestore className="h-5 w-5" />
+            Reactivate user
+          </DialogTitle>
+          <DialogDescription className="text-base">
+            Restore <strong>{displayName}</strong> ({user.email}) to active
+            status. Their history, signups, and achievements stay intact.
+          </DialogDescription>
+        </DialogHeader>
+
+        {reasonLabel && (
+          <div
+            className="rounded-md border border-muted bg-muted/40 px-3 py-2 text-sm text-muted-foreground"
+            data-testid="reactivate-user-reason"
+          >
+            <span className="font-medium text-foreground">
+              Archived because:
+            </span>{" "}
+            {reasonLabel}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label
+            htmlFor="reactivate-note"
+            className="text-sm font-medium"
+          >
+            Note{" "}
+            <span className="font-normal text-muted-foreground">
+              (optional)
+            </span>
+          </Label>
+          <Textarea
+            id="reactivate-note"
+            placeholder="e.g. Confirmed still volunteering on regular shifts"
+            value={note}
+            onChange={(e) => setNote(e.target.value.slice(0, NOTE_MAX_LENGTH))}
+            disabled={isSubmitting}
+            rows={3}
+            data-testid="reactivate-user-note-input"
+          />
+          <p className="text-xs text-muted-foreground text-right">
+            {note.length}/{NOTE_MAX_LENGTH}
+          </p>
+        </div>
+
+        {error && (
+          <Alert
+            className="border-red-200 bg-red-50 dark:border-red-900/50 dark:bg-red-950/20"
+            data-testid="reactivate-user-error"
+          >
+            <AlertDescription className="text-red-800 dark:text-red-300">
+              {error}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter className="flex-col-reverse sm:flex-row sm:justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setIsOpen(false)}
+            disabled={isSubmitting}
+            data-testid="reactivate-user-cancel-button"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleReactivate}
+            disabled={isSubmitting}
+            className="bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-500 dark:hover:bg-emerald-600"
+            data-testid="reactivate-user-confirm-button"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Reactivating…
+              </>
+            ) : (
+              <>
+                <ArchiveRestore className="mr-2 h-4 w-4" />
+                Reactivate user
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/users-data-table.tsx
+++ b/web/src/components/users-data-table.tsx
@@ -21,6 +21,7 @@ import {
   MoreHorizontal,
   GitMerge,
   Archive,
+  ArchiveRestore,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -53,6 +54,7 @@ import {
 import { type VolunteerGrade, type ArchiveReason } from "@/generated/client";
 import { DeleteUserDialog } from "@/components/delete-user-dialog";
 import { MergeUserDialog } from "@/components/merge-user-dialog";
+import { ReactivateUserDialog } from "@/components/reactivate-user-dialog";
 import { TableSkeleton } from "@/components/loading-skeleton";
 
 export interface User {
@@ -350,6 +352,18 @@ export const columns: ColumnDef<User>[] = [
                   Merge with...
                 </DropdownMenuItem>
               </MergeUserDialog>
+              {user.archivedAt && (
+                <ReactivateUserDialog user={user}>
+                  <DropdownMenuItem
+                    className="flex items-center gap-2 text-emerald-700 dark:text-emerald-400 focus:text-emerald-700 dark:focus:text-emerald-400 focus:bg-emerald-50 dark:focus:bg-emerald-950/30"
+                    onSelect={(e) => e.preventDefault()}
+                    data-testid={`reactivate-user-${user.id}`}
+                  >
+                    <ArchiveRestore className="h-4 w-4" />
+                    Reactivate user
+                  </DropdownMenuItem>
+                </ReactivateUserDialog>
+              )}
               <DeleteUserDialog user={user}>
                 <DropdownMenuItem
                   className="flex items-center gap-2 text-red-600 dark:text-red-400 focus:text-red-600 dark:focus:text-red-400 focus:bg-red-50 dark:focus:bg-red-900/20"

--- a/web/src/lib/archive-service.test.ts
+++ b/web/src/lib/archive-service.test.ts
@@ -70,17 +70,21 @@ describe("archive-service", () => {
   describe("where-clause helpers", () => {
     const now = new Date("2026-01-01T00:00:00Z");
 
-    it("whereNeverMigrated filters migrated+incomplete volunteers", () => {
+    it("whereNeverMigrated filters migrated+incomplete volunteers and protects manual/regular activity", () => {
       const w = whereNeverMigrated();
       expect(w).toMatchObject({
         role: "VOLUNTEER",
         archivedAt: null,
         isMigrated: true,
         profileCompleted: false,
+        signups: { none: { status: "CONFIRMED" } },
+        regularVolunteers: {
+          none: { isActive: true, isPausedByUser: false },
+        },
       });
     });
 
-    it("whereNeverActivatedNudge uses the 1-month cutoff and requires no nudge+no confirmed shifts", () => {
+    it("whereNeverActivatedNudge uses the 1-month cutoff and excludes manual/regular activity", () => {
       const w = whereNeverActivatedNudge(now);
       const expectedCutoff = subMonths(
         now,
@@ -92,11 +96,14 @@ describe("archive-service", () => {
         isMigrated: false,
         firstShiftNudgeSentAt: null,
         signups: { none: { status: "CONFIRMED" } },
+        regularVolunteers: {
+          none: { isActive: true, isPausedByUser: false },
+        },
       });
       expect((w.createdAt as { lte: Date }).lte).toEqual(expectedCutoff);
     });
 
-    it("whereNeverActivatedArchive uses the 3-month cutoff", () => {
+    it("whereNeverActivatedArchive uses the 3-month cutoff and excludes manual/regular activity", () => {
       const w = whereNeverActivatedArchive(now);
       const expectedCutoff = subMonths(
         now,
@@ -108,6 +115,9 @@ describe("archive-service", () => {
         archivedAt: null,
         isMigrated: false,
         signups: { none: { status: "CONFIRMED" } },
+        regularVolunteers: {
+          none: { isActive: true, isPausedByUser: false },
+        },
       });
     });
   });

--- a/web/src/lib/archive-service.ts
+++ b/web/src/lib/archive-service.ts
@@ -51,15 +51,30 @@ function activeVolunteerWhere(): Prisma.UserWhereInput {
   };
 }
 
+// Volunteers who are manually assigned to shifts (admin-created CONFIRMED
+// signups) or set up as a regular have real activity that the platform doesn't
+// see otherwise — they may never log in or finish their profile. Archive rules
+// must treat both as "active" so we don't sweep them up.
+const noConfirmedSignups: Prisma.UserWhereInput = {
+  signups: { none: { status: "CONFIRMED" } },
+};
+const noActiveRegular: Prisma.UserWhereInput = {
+  regularVolunteers: {
+    none: { isActive: true, isPausedByUser: false },
+  },
+};
+
 /**
  * Users who migrated from the legacy system but never completed setup.
- * No grace period — all such users are eligible immediately.
+ * Protected if they have manual CONFIRMED signups or an active regular slot.
  */
 export function whereNeverMigrated(): Prisma.UserWhereInput {
   return {
     ...activeVolunteerWhere(),
     isMigrated: true,
     profileCompleted: false,
+    ...noConfirmedSignups,
+    ...noActiveRegular,
   };
 }
 
@@ -74,7 +89,8 @@ export function whereNeverActivatedNudge(now: Date): Prisma.UserWhereInput {
     isMigrated: false,
     createdAt: { lte: cutoff },
     firstShiftNudgeSentAt: null,
-    signups: { none: { status: "CONFIRMED" } },
+    ...noConfirmedSignups,
+    ...noActiveRegular,
   };
 }
 
@@ -88,7 +104,8 @@ export function whereNeverActivatedArchive(now: Date): Prisma.UserWhereInput {
     ...activeVolunteerWhere(),
     isMigrated: false,
     createdAt: { lte: cutoff },
-    signups: { none: { status: "CONFIRMED" } },
+    ...noConfirmedSignups,
+    ...noActiveRegular,
   };
 }
 
@@ -112,8 +129,9 @@ async function getUsersWithLastShift(now: Date): Promise<
   }>
 > {
   // Returns all non-archived volunteers with their most recent CONFIRMED
-  // signup's shift.start (null if none). Intentionally not paginated — the
-  // cron + admin views both need the full candidate set.
+  // signup's shift.start (null if none). Excludes users with an active regular
+  // slot — they're considered active even if their last CONFIRMED shift is
+  // stale, since admins manage their roster outside the platform.
   return prisma.$queryRaw`
     SELECT
       u.id,
@@ -133,7 +151,14 @@ async function getUsersWithLastShift(now: Date): Promise<
         WHERE s."userId" = u.id AND s.status = 'CONFIRMED'
       ) AS "lastConfirmedShiftAt"
     FROM "User" u
-    WHERE u.role = 'VOLUNTEER' AND u."archivedAt" IS NULL
+    WHERE u.role = 'VOLUNTEER'
+      AND u."archivedAt" IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM "RegularVolunteer" rv
+        WHERE rv."userId" = u.id
+          AND rv."isActive" = TRUE
+          AND rv."isPausedByUser" = FALSE
+      )
   `;
 }
 

--- a/web/src/lib/auth-options.ts
+++ b/web/src/lib/auth-options.ts
@@ -126,6 +126,7 @@ export const authOptions: NextAuthOptions = {
             await unarchiveUser({
               userId: user.id,
               triggerSource: ArchiveTriggerSource.SELF_REACTIVATION,
+              actorId: user.id,
             });
           } else {
             throw new Error("AccountArchived");
@@ -256,6 +257,7 @@ export const authOptions: NextAuthOptions = {
               await unarchiveUser({
                 userId: existingUser.id,
                 triggerSource: ArchiveTriggerSource.SELF_REACTIVATION,
+                actorId: existingUser.id,
               });
               existingUser.archivedAt = null;
             }


### PR DESCRIPTION
## Summary

- **New admin reactivate UI**: `ReactivateUserDialog` with optional note. Surfaced in the users data-table actions menu (archived rows only) and as a banner on the volunteer detail page showing archive reason + date.
- **Archive rules now respect off-platform activity**: manually-assigned CONFIRMED signups and active regular slots (`isActive=true`, `isPausedByUser=false`) protect a volunteer from `whereNeverMigrated`, `whereNeverActivatedNudge`, `whereNeverActivatedArchive`, and the inactive 11/12-month sweeps. Volunteers who never log in but are rostered by admins won't be archived.
- **Passkey login now checks `archivedAt`**: previously an archived user with a passkey could sign in and bypass the archive entirely. Now auto-reactivates on a successful assertion (same trust model as OAuth).
- **Self-reactivation paths log `actorId`**: credentials, web OAuth, mobile OAuth, and passkey all record the user as the actor in `ArchiveLog`, so the audit trail distinguishes self-actions from system events.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (163/163, including 21 archive-service tests with updated assertions)
- [ ] Manually verify in `/admin/users?archived=only`: row actions menu shows "Reactivate user", dialog opens, note is optional, success toast appears, row leaves the archived filter
- [ ] Manually verify on `/admin/volunteers/[id]` for an archived user: amber banner with reason + date + Reactivate button
- [ ] Manually verify reactivate flow does not regress: archived credentials user still sees the AccountArchived banner on `/login` and "Reactivate my account" still works
- [ ] Verify passkey login on an archived account auto-reactivates and signs in
- [ ] Confirm archive cron run no longer flags volunteers with active regular slots or admin-created CONFIRMED signups

🤖 Generated with [Claude Code](https://claude.com/claude-code)