### PR TITLE
feat(web): homepage redesign A/B test with PostHog funnel

### DIFF
--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -8,6 +8,12 @@ import { getEmailService } from "@/lib/email-service";
 import { validatePassword } from "@/lib/utils/password-validation";
 import { checkForBot } from "@/lib/bot-protection";
 import { calculateAge, getBaseUrl } from "@/lib/utils";
+import {
+  captureFunnelEvent,
+  FunnelEvent,
+  getPhidFromCookies,
+} from "@/lib/funnel";
+import { phAlias } from "@/lib/posthog-server";
 
 /**
  * Validation schema for user registration
@@ -322,6 +328,22 @@ export async function POST(req: Request) {
         // Don't fail registration if email sending fails, just log the error
       }
     }
+
+    // Funnel attribution: stitch the anonymous distinct_id (eea_phid cookie)
+    // onto the new user so their experiment exposure → conversion path is
+    // captured under one identity in PostHog.
+    const phid = await getPhidFromCookies();
+    if (phid && user.id) {
+      phAlias({ distinctId: user.id, alias: phid });
+    }
+    captureFunnelEvent({
+      event: FunnelEvent.REGISTER_COMPLETED,
+      userId: user.id ?? null,
+      phid,
+      properties: {
+        is_migration: isMigration,
+      },
+    });
 
     return NextResponse.json(
       {

--- a/web/src/app/api/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/shifts/[id]/signup/route.ts
@@ -9,6 +9,11 @@ import { MAX_NOTE_LENGTH, GUARDIAN_REQUIRED_AGE, calculateAge } from "@/lib/util
 import { isAMShift, getShiftDate } from "@/lib/concurrent-shifts";
 import { getShiftConfirmedCount } from "@/lib/placeholder-utils";
 import sanitizeHtml from "sanitize-html";
+import {
+  captureFunnelEvent,
+  FunnelEvent,
+  getPhidFromCookies,
+} from "@/lib/funnel";
 
 /**
  * HTML sanitizer for serverless environment.
@@ -236,6 +241,18 @@ export async function POST(
 
     // Achievements will be calculated when user visits dashboard/achievements page
 
+    captureFunnelEvent({
+      event: FunnelEvent.SHIFT_SIGNUP_COMPLETED,
+      userId: user.id,
+      phid: await getPhidFromCookies(),
+      properties: {
+        shift_id: shift.id,
+        shift_location: shift.location ?? null,
+        signup_status: "WAITLISTED",
+        auto_approved: false,
+      },
+    });
+
     return NextResponse.json(signup);
   }
 
@@ -259,6 +276,18 @@ export async function POST(
     );
 
     // Achievements will be calculated when user visits dashboard/achievements page
+
+    captureFunnelEvent({
+      event: FunnelEvent.SHIFT_SIGNUP_COMPLETED,
+      userId: user.id,
+      phid: await getPhidFromCookies(),
+      properties: {
+        shift_id: shift.id,
+        shift_location: shift.location ?? null,
+        signup_status: autoApprovalResult.status,
+        auto_approved: autoApprovalResult.autoApproved,
+      },
+    });
 
     // Return signup with updated status and auto-approval flag
     // Use the signup object we already have and update its status based on auto-approval result

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -352,6 +352,156 @@ h6 {
   @apply focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2;
 }
 
+/* ============================================
+   Civic dashboard homepage utilities
+   ============================================ */
+
+/* Tabular figures for stat numbers — prevents layout jitter on counter updates */
+.tnum {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+}
+
+/* Mono caps label — terminal-ish data labels */
+.mono-label {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono",
+    Consolas, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.6875rem; /* 11px */
+  font-weight: 500;
+}
+
+/* Dotted hairline divider */
+.divider-dotted {
+  background-image: radial-gradient(
+    currentColor 1px,
+    transparent 1px
+  );
+  background-size: 6px 1px;
+  background-repeat: repeat-x;
+  background-position: 0 50%;
+  height: 1px;
+  width: 100%;
+  opacity: 0.35;
+}
+
+/* Subtle paper grid background — used behind the dashboard hero */
+.paper-grid {
+  background-image:
+    linear-gradient(to right, color-mix(in srgb, var(--ee-fg) 4%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in srgb, var(--ee-fg) 4%, transparent) 1px, transparent 1px);
+  background-size: 32px 32px;
+  background-position: -1px -1px;
+}
+.dark .paper-grid {
+  background-image:
+    linear-gradient(to right, color-mix(in srgb, var(--ee-fg) 6%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in srgb, var(--ee-fg) 6%, transparent) 1px, transparent 1px);
+}
+
+/* Sticker-style chartreuse highlight applied behind inline text */
+.sticker {
+  position: relative;
+  display: inline-block;
+  isolation: isolate;
+}
+.sticker::before {
+  content: "";
+  position: absolute;
+  inset: 0.05em -0.18em 0.08em -0.18em;
+  background: var(--ee-accent);
+  z-index: -1;
+  transform: rotate(-1.2deg) skew(-3deg);
+  border-radius: 4px;
+}
+.dark .sticker::before {
+  background: #c8d33a;
+}
+
+/* Live pulse dot */
+.live-dot {
+  position: relative;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #16a34a;
+  box-shadow: 0 0 0 0 rgb(22 163 74 / 0.6);
+}
+.live-dot::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: inherit;
+  animation: live-pulse 2s ease-out infinite;
+  opacity: 0.6;
+}
+@keyframes live-pulse {
+  0% { transform: scale(1); opacity: 0.6; }
+  80%, 100% { transform: scale(2.4); opacity: 0; }
+}
+.dark .live-dot { background: #4ade80; }
+
+/* Dashboard panel — bordered, paper-backed surface used across hero/stats */
+.dash-panel {
+  background: var(--ee-card-bg);
+  border: 1.5px solid var(--ee-fg);
+  border-radius: 14px;
+  position: relative;
+}
+.dark .dash-panel {
+  border-color: color-mix(in srgb, var(--ee-fg) 35%, transparent);
+}
+
+/* Capacity meter — chunky terminal-style bar */
+.cap-bar {
+  height: 8px;
+  background: color-mix(in srgb, var(--ee-fg) 8%, transparent);
+  border-radius: 999px;
+  overflow: hidden;
+  position: relative;
+}
+.cap-bar > span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--ee-primary), var(--ee-primary-700));
+  border-radius: 999px;
+  transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.cap-bar.urgent > span {
+  background: linear-gradient(90deg, #d97706, #f59e0b);
+}
+
+/* Stat tile number — large display figure */
+.stat-figure {
+  font-family: var(--font-fraunces);
+  font-variation-settings: "WONK" 0, "SOFT" 50;
+  font-weight: 600;
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Marquee for activity ticker (CSS-only) */
+@keyframes ticker-scroll {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+.ticker-track {
+  display: inline-flex;
+  gap: 3rem;
+  padding-right: 3rem;
+  animation: ticker-scroll 40s linear infinite;
+  will-change: transform;
+}
+.ticker-mask:hover .ticker-track {
+  animation-play-state: paused;
+}
+@media (prefers-reduced-motion: reduce) {
+  .ticker-track { animation: none; }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,14 +1,13 @@
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import Image from "next/image";
-import {
-  HomePageWrapper,
-  HeroContent,
-  FeatureCard,
-  FeatureGrid,
-} from "@/components/home-animated";
 import type { Metadata } from "next";
 import { buildPageMetadata, buildOrganizationSchema } from "@/lib/seo";
+import {
+  FeatureFlag,
+  getFlagVariant,
+  type HomepageVariant,
+} from "@/lib/posthog-server";
+import { captureFunnelEvent, FunnelEvent, getPhidFromCookies } from "@/lib/funnel";
+import { HomeControl } from "@/components/home-control";
+import { HomeDashboard } from "@/components/home-dashboard";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Make a Difference One Plate at a Time",
@@ -17,9 +16,47 @@ export const metadata: Metadata = buildPageMetadata({
   path: "/",
 });
 
-// Auth redirect handled by middleware - this page is now fully static
-export default function Home() {
+const VALID_VARIANTS: HomepageVariant[] = ["control", "dashboard"];
+
+function isValidVariant(value: unknown): value is HomepageVariant {
+  return typeof value === "string" && VALID_VARIANTS.includes(value as HomepageVariant);
+}
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const organizationSchema = buildOrganizationSchema();
+  const params = await searchParams;
+  const phid = await getPhidFromCookies();
+
+  // QA override — `?variant=control` or `?variant=dashboard` forces a variant
+  // for screenshot testing without needing a flag toggle.
+  const overrideRaw = Array.isArray(params.variant)
+    ? params.variant[0]
+    : params.variant;
+  const override = isValidVariant(overrideRaw) ? overrideRaw : undefined;
+
+  const variant: HomepageVariant =
+    override ??
+    (phid
+      ? await getFlagVariant<HomepageVariant>(
+          FeatureFlag.HOMEPAGE_REDESIGN,
+          phid,
+          "control"
+        )
+      : "control");
+
+  // Funnel exposure event — counted as the entry point of the experiment.
+  captureFunnelEvent({
+    event: FunnelEvent.HOMEPAGE_VIEWED,
+    phid,
+    properties: {
+      variant,
+      override: !!override,
+    },
+  });
 
   return (
     <>
@@ -27,216 +64,7 @@ export default function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
       />
-      <HomePageWrapper data-testid="home-page">
-      <section className="section-hero md:py-14" data-testid="hero-section">
-        <div className="grid gap-8 md:grid-cols-2 md:items-center">
-          <HeroContent>
-            <h1
-              className="text-5xl md:text-6xl font-bold leading-tight mb-6 text-foreground"
-              data-testid="hero-title"
-            >
-              Making a difference one plate at a time
-            </h1>
-            <p
-              className="text-lg text-muted-foreground mb-8 leading-relaxed"
-              data-testid="hero-description"
-            >
-              Everybody Eats is an innovative, charitable restaurant,
-              transforming rescued food into quality 3-course meals on a
-              pay-what-you-can basis. Join us and be part of reducing food
-              waste, food insecurity and social isolation in Aotearoa.
-            </p>
-            <div
-              className="flex flex-col sm:flex-row gap-4"
-              data-testid="hero-actions"
-            >
-              <Button
-                asChild
-                size="lg"
-                className="btn-primary group"
-                data-testid="hero-browse-shifts-button"
-              >
-                <Link href="/shifts" className="flex items-center gap-2">
-                  <span>Browse volunteer shifts</span>
-                  <svg
-                    className="w-4 h-4 transition-transform group-hover:translate-x-1"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M13 7l5 5m0 0l-5 5m5-5H6"
-                    />
-                  </svg>
-                </Link>
-              </Button>
-              <Button
-                asChild
-                variant="outline"
-                size="lg"
-                className="btn-outline"
-                data-testid="hero-join-volunteer-button"
-              >
-                <Link href="/register">Join as volunteer</Link>
-              </Button>
-            </div>
-          </HeroContent>
-          <HeroContent className="hidden md:block">
-            <div className="relative">
-              <div
-                className="aspect-[4/3] w-full rounded-2xl overflow-hidden border-2 shadow-2xl"
-                style={{ borderColor: "var(--ee-border)" }}
-              >
-                <Image
-                  src="/hero.jpg"
-                  alt="People enjoying meals together at Everybody Eats restaurant"
-                  fill
-                  className="object-cover rounded-2xl"
-                  priority
-                  sizes="(max-width: 768px) 100vw, 50vw"
-                  data-testid="hero-image"
-                />
-              </div>
-            </div>
-          </HeroContent>
-        </div>
-      </section>
-
-      <section className="section-content py-10" data-testid="features-section">
-        <div>
-          <FeatureGrid className="grid md:grid-cols-3 gap-8">
-            <FeatureCard
-              className="text-center p-6 card"
-              delay={0.3}
-              data-testid="feature-community-impact"
-            >
-              <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg
-                  className="w-6 h-6 text-primary"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z"
-                  />
-                </svg>
-              </div>
-              <h3 className="text-xl font-semibold mb-2">Community Impact</h3>
-              <p className="text-muted-foreground">
-                Join hundreds of volunteers making a real difference in our
-                communities across New Zealand.
-              </p>
-            </FeatureCard>
-
-            <FeatureCard
-              className="text-center p-6 card"
-              delay={0.4}
-              data-testid="feature-flexible-scheduling"
-            >
-              <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg
-                  className="w-6 h-6 text-primary"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-              </div>
-              <h3 className="text-xl font-semibold mb-2">
-                Flexible Scheduling
-              </h3>
-              <p className="text-muted-foreground">
-                Choose shifts that fit your schedule. From prep work to service,
-                find opportunities that work for you.
-              </p>
-            </FeatureCard>
-
-            <FeatureCard
-              className="text-center p-6 card"
-              delay={0.5}
-              data-testid="feature-meaningful-work"
-            >
-              <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
-                <svg
-                  className="w-6 h-6 text-primary"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-                  />
-                </svg>
-              </div>
-              <h3 className="text-xl font-semibold mb-2">Meaningful Work</h3>
-              <p className="text-muted-foreground">
-                Help fight food waste and food insecurity while building
-                connections in your local community.
-              </p>
-            </FeatureCard>
-          </FeatureGrid>
-        </div>
-      </section>
-
-      <section className="section-content py-4" data-testid="cta-section">
-        <div className="max-w-2xl mx-auto text-center space-y-8">
-          <div
-            className="mt-16 p-8 bg-primary-light rounded-xl"
-            data-testid="final-cta-section"
-          >
-            <h2
-              className="text-2xl font-semibold mb-4"
-              data-testid="final-cta-title"
-            >
-              Ready to Make a Difference?
-            </h2>
-            <p className="text-muted-foreground mb-6">
-              Every volunteer hour contributes to stronger, more connected
-              communities.
-              <br />
-              Join us in our mission to ensure everybody eats.
-            </p>
-            <div
-                className="flex flex-col sm:flex-row gap-4 justify-center"
-                data-testid="final-cta-buttons"
-              >
-                <Button
-                  asChild
-                  size="lg"
-                  className="btn-primary"
-                  data-testid="final-get-started-button"
-                >
-                  <Link href="/register">Get Started</Link>
-                </Button>
-                <Button
-                  asChild
-                  variant="outline"
-                  size="lg"
-                  data-testid="final-sign-in-button"
-                >
-                  <Link href="/login">Sign In</Link>
-                </Button>
-              </div>
-          </div>
-        </div>
-      </section>
-    </HomePageWrapper>
+      {variant === "dashboard" ? <HomeDashboard /> : <HomeControl />}
     </>
   );
 }

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -4,6 +4,11 @@ import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
 import { buildPageMetadata } from "@/lib/seo";
 import { RegisterForm } from "./register-form";
+import {
+  captureFunnelEvent,
+  FunnelEvent,
+  getPhidFromCookies,
+} from "@/lib/funnel";
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Join as Volunteer",
@@ -70,10 +75,16 @@ async function getShiftTypes() {
  * Collects comprehensive user profile information during signup
  */
 export default async function RegisterPage() {
-  const [locationOptions, shiftTypes] = await Promise.all([
+  const [locationOptions, shiftTypes, phid] = await Promise.all([
     getLocationOptions(),
     getShiftTypes(),
+    getPhidFromCookies(),
   ]);
+
+  captureFunnelEvent({
+    event: FunnelEvent.REGISTER_STARTED,
+    phid,
+  });
 
   return (
     <Suspense fallback={<div>Loading registration form...</div>}>

--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -18,6 +18,11 @@ import { getAuthInfo } from "@/lib/auth-utils";
 import { LocationAddress } from "@/components/location-address";
 import type { Metadata } from "next";
 import { buildPageMetadata, buildShiftEventSchema } from "@/lib/seo";
+import {
+  captureFunnelEvent,
+  FunnelEvent,
+  getPhidFromCookies,
+} from "@/lib/funnel";
 
 export async function generateMetadata({
   searchParams,
@@ -84,6 +89,12 @@ export default async function ShiftsCalendarPage({
 }) {
   const { user, isLoggedIn } = await getAuthInfo();
   const params = await searchParams;
+  const phid = await getPhidFromCookies();
+  captureFunnelEvent({
+    event: FunnelEvent.SHIFTS_BROWSED,
+    userId: (user as { id?: string } | null)?.id ?? null,
+    phid,
+  });
 
   // Get current user
   let currentUser = null;

--- a/web/src/components/home-animated.tsx
+++ b/web/src/components/home-animated.tsx
@@ -1,12 +1,41 @@
 "use client";
 
 import { motion } from "motion/react";
-import { fadeVariants, slideUpVariants, staggerContainer } from "@/lib/motion";
+import {
+  fadeVariants,
+  slideUpVariants,
+  staggerContainer,
+  staggerItem,
+} from "@/lib/motion";
 
 interface AnimatedProps {
   children: React.ReactNode;
   className?: string;
   [key: string]: unknown; // Allow arbitrary props like data-testid
+}
+
+// Generic stagger item — fades up as part of a parent stagger container
+export function StaggerItem({ children, className, ...props }: AnimatedProps) {
+  return (
+    <motion.div variants={staggerItem} className={className} {...props}>
+      {children}
+    </motion.div>
+  );
+}
+
+// Reusable stagger container (parent for StaggerItem children)
+export function StaggerGroup({ children, className, ...props }: AnimatedProps) {
+  return (
+    <motion.div
+      variants={staggerContainer}
+      initial="hidden"
+      animate="visible"
+      className={className}
+      {...props}
+    >
+      {children}
+    </motion.div>
+  );
 }
 
 // Animated wrapper for the home page

--- a/web/src/components/home-control.tsx
+++ b/web/src/components/home-control.tsx
@@ -1,0 +1,229 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import {
+  HomePageWrapper,
+  HeroContent,
+  FeatureCard,
+  FeatureGrid,
+} from "@/components/home-animated";
+
+/**
+ * Original homepage layout — used as the "control" arm of the
+ * homepage-redesign A/B test. Preserved verbatim from the pre-redesign
+ * version so test IDs and copy are stable across both variants.
+ */
+export function HomeControl() {
+  return (
+    <HomePageWrapper data-testid="home-page">
+      <section className="section-hero md:py-14" data-testid="hero-section">
+        <div className="grid gap-8 md:grid-cols-2 md:items-center">
+          <HeroContent>
+            <h1
+              className="text-5xl md:text-6xl font-bold leading-tight mb-6 text-foreground"
+              data-testid="hero-title"
+            >
+              Making a difference one plate at a time
+            </h1>
+            <p
+              className="text-lg text-muted-foreground mb-8 leading-relaxed"
+              data-testid="hero-description"
+            >
+              Everybody Eats is an innovative, charitable restaurant,
+              transforming rescued food into quality 3-course meals on a
+              pay-what-you-can basis. Join us and be part of reducing food
+              waste, food insecurity and social isolation in Aotearoa.
+            </p>
+            <div
+              className="flex flex-col sm:flex-row gap-4"
+              data-testid="hero-actions"
+            >
+              <Button
+                asChild
+                size="lg"
+                className="btn-primary group"
+                data-testid="hero-browse-shifts-button"
+              >
+                <Link href="/shifts" className="flex items-center gap-2">
+                  <span>Browse volunteer shifts</span>
+                  <svg
+                    className="w-4 h-4 transition-transform group-hover:translate-x-1"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M13 7l5 5m0 0l-5 5m5-5H6"
+                    />
+                  </svg>
+                </Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="btn-outline"
+                data-testid="hero-join-volunteer-button"
+              >
+                <Link href="/register">Join as volunteer</Link>
+              </Button>
+            </div>
+          </HeroContent>
+          <HeroContent className="hidden md:block">
+            <div className="relative">
+              <div
+                className="aspect-[4/3] w-full rounded-2xl overflow-hidden border-2 shadow-2xl"
+                style={{ borderColor: "var(--ee-border)" }}
+              >
+                <Image
+                  src="/hero.jpg"
+                  alt="People enjoying meals together at Everybody Eats restaurant"
+                  fill
+                  className="object-cover rounded-2xl"
+                  priority
+                  sizes="(max-width: 768px) 100vw, 50vw"
+                  data-testid="hero-image"
+                />
+              </div>
+            </div>
+          </HeroContent>
+        </div>
+      </section>
+
+      <section className="section-content py-10" data-testid="features-section">
+        <div>
+          <FeatureGrid className="grid md:grid-cols-3 gap-8">
+            <FeatureCard
+              className="text-center p-6 card"
+              delay={0.3}
+              data-testid="feature-community-impact"
+            >
+              <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg
+                  className="w-6 h-6 text-primary"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z"
+                  />
+                </svg>
+              </div>
+              <h3 className="text-xl font-semibold mb-2">Community Impact</h3>
+              <p className="text-muted-foreground">
+                Join hundreds of volunteers making a real difference in our
+                communities across New Zealand.
+              </p>
+            </FeatureCard>
+
+            <FeatureCard
+              className="text-center p-6 card"
+              delay={0.4}
+              data-testid="feature-flexible-scheduling"
+            >
+              <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg
+                  className="w-6 h-6 text-primary"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+              </div>
+              <h3 className="text-xl font-semibold mb-2">
+                Flexible Scheduling
+              </h3>
+              <p className="text-muted-foreground">
+                Choose shifts that fit your schedule. From prep work to service,
+                find opportunities that work for you.
+              </p>
+            </FeatureCard>
+
+            <FeatureCard
+              className="text-center p-6 card"
+              delay={0.5}
+              data-testid="feature-meaningful-work"
+            >
+              <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg
+                  className="w-6 h-6 text-primary"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+                  />
+                </svg>
+              </div>
+              <h3 className="text-xl font-semibold mb-2">Meaningful Work</h3>
+              <p className="text-muted-foreground">
+                Help fight food waste and food insecurity while building
+                connections in your local community.
+              </p>
+            </FeatureCard>
+          </FeatureGrid>
+        </div>
+      </section>
+
+      <section className="section-content py-4" data-testid="cta-section">
+        <div className="max-w-2xl mx-auto text-center space-y-8">
+          <div
+            className="mt-16 p-8 bg-primary-light rounded-xl"
+            data-testid="final-cta-section"
+          >
+            <h2
+              className="text-2xl font-semibold mb-4"
+              data-testid="final-cta-title"
+            >
+              Ready to Make a Difference?
+            </h2>
+            <p className="text-muted-foreground mb-6">
+              Every volunteer hour contributes to stronger, more connected
+              communities.
+              <br />
+              Join us in our mission to ensure everybody eats.
+            </p>
+            <div
+              className="flex flex-col sm:flex-row gap-4 justify-center"
+              data-testid="final-cta-buttons"
+            >
+              <Button
+                asChild
+                size="lg"
+                className="btn-primary"
+                data-testid="final-get-started-button"
+              >
+                <Link href="/register">Get Started</Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                data-testid="final-sign-in-button"
+              >
+                <Link href="/login">Sign In</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </HomePageWrapper>
+  );
+}

--- a/web/src/components/home-dashboard.tsx
+++ b/web/src/components/home-dashboard.tsx
@@ -1,0 +1,582 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import {
+  HomePageWrapper,
+  HeroContent,
+  FeatureCard,
+  FeatureGrid,
+  StaggerGroup,
+  StaggerItem,
+} from "@/components/home-animated";
+import {
+  getHomeStats,
+  type UpcomingShift,
+  type RecentActivityItem,
+} from "@/lib/home-stats";
+import { formatInNZT } from "@/lib/timezone";
+
+const fmtNum = (n: number) => new Intl.NumberFormat("en-NZ").format(n);
+
+function formatRelativeFromNow(date: Date): string {
+  const diff = Date.now() - date.getTime();
+  const past = diff >= 0;
+  const minutes = Math.round(Math.abs(diff) / 60000);
+  if (minutes < 1) return past ? "just now" : "any moment";
+  if (minutes < 60) return past ? `${minutes}m ago` : `in ${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return past ? `${hours}h ago` : `in ${hours}h`;
+  const days = Math.round(hours / 24);
+  return past ? `${days}d ago` : `in ${days}d`;
+}
+
+export async function HomeDashboard() {
+  const stats = await getHomeStats();
+
+  return (
+    <HomePageWrapper data-testid="home-page">
+      {/* ───────── HERO / LIVE STATUS ───────── */}
+      <section
+        className="relative overflow-hidden md:py-12"
+        data-testid="hero-section"
+      >
+        <div className="paper-grid absolute inset-x-0 top-0 -z-10 h-full opacity-60" />
+
+        <div className="grid gap-10 md:grid-cols-12 md:items-stretch">
+          {/* Left: headline + CTAs */}
+          <HeroContent className="md:col-span-7">
+            <div className="mono-label mb-5 inline-flex items-center gap-2 text-[var(--ee-primary)]">
+              <span>01 / Volunteer Portal</span>
+              <span aria-hidden>—</span>
+              <span>Everybody Eats Aotearoa</span>
+            </div>
+
+            <h1
+              className="text-[clamp(2.5rem,6vw,4.5rem)] font-semibold leading-[0.95] tracking-tight text-foreground"
+              data-testid="hero-title"
+            >
+              Making{" "}
+              <span className="sticker italic">a difference</span>{" "}
+              one plate at a time
+            </h1>
+
+            <p
+              className="mt-7 max-w-xl text-base leading-relaxed text-muted-foreground md:text-lg"
+              data-testid="hero-description"
+            >
+              Everybody Eats is an innovative, charitable restaurant,
+              transforming rescued food into quality 3-course meals on a
+              pay-what-you-can basis. Join us and be part of reducing food
+              waste, food insecurity and social isolation in Aotearoa.
+            </p>
+
+            <div
+              className="mt-8 flex flex-col gap-3 sm:flex-row"
+              data-testid="hero-actions"
+            >
+              <Button
+                asChild
+                size="lg"
+                className="btn-primary group"
+                data-testid="hero-browse-shifts-button"
+              >
+                <Link href="/shifts" className="flex items-center gap-2">
+                  <span>Browse volunteer shifts</span>
+                  <svg
+                    className="h-4 w-4 transition-transform group-hover:translate-x-1"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M13 7l5 5m0 0l-5 5m5-5H6"
+                    />
+                  </svg>
+                </Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className="btn-outline"
+                data-testid="hero-join-volunteer-button"
+              >
+                <Link href="/register">Join as volunteer</Link>
+              </Button>
+            </div>
+
+            {/* Inline impact strip — readable next to the CTAs */}
+            <dl className="mt-10 grid grid-cols-3 gap-6 border-t border-current/10 pt-6">
+              <div>
+                <dt className="mono-label text-muted-foreground">Volunteers</dt>
+                <dd className="stat-figure tnum mt-1.5 text-3xl md:text-4xl">
+                  {fmtNum(stats.volunteers)}
+                </dd>
+              </div>
+              <div>
+                <dt className="mono-label text-muted-foreground">
+                  Meals served
+                </dt>
+                <dd className="stat-figure tnum mt-1.5 text-3xl md:text-4xl">
+                  {fmtNum(stats.mealsServed)}
+                </dd>
+              </div>
+              <div>
+                <dt className="mono-label text-muted-foreground">
+                  Hours of mahi
+                </dt>
+                <dd className="stat-figure tnum mt-1.5 text-3xl md:text-4xl">
+                  {fmtNum(stats.hoursLogged)}
+                </dd>
+              </div>
+            </dl>
+          </HeroContent>
+
+          {/* Right: dashboard panel + hero photo */}
+          <HeroContent className="hidden md:col-span-5 md:block">
+            <div className="dash-panel sticky top-8 overflow-hidden">
+              <div className="flex items-center justify-between border-b border-current/15 px-5 py-3">
+                <div className="mono-label flex items-center gap-2">
+                  <span className="live-dot" aria-hidden />
+                  <span>Live status</span>
+                </div>
+                <div className="mono-label opacity-60">
+                  Updated {formatRelativeFromNow(new Date(stats.generatedAt))}
+                </div>
+              </div>
+
+              <div className="px-5 py-6">
+                <div className="mono-label text-muted-foreground">
+                  Mahi available now
+                </div>
+                <div className="mt-1 flex items-end gap-3">
+                  <span className="stat-figure tnum text-7xl text-foreground">
+                    {fmtNum(stats.openShiftsCount)}
+                  </span>
+                  <span className="mb-2 text-sm text-muted-foreground">
+                    shifts open across {stats.activeLocations} restaurants
+                  </span>
+                </div>
+
+                <ul className="mt-5 space-y-2">
+                  {stats.locationStatus.map((loc) => (
+                    <li
+                      key={loc.name}
+                      className="flex items-center justify-between text-sm"
+                    >
+                      <span className="flex items-center gap-2.5">
+                        <span
+                          className={`h-2 w-2 rounded-full ${
+                            loc.openShifts > 0
+                              ? "bg-[var(--ee-primary)]"
+                              : "bg-current/20"
+                          }`}
+                          aria-hidden
+                        />
+                        <span>{loc.name}</span>
+                      </span>
+                      <span className="mono-label tnum text-muted-foreground">
+                        {loc.openShifts > 0
+                          ? `${loc.spotsLeft} spots · ${loc.openShifts} shifts`
+                          : "fully crewed"}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="divider-dotted text-current" />
+
+              <figure className="relative">
+                <div className="relative aspect-[5/3] w-full overflow-hidden">
+                  <Image
+                    src="/hero.jpg"
+                    alt="People enjoying meals together at Everybody Eats restaurant"
+                    fill
+                    className="object-cover"
+                    priority
+                    sizes="(max-width: 768px) 100vw, 40vw"
+                    data-testid="hero-image"
+                  />
+                </div>
+              </figure>
+            </div>
+          </HeroContent>
+        </div>
+      </section>
+
+      {/* ───────── LIVE: OPEN SHIFTS + ACTIVITY FEED ───────── */}
+      <section className="section-content py-16">
+        <div className="mb-8 flex items-end justify-between gap-4">
+          <div>
+            <div className="mono-label text-[var(--ee-primary)]">
+              02 / Right now
+            </div>
+            <h2 className="mt-2 text-3xl font-semibold tracking-tight md:text-4xl">
+              What&rsquo;s happening across the whānau
+            </h2>
+          </div>
+          <Link
+            href="/shifts"
+            className="mono-label hidden items-center gap-1 text-[var(--ee-primary)] hover:underline md:inline-flex"
+          >
+            See all shifts →
+          </Link>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-12">
+          <div className="dash-panel md:col-span-7">
+            <div className="flex items-center justify-between border-b border-current/15 px-5 py-3">
+              <div className="mono-label flex items-center gap-2">
+                <span className="live-dot" aria-hidden />
+                Open shifts
+              </div>
+              <div className="mono-label opacity-60">
+                Next {stats.upcomingShifts.length}
+              </div>
+            </div>
+            {stats.upcomingShifts.length === 0 ? (
+              <div className="px-5 py-12 text-center text-sm text-muted-foreground">
+                No upcoming shifts published yet — check back soon.
+              </div>
+            ) : (
+              <StaggerGroup>
+                <ul className="divide-y divide-current/10">
+                  {stats.upcomingShifts.map((shift) => (
+                    <ShiftRow key={shift.id} shift={shift} />
+                  ))}
+                </ul>
+              </StaggerGroup>
+            )}
+            <div className="border-t border-current/15 px-5 py-3 text-center">
+              <Link
+                href="/shifts"
+                className="mono-label text-[var(--ee-primary)] hover:underline"
+              >
+                Browse all shifts →
+              </Link>
+            </div>
+          </div>
+
+          <div className="dash-panel md:col-span-5">
+            <div className="flex items-center justify-between border-b border-current/15 px-5 py-3">
+              <div className="mono-label flex items-center gap-2">
+                <span className="live-dot" aria-hidden />
+                Recent signups
+              </div>
+              <div className="mono-label opacity-60">
+                {stats.recentActivity.length} updates
+              </div>
+            </div>
+            {stats.recentActivity.length === 0 ? (
+              <div className="px-5 py-12 text-center text-sm text-muted-foreground">
+                Be the first to sign up this week.
+              </div>
+            ) : (
+              <StaggerGroup>
+                <ul className="divide-y divide-current/10">
+                  {stats.recentActivity.map((item) => (
+                    <ActivityRow key={item.id} item={item} />
+                  ))}
+                </ul>
+              </StaggerGroup>
+            )}
+          </div>
+        </div>
+
+        <div className="ticker-mask mt-12 overflow-hidden border-y-2 border-current/15 py-4">
+          <div className="ticker-track mono-label whitespace-nowrap text-foreground">
+            {Array.from({ length: 2 }).flatMap((_, repIdx) =>
+              [
+                `${fmtNum(stats.mealsServed)} meals served`,
+                `${fmtNum(stats.volunteers)} volunteers`,
+                `${fmtNum(stats.hoursLogged)} hours of mahi`,
+                `${fmtNum(stats.shiftsThisWeek)} shifts this week`,
+                `Pay-what-you-can`,
+                `Rescued food, restaurant quality`,
+                `Manaakitanga in action`,
+              ].map((label, i) => (
+                <span
+                  key={`${repIdx}-${i}`}
+                  className="inline-flex items-center gap-3"
+                >
+                  <span>{label}</span>
+                  <span aria-hidden className="text-[var(--ee-primary)]">
+                    ✦
+                  </span>
+                </span>
+              ))
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* ───────── HOW IT WORKS / FEATURE CARDS (preserved testids) ───────── */}
+      <section className="section-content py-16" data-testid="features-section">
+        <div className="mb-10">
+          <div className="mono-label text-[var(--ee-primary)]">
+            03 / How volunteering works
+          </div>
+          <h2 className="mt-2 text-3xl font-semibold tracking-tight md:text-4xl">
+            Three ways your time turns into{" "}
+            <span className="sticker italic">manaakitanga</span>
+          </h2>
+        </div>
+
+        <FeatureGrid className="grid gap-5 md:grid-cols-3">
+          <FeatureCard
+            className="dash-panel flex h-full flex-col p-6"
+            delay={0.05}
+            data-testid="feature-community-impact"
+          >
+            <div className="mono-label flex items-center justify-between text-[var(--ee-primary)]">
+              <span>01 — Tāngata</span>
+              <span className="opacity-50">People</span>
+            </div>
+            <h3 className="mt-4 text-2xl font-semibold tracking-tight">
+              Community Impact
+            </h3>
+            <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+              Join {fmtNum(stats.volunteers)}+ volunteers making a real
+              difference in our communities across New Zealand.
+            </p>
+            <div className="mt-6 flex items-baseline gap-2">
+              <span className="stat-figure tnum text-3xl">
+                {fmtNum(stats.volunteers)}
+              </span>
+              <span className="mono-label text-muted-foreground">
+                active whānau
+              </span>
+            </div>
+          </FeatureCard>
+
+          <FeatureCard
+            className="dash-panel flex h-full flex-col p-6"
+            delay={0.12}
+            data-testid="feature-flexible-scheduling"
+          >
+            <div className="mono-label flex items-center justify-between text-[var(--ee-primary)]">
+              <span>02 — Wā</span>
+              <span className="opacity-50">Time</span>
+            </div>
+            <h3 className="mt-4 text-2xl font-semibold tracking-tight">
+              Flexible Scheduling
+            </h3>
+            <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+              Choose shifts that fit your schedule. From prep work to service,
+              find opportunities that work for you.
+            </p>
+            <div className="mt-6 flex items-baseline gap-2">
+              <span className="stat-figure tnum text-3xl">
+                {fmtNum(stats.shiftsThisWeek)}
+              </span>
+              <span className="mono-label text-muted-foreground">
+                shifts this week
+              </span>
+            </div>
+          </FeatureCard>
+
+          <FeatureCard
+            className="dash-panel flex h-full flex-col p-6"
+            delay={0.19}
+            data-testid="feature-meaningful-work"
+          >
+            <div className="mono-label flex items-center justify-between text-[var(--ee-primary)]">
+              <span>03 — Kai</span>
+              <span className="opacity-50">Food</span>
+            </div>
+            <h3 className="mt-4 text-2xl font-semibold tracking-tight">
+              Meaningful Work
+            </h3>
+            <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+              Help fight food waste and food insecurity while building
+              connections in your local community.
+            </p>
+            <div className="mt-6 flex items-baseline gap-2">
+              <span className="stat-figure tnum text-3xl">
+                {fmtNum(stats.mealsServed)}
+              </span>
+              <span className="mono-label text-muted-foreground">
+                meals served
+              </span>
+            </div>
+          </FeatureCard>
+        </FeatureGrid>
+      </section>
+
+      {/* ───────── FINAL CTA (preserved testids/copy) ───────── */}
+      <section className="section-content pb-20 pt-4" data-testid="cta-section">
+        <div
+          className="dash-panel relative overflow-hidden p-8 md:p-14"
+          data-testid="final-cta-section"
+          style={{
+            background:
+              "linear-gradient(135deg, var(--ee-primary), var(--ee-gradient-end))",
+            borderColor: "transparent",
+            color: "white",
+          }}
+        >
+          <div className="paper-grid absolute inset-0 opacity-10" />
+          <div className="relative grid gap-8 md:grid-cols-12 md:items-center">
+            <div className="md:col-span-7">
+              <div className="mono-label opacity-70">04 / Join us</div>
+              <h2
+                className="mt-3 text-3xl font-semibold tracking-tight text-white md:text-5xl"
+                data-testid="final-cta-title"
+              >
+                Ready to Make a{" "}
+                <span className="sticker italic text-[#0e3a23]">
+                  Difference?
+                </span>
+              </h2>
+              <p className="mt-4 max-w-xl text-base text-white/85 md:text-lg">
+                Every volunteer hour contributes to stronger, more connected
+                communities. Join us in our mission to ensure everybody eats.
+              </p>
+              <div
+                className="mt-7 flex flex-col gap-3 sm:flex-row"
+                data-testid="final-cta-buttons"
+              >
+                <Button
+                  asChild
+                  size="lg"
+                  className="bg-[var(--ee-accent)] text-[#0e3a23] hover:bg-[var(--ee-accent-subtle)]"
+                  data-testid="final-get-started-button"
+                >
+                  <Link href="/register">Get Started</Link>
+                </Button>
+                <Button
+                  asChild
+                  variant="outline"
+                  size="lg"
+                  className="border-2 border-white/70 bg-transparent text-white hover:bg-white hover:text-[#0e3a23]"
+                  data-testid="final-sign-in-button"
+                >
+                  <Link href="/login">Sign In</Link>
+                </Button>
+              </div>
+            </div>
+            <div className="md:col-span-5">
+              <div className="rounded-xl border border-white/25 bg-white/5 p-6 backdrop-blur-sm">
+                <div className="mono-label opacity-80">Right now</div>
+                <ul className="mt-4 space-y-3.5">
+                  <CtaStat
+                    label="Spots open this week"
+                    value={fmtNum(stats.openSpots)}
+                  />
+                  <CtaStat
+                    label="Volunteers in the whānau"
+                    value={fmtNum(stats.volunteers)}
+                  />
+                  <CtaStat
+                    label="Meals served, all-time"
+                    value={fmtNum(stats.mealsServed)}
+                  />
+                </ul>
+                <div className="mono-label mt-5 text-white/60">
+                  Ngā mihi — thank you for being part of it.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </HomePageWrapper>
+  );
+}
+
+function ShiftRow({ shift }: { shift: UpcomingShift }) {
+  const day = formatInNZT(shift.start, "EEE d MMM");
+  const startTime = formatInNZT(shift.start, "h:mma");
+  const endTime = formatInNZT(shift.end, "h:mma");
+  const fillPct = Math.min(
+    100,
+    Math.round((shift.confirmed / Math.max(1, shift.capacity)) * 100)
+  );
+  const urgent = shift.spotsLeft > 0 && fillPct >= 75;
+  return (
+    <StaggerItem>
+      <li>
+        <Link
+          href={`/shifts/${shift.id}`}
+          className="grid grid-cols-[1fr_auto] items-center gap-3 px-5 py-4 transition-colors hover:bg-current/[0.03] md:grid-cols-[1fr_180px_auto]"
+        >
+          <div className="min-w-0">
+            <div className="mono-label tnum text-[var(--ee-primary)]">
+              {day} · {startTime}–{endTime}
+            </div>
+            <div className="mt-1 truncate text-base font-semibold">
+              {shift.shiftType}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {shift.location ?? "Location TBC"}
+            </div>
+          </div>
+          <div className="hidden flex-col gap-1.5 md:flex">
+            <div className={`cap-bar ${urgent ? "urgent" : ""}`}>
+              <span style={{ width: `${fillPct}%` }} />
+            </div>
+            <div className="mono-label tnum flex justify-between text-muted-foreground">
+              <span>
+                {shift.confirmed}/{shift.capacity} crewed
+              </span>
+              <span>{fillPct}%</span>
+            </div>
+          </div>
+          <div className="text-right">
+            {shift.spotsLeft > 0 ? (
+              <span className="mono-label inline-flex items-center gap-1 rounded-full border border-[var(--ee-primary)]/20 bg-[var(--ee-primary)]/5 px-2.5 py-1 text-[var(--ee-primary)]">
+                <span className="tnum">{shift.spotsLeft}</span> open
+              </span>
+            ) : (
+              <span className="mono-label inline-flex items-center rounded-full bg-current/10 px-2.5 py-1 text-muted-foreground">
+                Full · waitlist
+              </span>
+            )}
+          </div>
+        </Link>
+      </li>
+    </StaggerItem>
+  );
+}
+
+function ActivityRow({ item }: { item: RecentActivityItem }) {
+  return (
+    <StaggerItem>
+      <li className="flex items-start gap-3 px-5 py-3.5">
+        <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--ee-primary)]/10 text-sm font-semibold text-[var(--ee-primary)]">
+          {item.firstName.slice(0, 1).toUpperCase()}
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm leading-snug">
+            <span className="font-semibold">{item.firstName}</span>{" "}
+            <span className="text-muted-foreground">signed up for</span>{" "}
+            <span className="font-medium">{item.shiftType}</span>
+            {item.location && (
+              <>
+                <span className="text-muted-foreground"> at </span>
+                <span className="font-medium">{item.location}</span>
+              </>
+            )}
+          </p>
+          <div className="mono-label tnum mt-1 text-muted-foreground">
+            {formatRelativeFromNow(item.createdAt)} ·{" "}
+            {formatInNZT(item.start, "EEE d MMM")}
+          </div>
+        </div>
+      </li>
+    </StaggerItem>
+  );
+}
+
+function CtaStat({ label, value }: { label: string; value: string }) {
+  return (
+    <li className="flex items-baseline justify-between gap-3 border-b border-white/15 pb-3 last:border-0 last:pb-0">
+      <span className="text-sm text-white/85">{label}</span>
+      <span className="stat-figure tnum text-2xl text-white">{value}</span>
+    </li>
+  );
+}

--- a/web/src/lib/funnel.ts
+++ b/web/src/lib/funnel.ts
@@ -1,0 +1,50 @@
+import { cookies } from "next/headers";
+import type { NextRequest } from "next/server";
+import { phCapture } from "@/lib/posthog-server";
+
+export const PHID_COOKIE = "eea_phid";
+
+/** Canonical funnel event names — keep in one place. */
+export const FunnelEvent = {
+  HOMEPAGE_VIEWED: "homepage_viewed",
+  REGISTER_STARTED: "register_started",
+  REGISTER_COMPLETED: "register_completed",
+  SHIFTS_BROWSED: "shifts_browsed",
+  SHIFT_SIGNUP_COMPLETED: "shift_signup_completed",
+} as const;
+
+export type FunnelEventName = (typeof FunnelEvent)[keyof typeof FunnelEvent];
+
+/** Read the anonymous PostHog distinct_id cookie inside a server component. */
+export async function getPhidFromCookies(): Promise<string | undefined> {
+  const store = await cookies();
+  return store.get(PHID_COOKIE)?.value;
+}
+
+/** Read the anonymous distinct_id from an API-route NextRequest. */
+export function getPhidFromRequest(req: NextRequest): string | undefined {
+  return req.cookies.get(PHID_COOKIE)?.value;
+}
+
+/**
+ * Capture a funnel event with the best distinct_id available — preferring an
+ * authenticated user id, falling back to the cookie. No-ops if neither is set.
+ */
+export function captureFunnelEvent(args: {
+  event: FunnelEventName;
+  userId?: string | null;
+  phid?: string | null;
+  properties?: Record<string, unknown>;
+}): void {
+  const distinctId = args.userId || args.phid;
+  if (!distinctId) return;
+  phCapture({
+    distinctId,
+    event: args.event,
+    properties: {
+      ...(args.properties ?? {}),
+      ...(args.phid ? { phid: args.phid } : {}),
+      ...(args.userId ? { user_id: args.userId } : {}),
+    },
+  });
+}

--- a/web/src/lib/home-stats.ts
+++ b/web/src/lib/home-stats.ts
@@ -1,0 +1,215 @@
+import { prisma } from "@/lib/prisma";
+
+export type HomeStats = {
+  volunteers: number;
+  mealsServed: number;
+  hoursLogged: number;
+  openShiftsCount: number;
+  openSpots: number;
+  activeLocations: number;
+  upcomingShifts: UpcomingShift[];
+  recentActivity: RecentActivityItem[];
+  locationStatus: LocationStatus[];
+  shiftsThisWeek: number;
+  generatedAt: string;
+};
+
+export type UpcomingShift = {
+  id: string;
+  start: Date;
+  end: Date;
+  location: string | null;
+  shiftType: string;
+  capacity: number;
+  confirmed: number;
+  spotsLeft: number;
+};
+
+export type RecentActivityItem = {
+  id: string;
+  firstName: string;
+  shiftType: string;
+  location: string | null;
+  start: Date;
+  createdAt: Date;
+};
+
+export type LocationStatus = {
+  name: string;
+  openShifts: number;
+  spotsLeft: number;
+};
+
+// Public-facing location list — only the three customer-facing restaurants
+// are shown on the homepage. "Active locations" count still reflects all
+// active locations in the database.
+const PUBLIC_LOCATION_NAMES = ["Wellington", "Glen Innes", "Onehunga"] as const;
+
+const startOfWeekUTC = (now: Date) => {
+  const day = now.getUTCDay();
+  const diff = (day + 6) % 7; // Monday as week start
+  const start = new Date(now);
+  start.setUTCDate(now.getUTCDate() - diff);
+  start.setUTCHours(0, 0, 0, 0);
+  return start;
+};
+
+const endOfWeekUTC = (now: Date) => {
+  const start = startOfWeekUTC(now);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 7);
+  return end;
+};
+
+export async function getHomeStats(): Promise<HomeStats> {
+  const now = new Date();
+  const weekStart = startOfWeekUTC(now);
+  const weekEnd = endOfWeekUTC(now);
+
+  const [
+    volunteers,
+    mealsAggregate,
+    completedSignups,
+    openShiftsRaw,
+    activeLocations,
+    upcomingShifts,
+    recentSignups,
+    weekShifts,
+    locationsList,
+  ] = await Promise.all([
+    prisma.user.count({
+      where: { role: "VOLUNTEER", archivedAt: null },
+    }),
+    prisma.mealsServed.aggregate({
+      _sum: { mealsServed: true },
+    }),
+    prisma.signup.findMany({
+      where: {
+        status: "CONFIRMED",
+        shift: { end: { lt: now } },
+      },
+      select: {
+        shift: { select: { start: true, end: true } },
+      },
+      take: 20000,
+    }),
+    prisma.shift.findMany({
+      where: { start: { gte: now } },
+      select: {
+        id: true,
+        capacity: true,
+        location: true,
+        signups: {
+          where: { status: "CONFIRMED" },
+          select: { id: true },
+        },
+      },
+    }),
+    prisma.location.count({ where: { isActive: true } }),
+    prisma.shift.findMany({
+      where: { start: { gte: now } },
+      orderBy: { start: "asc" },
+      take: 6,
+      include: {
+        shiftType: { select: { name: true } },
+        signups: {
+          where: { status: "CONFIRMED" },
+          select: { id: true },
+        },
+      },
+    }),
+    prisma.signup.findMany({
+      where: {
+        status: "CONFIRMED",
+        shift: { start: { gte: now } },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 6,
+      include: {
+        user: { select: { firstName: true, name: true } },
+        shift: {
+          select: {
+            start: true,
+            location: true,
+            shiftType: { select: { name: true } },
+          },
+        },
+      },
+    }),
+    prisma.shift.count({
+      where: { start: { gte: weekStart, lt: weekEnd } },
+    }),
+    prisma.location.findMany({
+      where: { isActive: true, name: { in: [...PUBLIC_LOCATION_NAMES] } },
+      select: { name: true },
+    }),
+  ]);
+
+  // Hours logged: sum of completed CONFIRMED signups' shift duration (hours)
+  let hoursLoggedMs = 0;
+  for (const s of completedSignups) {
+    hoursLoggedMs += s.shift.end.getTime() - s.shift.start.getTime();
+  }
+  const hoursLogged = Math.round(hoursLoggedMs / (1000 * 60 * 60));
+
+  // Open shifts derived
+  const openShiftsCount = openShiftsRaw.filter(
+    (s) => s.signups.length < s.capacity
+  ).length;
+  const openSpots = openShiftsRaw.reduce(
+    (sum, s) => sum + Math.max(0, s.capacity - s.signups.length),
+    0
+  );
+
+  // Per-location status — only the three customer-facing restaurants,
+  // ordered canonically so the panel always reads the same way.
+  const activeNames = new Set(locationsList.map((l) => l.name));
+  const locationStatus: LocationStatus[] = PUBLIC_LOCATION_NAMES.filter((n) =>
+    activeNames.has(n)
+  ).map((name) => {
+    const shifts = openShiftsRaw.filter((s) => s.location === name);
+    const open = shifts.filter((s) => s.signups.length < s.capacity).length;
+    const spots = shifts.reduce(
+      (sum, s) => sum + Math.max(0, s.capacity - s.signups.length),
+      0
+    );
+    return { name, openShifts: open, spotsLeft: spots };
+  });
+
+  const upcoming: UpcomingShift[] = upcomingShifts.map((s) => ({
+    id: s.id,
+    start: s.start,
+    end: s.end,
+    location: s.location,
+    shiftType: s.shiftType.name,
+    capacity: s.capacity,
+    confirmed: s.signups.length,
+    spotsLeft: Math.max(0, s.capacity - s.signups.length),
+  }));
+
+  const activity: RecentActivityItem[] = recentSignups.map((s) => {
+    const fallback = (s.user.name ?? "").trim().split(/\s+/)[0] || "Someone";
+    return {
+      id: s.id,
+      firstName: s.user.firstName ?? fallback,
+      shiftType: s.shift.shiftType.name,
+      location: s.shift.location,
+      start: s.shift.start,
+      createdAt: s.createdAt,
+    };
+  });
+
+  return {
+    volunteers,
+    mealsServed: mealsAggregate._sum.mealsServed ?? 0,
+    hoursLogged,
+    openShiftsCount,
+    openSpots,
+    activeLocations,
+    upcomingShifts: upcoming,
+    recentActivity: activity,
+    locationStatus,
+    shiftsThisWeek: weekShifts,
+    generatedAt: now.toISOString(),
+  };
+}

--- a/web/src/lib/posthog-server.ts
+++ b/web/src/lib/posthog-server.ts
@@ -17,7 +17,11 @@ export function getPostHogServer(): PostHog {
 /** Feature flag names — keep in one place per PostHog integration rules */
 export enum FeatureFlag {
   CHAT_GUIDES = "chat-guides",
+  HOMEPAGE_REDESIGN = "homepage-redesign",
 }
+
+/** Variant names for the homepage A/B test. Keep in sync with PostHog config. */
+export type HomepageVariant = "control" | "dashboard";
 
 /**
  * Check a boolean feature flag for a given user.
@@ -32,5 +36,63 @@ export async function isFeatureEnabled(
     return await ph.isFeatureEnabled(flag, distinctId) ?? false;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Resolve a multivariate flag to its assigned variant string. Returns the
+ * provided fallback if PostHog is unavailable or the flag is unconfigured.
+ */
+export async function getFlagVariant<T extends string>(
+  flag: FeatureFlag,
+  distinctId: string,
+  fallback: T,
+): Promise<T> {
+  try {
+    const ph = getPostHogServer();
+    const value = await ph.getFeatureFlag(flag, distinctId);
+    if (typeof value === "string") return value as T;
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Fire-and-forget server-side event capture. PostHog's flushAt:1 means the
+ * payload is sent immediately, so we don't need to await flush in normal cases.
+ */
+export function phCapture(args: {
+  distinctId: string;
+  event: string;
+  properties?: Record<string, unknown>;
+}): void {
+  try {
+    getPostHogServer().capture({
+      distinctId: args.distinctId,
+      event: args.event,
+      properties: args.properties,
+    });
+  } catch (err) {
+    console.error("phCapture failed", err);
+  }
+}
+
+/**
+ * Stitch an anonymous distinct_id (cookie-based) onto an authenticated user
+ * so subsequent events for the user roll up to the same person/funnel.
+ */
+export function phAlias(args: {
+  distinctId: string; // canonical id (user.id)
+  alias: string; // previous anonymous id (eea_phid)
+}): void {
+  if (!args.alias || args.alias === args.distinctId) return;
+  try {
+    getPostHogServer().alias({
+      distinctId: args.distinctId,
+      alias: args.alias,
+    });
+  } catch (err) {
+    console.error("phAlias failed", err);
   }
 }

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -2,8 +2,11 @@ import { getToken } from "next-auth/jwt";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+const PHID_COOKIE = "eea_phid";
+const PHID_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
 export async function middleware(request: NextRequest) {
-  // Redirect authenticated users away from the homepage
+  // Authenticated users skip the homepage entirely
   if (request.nextUrl.pathname === "/") {
     const token = await getToken({ req: request });
     if (token) {
@@ -13,9 +16,23 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  return NextResponse.next();
+  // Ensure every visitor to a public funnel entry point has a stable
+  // anonymous distinct_id used as the PostHog A/B-test bucketing key.
+  const response = NextResponse.next();
+  if (!request.cookies.has(PHID_COOKIE)) {
+    response.cookies.set(PHID_COOKIE, crypto.randomUUID(), {
+      maxAge: PHID_MAX_AGE,
+      sameSite: "lax",
+      path: "/",
+      httpOnly: false, // readable by client-side analytics if ever needed
+    });
+  }
+
+  return response;
 }
 
 export const config = {
-  matcher: ["/"],
+  // Funnel-relevant public paths. Cookie persists once set, so the entry
+  // points just need to guarantee it's installed at first contact.
+  matcher: ["/", "/register", "/login", "/shifts/:path*"],
 };


### PR DESCRIPTION
## Summary

- Adds a new **civic-dashboard** homepage variant (`HomeDashboard`) alongside the original 3-card layout (`HomeControl`).
- Server-side variant routing in `src/app/page.tsx` reads a long-lived anonymous cookie (`eea_phid`, set by middleware on `/`, `/register`, `/login`, `/shifts/*`) and asks PostHog for the `homepage-redesign` multivariate flag. Falls back to `control` when PostHog is unreachable.
- Instruments a five-step server-side funnel so the experiment can be measured end-to-end:
  - `homepage_viewed` (with `variant` prop) → `register_started` → `register_completed` → `shifts_browsed` → `shift_signup_completed` (conversion).
- On `register_completed`, calls `phAlias({distinctId: user.id, alias: phid})` so PostHog stitches the anonymous → authenticated journey under one identity.
- All existing `data-testid` and required copy preserved on both variants — `home.spec.ts` should pass against either.
- QA override: `?variant=control` or `?variant=dashboard` forces a render without flipping the flag.

## What needs to happen in PostHog before this is "live"

1. Create a multivariate flag, key `homepage-redesign`, variants `control` + `dashboard`, rollout 50/50.
2. Create an experiment linking that flag with `shift_signup_completed` as the goal metric. Add `register_completed` and `shifts_browsed` as funnel steps for a stepwise breakdown.

Until step 1 is done, every visitor receives `control` (the safe fallback), so this PR is no-op for users on merge.

## Test plan

- [ ] `?variant=control` renders the original layout
- [ ] `?variant=dashboard` renders the new dashboard layout
- [ ] `eea_phid` cookie is present after first visit, persists across navigation
- [ ] `npx playwright test home.spec.ts --project=chromium` passes against both variants
- [ ] PostHog Live Events shows `homepage_viewed` with `variant` property
- [ ] Registering a user fires `register_completed` and a subsequent alias (anon → user.id)
- [ ] Signing up for a shift fires `shift_signup_completed` with `signup_status` and `auto_approved` props
- [ ] Authenticated users still redirect to `/dashboard` (volunteer) / `/admin` (admin)
- [ ] Mobile layout: hero image hidden on 375px, dashboard panel hidden but content section still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)