### PR TITLE
chore(web): tighten admin sidebar grouping

### DIFF
--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -92,7 +92,8 @@ export const adminNavCategories: AdminNavCategory[] = [
         title: "Milestone Analytics",
         href: "/admin/analytics/milestones",
         icon: Award,
-        description: "Shift milestones, volunteer recognition, and 12-month projections",
+        description:
+          "Shift milestones, volunteer recognition, and 12-month projections",
         commandKey: "milestones",
       },
     ],
@@ -171,7 +172,7 @@ export const adminNavCategories: AdminNavCategory[] = [
     ],
   },
   {
-    label: "Restaurant",
+    label: "Restaurants",
     items: [
       {
         title: "Daily Menus",
@@ -313,7 +314,7 @@ export const publicNavItems: AdminNavItem[] = [
     description: "Opens in new tab",
     opensInNewTab: true,
     commandKey: "public-resources",
-  }
+  },
 ];
 
 // Helper function to get icon color for command palette
@@ -351,7 +352,7 @@ export const getIconColor = (
     "Restaurant Managers": "text-orange-600",
 
     // Communications
-    "Announcements": "text-orange-500",
+    Announcements: "text-orange-500",
     "Shortage Notifications": "text-amber-600",
     "Newsletter Lists": "text-cyan-600",
     Surveys: "text-violet-600",

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -55,6 +55,13 @@ export const adminNavCategories: AdminNavCategory[] = [
         description: "Overview and statistics",
         commandKey: "dashboard",
       },
+      {
+        title: "Site Settings",
+        href: "/admin/site-settings",
+        icon: Settings,
+        description: "Configure site-wide settings and URLs",
+        commandKey: "site-settings",
+      },
     ],
   },
   {
@@ -91,7 +98,7 @@ export const adminNavCategories: AdminNavCategory[] = [
     ],
   },
   {
-    label: "Volunteer Management",
+    label: "Volunteers",
     items: [
       {
         title: "All Users",
@@ -138,7 +145,7 @@ export const adminNavCategories: AdminNavCategory[] = [
     ],
   },
   {
-    label: "Shift Management",
+    label: "Shifts",
     items: [
       {
         title: "Create Shift",
@@ -155,13 +162,6 @@ export const adminNavCategories: AdminNavCategory[] = [
         commandKey: "shifts",
       },
       {
-        title: "Shortage Notifications",
-        href: "/admin/notifications",
-        icon: Bell,
-        description: "Send shift shortage alerts",
-        commandKey: "notifications",
-      },
-      {
         title: "Auto-Accept Rules",
         href: "/admin/auto-accept-rules",
         icon: Settings,
@@ -171,7 +171,7 @@ export const adminNavCategories: AdminNavCategory[] = [
     ],
   },
   {
-    label: "Restaurant Management",
+    label: "Restaurant",
     items: [
       {
         title: "Daily Menus",
@@ -197,21 +197,21 @@ export const adminNavCategories: AdminNavCategory[] = [
     ],
   },
   {
-    label: "Resources",
+    label: "Communications",
     items: [
       {
-        title: "Resource Hub",
-        href: "/admin/resources",
-        icon: FileText,
-        description: "Manage volunteer resources",
-        commandKey: "resources",
+        title: "Announcements",
+        href: "/admin/announcements",
+        icon: Megaphone,
+        description: "Send targeted announcements to volunteers",
+        commandKey: "announcements",
       },
       {
-        title: "Site Settings",
-        href: "/admin/site-settings",
-        icon: Settings,
-        description: "Configure site-wide settings and URLs",
-        commandKey: "site-settings",
+        title: "Shortage Notifications",
+        href: "/admin/notifications",
+        icon: Bell,
+        description: "Send shift shortage alerts",
+        commandKey: "notifications",
       },
       {
         title: "Newsletter Lists",
@@ -227,6 +227,18 @@ export const adminNavCategories: AdminNavCategory[] = [
         description: "Create and manage feedback surveys",
         commandKey: "surveys",
       },
+    ],
+  },
+  {
+    label: "Content & AI",
+    items: [
+      {
+        title: "Resource Hub",
+        href: "/admin/resources",
+        icon: FileText,
+        description: "Manage volunteer resources",
+        commandKey: "resources",
+      },
       {
         title: "Chat Guides",
         href: "/admin/chat-guides",
@@ -241,18 +253,6 @@ export const adminNavCategories: AdminNavCategory[] = [
         description: "View volunteer conversations with the AI assistant",
         commandKey: "chat-logs",
       },
-      {
-        title: "Announcements",
-        href: "/admin/announcements",
-        icon: Megaphone,
-        description: "Send targeted announcements to volunteers",
-        commandKey: "announcements",
-      },
-    ],
-  },
-  {
-    label: "Safety",
-    items: [
       {
         title: "Content Moderation",
         href: "/admin/moderation",
@@ -324,39 +324,42 @@ export const getIconColor = (
   const colorMap: Record<string, string> = {
     // Overview
     Dashboard: "text-blue-600",
+    "Site Settings": "text-slate-600",
+
+    // Analytics
     "Restaurant Analytics": "text-purple-600",
     "Volunteer Engagement": "text-emerald-600",
     "Volunteer Recruitment": "text-violet-600",
     "Milestone Analytics": "text-amber-600",
 
-    // Volunteer Management
+    // Volunteers
     "All Users": "text-purple-600",
     "Regular Volunteers": "text-yellow-600",
-    "Restaurant Managers": "text-orange-600",
     "Parental Consent": "text-blue-600",
     "Custom Labels": "text-indigo-600",
     Achievements: "text-amber-600",
     Archiving: "text-rose-600",
-    "Newsletter Lists": "text-cyan-600",
 
-    // Restaurant Management
-    "Daily Menus": "text-orange-600",
-
-    // Shift Management
+    // Shifts
     "Create Shift": "text-green-600",
     "Manage Shifts": "text-green-600",
-    "Restaurant Locations": "text-blue-600",
-    "Shortage Notifications": "text-amber-600",
     "Auto-Accept Rules": "text-gray-600",
 
-    // Resources
+    // Restaurant
+    "Daily Menus": "text-orange-600",
+    "Restaurant Locations": "text-blue-600",
+    "Restaurant Managers": "text-orange-600",
+
+    // Communications
+    "Announcements": "text-orange-500",
+    "Shortage Notifications": "text-amber-600",
+    "Newsletter Lists": "text-cyan-600",
+    Surveys: "text-violet-600",
+
+    // Content & AI
     "Resource Hub": "text-blue-500",
-    "Site Settings": "text-slate-600",
     "Chat Guides": "text-emerald-500",
     "Chat Logs": "text-emerald-600",
-    "Announcements": "text-orange-500",
-
-    // Safety
     "Content Moderation": "text-red-600",
 
     // User Migration

--- a/web/tests/e2e/admin-command-palette.spec.ts
+++ b/web/tests/e2e/admin-command-palette.spec.ts
@@ -99,11 +99,11 @@ test.describe("Admin Command Palette", () => {
       ).toBeVisible();
       await expect(
         page.locator("[cmdk-group-heading]", {
-          hasText: "Volunteer Management",
+          hasText: "Volunteers",
         })
       ).toBeVisible();
       await expect(
-        page.locator("[cmdk-group-heading]", { hasText: "Shift Management" })
+        page.locator("[cmdk-group-heading]", { hasText: "Shifts" })
       ).toBeVisible();
       await expect(
         page.locator("[cmdk-group-heading]", { hasText: "User Migration" })
@@ -155,7 +155,7 @@ test.describe("Admin Command Palette", () => {
 
       await expect(
         commandDialog.locator("[cmdk-group-heading]", {
-          hasText: "Volunteer Management",
+          hasText: "Volunteers",
         })
       ).toBeVisible();
       await expect(commandDialog.getByText("All Users")).toBeVisible();
@@ -163,7 +163,7 @@ test.describe("Admin Command Palette", () => {
 
       await expect(
         commandDialog.locator("[cmdk-group-heading]", {
-          hasText: "Shift Management",
+          hasText: "Shifts",
         })
       ).toBeVisible();
       await expect(commandDialog.getByText("Create Shift")).toBeVisible();
@@ -240,7 +240,7 @@ test.describe("Admin Command Palette", () => {
       ).not.toBeVisible();
       await expect(
         page.locator("[cmdk-group-heading]", {
-          hasText: "Volunteer Management",
+          hasText: "Volunteers",
         })
       ).not.toBeVisible();
     });
@@ -255,7 +255,7 @@ test.describe("Admin Command Palette", () => {
       const commandDialog = page.getByRole("dialog");
       await expect(
         commandDialog.locator("[cmdk-group-heading]", {
-          hasText: "Shift Management",
+          hasText: "Shifts",
         })
       ).toBeVisible();
       await expect(commandDialog.getByText("Create Shift")).toBeVisible();


### PR DESCRIPTION
Re-shuffles the admin sidebar to fix the two pain points: the **Resources** group had become a junk drawer (Resource Hub, Site Settings, Newsletter Lists, Surveys, Chat Guides, Chat Logs, Announcements all under one label), and **Safety** held just one item.

## New grouping

| Group | Items |
|---|---|
| **Overview** | Dashboard, Site Settings *(moved here as a global concern)* |
| **Analytics** | (unchanged) |
| **Volunteers** *(was "Volunteer Management")* | All Users, Regular Volunteers, Parental Consent, Custom Labels, Achievements, Archiving |
| **Shifts** *(was "Shift Management")* | Create Shift, Manage Shifts, Auto-Accept Rules — *Shortage Notifications moved to Communications* |
| **Restaurant** *(was "Restaurant Management")* | Daily Menus, Restaurant Locations, Restaurant Managers |
| **Communications** *(new)* | Announcements, Shortage Notifications, Newsletter Lists, Surveys |
| **Content & AI** *(new, replaces Resources)* | Resource Hub, Chat Guides, Chat Logs, Content Moderation |
| **User Migration** | (unchanged) |

The "X Management" suffix on three groups was redundant — every nav item is something you manage. Shorter labels are easier to scan.

## Other changes
- Drops the singleton "Safety" group; Content Moderation lives with Chat Logs / chat guides under Content & AI since it's broadly about the content & conversations volunteers see.
- Updates the admin command-palette e2e tests for the renamed group headings.

## Test plan
- [ ] `/admin` — sidebar shows the new groups in the order above; click each item, lands on the correct page.
- [ ] Cmd+K command palette — opens, group headings match the new labels, every item navigates correctly.
- [ ] Shortage Notifications (new home: Communications) still works end-to-end.
- [ ] Site Settings (new home: Overview) still works end-to-end.
- [ ] Run `npm run test:e2e -- --grep admin-command-palette --project=chromium`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)