### PR TITLE
fix(web): improve dashboard variant readability and layout

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -44,8 +44,9 @@
   /* Everybody Eats brand-inspired palette */
   --ee-bg: #fffdf7; /* warm off-white */
   --ee-fg: #101418; /* near-black */
-  --ee-primary: #0e3a23; /* brand green */
+  --ee-primary: #0e3a23; /* brand green — used for filled/gradient surfaces */
   --ee-primary-700: #256628; /* darker hover */
+  --ee-primary-text: #0e3a23; /* brand green — used for text/icons; brightens in dark mode */
   --ee-primary-light: #e8f5e8; /* light green tint */
   --ee-accent: #f8fb69; /* brand accent */
   --ee-accent-subtle: #fcfd94; /* lighter accent */
@@ -94,6 +95,7 @@
   --ee-fg: #e5f0e8 !important;
   --ee-primary: #1d5337;
   --ee-primary-700: #3d8b40;
+  --ee-primary-text: #86d99b; /* lighter green so accents stay readable on dark bg */
   --ee-primary-light: #1a2f1a;
   --ee-accent: #3a3b2a; /* Much darker olive for dark mode */
   --ee-accent-subtle: #2a2b20; /* Very subtle for dark mode backgrounds */

--- a/web/src/components/home-dashboard.tsx
+++ b/web/src/components/home-dashboard.tsx
@@ -45,7 +45,7 @@ export async function HomeDashboard() {
         <div className="grid gap-10 md:grid-cols-12 md:items-stretch">
           {/* Left: headline + CTAs */}
           <HeroContent className="md:col-span-7">
-            <div className="mono-label mb-5 inline-flex items-center gap-2 text-[var(--ee-primary)]">
+            <div className="mono-label mb-5 inline-flex items-center gap-2 text-[var(--ee-primary-text)]">
               <span>01 / Volunteer Portal</span>
               <span aria-hidden>—</span>
               <span>Everybody Eats Aotearoa</span>
@@ -171,7 +171,7 @@ export async function HomeDashboard() {
                         <span
                           className={`h-2 w-2 rounded-full ${
                             loc.openShifts > 0
-                              ? "bg-[var(--ee-primary)]"
+                              ? "bg-[var(--ee-primary-text)]"
                               : "bg-current/20"
                           }`}
                           aria-hidden
@@ -212,7 +212,7 @@ export async function HomeDashboard() {
       <section className="section-content py-16">
         <div className="mb-8 flex items-end justify-between gap-4">
           <div>
-            <div className="mono-label text-[var(--ee-primary)]">
+            <div className="mono-label text-[var(--ee-primary-text)]">
               02 / Right now
             </div>
             <h2 className="mt-2 text-3xl font-semibold tracking-tight md:text-4xl">
@@ -221,13 +221,13 @@ export async function HomeDashboard() {
           </div>
           <Link
             href="/shifts"
-            className="mono-label hidden items-center gap-1 text-[var(--ee-primary)] hover:underline md:inline-flex"
+            className="mono-label hidden items-center gap-1 text-[var(--ee-primary-text)] hover:underline md:inline-flex"
           >
             See all shifts →
           </Link>
         </div>
 
-        <div className="grid gap-6 md:grid-cols-12">
+        <div className="grid gap-6 md:grid-cols-12 md:items-start">
           <div className="dash-panel md:col-span-7">
             <div className="flex items-center justify-between border-b border-current/15 px-5 py-3">
               <div className="mono-label flex items-center gap-2">
@@ -254,15 +254,15 @@ export async function HomeDashboard() {
             <div className="border-t border-current/15 px-5 py-3 text-center">
               <Link
                 href="/shifts"
-                className="mono-label text-[var(--ee-primary)] hover:underline"
+                className="mono-label text-[var(--ee-primary-text)] hover:underline"
               >
                 Browse all shifts →
               </Link>
             </div>
           </div>
 
-          <div className="dash-panel md:col-span-5">
-            <div className="flex items-center justify-between border-b border-current/15 px-5 py-3">
+          <div className="dash-panel flex flex-col md:col-span-5">
+            <div className="flex shrink-0 items-center justify-between border-b border-current/15 px-5 py-3">
               <div className="mono-label flex items-center gap-2">
                 <span className="live-dot" aria-hidden />
                 Recent signups
@@ -272,17 +272,19 @@ export async function HomeDashboard() {
               </div>
             </div>
             {stats.recentActivity.length === 0 ? (
-              <div className="px-5 py-12 text-center text-sm text-muted-foreground">
+              <div className="flex flex-1 items-center justify-center px-5 py-12 text-center text-sm text-muted-foreground">
                 Be the first to sign up this week.
               </div>
             ) : (
-              <StaggerGroup>
-                <ul className="divide-y divide-current/10">
-                  {stats.recentActivity.map((item) => (
-                    <ActivityRow key={item.id} item={item} />
-                  ))}
-                </ul>
-              </StaggerGroup>
+              <div className="scrollbar-hide max-h-[640px] overflow-y-auto">
+                <StaggerGroup>
+                  <ul className="divide-y divide-current/10">
+                    {stats.recentActivity.map((item) => (
+                      <ActivityRow key={item.id} item={item} />
+                    ))}
+                  </ul>
+                </StaggerGroup>
+              </div>
             )}
           </div>
         </div>
@@ -304,7 +306,7 @@ export async function HomeDashboard() {
                   className="inline-flex items-center gap-3"
                 >
                   <span>{label}</span>
-                  <span aria-hidden className="text-[var(--ee-primary)]">
+                  <span aria-hidden className="text-[var(--ee-primary-text)]">
                     ✦
                   </span>
                 </span>
@@ -317,7 +319,7 @@ export async function HomeDashboard() {
       {/* ───────── HOW IT WORKS / FEATURE CARDS (preserved testids) ───────── */}
       <section className="section-content py-16" data-testid="features-section">
         <div className="mb-10">
-          <div className="mono-label text-[var(--ee-primary)]">
+          <div className="mono-label text-[var(--ee-primary-text)]">
             03 / How volunteering works
           </div>
           <h2 className="mt-2 text-3xl font-semibold tracking-tight md:text-4xl">
@@ -332,7 +334,7 @@ export async function HomeDashboard() {
             delay={0.05}
             data-testid="feature-community-impact"
           >
-            <div className="mono-label flex items-center justify-between text-[var(--ee-primary)]">
+            <div className="mono-label flex items-center justify-between text-[var(--ee-primary-text)]">
               <span>01 — Tāngata</span>
               <span className="opacity-50">People</span>
             </div>
@@ -358,7 +360,7 @@ export async function HomeDashboard() {
             delay={0.12}
             data-testid="feature-flexible-scheduling"
           >
-            <div className="mono-label flex items-center justify-between text-[var(--ee-primary)]">
+            <div className="mono-label flex items-center justify-between text-[var(--ee-primary-text)]">
               <span>02 — Wā</span>
               <span className="opacity-50">Time</span>
             </div>
@@ -384,7 +386,7 @@ export async function HomeDashboard() {
             delay={0.19}
             data-testid="feature-meaningful-work"
           >
-            <div className="mono-label flex items-center justify-between text-[var(--ee-primary)]">
+            <div className="mono-label flex items-center justify-between text-[var(--ee-primary-text)]">
               <span>03 — Kai</span>
               <span className="opacity-50">Food</span>
             </div>
@@ -443,7 +445,7 @@ export async function HomeDashboard() {
                 <Button
                   asChild
                   size="lg"
-                  className="bg-[var(--ee-accent)] text-[#0e3a23] hover:bg-[var(--ee-accent-subtle)]"
+                  className="bg-[#f8fb69] font-semibold text-[#0e3a23] shadow-sm hover:bg-[#fcfd94]"
                   data-testid="final-get-started-button"
                 >
                   <Link href="/register">Get Started</Link>
@@ -505,7 +507,7 @@ function ShiftRow({ shift }: { shift: UpcomingShift }) {
           className="grid grid-cols-[1fr_auto] items-center gap-3 px-5 py-4 transition-colors hover:bg-current/[0.03] md:grid-cols-[1fr_180px_auto]"
         >
           <div className="min-w-0">
-            <div className="mono-label tnum text-[var(--ee-primary)]">
+            <div className="mono-label tnum text-[var(--ee-primary-text)]">
               {day} · {startTime}–{endTime}
             </div>
             <div className="mt-1 truncate text-base font-semibold">
@@ -528,7 +530,7 @@ function ShiftRow({ shift }: { shift: UpcomingShift }) {
           </div>
           <div className="text-right">
             {shift.spotsLeft > 0 ? (
-              <span className="mono-label inline-flex items-center gap-1 rounded-full border border-[var(--ee-primary)]/20 bg-[var(--ee-primary)]/5 px-2.5 py-1 text-[var(--ee-primary)]">
+              <span className="mono-label inline-flex items-center gap-1 rounded-full border border-[var(--ee-primary-text)]/30 bg-[var(--ee-primary-text)]/10 px-2.5 py-1 text-[var(--ee-primary-text)]">
                 <span className="tnum">{shift.spotsLeft}</span> open
               </span>
             ) : (
@@ -547,7 +549,7 @@ function ActivityRow({ item }: { item: RecentActivityItem }) {
   return (
     <StaggerItem>
       <li className="flex items-start gap-3 px-5 py-3.5">
-        <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--ee-primary)]/10 text-sm font-semibold text-[var(--ee-primary)]">
+        <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--ee-primary-text)]/15 text-sm font-semibold text-[var(--ee-primary-text)]">
           {item.firstName.slice(0, 1).toUpperCase()}
         </div>
         <div className="min-w-0 flex-1">

--- a/web/src/lib/home-stats.ts
+++ b/web/src/lib/home-stats.ts
@@ -124,7 +124,7 @@ export async function getHomeStats(): Promise<HomeStats> {
         shift: { start: { gte: now } },
       },
       orderBy: { createdAt: "desc" },
-      take: 6,
+      take: 30,
       include: {
         user: { select: { firstName: true, name: true } },
         shift: {


### PR DESCRIPTION
## Summary

Follow-up to #824 addressing dark-mode legibility and the panel-height mismatch in the dashboard homepage variant.

- **Dark-mode brand text** — introduces a `--ee-primary-text` CSS token that stays `#0e3a23` in light mode but switches to `#86d99b` in dark, so brand-green labels, dot indicators, link arrows, and avatar tints stay readable on the dark background. Sweeps `home-dashboard.tsx` to use it everywhere green is rendered as text or as a small accent.
- **Get Started CTA** — was rendering as dark olive on dark green in dark mode (`var(--ee-accent)` is muted in dark theme). Hardcodes the bright chartreuse since the CTA panel itself stays brand green in both themes.
- **Recent signups** — bumped from 6 to 30, with the panel now scrolling internally (max-height 640px) so it doesn't dwarf the open-shifts column.
- **Layout gap** — removed the implicit grid stretch between the open-shifts and recent-signups panels (`md:items-start`) so neither artificially expands to match the other's height.

## Test plan

- [ ] Toggle dark mode on `/?variant=dashboard` — brand green labels, mono-label headers, "See all shifts →" link, location dots, and activity avatar circles all readable
- [ ] Get Started button in the final CTA is bright chartreuse on dark green in both themes
- [ ] Recent signups panel shows up to 30 items, scrolls internally without cutting rows mid-text
- [ ] Open shifts and recent signups panels end at sensible heights — no stretched empty space below either
- [ ] Light mode visually unchanged from the original dashboard variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)