### PR TITLE
feat(web): clickable bars on recruitment & milestone analytics

### DIFF
--- a/web/src/app/admin/analytics/engagement/recruitment-section.tsx
+++ b/web/src/app/admin/analytics/engagement/recruitment-section.tsx
@@ -32,7 +32,6 @@ import type {
   RecruitmentData,
   RecruitmentFunnelBreakdown,
   RecruitmentSegment,
-  TimeBucketKey,
 } from "@/lib/recruitment-types";
 import { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
 import { RecruitmentUsersDialog } from "../recruitment/recruitment-users-dialog";
@@ -141,17 +140,6 @@ interface ActiveSegment {
   title: string;
   subtitle?: string;
 }
-
-const TIME_BUCKET_LABELS: Record<TimeBucketKey, string> = {
-  sameDay: "Same day",
-  within3Days: "1–3 days",
-  within7Days: "4–7 days",
-  within14Days: "8–14 days",
-  within30Days: "15–30 days",
-  within60Days: "31–60 days",
-  within90Days: "61–90 days",
-  over90Days: "More than 90 days",
-};
 
 export function RecruitmentSection({ data, months, location }: Props) {
   const { resolvedTheme } = useTheme();

--- a/web/src/app/admin/analytics/engagement/recruitment-section.tsx
+++ b/web/src/app/admin/analytics/engagement/recruitment-section.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { motion } from "motion/react";
 import { staggerContainer, staggerItem } from "@/lib/motion";
@@ -30,8 +31,11 @@ import {
 import type {
   RecruitmentData,
   RecruitmentFunnelBreakdown,
+  RecruitmentSegment,
+  TimeBucketKey,
 } from "@/lib/recruitment-types";
 import { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
+import { RecruitmentUsersDialog } from "../recruitment/recruitment-users-dialog";
 
 const Chart = dynamic(() => import("react-apexcharts"), { ssr: false });
 
@@ -132,6 +136,23 @@ function stageValue(
   }
 }
 
+interface ActiveSegment {
+  segment: RecruitmentSegment;
+  title: string;
+  subtitle?: string;
+}
+
+const TIME_BUCKET_LABELS: Record<TimeBucketKey, string> = {
+  sameDay: "Same day",
+  within3Days: "1–3 days",
+  within7Days: "4–7 days",
+  within14Days: "8–14 days",
+  within30Days: "15–30 days",
+  within60Days: "31–60 days",
+  within90Days: "61–90 days",
+  over90Days: "More than 90 days",
+};
+
 export function RecruitmentSection({ data, months, location }: Props) {
   const { resolvedTheme } = useTheme();
   const chartMode = (resolvedTheme === "dark" ? "dark" : "light") as
@@ -141,6 +162,14 @@ export function RecruitmentSection({ data, months, location }: Props) {
   const { funnel, registrationTrend, locations } = data;
   const total = funnel.totalRegistrations;
   const periodLabel = MONTHS_LABELS[months] ?? `${months} months`;
+
+  const [activeSegment, setActiveSegment] = useState<ActiveSegment | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const openSegment = (s: ActiveSegment) => {
+    setActiveSegment(s);
+    setDialogOpen(true);
+  };
 
   const locationColors = locations.map((loc, i) => colorForLocation(loc, i));
 
@@ -381,6 +410,30 @@ export function RecruitmentSection({ data, months, location }: Props) {
                       stacked: true,
                       toolbar: { show: false },
                       background: "transparent",
+                      events: {
+                        dataPointSelection: (_e, _ctx, config) => {
+                          if (!config) return;
+                          const point = registrationTrend[config.dataPointIndex];
+                          if (!point) return;
+                          // When there are no per-location series, clicking still
+                          // resolves to the single combined bar — drill into
+                          // "Unspecified" only if the user has no other location.
+                          const segLoc =
+                            locations.length > 0
+                              ? locations[config.seriesIndex] ??
+                                UNSPECIFIED_LOCATION
+                              : UNSPECIFIED_LOCATION;
+                          openSegment({
+                            segment: {
+                              chart: "trend",
+                              monthKey: point.monthKey,
+                              location: segLoc,
+                            },
+                            title: `New registrations · ${point.month}`,
+                            subtitle: `${segLoc} · grouped by furthest stage reached`,
+                          });
+                        },
+                      },
                     },
                     plotOptions: {
                       bar: {
@@ -388,6 +441,9 @@ export function RecruitmentSection({ data, months, location }: Props) {
                         borderRadiusApplication: "end" as const,
                         columnWidth: "65%",
                       },
+                    },
+                    states: {
+                      active: { filter: { type: "none" } },
                     },
                     xaxis: {
                       categories: registrationTrend.map((t) => t.month),
@@ -558,8 +614,10 @@ export function RecruitmentSection({ data, months, location }: Props) {
                           {segments.map((seg, si) => (
                             <Tooltip key={seg.loc}>
                               <TooltipTrigger asChild>
-                                <motion.div
-                                  className="h-full"
+                                <motion.button
+                                  type="button"
+                                  aria-label={`View ${seg.value.toLocaleString()} ${seg.loc} volunteers at ${stage.name} stage`}
+                                  className="h-full cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 hover:opacity-80 transition-opacity"
                                   style={{ background: seg.color }}
                                   initial={{ width: 0 }}
                                   animate={{ width: `${seg.widthPct}%` }}
@@ -568,12 +626,26 @@ export function RecruitmentSection({ data, months, location }: Props) {
                                     delay: 0.1 + i * 0.12 + si * 0.04,
                                     ease: [0.4, 0, 0.2, 1],
                                   }}
+                                  onClick={() =>
+                                    openSegment({
+                                      segment: {
+                                        chart: "funnel",
+                                        stage: stage.key,
+                                        location: seg.loc,
+                                      },
+                                      title: `${stage.name} · ${seg.loc}`,
+                                      subtitle: `${seg.value.toLocaleString()} volunteers from the last ${periodLabel}, grouped by furthest stage reached`,
+                                    })
+                                  }
                                 />
                               </TooltipTrigger>
                               <TooltipContent side="top">
                                 <span className="font-medium">{seg.loc}</span>:{" "}
                                 {seg.value.toLocaleString()} (
-                                {pct(seg.value, stage.value)}% of stage)
+                                {pct(seg.value, stage.value)}% of stage) ·{" "}
+                                <span className="text-muted-foreground">
+                                  click for list
+                                </span>
                               </TooltipContent>
                             </Tooltip>
                           ))}
@@ -633,6 +705,28 @@ export function RecruitmentSection({ data, months, location }: Props) {
                     stacked: true,
                     toolbar: { show: false },
                     background: "transparent",
+                    events: {
+                      dataPointSelection: (_e, _ctx, config) => {
+                        if (!config) return;
+                        const bucket =
+                          timeToFirstShiftBuckets[config.dataPointIndex];
+                        if (!bucket) return;
+                        const segLoc =
+                          locations.length > 0
+                            ? locations[config.seriesIndex] ??
+                              UNSPECIFIED_LOCATION
+                            : UNSPECIFIED_LOCATION;
+                        openSegment({
+                          segment: {
+                            chart: "timeToFirstShift",
+                            bucket: bucket[1],
+                            location: segLoc,
+                          },
+                          title: `First shift in ${bucket[0]} · ${segLoc}`,
+                          subtitle: `Volunteers from the last ${periodLabel} who completed their first shift in this window`,
+                        });
+                      },
+                    },
                   },
                   plotOptions: {
                     bar: {
@@ -641,6 +735,9 @@ export function RecruitmentSection({ data, months, location }: Props) {
                       borderRadiusApplication: "end" as const,
                       barHeight: "55%",
                     },
+                  },
+                  states: {
+                    active: { filter: { type: "none" } },
                   },
                   xaxis: {
                     categories: timeToFirstShiftBuckets.map(([label]) => label),
@@ -719,6 +816,16 @@ export function RecruitmentSection({ data, months, location }: Props) {
           </Card>
         </motion.div>
       )}
+
+      <RecruitmentUsersDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        segment={activeSegment?.segment ?? null}
+        title={activeSegment?.title ?? ""}
+        subtitle={activeSegment?.subtitle}
+        months={months}
+        locationFilter={location}
+      />
     </motion.div>
   );
 }

--- a/web/src/app/admin/analytics/milestones/milestone-analytics-client.tsx
+++ b/web/src/app/admin/analytics/milestones/milestone-analytics-client.tsx
@@ -44,6 +44,11 @@ import {
 import Link from "next/link";
 import type { MilestoneData } from "@/lib/milestone-analytics";
 import { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
+import {
+  MILESTONE_DISTRIBUTION_BANDS,
+  type MilestoneSegment,
+} from "@/lib/milestone-segment-types";
+import { MilestoneUsersDialog } from "./milestone-users-dialog";
 
 const Chart = dynamic(() => import("react-apexcharts"), { ssr: false });
 
@@ -141,6 +146,12 @@ function MilestoneCard({
   );
 }
 
+interface ActiveMilestoneSegment {
+  segment: MilestoneSegment;
+  title: string;
+  subtitle?: string;
+}
+
 export function MilestoneAnalyticsClient({
   data,
   months: initialMonths,
@@ -155,9 +166,17 @@ export function MilestoneAnalyticsClient({
   const [selectedMilestone, setSelectedMilestone] = useState<number>(100);
   const [recentThresholdFilter, setRecentThresholdFilter] =
     useState<string>("all");
+  const [activeSegment, setActiveSegment] =
+    useState<ActiveMilestoneSegment | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const chartThemeMode = (resolvedTheme === "dark" ? "dark" : "light") as
     | "dark"
     | "light";
+
+  const openSegment = (s: ActiveMilestoneSegment) => {
+    setActiveSegment(s);
+    setDialogOpen(true);
+  };
 
   const handleApplyFilters = () => {
     const params = new URLSearchParams({ months, location });
@@ -354,6 +373,25 @@ export function MilestoneAnalyticsClient({
                         stacked: true,
                         toolbar: { show: false },
                         background: "transparent",
+                        events: {
+                          dataPointSelection: (_e, _ctx, config) => {
+                            if (!config) return;
+                            const m = data.milestoneHits[config.dataPointIndex];
+                            if (!m) return;
+                            const segLoc =
+                              restaurantList[config.seriesIndex] ??
+                              UNSPECIFIED_LOCATION;
+                            openSegment({
+                              segment: {
+                                chart: "milestoneHits",
+                                threshold: m.threshold,
+                                location: segLoc,
+                              },
+                              title: `${m.threshold}-shift milestone hits · ${segLoc}`,
+                              subtitle: `Volunteers whose ${m.threshold}th confirmed shift fell within the last ${periodLabel}`,
+                            });
+                          },
+                        },
                       },
                       plotOptions: {
                         bar: {
@@ -361,6 +399,9 @@ export function MilestoneAnalyticsClient({
                           columnWidth: "55%",
                           borderRadiusApplication: "end" as const,
                         },
+                      },
+                      states: {
+                        active: { filter: { type: "none" } },
                       },
                       xaxis: {
                         categories: hitsCategories.map((c) => `${c} shifts`),
@@ -463,6 +504,30 @@ export function MilestoneAnalyticsClient({
                         stacked: true,
                         toolbar: { show: false },
                         background: "transparent",
+                        events: {
+                          dataPointSelection: (_e, _ctx, config) => {
+                            if (!config) return;
+                            const bucket =
+                              data.distribution[config.dataPointIndex];
+                            const band =
+                              MILESTONE_DISTRIBUTION_BANDS[
+                                config.dataPointIndex
+                              ];
+                            if (!bucket || !band) return;
+                            const segLoc =
+                              restaurantList[config.seriesIndex] ??
+                              UNSPECIFIED_LOCATION;
+                            openSegment({
+                              segment: {
+                                chart: "milestoneDistribution",
+                                band,
+                                location: segLoc,
+                              },
+                              title: `${bucket.label} shifts · ${segLoc}`,
+                              subtitle: `Volunteers currently in the ${bucket.label}-shift band`,
+                            });
+                          },
+                        },
                       },
                       plotOptions: {
                         bar: {
@@ -471,6 +536,9 @@ export function MilestoneAnalyticsClient({
                           borderRadiusApplication: "end" as const,
                           barHeight: "60%",
                         },
+                      },
+                      states: {
+                        active: { filter: { type: "none" } },
                       },
                       xaxis: {
                         categories: distCategories,
@@ -612,6 +680,25 @@ export function MilestoneAnalyticsClient({
                       stacked: true,
                       toolbar: { show: false },
                       background: "transparent",
+                      events: {
+                        dataPointSelection: (_e, _ctx, config) => {
+                          if (!config) return;
+                          const p = data.projections[config.dataPointIndex];
+                          if (!p) return;
+                          const segLoc =
+                            restaurantList[config.seriesIndex] ??
+                            UNSPECIFIED_LOCATION;
+                          openSegment({
+                            segment: {
+                              chart: "milestoneProjections",
+                              threshold: p.threshold,
+                              location: segLoc,
+                            },
+                            title: `Projected to hit ${p.threshold} shifts · ${segLoc}`,
+                            subtitle: `Volunteers on track to cross ${p.threshold} shifts in the next 12 months at their current rate`,
+                          });
+                        },
+                      },
                     },
                     plotOptions: {
                       bar: {
@@ -620,6 +707,9 @@ export function MilestoneAnalyticsClient({
                         borderRadiusApplication: "end" as const,
                         columnWidth: "50%",
                       },
+                    },
+                    states: {
+                      active: { filter: { type: "none" } },
                     },
                     xaxis: {
                       categories: projCategories,
@@ -973,6 +1063,16 @@ export function MilestoneAnalyticsClient({
           </Card>
         </motion.div>
       </motion.div>
+
+      <MilestoneUsersDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        segment={activeSegment?.segment ?? null}
+        title={activeSegment?.title ?? ""}
+        subtitle={activeSegment?.subtitle}
+        months={initialMonths}
+        locationFilter={initialLocation}
+      />
     </div>
   );
 }

--- a/web/src/app/admin/analytics/milestones/milestone-users-dialog.tsx
+++ b/web/src/app/admin/analytics/milestones/milestone-users-dialog.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Loader2, AlertTriangle, Trophy } from "lucide-react";
+import { formatInNZT } from "@/lib/timezone";
+import type {
+  MilestoneSegment,
+  MilestoneSegmentResult,
+  MilestoneSegmentUser,
+} from "@/lib/milestone-segment-types";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  segment: MilestoneSegment | null;
+  title: string;
+  subtitle?: string;
+  months: string;
+  locationFilter: string;
+}
+
+function getDisplayName(u: MilestoneSegmentUser): string {
+  if (u.name) return u.name;
+  if (u.firstName || u.lastName)
+    return `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim();
+  return u.email;
+}
+
+function getInitials(u: MilestoneSegmentUser): string {
+  if (u.name) {
+    return u.name
+      .split(" ")
+      .map((n) => n.charAt(0))
+      .join("")
+      .substring(0, 2)
+      .toUpperCase();
+  }
+  if (u.firstName || u.lastName) {
+    return `${u.firstName?.charAt(0) ?? ""}${u.lastName?.charAt(0) ?? ""}`.toUpperCase();
+  }
+  return u.email.charAt(0).toUpperCase();
+}
+
+function buildSegmentParams(
+  segment: MilestoneSegment,
+  months: string,
+  locationFilter: string
+): URLSearchParams {
+  const p = new URLSearchParams();
+  p.set("chart", segment.chart);
+  p.set("segmentLocation", segment.location);
+  p.set("months", months);
+  if (locationFilter) p.set("location", locationFilter);
+  if (segment.chart === "milestoneDistribution") {
+    p.set("band", segment.band);
+  } else {
+    p.set("threshold", String(segment.threshold));
+  }
+  return p;
+}
+
+export function MilestoneUsersDialog({
+  open,
+  onOpenChange,
+  segment,
+  title,
+  subtitle,
+  months,
+  locationFilter,
+}: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl p-0 gap-0 max-h-[85vh] flex flex-col">
+        {segment && open ? (
+          <DialogBody
+            key={JSON.stringify({ segment, months, locationFilter })}
+            segment={segment}
+            title={title}
+            subtitle={subtitle}
+            months={months}
+            locationFilter={locationFilter}
+          />
+        ) : (
+          <DialogHeader className="px-6 py-4">
+            <DialogTitle>{title || "Volunteers"}</DialogTitle>
+          </DialogHeader>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface BodyProps {
+  segment: MilestoneSegment;
+  title: string;
+  subtitle?: string;
+  months: string;
+  locationFilter: string;
+}
+
+function DialogBody({
+  segment,
+  title,
+  subtitle,
+  months,
+  locationFilter,
+}: BodyProps) {
+  const [data, setData] = useState<MilestoneSegmentResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    const params = buildSegmentParams(segment, months, locationFilter);
+
+    fetch(`/api/admin/analytics/milestones/users?${params}`, {
+      signal: ac.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? "Failed to load volunteers");
+        }
+        return res.json() as Promise<MilestoneSegmentResult>;
+      })
+      .then((result) => {
+        if (ac.signal.aborted) return;
+        setData(result);
+      })
+      .catch((err: Error) => {
+        if (err.name === "AbortError") return;
+        setError(err.message);
+      })
+      .finally(() => {
+        if (ac.signal.aborted) return;
+        setLoading(false);
+      });
+
+    return () => ac.abort();
+  }, [segment, months, locationFilter]);
+
+  return (
+    <>
+      <DialogHeader className="px-6 py-4 border-b">
+        <DialogTitle className="flex items-center gap-2 text-lg">
+          <Trophy className="h-4 w-4 text-amber-500" />
+          {title}
+        </DialogTitle>
+        {subtitle && (
+          <DialogDescription className="text-sm">{subtitle}</DialogDescription>
+        )}
+        {data && (
+          <p className="text-xs text-muted-foreground pt-1 tabular-nums">
+            {data.total.toLocaleString()} volunteer
+            {data.total === 1 ? "" : "s"}
+            {data.total > data.cap && (
+              <span> · showing first {data.cap.toLocaleString()}</span>
+            )}
+          </p>
+        )}
+      </DialogHeader>
+
+      <div className="flex-1 min-h-0">
+        {loading && <DialogLoading />}
+        {!loading && error && <DialogError message={error} />}
+        {!loading && !error && data && data.users.length === 0 && (
+          <DialogEmpty />
+        )}
+        {!loading && !error && data && data.users.length > 0 && (
+          <ScrollArea className="h-[60vh]">
+            <ul className="px-4 py-3">
+              {data.users.map((u) => (
+                <UserRow key={u.id} user={u} segment={segment} />
+              ))}
+            </ul>
+          </ScrollArea>
+        )}
+      </div>
+    </>
+  );
+}
+
+function UserRow({
+  user,
+  segment,
+}: {
+  user: MilestoneSegmentUser;
+  segment: MilestoneSegment;
+}) {
+  const displayName = getDisplayName(user);
+  return (
+    <li>
+      <Link
+        href={`/admin/volunteers/${user.id}`}
+        className="flex items-center gap-3 px-2 py-2 rounded-md hover:bg-slate-50 dark:hover:bg-zinc-900/60 transition-colors group"
+      >
+        <Avatar className="h-8 w-8 shadow-sm">
+          <AvatarImage src={user.profilePhotoUrl ?? ""} alt={displayName} />
+          <AvatarFallback className="bg-gradient-to-br from-amber-500 to-pink-600 text-white text-xs font-semibold">
+            {getInitials(user)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium truncate group-hover:text-foreground">
+            {displayName}
+          </p>
+          <p className="text-xs text-muted-foreground truncate">
+            {user.email}
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <Badge
+            variant="outline"
+            className="text-xs tabular-nums bg-slate-50 dark:bg-zinc-900/40"
+          >
+            {user.totalShifts.toLocaleString()} shifts
+          </Badge>
+
+          {segment.chart === "milestoneHits" && user.achievedAt && (
+            <span className="text-xs text-muted-foreground tabular-nums hidden sm:inline">
+              {formatInNZT(user.achievedAt, "d MMM yyyy")}
+            </span>
+          )}
+
+          {segment.chart === "milestoneProjections" &&
+            user.projectedMonths != null && (
+              <Badge
+                variant={
+                  user.projectedMonths <= 3
+                    ? "default"
+                    : user.projectedMonths <= 6
+                      ? "secondary"
+                      : "outline"
+                }
+                className="text-xs tabular-nums"
+              >
+                ~{user.projectedMonths} mo
+              </Badge>
+            )}
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+function DialogLoading() {
+  return (
+    <div className="px-6 py-6 space-y-4">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading volunteers…
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 px-2 py-2">
+            <Skeleton className="h-8 w-8 rounded-full" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3.5 w-32" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DialogError({ message }: { message: string }) {
+  return (
+    <div className="px-6 py-10 flex flex-col items-center text-center gap-2 text-sm">
+      <AlertTriangle className="h-5 w-5 text-amber-500" />
+      <p className="font-medium">Couldn&rsquo;t load volunteers</p>
+      <p className="text-xs text-muted-foreground max-w-sm">{message}</p>
+    </div>
+  );
+}
+
+function DialogEmpty() {
+  return (
+    <div className="px-6 py-10 flex flex-col items-center text-center gap-2 text-sm">
+      <Trophy className="h-5 w-5 text-muted-foreground" />
+      <p className="font-medium">No volunteers in this segment</p>
+      <p className="text-xs text-muted-foreground">
+        Try adjusting the period or location filter.
+      </p>
+    </div>
+  );
+}

--- a/web/src/app/admin/analytics/recruitment/recruitment-users-dialog.tsx
+++ b/web/src/app/admin/analytics/recruitment/recruitment-users-dialog.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Loader2, AlertTriangle, Users } from "lucide-react";
+import type {
+  FurthestStage,
+  RecruitmentSegment,
+  RecruitmentSegmentResult,
+  RecruitmentSegmentUser,
+} from "@/lib/recruitment-types";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  segment: RecruitmentSegment | null;
+  title: string;
+  subtitle?: string;
+  months: string;
+  locationFilter: string;
+}
+
+interface StageInfo {
+  label: string;
+  description: string;
+  className: string;
+}
+
+const STAGE_INFO: Record<FurthestStage, StageInfo> = {
+  registered: {
+    label: "Stopped at registration",
+    description: "Created an account but didn't complete profile",
+    className:
+      "bg-red-50 dark:bg-red-950/20 text-red-700 dark:text-red-400 border-red-200 dark:border-red-900",
+  },
+  profileComplete: {
+    label: "Stopped at profile complete",
+    description: "Completed profile but no shift signups yet",
+    className:
+      "bg-amber-50 dark:bg-amber-950/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-900",
+  },
+  signedUp: {
+    label: "Signed up — no completed shift",
+    description: "Has a signup but no confirmed shift completed yet",
+    className:
+      "bg-blue-50 dark:bg-blue-950/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-900",
+  },
+  completedShift: {
+    label: "Completed first shift",
+    description: "Reached the end of the funnel",
+    className:
+      "bg-emerald-50 dark:bg-emerald-950/20 text-emerald-700 dark:text-emerald-400 border-emerald-200 dark:border-emerald-900",
+  },
+};
+
+const STAGE_ORDER: FurthestStage[] = [
+  "completedShift",
+  "signedUp",
+  "profileComplete",
+  "registered",
+];
+
+function getDisplayName(u: RecruitmentSegmentUser): string {
+  if (u.name) return u.name;
+  if (u.firstName || u.lastName)
+    return `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim();
+  return u.email;
+}
+
+function getInitials(u: RecruitmentSegmentUser): string {
+  if (u.name) {
+    return u.name
+      .split(" ")
+      .map((n) => n.charAt(0))
+      .join("")
+      .substring(0, 2)
+      .toUpperCase();
+  }
+  if (u.firstName || u.lastName) {
+    return `${u.firstName?.charAt(0) ?? ""}${u.lastName?.charAt(0) ?? ""}`.toUpperCase();
+  }
+  return u.email.charAt(0).toUpperCase();
+}
+
+function buildSegmentParams(
+  segment: RecruitmentSegment,
+  months: string,
+  locationFilter: string
+): URLSearchParams {
+  const p = new URLSearchParams();
+  p.set("chart", segment.chart);
+  p.set("segmentLocation", segment.location);
+  p.set("months", months);
+  if (locationFilter) p.set("location", locationFilter);
+  if (segment.chart === "trend") p.set("monthKey", segment.monthKey);
+  if (segment.chart === "funnel") p.set("stage", segment.stage);
+  if (segment.chart === "timeToFirstShift") p.set("bucket", segment.bucket);
+  return p;
+}
+
+export function RecruitmentUsersDialog({
+  open,
+  onOpenChange,
+  segment,
+  title,
+  subtitle,
+  months,
+  locationFilter,
+}: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl p-0 gap-0 max-h-[85vh] flex flex-col">
+        {segment && open ? (
+          <DialogBody
+            key={JSON.stringify({ segment, months, locationFilter })}
+            segment={segment}
+            title={title}
+            subtitle={subtitle}
+            months={months}
+            locationFilter={locationFilter}
+          />
+        ) : (
+          <DialogHeader className="px-6 py-4">
+            <DialogTitle>{title || "Volunteers"}</DialogTitle>
+          </DialogHeader>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface BodyProps {
+  segment: RecruitmentSegment;
+  title: string;
+  subtitle?: string;
+  months: string;
+  locationFilter: string;
+}
+
+function DialogBody({
+  segment,
+  title,
+  subtitle,
+  months,
+  locationFilter,
+}: BodyProps) {
+  const [data, setData] = useState<RecruitmentSegmentResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    const params = buildSegmentParams(segment, months, locationFilter);
+
+    fetch(`/api/admin/analytics/recruitment/users?${params}`, {
+      signal: ac.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? "Failed to load volunteers");
+        }
+        return res.json() as Promise<RecruitmentSegmentResult>;
+      })
+      .then((result) => {
+        if (ac.signal.aborted) return;
+        setData(result);
+      })
+      .catch((err: Error) => {
+        if (err.name === "AbortError") return;
+        setError(err.message);
+      })
+      .finally(() => {
+        if (ac.signal.aborted) return;
+        setLoading(false);
+      });
+
+    return () => ac.abort();
+  }, [segment, months, locationFilter]);
+
+  const grouped = useMemo(() => {
+    const groups = new Map<FurthestStage, RecruitmentSegmentUser[]>();
+    if (!data) return groups;
+    for (const stage of STAGE_ORDER) groups.set(stage, []);
+    for (const user of data.users) {
+      groups.get(user.furthestStage)?.push(user);
+    }
+    return groups;
+  }, [data]);
+
+  return (
+    <>
+      <DialogHeader className="px-6 py-4 border-b">
+        <DialogTitle className="flex items-center gap-2 text-lg">
+          <Users className="h-4 w-4 text-violet-500" />
+          {title}
+        </DialogTitle>
+        {subtitle && (
+          <DialogDescription className="text-sm">{subtitle}</DialogDescription>
+        )}
+        {data && (
+          <p className="text-xs text-muted-foreground pt-1 tabular-nums">
+            {data.total.toLocaleString()} volunteer
+            {data.total === 1 ? "" : "s"}
+            {data.total > data.cap && (
+              <span> · showing first {data.cap.toLocaleString()}</span>
+            )}
+          </p>
+        )}
+      </DialogHeader>
+
+      <div className="flex-1 min-h-0">
+        {loading && <DialogLoading />}
+        {!loading && error && <DialogError message={error} />}
+        {!loading && !error && data && data.users.length === 0 && (
+          <DialogEmpty />
+        )}
+        {!loading && !error && data && data.users.length > 0 && (
+          <ScrollArea className="h-[60vh]">
+            <div className="px-6 py-4 space-y-6">
+              {STAGE_ORDER.map((stage) => {
+                const users = grouped.get(stage) ?? [];
+                if (users.length === 0) return null;
+                const info = STAGE_INFO[stage];
+                return (
+                  <section key={stage}>
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        <Badge
+                          variant="outline"
+                          className={`${info.className} font-medium`}
+                        >
+                          {info.label}
+                        </Badge>
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                          {users.length.toLocaleString()}
+                        </span>
+                      </div>
+                    </div>
+                    <p className="text-xs text-muted-foreground mb-3 pl-1">
+                      {info.description}
+                    </p>
+                    <ul className="space-y-1">
+                      {users.map((u) => (
+                        <UserRow key={u.id} user={u} />
+                      ))}
+                    </ul>
+                  </section>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        )}
+      </div>
+    </>
+  );
+}
+
+function UserRow({ user }: { user: RecruitmentSegmentUser }) {
+  const displayName = getDisplayName(user);
+  return (
+    <li>
+      <Link
+        href={`/admin/volunteers/${user.id}`}
+        className="flex items-center gap-3 px-2 py-2 rounded-md hover:bg-slate-50 dark:hover:bg-zinc-900/60 transition-colors group"
+      >
+        <Avatar className="h-8 w-8 shadow-sm">
+          <AvatarImage src={user.profilePhotoUrl ?? ""} alt={displayName} />
+          <AvatarFallback className="bg-gradient-to-br from-blue-500 to-purple-600 text-white text-xs font-semibold">
+            {getInitials(user)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium truncate group-hover:text-foreground">
+            {displayName}
+          </p>
+          <p className="text-xs text-muted-foreground truncate">
+            {user.email}
+          </p>
+        </div>
+        {user.daysToFirstShift != null && (
+          <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+            {user.daysToFirstShift === 0
+              ? "same day"
+              : `${user.daysToFirstShift} day${user.daysToFirstShift === 1 ? "" : "s"}`}
+          </span>
+        )}
+      </Link>
+    </li>
+  );
+}
+
+function DialogLoading() {
+  return (
+    <div className="px-6 py-6 space-y-4">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading volunteers…
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 px-2 py-2">
+            <Skeleton className="h-8 w-8 rounded-full" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3.5 w-32" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DialogError({ message }: { message: string }) {
+  return (
+    <div className="px-6 py-10 flex flex-col items-center text-center gap-2 text-sm">
+      <AlertTriangle className="h-5 w-5 text-amber-500" />
+      <p className="font-medium">Couldn&rsquo;t load volunteers</p>
+      <p className="text-xs text-muted-foreground max-w-sm">{message}</p>
+    </div>
+  );
+}
+
+function DialogEmpty() {
+  return (
+    <div className="px-6 py-10 flex flex-col items-center text-center gap-2 text-sm">
+      <Users className="h-5 w-5 text-muted-foreground" />
+      <p className="font-medium">No volunteers in this segment</p>
+      <p className="text-xs text-muted-foreground">
+        Try adjusting the period or location filter.
+      </p>
+    </div>
+  );
+}

--- a/web/src/app/api/admin/analytics/milestones/users/route.ts
+++ b/web/src/app/api/admin/analytics/milestones/users/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { getMilestoneSegmentUsers } from "@/lib/milestone-users";
+import {
+  MILESTONE_DISTRIBUTION_BANDS,
+  type MilestoneDistributionBand,
+  type MilestoneSegment,
+} from "@/lib/milestone-segment-types";
+
+const VALID_THRESHOLDS = new Set([10, 25, 50, 100, 200, 500]);
+const VALID_BANDS = new Set<MilestoneDistributionBand>(
+  MILESTONE_DISTRIBUTION_BANDS
+);
+
+function parseSegment(params: URLSearchParams): MilestoneSegment | null {
+  const chart = params.get("chart");
+  const location = params.get("segmentLocation");
+  if (!location) return null;
+
+  if (chart === "milestoneHits" || chart === "milestoneProjections") {
+    const threshold = parseInt(params.get("threshold") || "", 10);
+    if (!VALID_THRESHOLDS.has(threshold)) return null;
+    return { chart, threshold, location };
+  }
+
+  if (chart === "milestoneDistribution") {
+    const band = params.get("band") as MilestoneDistributionBand | null;
+    if (!band || !VALID_BANDS.has(band)) return null;
+    return { chart, band, location };
+  }
+
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const params = request.nextUrl.searchParams;
+  const segment = parseSegment(params);
+  if (!segment) {
+    return NextResponse.json(
+      { error: "Invalid segment parameters" },
+      { status: 400 }
+    );
+  }
+
+  const monthsRaw = parseInt(params.get("months") || "12", 10);
+  const months =
+    Number.isFinite(monthsRaw) && monthsRaw > 0 && monthsRaw <= 36
+      ? monthsRaw
+      : 12;
+  const locationFilter = params.get("location");
+
+  try {
+    const data = await getMilestoneSegmentUsers({
+      segment,
+      months,
+      locationFilter,
+    });
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error fetching milestone segment users:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch volunteers" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/app/api/admin/analytics/recruitment/users/route.ts
+++ b/web/src/app/api/admin/analytics/recruitment/users/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { getRecruitmentSegmentUsers } from "@/lib/recruitment-users";
+import type {
+  FunnelStageKey,
+  RecruitmentSegment,
+  TimeBucketKey,
+} from "@/lib/recruitment-types";
+
+const FUNNEL_STAGES: ReadonlySet<FunnelStageKey> = new Set([
+  "totalRegistrations",
+  "profileComplete",
+  "signedUp",
+  "completedShift",
+]);
+
+const TIME_BUCKETS: ReadonlySet<TimeBucketKey> = new Set([
+  "sameDay",
+  "within3Days",
+  "within7Days",
+  "within14Days",
+  "within30Days",
+  "within60Days",
+  "within90Days",
+  "over90Days",
+]);
+
+function parseSegment(params: URLSearchParams): RecruitmentSegment | null {
+  const chart = params.get("chart");
+  const location = params.get("segmentLocation");
+  if (!location) return null;
+
+  if (chart === "trend") {
+    const monthKey = params.get("monthKey");
+    if (!monthKey || !/^\d{4}-\d{2}$/.test(monthKey)) return null;
+    return { chart, monthKey, location };
+  }
+
+  if (chart === "funnel") {
+    const stage = params.get("stage");
+    if (!stage || !FUNNEL_STAGES.has(stage as FunnelStageKey)) return null;
+    return { chart, stage: stage as FunnelStageKey, location };
+  }
+
+  if (chart === "timeToFirstShift") {
+    const bucket = params.get("bucket");
+    if (!bucket || !TIME_BUCKETS.has(bucket as TimeBucketKey)) return null;
+    return { chart, bucket: bucket as TimeBucketKey, location };
+  }
+
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const params = request.nextUrl.searchParams;
+  const segment = parseSegment(params);
+  if (!segment) {
+    return NextResponse.json(
+      { error: "Invalid segment parameters" },
+      { status: 400 }
+    );
+  }
+
+  const monthsRaw = parseInt(params.get("months") || "3", 10);
+  const months =
+    Number.isFinite(monthsRaw) && monthsRaw > 0 && monthsRaw <= 24
+      ? monthsRaw
+      : 3;
+  const locationFilter = params.get("location");
+
+  try {
+    const data = await getRecruitmentSegmentUsers({
+      segment,
+      months,
+      locationFilter,
+    });
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error fetching recruitment segment users:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch volunteers" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/lib/milestone-segment-types.ts
+++ b/web/src/lib/milestone-segment-types.ts
@@ -1,0 +1,66 @@
+// Client-safe types for milestone analytics segments. Kept separate from
+// `@/lib/milestone-analytics` so client components can import without pulling
+// Prisma into the bundle.
+
+export const MILESTONE_DISTRIBUTION_BANDS = [
+  "d_1_9",
+  "d_10_24",
+  "d_25_49",
+  "d_50_99",
+  "d_100_199",
+  "d_200_499",
+  "d_500_plus",
+] as const;
+export type MilestoneDistributionBand =
+  (typeof MILESTONE_DISTRIBUTION_BANDS)[number];
+
+export const DISTRIBUTION_BAND_LABEL: Record<MilestoneDistributionBand, string> =
+  {
+    d_1_9: "1–9 shifts",
+    d_10_24: "10–24 shifts",
+    d_25_49: "25–49 shifts",
+    d_50_99: "50–99 shifts",
+    d_100_199: "100–199 shifts",
+    d_200_499: "200–499 shifts",
+    d_500_plus: "500+ shifts",
+  };
+
+export type MilestoneSegment =
+  | {
+      chart: "milestoneHits";
+      threshold: number;
+      location: string;
+    }
+  | {
+      chart: "milestoneDistribution";
+      band: MilestoneDistributionBand;
+      location: string;
+    }
+  | {
+      chart: "milestoneProjections";
+      threshold: number;
+      location: string;
+    };
+
+export interface MilestoneSegmentUser {
+  id: string;
+  email: string;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  profilePhotoUrl: string | null;
+  defaultLocation: string | null;
+  totalShifts: number;
+  /** Average shifts per month over the last 6 months (projections only) */
+  monthlyRate: number | null;
+  /** Months until they hit the threshold at current rate (projections only) */
+  projectedMonths: number | null;
+  /** ISO date the user crossed the threshold (milestoneHits only) */
+  achievedAt: string | null;
+}
+
+export interface MilestoneSegmentResult {
+  users: MilestoneSegmentUser[];
+  total: number;
+  cap: number;
+}

--- a/web/src/lib/milestone-users.ts
+++ b/web/src/lib/milestone-users.ts
@@ -1,0 +1,325 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/client";
+import { nowInNZT } from "@/lib/timezone";
+import { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
+import {
+  type MilestoneDistributionBand,
+  type MilestoneSegment,
+  type MilestoneSegmentResult,
+  type MilestoneSegmentUser,
+} from "@/lib/milestone-segment-types";
+
+const RESULT_CAP = 500;
+const PROJECTION_MONTHS = 12;
+
+interface BaseUserRow {
+  id: string;
+  email: string;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  profilePhotoUrl: string | null;
+  defaultLocation: string | null;
+  totalShifts: number | bigint;
+}
+
+interface HitRow extends BaseUserRow {
+  achievedAt: Date;
+}
+
+interface ProjectionRow extends BaseUserRow {
+  recentShifts: number | bigint;
+}
+
+function defaultLocationMatchSql(loc: string): Prisma.Sql {
+  if (loc === UNSPECIFIED_LOCATION) {
+    return Prisma.sql`(u."defaultLocation" IS NULL OR u."defaultLocation" = '')`;
+  }
+  return Prisma.sql`u."defaultLocation" = ${loc}`;
+}
+
+function availableLocationsFilterSql(filter: string | null): Prisma.Sql {
+  if (!filter || filter === "all") return Prisma.empty;
+  return Prisma.sql`AND u."availableLocations" LIKE ${`%"${filter}"%`}`;
+}
+
+function periodStart(months: number): Date {
+  const nz = nowInNZT();
+  nz.setMonth(nz.getMonth() - months);
+  return new Date(nz.getTime());
+}
+
+function nowDate(): Date {
+  return new Date(nowInNZT().getTime());
+}
+
+function bandRangeSql(band: MilestoneDistributionBand): Prisma.Sql {
+  switch (band) {
+    case "d_1_9":
+      return Prisma.sql`n BETWEEN 1 AND 9`;
+    case "d_10_24":
+      return Prisma.sql`n BETWEEN 10 AND 24`;
+    case "d_25_49":
+      return Prisma.sql`n BETWEEN 25 AND 49`;
+    case "d_50_99":
+      return Prisma.sql`n BETWEEN 50 AND 99`;
+    case "d_100_199":
+      return Prisma.sql`n BETWEEN 100 AND 199`;
+    case "d_200_499":
+      return Prisma.sql`n BETWEEN 200 AND 499`;
+    case "d_500_plus":
+      return Prisma.sql`n >= 500`;
+  }
+}
+
+function baseUser(row: BaseUserRow): Omit<
+  MilestoneSegmentUser,
+  "monthlyRate" | "projectedMonths" | "achievedAt"
+> {
+  return {
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    firstName: row.firstName,
+    lastName: row.lastName,
+    profilePhotoUrl: row.profilePhotoUrl,
+    defaultLocation: row.defaultLocation,
+    totalShifts: Number(row.totalShifts),
+  };
+}
+
+interface Args {
+  segment: MilestoneSegment;
+  months: number;
+  locationFilter: string | null;
+}
+
+export async function getMilestoneSegmentUsers(
+  args: Args
+): Promise<MilestoneSegmentResult> {
+  const { segment, months, locationFilter } = args;
+  const now = nowDate();
+  const start = periodStart(months);
+  const sixMonthsAgo = periodStart(6);
+  const locFilter = availableLocationsFilterSql(locationFilter);
+  const locMatch = defaultLocationMatchSql(segment.location);
+
+  switch (segment.chart) {
+    case "milestoneHits":
+      return getHitUsers(
+        segment.threshold,
+        start,
+        now,
+        locMatch,
+        locFilter
+      );
+    case "milestoneDistribution":
+      return getDistributionUsers(segment.band, now, locMatch, locFilter);
+    case "milestoneProjections":
+      return getProjectionUsers(
+        segment.threshold,
+        sixMonthsAgo,
+        now,
+        locMatch,
+        locFilter
+      );
+  }
+}
+
+async function getHitUsers(
+  threshold: number,
+  periodStartDate: Date,
+  now: Date,
+  locMatch: Prisma.Sql,
+  locFilter: Prisma.Sql
+): Promise<MilestoneSegmentResult> {
+  const cte = Prisma.sql`
+    WITH ranked AS (
+      SELECT
+        sg."userId" AS id,
+        u.email,
+        u.name,
+        u."firstName"        AS "firstName",
+        u."lastName"         AS "lastName",
+        u."profilePhotoUrl"  AS "profilePhotoUrl",
+        u."defaultLocation"  AS "defaultLocation",
+        sh."end" AS shift_end,
+        ROW_NUMBER() OVER (PARTITION BY sg."userId" ORDER BY sh."end") AS rn,
+        COUNT(*) OVER (PARTITION BY sg."userId") AS total_shifts
+      FROM "Signup" sg
+      JOIN "Shift" sh ON sh.id = sg."shiftId"
+      JOIN "User"  u  ON u.id  = sg."userId"
+      WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+        AND sh."end" < ${now}
+        AND u.role = 'VOLUNTEER'::"Role"
+        AND ${locMatch}
+        ${locFilter}
+    ),
+    filtered AS (
+      SELECT
+        id, email, name, "firstName", "lastName", "profilePhotoUrl",
+        "defaultLocation",
+        shift_end AS "achievedAt",
+        total_shifts::int AS "totalShifts"
+      FROM ranked
+      WHERE rn = ${threshold}
+        AND shift_end >= ${periodStartDate}
+        AND shift_end < ${now}
+    )
+  `;
+
+  const [rows, countRows] = await Promise.all([
+    prisma.$queryRaw<HitRow[]>`
+      ${cte}
+      SELECT * FROM filtered
+      ORDER BY "achievedAt" DESC
+      LIMIT ${RESULT_CAP}
+    `,
+    prisma.$queryRaw<Array<{ total: bigint }>>`
+      ${cte}
+      SELECT COUNT(*)::bigint AS total FROM filtered
+    `,
+  ]);
+
+  return {
+    users: rows.map((row) => ({
+      ...baseUser(row),
+      monthlyRate: null,
+      projectedMonths: null,
+      achievedAt: row.achievedAt.toISOString(),
+    })),
+    total: Number(countRows[0]?.total ?? 0),
+    cap: RESULT_CAP,
+  };
+}
+
+async function getDistributionUsers(
+  band: MilestoneDistributionBand,
+  now: Date,
+  locMatch: Prisma.Sql,
+  locFilter: Prisma.Sql
+): Promise<MilestoneSegmentResult> {
+  const range = bandRangeSql(band);
+  const cte = Prisma.sql`
+    WITH user_totals AS (
+      SELECT
+        u.id,
+        u.email,
+        u.name,
+        u."firstName"        AS "firstName",
+        u."lastName"         AS "lastName",
+        u."profilePhotoUrl"  AS "profilePhotoUrl",
+        u."defaultLocation"  AS "defaultLocation",
+        COUNT(sg.id)::int AS n
+      FROM "User" u
+      JOIN "Signup" sg ON sg."userId" = u.id
+      JOIN "Shift"  sh ON sh.id = sg."shiftId"
+      WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+        AND sh."end" < ${now}
+        AND u.role = 'VOLUNTEER'::"Role"
+        AND ${locMatch}
+        ${locFilter}
+      GROUP BY u.id
+    ),
+    filtered AS (
+      SELECT *, n AS "totalShifts"
+      FROM user_totals
+      WHERE ${range}
+    )
+  `;
+
+  const [rows, countRows] = await Promise.all([
+    prisma.$queryRaw<BaseUserRow[]>`
+      ${cte}
+      SELECT * FROM filtered
+      ORDER BY "totalShifts" DESC, name NULLS LAST
+      LIMIT ${RESULT_CAP}
+    `,
+    prisma.$queryRaw<Array<{ total: bigint }>>`
+      ${cte}
+      SELECT COUNT(*)::bigint AS total FROM filtered
+    `,
+  ]);
+
+  return {
+    users: rows.map((row) => ({
+      ...baseUser(row),
+      monthlyRate: null,
+      projectedMonths: null,
+      achievedAt: null,
+    })),
+    total: Number(countRows[0]?.total ?? 0),
+    cap: RESULT_CAP,
+  };
+}
+
+async function getProjectionUsers(
+  threshold: number,
+  sixMonthsAgo: Date,
+  now: Date,
+  locMatch: Prisma.Sql,
+  locFilter: Prisma.Sql
+): Promise<MilestoneSegmentResult> {
+  // Mirror the projection logic in getMilestoneData: rate over last 6 months,
+  // not yet at threshold, projected within 12 months.
+  const cte = Prisma.sql`
+    WITH user_totals AS (
+      SELECT
+        u.id,
+        u.email,
+        u.name,
+        u."firstName"        AS "firstName",
+        u."lastName"         AS "lastName",
+        u."profilePhotoUrl"  AS "profilePhotoUrl",
+        u."defaultLocation"  AS "defaultLocation",
+        COUNT(*)::int AS "totalShifts",
+        COUNT(*) FILTER (WHERE sh."end" >= ${sixMonthsAgo})::int AS "recentShifts"
+      FROM "User" u
+      JOIN "Signup" sg ON sg."userId" = u.id
+      JOIN "Shift"  sh ON sh.id = sg."shiftId"
+      WHERE sg.status = 'CONFIRMED'::"SignupStatus"
+        AND sh."end" < ${now}
+        AND u.role = 'VOLUNTEER'::"Role"
+        AND ${locMatch}
+        ${locFilter}
+      GROUP BY u.id
+    ),
+    filtered AS (
+      SELECT *
+      FROM user_totals
+      WHERE "totalShifts" < ${threshold}
+        AND "recentShifts" > 0
+        AND (${threshold} - "totalShifts")::float / ("recentShifts"::float / 6) <= ${PROJECTION_MONTHS}
+    )
+  `;
+
+  const [rows, countRows] = await Promise.all([
+    prisma.$queryRaw<ProjectionRow[]>`
+      ${cte}
+      SELECT * FROM filtered
+      ORDER BY "totalShifts" DESC, name NULLS LAST
+      LIMIT ${RESULT_CAP}
+    `,
+    prisma.$queryRaw<Array<{ total: bigint }>>`
+      ${cte}
+      SELECT COUNT(*)::bigint AS total FROM filtered
+    `,
+  ]);
+
+  return {
+    users: rows.map((row) => {
+      const monthlyRate = Number(row.recentShifts) / 6;
+      const shiftsNeeded = threshold - Number(row.totalShifts);
+      const projectedMonths =
+        monthlyRate > 0 ? Math.ceil(shiftsNeeded / monthlyRate) : null;
+      return {
+        ...baseUser(row),
+        monthlyRate: Math.round(monthlyRate * 10) / 10,
+        projectedMonths,
+        achievedAt: null,
+      };
+    }),
+    total: Number(countRows[0]?.total ?? 0),
+    cap: RESULT_CAP,
+  };
+}

--- a/web/src/lib/recruitment-types.ts
+++ b/web/src/lib/recruitment-types.ts
@@ -48,10 +48,65 @@ export interface RecruitmentFunnel {
 
 export interface RecruitmentTrendPoint {
   month: string;
+  /** Stable YYYY-MM key in NZ time, used to query users for this bar */
+  monthKey: string;
   /** Total across all locations for this month */
   count: number;
   /** Location name → count for that month */
   byLocation: Record<string, number>;
+}
+
+export type FunnelStageKey =
+  | "totalRegistrations"
+  | "profileComplete"
+  | "signedUp"
+  | "completedShift";
+
+export type TimeBucketKey =
+  | "sameDay"
+  | "within3Days"
+  | "within7Days"
+  | "within14Days"
+  | "within30Days"
+  | "within60Days"
+  | "within90Days"
+  | "over90Days";
+
+export type FurthestStage =
+  | "registered"
+  | "profileComplete"
+  | "signedUp"
+  | "completedShift";
+
+export type RecruitmentSegment =
+  | { chart: "trend"; monthKey: string; location: string }
+  | { chart: "funnel"; stage: FunnelStageKey; location: string }
+  | { chart: "timeToFirstShift"; bucket: TimeBucketKey; location: string };
+
+export interface RecruitmentSegmentUser {
+  id: string;
+  email: string;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  profilePhotoUrl: string | null;
+  defaultLocation: string | null;
+  profileCompleted: boolean;
+  /** ISO string */
+  createdAt: string;
+  /** ISO string, present when the user has completed at least one shift */
+  firstShiftDate: string | null;
+  /** Whole days from registration to first completed shift */
+  daysToFirstShift: number | null;
+  furthestStage: FurthestStage;
+}
+
+export interface RecruitmentSegmentResult {
+  users: RecruitmentSegmentUser[];
+  /** Total before the result cap was applied */
+  total: number;
+  /** Hard cap on returned users */
+  cap: number;
 }
 
 export interface RecruitmentData {

--- a/web/src/lib/recruitment-users.ts
+++ b/web/src/lib/recruitment-users.ts
@@ -1,0 +1,220 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/client";
+import { nowInNZT } from "@/lib/timezone";
+import {
+  UNSPECIFIED_LOCATION,
+  type FunnelStageKey,
+  type FurthestStage,
+  type RecruitmentSegment,
+  type RecruitmentSegmentResult,
+  type RecruitmentSegmentUser,
+  type TimeBucketKey,
+} from "@/lib/recruitment-types";
+
+const RESULT_CAP = 500;
+
+interface RawUserRow {
+  id: string;
+  email: string;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  profilePhotoUrl: string | null;
+  defaultLocation: string | null;
+  profileCompleted: boolean;
+  createdAt: Date;
+  firstShiftDate: Date | null;
+  totalSignups: number | bigint;
+  confirmedShifts: number | bigint;
+}
+
+function deriveFurthestStage(row: RawUserRow): FurthestStage {
+  if (Number(row.confirmedShifts) > 0) return "completedShift";
+  if (Number(row.totalSignups) > 0) return "signedUp";
+  if (row.profileCompleted) return "profileComplete";
+  return "registered";
+}
+
+function toUser(row: RawUserRow): RecruitmentSegmentUser {
+  const days =
+    row.firstShiftDate
+      ? Math.round(
+          (row.firstShiftDate.getTime() - row.createdAt.getTime()) / 86400000
+        )
+      : null;
+  return {
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    firstName: row.firstName,
+    lastName: row.lastName,
+    profilePhotoUrl: row.profilePhotoUrl,
+    defaultLocation: row.defaultLocation,
+    profileCompleted: row.profileCompleted,
+    createdAt: row.createdAt.toISOString(),
+    firstShiftDate: row.firstShiftDate ? row.firstShiftDate.toISOString() : null,
+    daysToFirstShift: days,
+    furthestStage: deriveFurthestStage(row),
+  };
+}
+
+// "Unspecified" segment matches NULL or empty defaultLocation; otherwise exact match.
+function defaultLocationMatchSql(loc: string): Prisma.Sql {
+  if (loc === UNSPECIFIED_LOCATION) {
+    return Prisma.sql`(u."defaultLocation" IS NULL OR u."defaultLocation" = '')`;
+  }
+  return Prisma.sql`u."defaultLocation" = ${loc}`;
+}
+
+// Mirrors the global location filter behaviour of getRecruitmentData (matches
+// the JSON-encoded availableLocations field).
+function availableLocationsFilterSql(filter: string | null): Prisma.Sql {
+  if (!filter || filter === "all") return Prisma.empty;
+  return Prisma.sql`AND u."availableLocations" LIKE ${`%"${filter}"%`}`;
+}
+
+function periodStart(months: number): Date {
+  const nz = nowInNZT();
+  nz.setMonth(nz.getMonth() - months);
+  return new Date(nz.getTime());
+}
+
+function nowDate(): Date {
+  return new Date(nowInNZT().getTime());
+}
+
+interface QueryArgs {
+  segment: RecruitmentSegment;
+  months: number;
+  locationFilter: string | null;
+}
+
+export async function getRecruitmentSegmentUsers(
+  args: QueryArgs
+): Promise<RecruitmentSegmentResult> {
+  const { segment, months, locationFilter } = args;
+  const now = nowDate();
+  const locFilter = availableLocationsFilterSql(locationFilter);
+  const locMatch = defaultLocationMatchSql(segment.location);
+
+  // Per-segment WHERE/HAVING clauses. The user_stats CTE shape is shared.
+  let dateRange: Prisma.Sql;
+  let stageHaving: Prisma.Sql;
+
+  switch (segment.chart) {
+    case "trend":
+      // The trend chart is always 12 months; we filter to the exact NZ month.
+      dateRange = Prisma.sql`
+        AND to_char(
+          date_trunc('month', (u."createdAt" AT TIME ZONE 'UTC') AT TIME ZONE 'Pacific/Auckland'),
+          'YYYY-MM'
+        ) = ${segment.monthKey}
+      `;
+      stageHaving = Prisma.sql`TRUE`;
+      break;
+
+    case "funnel": {
+      const start = periodStart(months);
+      dateRange = Prisma.sql`AND u."createdAt" >= ${start} AND u."createdAt" < ${now}`;
+      stageHaving = funnelStageHaving(segment.stage);
+      break;
+    }
+
+    case "timeToFirstShift": {
+      const start = periodStart(months);
+      dateRange = Prisma.sql`AND u."createdAt" >= ${start} AND u."createdAt" < ${now}`;
+      stageHaving = timeBucketHaving(segment.bucket);
+      break;
+    }
+  }
+
+  const cte = Prisma.sql`
+    WITH user_stats AS (
+      SELECT
+        u.id,
+        u.email,
+        u.name,
+        u."firstName"        AS "firstName",
+        u."lastName"         AS "lastName",
+        u."profilePhotoUrl"  AS "profilePhotoUrl",
+        u."defaultLocation"  AS "defaultLocation",
+        u."profileCompleted" AS "profileCompleted",
+        u."createdAt"        AS "createdAt",
+        COUNT(sg.id)::int AS "totalSignups",
+        COUNT(sg.id) FILTER (
+          WHERE sg.status = 'CONFIRMED'::"SignupStatus" AND sh."end" < ${now}
+        )::int AS "confirmedShifts",
+        MIN(sh."end") FILTER (
+          WHERE sg.status = 'CONFIRMED'::"SignupStatus" AND sh."end" < ${now}
+        ) AS "firstShiftDate"
+      FROM "User" u
+      LEFT JOIN "Signup" sg ON sg."userId" = u.id
+      LEFT JOIN "Shift"  sh ON sh.id = sg."shiftId"
+      WHERE u.role = 'VOLUNTEER'::"Role"
+        AND ${locMatch}
+        ${dateRange}
+        ${locFilter}
+      GROUP BY u.id
+    )
+  `;
+
+  const [rows, countRows] = await Promise.all([
+    prisma.$queryRaw<RawUserRow[]>`
+      ${cte}
+      SELECT *
+      FROM user_stats us
+      WHERE ${stageHaving}
+      ORDER BY us."createdAt" DESC
+      LIMIT ${RESULT_CAP}
+    `,
+    prisma.$queryRaw<Array<{ total: bigint }>>`
+      ${cte}
+      SELECT COUNT(*)::bigint AS total
+      FROM user_stats us
+      WHERE ${stageHaving}
+    `,
+  ]);
+
+  return {
+    users: rows.map(toUser),
+    total: Number(countRows[0]?.total ?? 0),
+    cap: RESULT_CAP,
+  };
+}
+
+function funnelStageHaving(stage: FunnelStageKey): Prisma.Sql {
+  switch (stage) {
+    case "totalRegistrations":
+      return Prisma.sql`TRUE`;
+    case "profileComplete":
+      return Prisma.sql`us."profileCompleted" = TRUE`;
+    case "signedUp":
+      return Prisma.sql`us."totalSignups" > 0`;
+    case "completedShift":
+      return Prisma.sql`us."confirmedShifts" > 0`;
+  }
+}
+
+function timeBucketHaving(bucket: TimeBucketKey): Prisma.Sql {
+  // Only users with a confirmed first shift fall into a bucket.
+  // Day diff matches the boundaries used in getRecruitmentData (lib/recruitment.ts).
+  const dayDiff = Prisma.sql`(EXTRACT(EPOCH FROM (us."firstShiftDate" - us."createdAt")) / 86400.0)`;
+  switch (bucket) {
+    case "sameDay":
+      return Prisma.sql`us."firstShiftDate" IS NOT NULL AND ${dayDiff} < 1`;
+    case "within3Days":
+      return Prisma.sql`us."firstShiftDate" IS NOT NULL AND ${dayDiff} >= 1 AND ${dayDiff} <= 3`;
+    case "within7Days":
+      return Prisma.sql`us."firstShiftDate" IS NOT NULL AND ${dayDiff} > 3 AND ${dayDiff} <= 7`;
+    case "within14Days":
+      return Prisma.sql`us."firstShiftDate" IS NOT NULL AND ${dayDiff} > 7 AND ${dayDiff} <= 14`;
+    case "within30Days":
+      return Prisma.sql`us."firstShiftDate" IS NOT NULL AND ${dayDiff} > 14 AND ${dayDiff} <= 30`;
+    case "within60Days":
+      return Prisma.sql`us."firstShiftDate" IS NOT NULL AND ${dayDiff} > 30 AND ${dayDiff} <= 60`;
+    case "within90Days":
+      return Prisma.sql`us."firstShiftDate" IS NOT NULL AND ${dayDiff} > 60 AND ${dayDiff} <= 90`;
+    case "over90Days":
+      return Prisma.sql`us."firstShiftDate" IS NOT NULL AND ${dayDiff} > 90`;
+  }
+}

--- a/web/src/lib/recruitment.ts
+++ b/web/src/lib/recruitment.ts
@@ -255,6 +255,7 @@ export async function getRecruitmentData(
         month: "short",
         year: "2-digit",
       }),
+      monthKey: key,
       count: bucket?.count ?? 0,
       byLocation: bucket?.byLocation ?? {},
     });


### PR DESCRIPTION
## Summary
- Each segment of every chart on **/admin/analytics/recruitment** and **/admin/analytics/milestones** is now clickable and opens a dialog listing the volunteers behind that segment, with rows linking through to the admin profile.
- For the recruitment funnel, dialog rows are grouped by *furthest stage reached* (registered → profile complete → signed up → completed shift) so admins can see drop-off cohorts at a glance.
- New admin-only endpoints power the dialogs and respect the existing period and location filters: `/api/admin/analytics/recruitment/users` and `/api/admin/analytics/milestones/users`.

## What's wired up
**Recruitment**
- New Registrations over time → users registered in that NZ month for the picked location
- Onboarding Funnel → all users who reached that stage in the period, grouped by furthest stage they later reached
- Time to First Shift Distribution → users whose registration → first shift fell in that bucket

**Milestones**
- Milestones Hit → users whose Nth confirmed shift landed in the period
- Volunteer Distribution → users currently in that shift-count band
- 12-Month Projections → users on track to cross that threshold within 12 months at their current rate

## Test plan
- [ ] Recruitment page: click each segment of all 3 charts and confirm the dialog shows the right cohort and counts
- [ ] Milestones page: click each segment of all 3 charts and confirm the dialog shows the right cohort and counts
- [ ] Filter by location + period and confirm dialog results respect the filters
- [ ] Click "Unspecified" stacks and confirm users with no `defaultLocation` show up
- [ ] Confirm rows link to `/admin/volunteers/[id]`
- [ ] Confirm non-admins get 403 from the new API routes
- [ ] Verify both dark and light themes render the dialog cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)