### PR TITLE
feat(web): announcements as push notifications + proper expiry picker

### DIFF
--- a/web/prisma/migrations/20260429110000_add_announcement_notifications/migration.sql
+++ b/web/prisma/migrations/20260429110000_add_announcement_notifications/migration.sql
@@ -1,0 +1,7 @@
+-- AlterEnum: add ANNOUNCEMENT notification type
+ALTER TYPE "NotificationType" ADD VALUE 'ANNOUNCEMENT';
+
+-- AlterTable: add optional in-app notification fields to Announcement
+ALTER TABLE "Announcement"
+  ADD COLUMN "sendNotification" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "notificationSentAt" TIMESTAMP(3);

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -467,6 +467,7 @@ enum NotificationType {
   UNDERAGE_USER_REGISTERED // Underage user registered - notify admins for parental consent
   SURVEY_ASSIGNED // A new survey has been assigned to you
   SHIFT_SHORTAGE // Admin sent shortage alert for shifts that need more volunteers
+  ANNOUNCEMENT // Admin published an announcement targeted at this volunteer
 }
 
 model RestaurantManager {
@@ -987,6 +988,10 @@ model Announcement {
   // Email
   sendEmail   Boolean   @default(false)
   emailSentAt DateTime?
+
+  // In-app notification + push
+  sendNotification   Boolean   @default(false)
+  notificationSentAt DateTime?
 
   author User @relation("AnnouncementAuthor", fields: [createdBy], references: [id])
 

--- a/web/src/app/admin/announcements/announcements-content.tsx
+++ b/web/src/app/admin/announcements/announcements-content.tsx
@@ -19,7 +19,10 @@ import {
   ChevronUp,
   Search,
   Mail,
+  Bell,
   CalendarClock,
+  CalendarIcon,
+  ClockIcon,
   UserPlus2,
   CheckCircle2,
 } from "lucide-react";
@@ -51,6 +54,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { Calendar } from "@/components/ui/calendar";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -77,6 +81,8 @@ type Announcement = {
   targetShiftIds: string[];
   sendEmail: boolean;
   emailSentAt: string | null;
+  sendNotification: boolean;
+  notificationSentAt: string | null;
   author: {
     id: string;
     name: string | null;
@@ -168,6 +174,7 @@ export function AnnouncementsContent({
   const [targetUsers, setTargetUsers] = useState<UserOption[]>([]);
   const [targetShifts, setTargetShifts] = useState<ShiftOption[]>([]);
   const [sendEmail, setSendEmail] = useState(false);
+  const [sendNotification, setSendNotification] = useState(false);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
   const [recipientPreview, setRecipientPreview] = useState<number | null>(null);
   const [isCountingRecipients, setIsCountingRecipients] = useState(false);
@@ -266,6 +273,7 @@ export function AnnouncementsContent({
     setTargetUsers([]);
     setTargetShifts([]);
     setSendEmail(false);
+    setSendNotification(false);
     setPreviewMode(false);
     setRecipientPreview(null);
     // Drop any prefill query string so reopening the form doesn't re-seed
@@ -408,6 +416,7 @@ export function AnnouncementsContent({
           targetUserIds,
           targetShiftIds,
           sendEmail,
+          sendNotification,
         }),
       });
 
@@ -420,9 +429,13 @@ export function AnnouncementsContent({
       setAnnouncements((prev) => [announcement, ...prev]);
       resetForm();
       setShowForm(false);
+      const dispatchedVia = [
+        sendEmail ? "emails" : null,
+        sendNotification ? "push notifications" : null,
+      ].filter(Boolean) as string[];
       toast.success(
-        sendEmail
-          ? "Announcement published — emails are sending in the background"
+        dispatchedVia.length > 0
+          ? `Announcement published — ${dispatchedVia.join(" + ")} sending in the background`
           : "Announcement published"
       );
     } catch (err) {
@@ -643,13 +656,10 @@ export function AnnouncementsContent({
 
               {/* Expiry */}
               <div className="space-y-2">
-                <Label htmlFor="ann-expires">Expiry Date (optional)</Label>
-                <Input
-                  id="ann-expires"
-                  type="datetime-local"
+                <Label>Expiry Date (optional)</Label>
+                <ExpiryDateTimePicker
                   value={expiresAt}
-                  onChange={(e) => setExpiresAt(e.target.value)}
-                  className="w-auto"
+                  onChange={setExpiresAt}
                 />
                 <p className="text-xs text-muted-foreground">
                   If set, the announcement will stop appearing in the feed
@@ -784,8 +794,28 @@ export function AnnouncementsContent({
                 </div>
               </div>
 
-              {/* Email */}
+              {/* Delivery options */}
               <div className="space-y-3 rounded-lg border bg-muted/20 p-4">
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <Checkbox
+                    checked={sendNotification}
+                    onCheckedChange={(checked) =>
+                      setSendNotification(checked === true)
+                    }
+                    className="mt-0.5"
+                  />
+                  <div>
+                    <span className="font-medium text-sm flex items-center gap-2">
+                      <Bell className="w-4 h-4" />
+                      Also send as push notification
+                    </span>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Each matched volunteer gets an in-app notification and
+                      a push to their mobile device. The push body uses a
+                      plain-text preview of the announcement.
+                    </p>
+                  </div>
+                </label>
                 <label className="flex items-start gap-2 cursor-pointer">
                   <Checkbox
                     checked={sendEmail}
@@ -800,9 +830,9 @@ export function AnnouncementsContent({
                       Also send as email
                     </span>
                     <p className="text-xs text-muted-foreground mt-0.5">
-                      Each matched volunteer will receive a transactional
-                      email with this announcement on top of seeing it in
-                      their feed. Sending happens in the background.
+                      Each matched volunteer receives a transactional email
+                      with the full announcement on top of seeing it in
+                      their feed.
                     </p>
                   </div>
                 </label>
@@ -899,6 +929,17 @@ export function AnnouncementsContent({
                                   "d MMM, h:mm a"
                                 )}
                               </span>
+                            )}
+                            {ann.sendNotification && (
+                              <Badge
+                                variant="outline"
+                                className="text-xs py-0 gap-1 border-emerald-300 text-emerald-700"
+                              >
+                                <Bell className="w-3 h-3" />
+                                {ann.notificationSentAt
+                                  ? "Push sent"
+                                  : "Push queued"}
+                              </Badge>
                             )}
                             {ann.sendEmail && (
                               <Badge
@@ -1338,6 +1379,101 @@ function SpecificShiftsPicker({
             </Badge>
           ))}
         </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Expiry Date+Time picker ────────────────────────────────────────────────
+
+/**
+ * Lightweight date+time picker that stores the value as a `datetime-local`
+ * string ("YYYY-MM-DDTHH:mm") so the form submit body stays simple. The
+ * native datetime-local input has frustrating cross-browser styling and no
+ * obvious clear affordance, hence the popover Calendar + time input + Clear
+ * button combo.
+ */
+function ExpiryDateTimePicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const [datePart, timePart] = value
+    ? [value.slice(0, 10), value.slice(11, 16)]
+    : ["", ""];
+  // Parse without UTC conversion: datetime-local strings are already in
+  // local time, so splitting and re-using the parts avoids timezone drift.
+  const dateValue = datePart ? new Date(`${datePart}T00:00:00`) : undefined;
+
+  const setDate = (d: Date | undefined) => {
+    if (!d) {
+      onChange("");
+      return;
+    }
+    const ymd = format(d, "yyyy-MM-dd");
+    onChange(`${ymd}T${timePart || "23:59"}`);
+  };
+
+  const setTime = (t: string) => {
+    if (!datePart) return; // ignore time changes until a date is picked
+    onChange(`${datePart}T${t || "23:59"}`);
+  };
+
+  const display = value
+    ? format(new Date(value), "EEE d MMM yyyy, h:mm a")
+    : "Pick a date and time";
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            className={cn(
+              "h-9 justify-start gap-2 font-normal",
+              !value && "text-muted-foreground"
+            )}
+          >
+            <CalendarIcon className="w-4 h-4" />
+            {display}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="single"
+            selected={dateValue}
+            onSelect={setDate}
+            initialFocus
+          />
+        </PopoverContent>
+      </Popover>
+
+      <div className="relative">
+        <ClockIcon className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+        <Input
+          type="time"
+          value={timePart}
+          onChange={(e) => setTime(e.target.value)}
+          disabled={!datePart}
+          className="pl-8 h-9 w-[130px]"
+          aria-label="Expiry time"
+        />
+      </div>
+
+      {value && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onChange("")}
+          className="gap-1 h-9 text-muted-foreground hover:text-foreground"
+        >
+          <X className="w-3.5 h-3.5" />
+          Clear
+        </Button>
       )}
     </div>
   );

--- a/web/src/app/admin/announcements/page.tsx
+++ b/web/src/app/admin/announcements/page.tsx
@@ -44,6 +44,7 @@ export default async function AnnouncementsPage() {
           createdAt: a.createdAt.toISOString(),
           expiresAt: a.expiresAt?.toISOString() ?? null,
           emailSentAt: a.emailSentAt?.toISOString() ?? null,
+          notificationSentAt: a.notificationSentAt?.toISOString() ?? null,
         }))}
         labels={labels}
         locations={locations.map((l) => l.name)}

--- a/web/src/app/api/admin/announcements/route.ts
+++ b/web/src/app/api/admin/announcements/route.ts
@@ -4,6 +4,7 @@ import { marked } from "marked";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { getEmailService } from "@/lib/email-service";
+import { createNotificationsForUsers } from "@/lib/notifications";
 import { getBaseUrl } from "@/lib/utils";
 import {
   AnnouncementTargeting,
@@ -42,6 +43,7 @@ export async function GET() {
         createdAt: ann.createdAt.toISOString(),
         expiresAt: ann.expiresAt?.toISOString() ?? null,
         emailSentAt: ann.emailSentAt?.toISOString() ?? null,
+        notificationSentAt: ann.notificationSentAt?.toISOString() ?? null,
         recipientCount,
       };
     })
@@ -53,16 +55,17 @@ export async function GET() {
 /**
  * POST /api/admin/announcements
  *
- * Creates a new announcement and (optionally) sends it as an email to all
- * matched volunteers. Email dispatch runs after the response is returned so
- * the request stays snappy on large recipient lists.
+ * Creates a new announcement and (optionally) dispatches it as an email
+ * and/or in-app push notification to all matched volunteers. Both dispatch
+ * paths run fire-and-forget after the response is returned so the request
+ * stays snappy on large recipient lists.
  *
  * Body: {
  *   title, body,
  *   imageUrl?, expiresAt?,
  *   targetLocations?, targetGrades?, targetLabelIds?,
  *   targetUserIds?, targetShiftIds?,
- *   sendEmail?
+ *   sendEmail?, sendNotification?
  * }
  */
 export async function POST(request: Request) {
@@ -95,6 +98,7 @@ export async function POST(request: Request) {
     targetUserIds,
     targetShiftIds,
     sendEmail,
+    sendNotification,
   } = body;
 
   if (!title?.trim()) {
@@ -120,6 +124,7 @@ export async function POST(request: Request) {
       expiresAt: expiresAt ? new Date(expiresAt) : null,
       createdBy: adminUser.id,
       sendEmail: Boolean(sendEmail),
+      sendNotification: Boolean(sendNotification),
       ...targeting,
     },
     include: {
@@ -131,10 +136,15 @@ export async function POST(request: Request) {
 
   const recipientCount = await countAnnouncementRecipients(targeting);
 
-  // Fire-and-forget email dispatch — keeps the admin response snappy.
+  // Fire-and-forget dispatch paths — keep the admin response snappy.
   if (sendEmail) {
     void dispatchAnnouncementEmails(announcement.id).catch((err) => {
       console.error("[announcements] email dispatch failed", err);
+    });
+  }
+  if (sendNotification) {
+    void dispatchAnnouncementNotifications(announcement.id).catch((err) => {
+      console.error("[announcements] notification dispatch failed", err);
     });
   }
 
@@ -144,6 +154,8 @@ export async function POST(request: Request) {
       createdAt: announcement.createdAt.toISOString(),
       expiresAt: announcement.expiresAt?.toISOString() ?? null,
       emailSentAt: announcement.emailSentAt?.toISOString() ?? null,
+      notificationSentAt:
+        announcement.notificationSentAt?.toISOString() ?? null,
       recipientCount,
     },
   });
@@ -195,5 +207,68 @@ async function dispatchAnnouncementEmails(announcementId: string) {
   await prisma.announcement.update({
     where: { id: announcementId },
     data: { emailSentAt: new Date() },
+  });
+}
+
+/**
+ * Strip markdown to a plain-text preview suitable for an OS-level push
+ * notification body (and the in-app inbox message). Drops links, formatting
+ * marks, list bullets, and collapses whitespace.
+ */
+function markdownToPreview(markdown: string, maxLength = 140): string {
+  const stripped = markdown
+    // images: ![alt](url) → alt
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    // links: [text](url) → text
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    // headings, blockquotes, list markers at line start
+    .replace(/^[ \t]*(?:#{1,6}|>|[-*+]|\d+\.)[ \t]+/gm, "")
+    // emphasis marks: **bold**, *italic*, _italic_, `code`
+    .replace(/[*_`]+/g, "")
+    // collapse whitespace
+    .replace(/\s+/g, " ")
+    .trim();
+  return stripped.length > maxLength
+    ? `${stripped.slice(0, maxLength - 1).trimEnd()}…`
+    : stripped;
+}
+
+/**
+ * Create an in-app notification (with push) for every matched volunteer.
+ * Uses createNotificationsForUsers which handles batched DB inserts, SSE
+ * fan-out to connected web sessions, and a single batched Expo push call
+ * with per-user badge counts. Stamps `notificationSentAt` on completion.
+ */
+async function dispatchAnnouncementNotifications(announcementId: string) {
+  const ann = await prisma.announcement.findUnique({
+    where: { id: announcementId },
+  });
+  if (!ann) return;
+
+  const recipients = await findAnnouncementRecipients(
+    targetingFromAnnouncement(ann)
+  );
+  if (recipients.length === 0) {
+    await prisma.announcement.update({
+      where: { id: announcementId },
+      data: { notificationSentAt: new Date() },
+    });
+    return;
+  }
+
+  await createNotificationsForUsers({
+    userIds: recipients.map((r) => r.id),
+    type: "ANNOUNCEMENT",
+    title: ann.title,
+    message: markdownToPreview(ann.body),
+    // Mobile app routes /dashboard to the home tab where announcements
+    // surface in the activity feed; web users land on the same page.
+    actionUrl: "/dashboard",
+    relatedId: ann.id,
+  });
+
+  await prisma.announcement.update({
+    where: { id: announcementId },
+    data: { notificationSentAt: new Date() },
   });
 }


### PR DESCRIPTION
Adds the second-most-requested follow-up to #798: announcements can now be fanned out as **in-app + push notifications** alongside (or instead of) email. Also fixes the expiry-date input which had no Clear button and inconsistent native styling.

## Notifications
- New "Also send as push notification" checkbox on the form, paired with the existing email checkbox.
- When ticked, every matched volunteer gets:
  - An in-app `Notification` row (visible in the bell + inbox).
  - A real Expo push to all their registered mobile devices.
  - Their unread-count badge on the app icon stays in sync.
- Uses the existing `createNotificationsForUsers` helper — batched DB inserts, SSE fan-out for connected web sessions, single batched Expo call with per-user badge counts.
- Push body is a plain-text preview of the markdown (links stripped, lists flattened, capped at 140 chars).
- `actionUrl` is `/dashboard` so taps on web and mobile both land on the activity feed where announcements surface.

## Schema
- `Announcement.sendNotification: Boolean` + `Announcement.notificationSentAt: DateTime?`.
- New `ANNOUNCEMENT` value on `NotificationType`.
- Migration: `20260429110000_add_announcement_notifications`.

## Expiry date picker
- Replaces `<input type="datetime-local">` with a Popover + Calendar + time input combo (matches `shift-date-time-section.tsx` style).
- Pretty display: `Wed 30 Apr 2026, 6:00 pm`.
- Visible Clear button when set.
- Stores the same `YYYY-MM-DDTHH:mm` string under the hood, so the POST body is unchanged.

## Test plan
- [ ] Create an announcement targeted at yourself with "Also send as push notification" ticked. Expect: in-app notification arrives (web bell pulses), Expo push lands on your phone, badge count goes up by 1.
- [ ] Create one with both Email + Push ticked. Both badges (`Push sent`, `Email sent`) appear on the card after dispatch finishes.
- [ ] Tap the push on mobile — opens the app to the home tab where the announcement shows in the feed.
- [ ] Open the form, set an expiry, click Clear → field resets cleanly.
- [ ] Set expiry, submit, reopen form → expiry is empty (unrelated `resetForm` behaviour but worth confirming).
- [ ] Run `npm run prisma:migrate` — migration applies, ANNOUNCEMENT enum value present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)