### PR TITLE
fix(web): gate shift signups on profileCompleted

### DIFF
--- a/mobile/components/shift-signup-sheet.tsx
+++ b/mobile/components/shift-signup-sheet.tsx
@@ -15,6 +15,7 @@ import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { router } from 'expo-router';
 
 import { Colors, Brand, FontFamily } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
@@ -93,6 +94,7 @@ export function ShiftSignupSheet({
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [profileIncomplete, setProfileIncomplete] = useState(false);
 
   const spotsLeft = Math.max(0, shift.capacity - shift.signedUp);
   const date = new Date(shift.start);
@@ -105,6 +107,7 @@ export function ShiftSignupSheet({
       setShowNoteField(false);
       setBackupShiftIds([]);
       setError(null);
+      setProfileIncomplete(false);
       setAutoApproval({ eligible: false, loading: true });
     }
   }, [visible]);
@@ -147,6 +150,7 @@ export function ShiftSignupSheet({
 
   const handleSubmit = useCallback(async () => {
     setError(null);
+    setProfileIncomplete(false);
     setIsSubmitting(true);
     try {
       const body: Record<string, unknown> = {};
@@ -166,6 +170,8 @@ export function ShiftSignupSheet({
       if (err instanceof ApiError) {
         if (err.status === 400 && err.message === 'Shift is full') {
           setError('This shift just filled up. You can join the waitlist instead.');
+        } else if (err.message === 'Profile incomplete') {
+          setProfileIncomplete(true);
         } else {
           setError(err.message);
         }
@@ -176,6 +182,11 @@ export function ShiftSignupSheet({
       setIsSubmitting(false);
     }
   }, [shift.id, isWaitlist, note, backupShiftIds, onSuccess, onClose]);
+
+  const handleGoToProfile = useCallback(() => {
+    onClose();
+    router.push('/profile/edit');
+  }, [onClose]);
 
   const title = isWaitlist
     ? '📋 Join Waitlist'
@@ -451,6 +462,60 @@ export function ShiftSignupSheet({
                   </Pressable>
                 );
               })}
+            </View>
+          )}
+
+          {/* Profile incomplete — actionable CTA to /profile/edit */}
+          {profileIncomplete && (
+            <View
+              style={[
+                ss.profileIncompleteBox,
+                { backgroundColor: isDark ? 'rgba(239,68,68,0.08)' : '#fef2f2' },
+              ]}>
+              <View style={ss.profileIncompleteHeader}>
+                <Ionicons
+                  name="alert-circle"
+                  size={18}
+                  color={isDark ? '#fca5a5' : '#dc2626'}
+                />
+                <Text
+                  style={[
+                    ss.profileIncompleteTitle,
+                    { color: isDark ? '#fca5a5' : '#dc2626' },
+                  ]}>
+                  Complete your profile to sign up
+                </Text>
+              </View>
+              <Text
+                style={[
+                  ss.profileIncompleteBody,
+                  { color: isDark ? '#fca5a5' : '#dc2626' },
+                ]}>
+                Your profile is missing some required information. Finish
+                filling it in and we&apos;ll get you signed up.
+              </Text>
+              <Pressable
+                onPress={handleGoToProfile}
+                style={({ pressed }) => [
+                  ss.profileIncompleteButton,
+                  {
+                    borderColor: isDark ? '#fca5a5' : '#dc2626',
+                    opacity: pressed ? 0.7 : 1,
+                  },
+                ]}>
+                <Ionicons
+                  name="person-outline"
+                  size={16}
+                  color={isDark ? '#fca5a5' : '#dc2626'}
+                />
+                <Text
+                  style={[
+                    ss.profileIncompleteButtonText,
+                    { color: isDark ? '#fca5a5' : '#dc2626' },
+                  ]}>
+                  Complete Profile
+                </Text>
+              </Pressable>
             </View>
           )}
 
@@ -753,6 +818,40 @@ const ss = StyleSheet.create({
     fontSize: 14,
     fontFamily: FontFamily.medium,
     lineHeight: 20,
+  },
+  profileIncompleteBox: {
+    padding: 14,
+    borderRadius: 12,
+    gap: 10,
+  },
+  profileIncompleteHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  profileIncompleteTitle: {
+    fontSize: 15,
+    fontFamily: FontFamily.semiBold,
+    lineHeight: 20,
+  },
+  profileIncompleteBody: {
+    fontSize: 14,
+    fontFamily: FontFamily.regular,
+    lineHeight: 20,
+  },
+  profileIncompleteButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+  },
+  profileIncompleteButtonText: {
+    fontSize: 14,
+    fontFamily: FontFamily.medium,
   },
 
   // Footer

--- a/web/prisma/migrations/20260429000000_backfill_profile_completed/migration.sql
+++ b/web/prisma/migrations/20260429000000_backfill_profile_completed/migration.sql
@@ -1,0 +1,20 @@
+-- Backfill profileCompleted for users who already meet the requirements.
+--
+-- Until now profileCompleted only flipped to true on migration registrations
+-- or on a subsequent /api/profile update. New email/password signups left it
+-- false even when the registration form supplied every required field. This
+-- caused the onboarding funnel to report more "signed up for a shift" than
+-- "profile complete" because the data didn't reflect reality.
+--
+-- The signup endpoint now gates on profileCompleted, so we backfill existing
+-- users with all required fields to keep them able to sign up.
+UPDATE "User"
+SET "profileCompleted" = true
+WHERE "profileCompleted" = false
+  AND "firstName" IS NOT NULL AND "firstName" <> ''
+  AND "phone" IS NOT NULL AND "phone" <> ''
+  AND "dateOfBirth" IS NOT NULL
+  AND "emergencyContactName" IS NOT NULL AND "emergencyContactName" <> ''
+  AND "emergencyContactPhone" IS NOT NULL AND "emergencyContactPhone" <> ''
+  AND "volunteerAgreementAccepted" = true
+  AND "healthSafetyPolicyAccepted" = true;

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -14,6 +14,7 @@ import {
   getPhidFromCookies,
 } from "@/lib/funnel";
 import { phAlias } from "@/lib/posthog-server";
+import { isProfileComplete } from "@/lib/profile-completion";
 
 /**
  * Validation schema for user registration
@@ -231,6 +232,19 @@ export async function POST(req: Request) {
 
       // Profile image (optional, nullable in DB)
       profilePhotoUrl: validatedData.profilePhotoUrl || null,
+
+      // Whether the registration form supplied every required profile field.
+      // The shift signup endpoint gates on this flag, so set it eagerly here
+      // instead of waiting for the user to revisit /api/profile.
+      profileCompleted: isProfileComplete({
+        firstName: validatedData.firstName,
+        phone: validatedData.phone,
+        dateOfBirth: validatedData.dateOfBirth,
+        emergencyContactName: validatedData.emergencyContactName,
+        emergencyContactPhone: validatedData.emergencyContactPhone,
+        volunteerAgreementAccepted: validatedData.volunteerAgreementAccepted,
+        healthSafetyPolicyAccepted: validatedData.healthSafetyPolicyAccepted,
+      }),
     };
 
     // For migration, update existing user; otherwise create new user

--- a/web/src/app/api/mobile/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/signup/route.ts
@@ -39,6 +39,7 @@ export async function POST(
       id: true,
       email: true,
       emailVerified: true,
+      profileCompleted: true,
       requiresParentalConsent: true,
       parentalConsentReceived: true,
       dateOfBirth: true,
@@ -56,6 +57,18 @@ export async function POST(
         error: "Email verification required",
         message:
           "Please verify your email address before signing up for shifts. Check your inbox for a verification email.",
+      },
+      { status: 403 }
+    );
+  }
+
+  // Mirror the web gate: a complete profile is required before signing up.
+  if (!user.profileCompleted) {
+    return NextResponse.json(
+      {
+        error: "Profile incomplete",
+        message:
+          "Please complete your profile before signing up for shifts. Visit your profile to fill in the remaining required fields.",
       },
       { status: 403 }
     );

--- a/web/src/app/api/profile/route.ts
+++ b/web/src/app/api/profile/route.ts
@@ -9,6 +9,7 @@ import { autoLabelUnder16User } from "@/lib/auto-label-utils";
 import { checkForBot } from "@/lib/bot-protection";
 import { CampaignMonitorService } from "@/lib/services/campaign-monitor";
 import { getEmailService } from "@/lib/email-service";
+import { isProfileComplete } from "@/lib/profile-completion";
 
 const updateProfileSchema = z.object({
   firstName: z.string().optional(),
@@ -352,35 +353,24 @@ export async function PUT(req: Request) {
     // Check if profile is now complete and send welcome email for OAuth users
     // This handles the case where OAuth users (Google/Facebook) bypass email verification
     // and should receive the welcome email after completing their profile
-    if (!user.profileCompleted && updatedUser.firstName) {
-      // Check if profile has all required fields
-      const hasRequiredFields =
-        updatedUser.phone &&
-        updatedUser.dateOfBirth &&
-        updatedUser.emergencyContactName &&
-        updatedUser.emergencyContactPhone &&
-        updatedUser.volunteerAgreementAccepted &&
-        updatedUser.healthSafetyPolicyAccepted;
+    if (!user.profileCompleted && isProfileComplete(updatedUser)) {
+      // Mark profile as completed
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { profileCompleted: true },
+      });
 
-      if (hasRequiredFields) {
-        // Mark profile as completed
-        await prisma.user.update({
-          where: { id: user.id },
-          data: { profileCompleted: true },
+      // Send welcome email
+      try {
+        const emailService = getEmailService();
+        await emailService.sendProfileCompletion({
+          to: updatedUser.email,
+          firstName: updatedUser.firstName,
         });
-
-        // Send welcome email
-        try {
-          const emailService = getEmailService();
-          await emailService.sendProfileCompletion({
-            to: updatedUser.email,
-            firstName: updatedUser.firstName,
-          });
-          console.log(`Profile completion email sent to ${updatedUser.email}`);
-        } catch (emailError) {
-          console.error("Failed to send profile completion email:", emailError);
-          // Don't fail the profile update if email sending fails
-        }
+        console.log(`Profile completion email sent to ${updatedUser.email}`);
+      } catch (emailError) {
+        console.error("Failed to send profile completion email:", emailError);
+        // Don't fail the profile update if email sending fails
       }
     }
 

--- a/web/src/app/api/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/shifts/[id]/signup/route.ts
@@ -45,6 +45,7 @@ export async function POST(
       id: true,
       email: true,
       emailVerified: true,
+      profileCompleted: true,
       requiresParentalConsent: true,
       parentalConsentReceived: true,
       firstName: true,
@@ -63,6 +64,20 @@ export async function POST(
         error: "Email verification required",
         message:
           "Please verify your email address before signing up for shifts. Check your inbox for a verification email.",
+      },
+      { status: 403 }
+    );
+  }
+
+  // A complete profile is required before signing up. Without this gate the
+  // onboarding funnel reports more "signed up" than "profile complete" because
+  // OAuth/legacy users could sign up with missing emergency contact / DOB.
+  if (!user.profileCompleted) {
+    return NextResponse.json(
+      {
+        error: "Profile incomplete",
+        message:
+          "Please complete your profile before signing up for shifts. Visit your profile to fill in the remaining required fields.",
       },
       { status: 403 }
     );

--- a/web/src/components/shift-signup-dialog.tsx
+++ b/web/src/components/shift-signup-dialog.tsx
@@ -23,7 +23,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { calculateAge } from "@/lib/utils";
-import { MessageSquareDot } from "lucide-react";
+import { MessageSquareDot, User } from "lucide-react";
+import Link from "next/link";
 
 interface ShiftSignupDialogProps {
   shift: {
@@ -86,6 +87,7 @@ export function ShiftSignupDialog({
   const [isResendingVerification, setIsResendingVerification] = useState(false);
   const [verificationResent, setVerificationResent] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [profileIncomplete, setProfileIncomplete] = useState(false);
   const [autoApprovalEligible, setAutoApprovalEligible] = useState<{
     eligible: boolean;
     ruleName?: string;
@@ -106,6 +108,7 @@ export function ShiftSignupDialog({
   useEffect(() => {
     if (open) {
       setError(null);
+      setProfileIncomplete(false);
       setSelectedBackupShiftIds([]);
       setShowNoteField(false);
     }
@@ -322,7 +325,12 @@ export function ShiftSignupDialog({
         }
       } else {
         const errorData = await response.json();
-        setError(errorData.error || "Failed to sign up");
+        if (errorData.error === "Profile incomplete") {
+          setProfileIncomplete(true);
+          setError(null);
+        } else {
+          setError(errorData.error || "Failed to sign up");
+        }
       }
     } catch (error) {
       console.error("Signup error:", error);
@@ -592,6 +600,34 @@ export function ShiftSignupDialog({
                 ))}
               </div>
             </div>
+          )}
+
+          {/* Profile Incomplete — actionable CTA to /profile/edit */}
+          {profileIncomplete && (
+            <InfoBox
+              title="Complete your profile to sign up"
+              variant="red"
+              testId="profile-incomplete-warning"
+            >
+              <div className="space-y-3">
+                <p className="text-red-700">
+                  Your profile is missing some required information. Finish
+                  filling it in and we&apos;ll get you signed up.
+                </p>
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  data-testid="complete-profile-button"
+                >
+                  <Link href="/profile/edit">
+                    <User className="h-4 w-4" />
+                    Complete Profile
+                  </Link>
+                </Button>
+              </div>
+            </InfoBox>
           )}
 
           {/* Error Display */}

--- a/web/src/lib/profile-completion.ts
+++ b/web/src/lib/profile-completion.ts
@@ -9,9 +9,48 @@ export interface ProfileCompletionStatus {
   canSignUpForShifts: boolean;
 }
 
+/**
+ * Required fields for a "complete" profile. Source of truth used by
+ * registration (sets the flag at creation), profile updates (flips the flag
+ * when missing fields are filled in), and the shift signup gate.
+ */
+export type ProfileCompletionInput = {
+  firstName?: string | null;
+  phone?: string | null;
+  dateOfBirth?: Date | string | null;
+  emergencyContactName?: string | null;
+  emergencyContactPhone?: string | null;
+  volunteerAgreementAccepted?: boolean | null;
+  healthSafetyPolicyAccepted?: boolean | null;
+};
+
+export type CompletedProfile = {
+  firstName: string;
+  phone: string;
+  dateOfBirth: NonNullable<ProfileCompletionInput["dateOfBirth"]>;
+  emergencyContactName: string;
+  emergencyContactPhone: string;
+  volunteerAgreementAccepted: true;
+  healthSafetyPolicyAccepted: true;
+};
+
+export function isProfileComplete<T extends ProfileCompletionInput>(
+  input: T
+): input is T & CompletedProfile {
+  return Boolean(
+    input.firstName &&
+      input.phone &&
+      input.dateOfBirth &&
+      input.emergencyContactName &&
+      input.emergencyContactPhone &&
+      input.volunteerAgreementAccepted &&
+      input.healthSafetyPolicyAccepted
+  );
+}
+
 export async function checkProfileCompletion(userId: string): Promise<ProfileCompletionStatus> {
   const { prisma } = await import("@/lib/prisma");
-  
+
   try {
     const user = await prisma.user.findUnique({
       where: { id: userId },
@@ -36,7 +75,7 @@ export async function checkProfileCompletion(userId: string): Promise<ProfileCom
     }
 
     const missingFields = [];
-    
+
     if (!user.phone) missingFields.push("Mobile number");
     if (!user.dateOfBirth) missingFields.push("Date of birth");
     if (!user.emergencyContactName) missingFields.push("Emergency contact name");

--- a/web/src/lib/profile-completion.ts
+++ b/web/src/lib/profile-completion.ts
@@ -55,6 +55,7 @@ export async function checkProfileCompletion(userId: string): Promise<ProfileCom
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
+        firstName: true,
         phone: true,
         dateOfBirth: true,
         emergencyContactName: true,
@@ -76,6 +77,7 @@ export async function checkProfileCompletion(userId: string): Promise<ProfileCom
 
     const missingFields = [];
 
+    if (!user.firstName) missingFields.push("First name");
     if (!user.phone) missingFields.push("Mobile number");
     if (!user.dateOfBirth) missingFields.push("Date of birth");
     if (!user.emergencyContactName) missingFields.push("Emergency contact name");
@@ -83,12 +85,12 @@ export async function checkProfileCompletion(userId: string): Promise<ProfileCom
     if (!user.volunteerAgreementAccepted) missingFields.push("Volunteer agreement");
     if (!user.healthSafetyPolicyAccepted) missingFields.push("Health & safety policy");
 
-    const isProfileComplete = missingFields.length === 0;
+    const profileComplete = isProfileComplete(user);
     const needsParentalConsent = user.requiresParentalConsent && !user.parentalConsentReceived;
-    const canSignUpForShifts = isProfileComplete && !needsParentalConsent;
+    const canSignUpForShifts = profileComplete && !needsParentalConsent;
 
     return {
-      isComplete: isProfileComplete,
+      isComplete: profileComplete,
       missingFields,
       needsParentalConsent,
       canSignUpForShifts,


### PR DESCRIPTION
## Summary

The onboarding funnel reported more **\"signed up for a shift\"** than **\"profile complete\"**, which shouldn't be possible. Root cause: `profileCompleted` was only flipped to `true` for migration registrations or after a follow-up `/api/profile` update. New email/password signups left the flag at the schema default of `false` even when the registration form had every required field, so the funnel's \"Profile Complete\" stage understated reality.

This PR fixes the source of the discrepancy and makes a complete profile a hard requirement before signing up:

- Adds a shared `isProfileComplete()` type predicate in `web/src/lib/profile-completion.ts` (single source of truth used by registration, profile updates, and the signup gate).
- Sets `profileCompleted` at user creation in `/api/auth/register` based on the supplied fields.
- Refactors `/api/profile` PUT to use the shared helper (drops a duplicated inline check).
- Gates `/api/shifts/[id]/signup` and `/api/mobile/shifts/[id]/signup` on `profileCompleted` with a `403 \"Profile incomplete\"` response.
- Surfaces an actionable **Complete Profile** CTA in both the web `shift-signup-dialog` and the mobile `shift-signup-sheet` when the API rejects with this error (matches the existing email-verification pattern).
- Adds a backfill migration (`20260429000000_backfill_profile_completed`) that flips the flag to `true` for existing users who already meet all the requirements, so they keep signup access on deploy.

## Test plan
- [ ] Register a fresh email/password account with all required fields → DB row has `profileCompleted = true`
- [ ] Register a fresh email/password account omitting an optional emergency contact → `profileCompleted = false`
- [ ] As an incomplete-profile user, attempt web signup via the dialog → CTA \"Complete Profile\" links to `/profile/edit` (no generic error box)
- [ ] As an incomplete-profile user, attempt mobile signup → sheet shows the same CTA, tapping it closes the sheet and routes to `/profile/edit`
- [ ] Complete the profile, retry signup → succeeds
- [ ] Run the backfill migration locally on a DB containing pre-existing complete users → their `profileCompleted` flips to `true`
- [ ] Verify the onboarding funnel on `/admin/analytics/engagement` no longer shows \"Signed Up for a Shift\" exceeding \"Profile Complete\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)