### PR TITLE
Direct messaging between admins and volunteers

### DIFF
--- a/mobile/app/(tabs)/chat.tsx
+++ b/mobile/app/(tabs)/chat.tsx
@@ -1,40 +1,21 @@
 import { Ionicons } from "@expo/vector-icons";
-import { BlurView } from "expo-blur";
-import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect";
 import * as Haptics from "expo-haptics";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useFocusEffect, useRouter } from "expo-router";
+import React, { useCallback, useEffect, useState } from "react";
 import {
-  Animated,
-  FlatList,
-  Keyboard,
-  LayoutAnimation,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
-  TextInput,
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import MarkdownDisplay from "react-native-markdown-display";
 
 import { Brand, Colors, FontFamily } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
-import { api } from "@/lib/api";
-import { chatWithAssistant } from "@/lib/chat";
+import { fetchTeamThread } from "@/lib/messages";
 
-/* ─── Types ─────────────────────────────────────────────────── */
-
-type Message = {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-};
-
-type Question = { emoji: string; label: string };
+/* ─── Editorial palette ─────────────────────────────────────── */
 
 type PaperTint = {
   paper: string;
@@ -44,26 +25,6 @@ type PaperTint = {
   accent: string;
   eyebrow: string;
 };
-
-/* ─── Data ──────────────────────────────────────────────────── */
-
-const WELCOME_MESSAGE: Message = {
-  id: "welcome",
-  role: "assistant",
-  content:
-    "Kia ora! I'm here to help with anything about volunteering at Everybody Eats. Ask me about what to expect on your first shift, kitchen safety, shift roles, or anything else 🌿",
-};
-
-const DEFAULT_SUGGESTED_QUESTIONS: Question[] = [
-  { emoji: "🍽️", label: "What happens on a typical shift?" },
-  { emoji: "🔪", label: "Kitchen safety tips" },
-  { emoji: "👥", label: "What are the volunteer grades?" },
-  { emoji: "📍", label: "Where are the kitchens?" },
-];
-
-const FLOATING_BAR_HEIGHT = 60;
-
-/* ─── Editorial palette (derived from theme) ────────────────── */
 
 function usePaperTint(
   isDark: boolean,
@@ -79,800 +40,216 @@ function usePaperTint(
   };
 }
 
-/* ─── Animated Typing Dots ──────────────────────────────────── */
+/* ─── Help landing ──────────────────────────────────────────── */
 
-const TypingDots = React.memo(function TypingDots({
-  color,
-}: {
-  color: string;
-}) {
-  const dot1 = useRef(new Animated.Value(0)).current;
-  const dot2 = useRef(new Animated.Value(0)).current;
-  const dot3 = useRef(new Animated.Value(0)).current;
-  const dots = [dot1, dot2, dot3];
-
-  useEffect(() => {
-    const animations = dots.map((dot, i) =>
-      Animated.loop(
-        Animated.sequence([
-          Animated.delay(i * 160),
-          Animated.timing(dot, {
-            toValue: 1,
-            duration: 280,
-            useNativeDriver: true,
-          }),
-          Animated.timing(dot, {
-            toValue: 0,
-            duration: 280,
-            useNativeDriver: true,
-          }),
-          Animated.delay((2 - i) * 160),
-        ])
-      )
-    );
-    animations.forEach((a) => a.start());
-    return () => animations.forEach((a) => a.stop());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  return (
-    <View style={styles.dotsRow}>
-      {dots.map((dot, i) => (
-        <Animated.View
-          key={i}
-          style={[
-            styles.dot,
-            {
-              backgroundColor: color,
-              opacity: dot.interpolate({
-                inputRange: [0, 1],
-                outputRange: [0.3, 1],
-              }),
-              transform: [
-                {
-                  translateY: dot.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [0, -4],
-                  }),
-                },
-              ],
-            },
-          ]}
-        />
-      ))}
-    </View>
-  );
-});
-
-/* ─── Leaf Seal (small warm avatar for chat stream) ─────────── */
-
-const LeafSeal = React.memo(function LeafSeal({
-  size = 24,
-  isDark = false,
-}: {
-  size?: number;
-  isDark?: boolean;
-}) {
-  return (
-    <View
-      style={{
-        width: size,
-        height: size,
-        borderRadius: size / 2,
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: isDark ? Brand.greenDark : Brand.greenLight,
-      }}
-    >
-      <Text style={{ fontSize: size * 0.48 }}>🌿</Text>
-    </View>
-  );
-});
-
-/* ─── Message Bubble ────────────────────────────────────────── */
-
-const MessageBubble = React.memo(function MessageBubble({
-  item,
-  colors,
-  isDark,
-  isFirstInGroup,
-  paperTint,
-}: {
-  item: Message;
-  colors: (typeof Colors)["light"];
-  isDark: boolean;
-  isFirstInGroup: boolean;
-  paperTint: PaperTint;
-}) {
-  const isUser = item.role === "user";
-
-  if (isUser) {
-    return (
-      <View
-        style={[
-          styles.messageRow,
-          styles.userRow,
-          { marginTop: isFirstInGroup ? 18 : 4 },
-        ]}
-      >
-        <View style={[styles.userBubble, { backgroundColor: Brand.green }]}>
-          <Text style={styles.userText}>{item.content}</Text>
-        </View>
-      </View>
-    );
-  }
-
-  return (
-    <View
-      style={[styles.assistantBlock, { marginTop: isFirstInGroup ? 24 : 10 }]}
-    >
-      {isFirstInGroup && (
-        <View style={styles.assistantMeta}>
-          <LeafSeal size={22} isDark={isDark} />
-          <Text
-            style={[styles.assistantMetaLabel, { color: paperTint.eyebrow }]}
-          >
-            EE ASSISTANT
-          </Text>
-        </View>
-      )}
-      <View style={styles.assistantBody}>
-        <MarkdownDisplay
-          style={{
-            body: {
-              color: colors.text,
-              fontFamily: FontFamily.regular,
-              fontSize: 15.5,
-              lineHeight: 24,
-            },
-            strong: { fontFamily: FontFamily.semiBold },
-            em: { fontFamily: FontFamily.regular, fontStyle: "italic" },
-            bullet_list: { marginVertical: 6 },
-            ordered_list: { marginVertical: 6 },
-            list_item: { marginVertical: 2 },
-            link: {
-              color: isDark ? Brand.greenLight : Brand.green,
-              fontFamily: FontFamily.semiBold,
-            },
-            paragraph: { marginTop: 0, marginBottom: 10 },
-            heading1: {
-              fontFamily: FontFamily.headingBold,
-              fontSize: 20,
-              marginBottom: 8,
-              marginTop: 14,
-              color: colors.text,
-              letterSpacing: -0.3,
-            },
-            heading2: {
-              fontFamily: FontFamily.headingBold,
-              fontSize: 17,
-              marginBottom: 6,
-              marginTop: 12,
-              color: colors.text,
-            },
-            heading3: {
-              fontFamily: FontFamily.semiBold,
-              fontSize: 14,
-              textTransform: "uppercase",
-              letterSpacing: 1.2,
-              marginBottom: 4,
-              marginTop: 10,
-              color: paperTint.eyebrow,
-            },
-            blockquote: {
-              borderLeftWidth: 2,
-              borderLeftColor: paperTint.eyebrow,
-              paddingLeft: 12,
-              marginVertical: 8,
-              backgroundColor: "transparent",
-            },
-            code_inline: {
-              backgroundColor: isDark ? "#252830" : "rgba(14,58,35,0.06)",
-              color: colors.text,
-              fontSize: 14,
-              paddingHorizontal: 4,
-              paddingVertical: 1,
-              borderRadius: 4,
-            },
-          }}
-        >
-          {item.content}
-        </MarkdownDisplay>
-      </View>
-    </View>
-  );
-});
-
-/* ─── Welcome Hero — Editorial ─────────────────────────────── */
-
-function WelcomeHero({
-  colors,
-  isDark,
-  onSuggestionPress,
-  questions,
-  paperTint,
-  topInset,
-}: {
-  colors: (typeof Colors)["light"];
-  isDark: boolean;
-  onSuggestionPress: (text: string) => void;
-  questions: Question[];
-  paperTint: PaperTint;
-  topInset: number;
-}) {
-  return (
-    <ScrollView
-      contentContainerStyle={[
-        styles.welcomeContainer,
-        {
-          paddingTop: topInset + 36,
-          paddingBottom: FLOATING_BAR_HEIGHT + 80,
-        },
-      ]}
-      showsVerticalScrollIndicator={false}
-      keyboardShouldPersistTaps="handled"
-    >
-      {/* Eyebrow label */}
-      <Text style={[styles.eyebrow, { color: paperTint.eyebrow }]}>
-        EVERYBODY EATS HELP
-      </Text>
-
-      {/* Hero block */}
-      <View style={styles.heroBlock}>
-        <Text style={styles.heroLine}>
-          <Text style={[styles.hero, { color: paperTint.ink }]}>Kia ora</Text>
-          <Text style={[styles.hero, { color: paperTint.accent }]}>.</Text>
-        </Text>
-        <Text style={[styles.heroSubtitle, { color: paperTint.inkSoft }]}>
-          What would you like to know{"\n"}about volunteering with us?
-        </Text>
-      </View>
-
-      {/* Hairline divider */}
-      <View style={[styles.hairline, { backgroundColor: paperTint.rule }]} />
-
-      {/* Suggestions header */}
-      <Text
-        style={[
-          styles.eyebrow,
-          { color: paperTint.eyebrow, marginTop: 28, marginBottom: 4 },
-        ]}
-      >
-        TRY ASKING
-      </Text>
-
-      {/* Numbered editorial list */}
-      <View style={styles.questionList}>
-        {questions.map((q, i) => (
-          <Pressable
-            key={q.label}
-            onPress={() => {
-              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-              onSuggestionPress(q.label);
-            }}
-            style={({ pressed }) => [
-              styles.questionRow,
-              {
-                borderBottomColor: paperTint.rule,
-                borderBottomWidth: StyleSheet.hairlineWidth,
-                opacity: pressed ? 0.55 : 1,
-              },
-              i === 0 && {
-                borderTopColor: paperTint.rule,
-                borderTopWidth: StyleSheet.hairlineWidth,
-              },
-            ]}
-            accessibilityLabel={q.label}
-            accessibilityRole="button"
-          >
-            <Text style={[styles.questionNumber, { color: paperTint.eyebrow }]}>
-              {String(i + 1).padStart(2, "0")}
-            </Text>
-            <Text
-              style={[styles.questionLabel, { color: colors.text }]}
-              numberOfLines={2}
-            >
-              {q.label}
-            </Text>
-            <Ionicons
-              name="arrow-forward"
-              size={16}
-              color={paperTint.eyebrow}
-              style={styles.questionArrow}
-            />
-          </Pressable>
-        ))}
-      </View>
-
-      {/* Footer colophon */}
-      <View style={styles.welcomeFooter}>
-        <View
-          style={[
-            styles.hairline,
-            { backgroundColor: paperTint.rule, marginBottom: 14 },
-          ]}
-        />
-        <Text style={[styles.eyebrowCentered, { color: colors.textSecondary }]}>
-          NGĀ MIHI · POWERED BY THE RESOURCE HUB
-        </Text>
-      </View>
-    </ScrollView>
-  );
-}
-
-/* ─── Main Screen ───────────────────────────────────────────── */
-
-export default function ChatScreen() {
+export default function HelpScreen() {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme];
   const isDark = colorScheme === "dark";
   const insets = useSafeAreaInsets();
   const paperTint = usePaperTint(isDark, colors);
+  const router = useRouter();
 
-  const [messages, setMessages] = useState<Message[]>([WELCOME_MESSAGE]);
-  const [input, setInput] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [suggestedQuestions, setSuggestedQuestions] = useState<Question[]>(
-    DEFAULT_SUGGESTED_QUESTIONS
-  );
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
-  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
-  const [composerHeight, setComposerHeight] = useState(FLOATING_BAR_HEIGHT);
-  const flatListRef = useRef<FlatList>(null);
-  const inputRef = useRef<TextInput>(null);
-  const pendingScrollIndexRef = useRef<number | null>(null);
-  const scrollMetricsRef = useRef({
-    offset: 0,
-    contentHeight: 0,
-    layoutHeight: 0,
-  });
+  const [unread, setUnread] = useState(false);
+  const [hoursLabel, setHoursLabel] = useState<string | null>(null);
+  const [openNow, setOpenNow] = useState<boolean | null>(null);
 
-  const showWelcome = messages.length <= 1;
-  const keyboardVisible = keyboardHeight > 0;
+  const loadStatus = useCallback(async () => {
+    try {
+      const data = await fetchTeamThread();
+      setUnread(data.thread.unread);
+      if (data.hours) {
+        setOpenNow(data.hours.isOpenNow);
+        if (data.hours.isOpenNow) {
+          setHoursLabel("Team is online · usually replies quickly");
+        } else if (data.hours.nextOpenLabel) {
+          setHoursLabel(data.hours.nextOpenLabel);
+        } else {
+          setHoursLabel(null);
+        }
+      } else {
+        setOpenNow(null);
+        setHoursLabel(null);
+      }
+    } catch {
+      // Quiet failure — landing screen still functions without status data.
+    }
+  }, []);
 
-  /* ── Keyboard tracking with smooth LayoutAnimation ── */
   useEffect(() => {
-    const showSub = Keyboard.addListener(
-      Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow",
-      (e) => {
-        if (Platform.OS === "ios") {
-          LayoutAnimation.configureNext({
-            duration: e.duration,
-            update: { type: LayoutAnimation.Types.keyboard },
-          });
-        }
-        setKeyboardHeight(e.endCoordinates.height);
-      }
-    );
-    const hideSub = Keyboard.addListener(
-      Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide",
-      (e) => {
-        if (Platform.OS === "ios" && e?.duration) {
-          LayoutAnimation.configureNext({
-            duration: e.duration,
-            update: { type: LayoutAnimation.Types.keyboard },
-          });
-        }
-        setKeyboardHeight(0);
-      }
-    );
-    return () => {
-      showSub.remove();
-      hideSub.remove();
-    };
-  }, []);
+    void loadStatus();
+  }, [loadStatus]);
 
-  /* ── Fetch suggested questions from API ── */
-  useEffect(() => {
-    api<{ suggestedQuestions: Question[] }>("/api/mobile/chat/config")
-      .then((data) => {
-        if (data.suggestedQuestions?.length > 0) {
-          setSuggestedQuestions(data.suggestedQuestions);
-        }
-      })
-      .catch(() => {
-        // Keep defaults on error
-      });
-  }, []);
-
-  /* ── Reset ── */
-  const resetChat = useCallback(() => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-    setMessages([WELCOME_MESSAGE]);
-    setInput("");
-    setIsLoading(false);
-    setShowScrollToBottom(false);
-    pendingScrollIndexRef.current = null;
-  }, []);
-
-  /* ── Send ── */
-  const sendMessage = useCallback(
-    async (text?: string) => {
-      const content = (text ?? input).trim();
-      if (!content || isLoading) return;
-
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-
-      const userMessage: Message = {
-        id: Date.now().toString(),
-        role: "user",
-        content,
-      };
-
-      setInput("");
-      setIsLoading(true);
-
-      const assistantId = (Date.now() + 1).toString();
-      const allMessages = [...messages, userMessage]
-        .filter((m) => m.id !== "welcome")
-        .map((m) => ({ role: m.role, content: m.content }));
-      pendingScrollIndexRef.current = messages.length;
-      setMessages((prev) => [...prev, userMessage]);
-
-      try {
-        await chatWithAssistant(allMessages, {
-          onStart: () => {
-            setIsLoading(false);
-            setMessages((prev) => [
-              ...prev,
-              { id: assistantId, role: "assistant", content: "" },
-            ]);
-          },
-          onToken: (token: string) => {
-            setMessages((prev) =>
-              prev.map((m) =>
-                m.id === assistantId ? { ...m, content: m.content + token } : m
-              )
-            );
-          },
-          onFinish: () => {
-            setIsLoading(false);
-          },
-          onError: (error: string) => {
-            setMessages((prev) =>
-              prev.map((m) =>
-                m.id === assistantId
-                  ? {
-                      ...m,
-                      content:
-                        "Sorry, I had trouble responding. Please try again — or contact the team directly if you need help right away 🌿",
-                    }
-                  : m
-              )
-            );
-            setIsLoading(false);
-            console.error("Chat error:", error);
-          },
-        });
-      } catch {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: assistantId,
-            role: "assistant" as const,
-            content:
-              "Sorry, I couldn't connect right now. Please check your connection and try again 🌿",
-          },
-        ]);
-        setIsLoading(false);
-      }
-    },
-    [input, isLoading, messages]
+  // Refresh on focus so the unread dot clears after the thread is read.
+  useFocusEffect(
+    useCallback(() => {
+      void loadStatus();
+    }, [loadStatus])
   );
 
-  /* ── Floating bar vertical position ── */
-  const floatingBottom = keyboardVisible
-    ? keyboardHeight + 8
-    : insets.bottom + 8;
-
-  /* ── Scroll tracking: show button when not at bottom and list is scrollable ── */
-  const updateScrollButton = useCallback(() => {
-    const { offset, contentHeight, layoutHeight } = scrollMetricsRef.current;
-    if (layoutHeight === 0) return;
-    const distanceFromBottom = contentHeight - (offset + layoutHeight);
-    const scrollable = contentHeight > layoutHeight + 20;
-    setShowScrollToBottom(scrollable && distanceFromBottom > 40);
-  }, []);
-
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      scrollMetricsRef.current.offset = e.nativeEvent.contentOffset.y;
-      scrollMetricsRef.current.contentHeight = e.nativeEvent.contentSize.height;
-      scrollMetricsRef.current.layoutHeight =
-        e.nativeEvent.layoutMeasurement.height;
-      updateScrollButton();
-    },
-    [updateScrollButton]
-  );
-
-  const handleContentSizeChange = useCallback(
-    (_w: number, h: number) => {
-      scrollMetricsRef.current.contentHeight = h;
-      // If a send was just triggered, pin the user's message to the top.
-      if (pendingScrollIndexRef.current !== null) {
-        const idx = pendingScrollIndexRef.current;
-        pendingScrollIndexRef.current = null;
-        requestAnimationFrame(() => {
-          flatListRef.current?.scrollToIndex({
-            index: idx,
-            viewPosition: 0,
-            animated: true,
-          });
-        });
-        return;
-      }
-      updateScrollButton();
-    },
-    [updateScrollButton]
-  );
-
-  const scrollToBottom = useCallback(() => {
+  const goToAi = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    // Force-scroll to the exact bottom using tracked metrics (RN's
-    // scrollToEnd can be off when content is still settling).
-    const { contentHeight, layoutHeight } = scrollMetricsRef.current;
-    const target = Math.max(0, contentHeight - layoutHeight);
-    flatListRef.current?.scrollToOffset({ offset: target, animated: true });
-  }, []);
-
-  /* ── Render message with grouping awareness ── */
-  const renderMessage = useCallback(
-    ({ item, index }: { item: Message; index: number }) => {
-      const prev = messages[index - 1];
-      return (
-        <MessageBubble
-          item={item}
-          colors={colors}
-          isDark={isDark}
-          isFirstInGroup={!prev || prev.role !== item.role}
-          paperTint={paperTint}
-        />
-      );
-    },
-    [messages, colors, isDark, paperTint]
-  );
-
-  /* ── Composer state ── */
-  const sendBtnInactive = isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.06)";
-  const hasInput = input.trim().length > 0 && !isLoading;
-  const useNativeGlass = isLiquidGlassAvailable();
-
-  const inputContents = (
-    <>
-      <View style={styles.glassInputField}>
-        <TextInput
-          ref={inputRef}
-          style={[
-            styles.glassInputText,
-            { color: colors.text, fontFamily: FontFamily.regular },
-          ]}
-          value={input}
-          onChangeText={setInput}
-          placeholder="Ask anything about volunteering…"
-          placeholderTextColor={colors.textSecondary}
-          multiline
-          maxLength={1000}
-          onSubmitEditing={() => sendMessage()}
-          returnKeyType="send"
-          editable={!isLoading}
-          accessibilityLabel="Message input"
-        />
-      </View>
-      <Pressable
-        onPress={() => sendMessage()}
-        disabled={!hasInput}
-        style={({ pressed }) => [
-          styles.glassSendBtn,
-          {
-            backgroundColor: hasInput ? Brand.green : sendBtnInactive,
-            transform: [{ scale: pressed && hasInput ? 0.9 : 1 }],
-          },
-        ]}
-        accessibilityLabel="Send message"
-        accessibilityRole="button"
-      >
-        <Ionicons
-          name="arrow-up"
-          size={18}
-          color={hasInput ? "#ffffff" : colors.textSecondary}
-        />
-      </Pressable>
-    </>
-  );
+    router.push("/help/ai");
+  };
+  const goToTeam = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    router.push("/help/team");
+  };
 
   return (
     <View style={[styles.container, { backgroundColor: paperTint.paper }]}>
-      {/* ── Header (only visible once a conversation starts) ── */}
-      {!showWelcome && (
-        <View
-          style={[
-            styles.header,
-            {
-              paddingTop: insets.top + 14,
-              borderBottomColor: paperTint.rule,
-            },
-          ]}
-        >
-          <View style={styles.headerLeft}>
-            <LeafSeal size={22} isDark={isDark} />
-            <Text style={[styles.headerTitle, { color: paperTint.eyebrow }]}>
-              EVERYBODY EATS HELP
-            </Text>
-            <View style={[styles.statusDot, { backgroundColor: "#22c55e" }]} />
-          </View>
-          <Pressable
-            onPress={resetChat}
-            style={({ pressed }) => [
-              styles.newChatBtn,
-              { opacity: pressed ? 0.55 : 1 },
-            ]}
-            accessibilityLabel="Start new conversation"
-            accessibilityRole="button"
-            hitSlop={12}
-          >
-            <Ionicons
-              name="create-outline"
-              size={16}
-              color={paperTint.eyebrow}
-            />
-            <Text style={[styles.newChatLabel, { color: paperTint.eyebrow }]}>
-              NEW
-            </Text>
-          </Pressable>
-        </View>
-      )}
-
-      {/* ── Content area ── */}
-      {showWelcome ? (
-        <WelcomeHero
-          colors={colors}
-          isDark={isDark}
-          onSuggestionPress={sendMessage}
-          questions={suggestedQuestions}
-          paperTint={paperTint}
-          topInset={insets.top}
-        />
-      ) : (
-        <FlatList
-          ref={flatListRef}
-          data={messages}
-          renderItem={renderMessage}
-          keyExtractor={(item) => item.id}
-          contentContainerStyle={[
-            styles.messageList,
-            { paddingBottom: composerHeight + floatingBottom },
-          ]}
-          keyboardShouldPersistTaps="handled"
-          onScroll={handleScroll}
-          scrollEventThrottle={32}
-          onContentSizeChange={handleContentSizeChange}
-          onLayout={(e) => {
-            scrollMetricsRef.current.layoutHeight = e.nativeEvent.layout.height;
-            updateScrollButton();
-          }}
-          onScrollToIndexFailed={(info) => {
-            setTimeout(() => {
-              flatListRef.current?.scrollToIndex({
-                index: Math.min(info.index, info.highestMeasuredFrameIndex),
-                viewPosition: 0,
-                animated: true,
-              });
-            }, 80);
-          }}
-          ListFooterComponent={
-            isLoading ? (
-              <View style={[styles.assistantBlock, { marginTop: 24 }]}>
-                <View style={styles.assistantMeta}>
-                  <LeafSeal size={22} isDark={isDark} />
-                  <Text
-                    style={[
-                      styles.assistantMetaLabel,
-                      { color: paperTint.eyebrow },
-                    ]}
-                  >
-                    EE ASSISTANT
-                  </Text>
-                </View>
-                <View style={[styles.assistantBody, styles.typingBody]}>
-                  <TypingDots color={colors.textSecondary} />
-                </View>
-              </View>
-            ) : null
-          }
-          ListFooterComponentStyle={styles.listFooter}
-        />
-      )}
-
-      {/* ── Floating scroll-to-bottom button ── */}
-      {!showWelcome && showScrollToBottom && (
-        <Pressable
-          onPress={scrollToBottom}
-          style={({ pressed }) => [
-            styles.scrollToBottomBtn,
-            {
-              bottom: floatingBottom + FLOATING_BAR_HEIGHT + 14,
-              backgroundColor: isDark ? "#1a1d21" : "#ffffff",
-              borderColor: isDark
-                ? "rgba(255,255,255,0.14)"
-                : "rgba(14,58,35,0.14)",
-              transform: [{ scale: pressed ? 0.9 : 1 }],
-            },
-          ]}
-          accessibilityLabel="Scroll to latest message"
-          accessibilityRole="button"
-          hitSlop={8}
-        >
-          <Ionicons name="arrow-down" size={18} color={paperTint.eyebrow} />
-        </Pressable>
-      )}
-
-      {/* ── Floating composer ── */}
-      <View
-        onLayout={(e) => {
-          const h = e.nativeEvent.layout.height;
-          if (h > 0 && Math.abs(h - composerHeight) > 0.5) {
-            setComposerHeight(h);
-          }
-        }}
-        style={[
-          styles.floatingWrap,
-          { bottom: floatingBottom },
-          Platform.OS === "ios" && {
-            shadowColor: "#000",
-            shadowOffset: { width: 0, height: 4 },
-            shadowOpacity: isDark ? 0.3 : 0.1,
-            shadowRadius: 16,
-          },
-          Platform.OS === "android" && { elevation: 8 },
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingTop: insets.top + 36, paddingBottom: insets.bottom + 48 },
         ]}
+        showsVerticalScrollIndicator={false}
       >
-        {showWelcome ? (
+        <Text style={[styles.eyebrow, { color: paperTint.eyebrow }]}>
+          EVERYBODY EATS HELP
+        </Text>
+
+        <View style={styles.heroBlock}>
+          <Text style={styles.heroLine}>
+            <Text style={[styles.hero, { color: paperTint.ink }]}>Kia ora</Text>
+            <Text style={[styles.hero, { color: paperTint.accent }]}>.</Text>
+          </Text>
+          <Text style={[styles.heroSubtitle, { color: paperTint.inkSoft }]}>
+            How can we help today?
+          </Text>
+        </View>
+
+        <View style={[styles.hairline, { backgroundColor: paperTint.rule }]} />
+
+        <Text
+          style={[
+            styles.eyebrow,
+            { color: paperTint.eyebrow, marginTop: 28, marginBottom: 4 },
+          ]}
+        >
+          PICK A CHANNEL
+        </Text>
+
+        <View style={styles.optionList}>
+          <OptionRow
+            emoji="🌿"
+            title="Ask the AI assistant"
+            description="Instant answers, day or night"
+            onPress={goToAi}
+            paperTint={paperTint}
+            colors={colors}
+            firstRow
+          />
+          <OptionRow
+            emoji="💬"
+            title="Message the team"
+            description={
+              hoursLabel ?? "Real humans · we'll reply when we're around"
+            }
+            onPress={goToTeam}
+            paperTint={paperTint}
+            colors={colors}
+            statusDotColor={
+              openNow == null
+                ? null
+                : openNow
+                ? "#22c55e"
+                : paperTint.inkSoft
+            }
+            unread={unread}
+          />
+        </View>
+
+        <View style={styles.welcomeFooter}>
           <View
             style={[
-              styles.glassBar,
-              styles.glassBarFallback,
-              {
-                backgroundColor: isDark ? "#1a1d21" : "#ffffff",
-                borderColor: isDark
-                  ? "rgba(255,255,255,0.12)"
-                  : "rgba(14, 58, 35, 0.14)",
-                borderWidth: StyleSheet.hairlineWidth,
-              },
+              styles.hairline,
+              { backgroundColor: paperTint.rule, marginBottom: 14 },
             ]}
-          >
-            {inputContents}
-          </View>
-        ) : useNativeGlass ? (
-          <GlassView glassEffectStyle="regular" style={styles.glassBar}>
-            {inputContents}
-          </GlassView>
-        ) : (
-          <View style={[styles.glassBar, styles.glassBarFallback]}>
-            <BlurView
-              intensity={isDark ? 60 : 80}
-              tint={isDark ? "dark" : "light"}
-              style={[StyleSheet.absoluteFill, { borderRadius: 22 }]}
-            />
+          />
+          <Text style={[styles.eyebrowCentered, { color: colors.textSecondary }]}>
+            NGĀ MIHI · WE&apos;RE HERE TO HELP
+          </Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+/* ─── Option row ────────────────────────────────────────────── */
+
+function OptionRow({
+  emoji,
+  title,
+  description,
+  onPress,
+  paperTint,
+  colors,
+  firstRow = false,
+  statusDotColor,
+  unread = false,
+}: {
+  emoji: string;
+  title: string;
+  description: string;
+  onPress: () => void;
+  paperTint: PaperTint;
+  colors: (typeof Colors)["light"];
+  firstRow?: boolean;
+  statusDotColor?: string | null;
+  unread?: boolean;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${title}. ${description}`}
+      style={({ pressed }) => [
+        styles.optionRow,
+        {
+          borderBottomColor: paperTint.rule,
+          borderBottomWidth: StyleSheet.hairlineWidth,
+          opacity: pressed ? 0.6 : 1,
+        },
+        firstRow && {
+          borderTopColor: paperTint.rule,
+          borderTopWidth: StyleSheet.hairlineWidth,
+        },
+      ]}
+    >
+      <View style={styles.optionEmojiWrap}>
+        <Text style={styles.optionEmoji}>{emoji}</Text>
+      </View>
+      <View style={styles.optionBody}>
+        <View style={styles.optionTitleRow}>
+          <Text style={[styles.optionTitle, { color: colors.text }]}>
+            {title}
+          </Text>
+          {unread && (
+            <View style={[styles.unreadDot, { backgroundColor: "#22c55e" }]} />
+          )}
+        </View>
+        <Text
+          style={[styles.optionDescription, { color: paperTint.inkSoft }]}
+          numberOfLines={2}
+        >
+          {description}
+        </Text>
+        {statusDotColor && (
+          <View style={styles.statusRow}>
             <View
-              style={[
-                StyleSheet.absoluteFill,
-                {
-                  backgroundColor: isDark
-                    ? "rgba(40,44,52,0.55)"
-                    : "rgba(255,253,247,0.78)",
-                  borderColor: isDark
-                    ? "rgba(255,255,255,0.18)"
-                    : "rgba(14, 58, 35, 0.14)",
-                  borderWidth: StyleSheet.hairlineWidth,
-                  borderRadius: 22,
-                },
-              ]}
+              style={[styles.statusInlineDot, { backgroundColor: statusDotColor }]}
             />
-            {inputContents}
           </View>
         )}
       </View>
-    </View>
+      <Ionicons
+        name="arrow-forward"
+        size={16}
+        color={paperTint.eyebrow}
+        style={styles.optionArrow}
+      />
+    </Pressable>
   );
 }
 
@@ -880,51 +257,7 @@ export default function ChatScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-
-  /* Header (chat state only) */
-  header: {
-    paddingHorizontal: 22,
-    paddingBottom: 14,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    zIndex: 2,
-  },
-  headerLeft: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-  },
-  headerTitle: {
-    fontFamily: FontFamily.semiBold,
-    fontSize: 12,
-    letterSpacing: 2.2,
-  },
-  statusDot: {
-    width: 6,
-    height: 6,
-    borderRadius: 3,
-    marginLeft: 2,
-  },
-  newChatBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    paddingVertical: 8,
-    paddingHorizontal: 4,
-  },
-  newChatLabel: {
-    fontFamily: FontFamily.semiBold,
-    fontSize: 11,
-    letterSpacing: 1.8,
-  },
-
-  /* Welcome — editorial */
-  welcomeContainer: {
-    flexGrow: 1,
-    paddingHorizontal: 24,
-  },
+  scrollContent: { paddingHorizontal: 24 },
   eyebrow: {
     fontFamily: FontFamily.semiBold,
     fontSize: 11,
@@ -937,12 +270,8 @@ const styles = StyleSheet.create({
     letterSpacing: 1.8,
     textAlign: "center",
   },
-  heroBlock: {
-    marginBottom: 28,
-  },
-  heroLine: {
-    marginBottom: 18,
-  },
+  heroBlock: { marginBottom: 28 },
+  heroLine: { marginBottom: 18 },
   hero: {
     fontFamily: FontFamily.headingBold,
     fontSize: 64,
@@ -959,156 +288,49 @@ const styles = StyleSheet.create({
     height: StyleSheet.hairlineWidth,
     width: "100%",
   },
-  questionList: {
-    marginTop: 4,
-  },
-  questionRow: {
+  optionList: { marginTop: 4 },
+  optionRow: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 18,
+    paddingVertical: 22,
     gap: 14,
   },
-  questionNumber: {
-    fontFamily: FontFamily.headingBold,
-    fontSize: 15,
-    width: 28,
-    letterSpacing: 0.5,
-  },
-  questionLabel: {
-    flex: 1,
-    fontFamily: FontFamily.medium,
-    fontSize: 16,
-    lineHeight: 22,
-  },
-  questionArrow: {
-    marginLeft: 4,
-  },
-  welcomeFooter: {
-    marginTop: 44,
-  },
-
-  /* Message list */
-  messageList: {
-    paddingHorizontal: 22,
-    paddingTop: 8,
-  },
-  listFooter: {
-    paddingBottom: 8,
-  },
-  messageRow: {
-    flexDirection: "row",
-  },
-  userRow: {
-    justifyContent: "flex-end",
-  },
-  userBubble: {
-    maxWidth: "80%",
-    paddingHorizontal: 16,
-    paddingVertical: 11,
-    borderRadius: 20,
-    borderBottomRightRadius: 6,
-  },
-  userText: {
-    color: "#ffffff",
-    fontFamily: FontFamily.regular,
-    fontSize: 15.5,
-    lineHeight: 22,
-  },
-
-  /* Assistant — editorial prose */
-  assistantBlock: {
-    flexDirection: "column",
-  },
-  assistantMeta: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    marginBottom: 10,
-  },
-  assistantMetaLabel: {
-    fontFamily: FontFamily.semiBold,
-    fontSize: 11,
-    letterSpacing: 1.8,
-  },
-  assistantBody: {
-    paddingLeft: 32,
-    paddingRight: 8,
-  },
-  typingBody: {
-    paddingTop: 4,
-    paddingBottom: 4,
-  },
-
-  /* Typing indicator */
-  dotsRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 5,
-    height: 22,
-  },
-  dot: {
-    width: 7,
-    height: 7,
-    borderRadius: 3.5,
-  },
-
-  /* Floating composer */
-  floatingWrap: {
-    position: "absolute",
-    left: 14,
-    right: 14,
-    zIndex: 10,
-  },
-  glassBar: {
-    flexDirection: "row",
-    alignItems: "flex-end",
-    borderRadius: 22,
-    padding: 6,
-    gap: 6,
-  },
-  glassBarFallback: {
-    overflow: "hidden",
-  },
-  glassInputField: {
-    flex: 1,
+  optionEmojiWrap: {
+    width: 36,
+    height: 36,
     borderRadius: 18,
-    paddingHorizontal: 14,
-    paddingVertical: Platform.OS === "ios" ? 10 : 6,
-    minHeight: 40,
-    justifyContent: "center",
-    backgroundColor: "transparent",
-  },
-  glassInputText: {
-    fontSize: 15.5,
-    lineHeight: 20,
-    maxHeight: 100,
-    paddingTop: 0,
-    paddingBottom: 0,
-    textAlignVertical: "center",
-  },
-  glassSendBtn: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
     alignItems: "center",
     justifyContent: "center",
   },
-
-  /* Scroll-to-bottom floating button */
-  scrollToBottomBtn: {
-    position: "absolute",
-    alignSelf: "center",
-    width: 38,
-    height: 38,
-    borderRadius: 19,
+  optionEmoji: { fontSize: 22 },
+  optionBody: { flex: 1 },
+  optionTitleRow: {
+    flexDirection: "row",
     alignItems: "center",
-    justifyContent: "center",
-    borderWidth: StyleSheet.hairlineWidth,
-    zIndex: 11,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 3 },
-    shadowOpacity: 0.14,
-    shadowRadius: 10,
-    elevation: 6,
+    gap: 8,
+    marginBottom: 2,
   },
+  optionTitle: {
+    fontFamily: FontFamily.semiBold,
+    fontSize: 17,
+    lineHeight: 22,
+  },
+  optionDescription: {
+    fontFamily: FontFamily.regular,
+    fontSize: 13.5,
+    lineHeight: 18,
+  },
+  optionArrow: { marginLeft: 4 },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  statusRow: { flexDirection: "row", alignItems: "center", marginTop: 4 },
+  statusInlineDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+  },
+  welcomeFooter: { marginTop: 44 },
 });

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -171,6 +171,8 @@ export default function RootLayout() {
               title: '',
             }}
           />
+          <Stack.Screen name="help/ai" options={{ headerShown: false }} />
+          <Stack.Screen name="help/team" options={{ headerShown: false }} />
         </Stack>
       </AuthGate>
       <StatusBar style="auto" />

--- a/mobile/app/help/ai.tsx
+++ b/mobile/app/help/ai.tsx
@@ -1,0 +1,1134 @@
+import { Ionicons } from "@expo/vector-icons";
+import { BlurView } from "expo-blur";
+import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect";
+import * as Haptics from "expo-haptics";
+import { useRouter } from "expo-router";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Animated,
+  FlatList,
+  Keyboard,
+  LayoutAnimation,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import MarkdownDisplay from "react-native-markdown-display";
+
+import { Brand, Colors, FontFamily } from "@/constants/theme";
+import { useColorScheme } from "@/hooks/use-color-scheme";
+import { api } from "@/lib/api";
+import { chatWithAssistant } from "@/lib/chat";
+
+/* ─── Types ─────────────────────────────────────────────────── */
+
+type Message = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+};
+
+type Question = { emoji: string; label: string };
+
+type PaperTint = {
+  paper: string;
+  ink: string;
+  inkSoft: string;
+  rule: string;
+  accent: string;
+  eyebrow: string;
+};
+
+/* ─── Data ──────────────────────────────────────────────────── */
+
+const WELCOME_MESSAGE: Message = {
+  id: "welcome",
+  role: "assistant",
+  content:
+    "Kia ora! I'm here to help with anything about volunteering at Everybody Eats. Ask me about what to expect on your first shift, kitchen safety, shift roles, or anything else 🌿",
+};
+
+const DEFAULT_SUGGESTED_QUESTIONS: Question[] = [
+  { emoji: "🍽️", label: "What happens on a typical shift?" },
+  { emoji: "🔪", label: "Kitchen safety tips" },
+  { emoji: "👥", label: "What are the volunteer grades?" },
+  { emoji: "📍", label: "Where are the kitchens?" },
+];
+
+const FLOATING_BAR_HEIGHT = 60;
+
+/* ─── Editorial palette (derived from theme) ────────────────── */
+
+function usePaperTint(
+  isDark: boolean,
+  colors: (typeof Colors)["light"]
+): PaperTint {
+  return {
+    paper: colors.background,
+    ink: isDark ? colors.text : Brand.green,
+    inkSoft: isDark ? colors.textSecondary : "#4a5a4f",
+    rule: isDark ? "rgba(232,245,232,0.12)" : "rgba(14,58,35,0.14)",
+    accent: Brand.accent,
+    eyebrow: isDark ? Brand.greenLight : Brand.green,
+  };
+}
+
+/* ─── Animated Typing Dots ──────────────────────────────────── */
+
+const TypingDots = React.memo(function TypingDots({
+  color,
+}: {
+  color: string;
+}) {
+  const dot1 = useRef(new Animated.Value(0)).current;
+  const dot2 = useRef(new Animated.Value(0)).current;
+  const dot3 = useRef(new Animated.Value(0)).current;
+  const dots = [dot1, dot2, dot3];
+
+  useEffect(() => {
+    const animations = dots.map((dot, i) =>
+      Animated.loop(
+        Animated.sequence([
+          Animated.delay(i * 160),
+          Animated.timing(dot, {
+            toValue: 1,
+            duration: 280,
+            useNativeDriver: true,
+          }),
+          Animated.timing(dot, {
+            toValue: 0,
+            duration: 280,
+            useNativeDriver: true,
+          }),
+          Animated.delay((2 - i) * 160),
+        ])
+      )
+    );
+    animations.forEach((a) => a.start());
+    return () => animations.forEach((a) => a.stop());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <View style={styles.dotsRow}>
+      {dots.map((dot, i) => (
+        <Animated.View
+          key={i}
+          style={[
+            styles.dot,
+            {
+              backgroundColor: color,
+              opacity: dot.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0.3, 1],
+              }),
+              transform: [
+                {
+                  translateY: dot.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [0, -4],
+                  }),
+                },
+              ],
+            },
+          ]}
+        />
+      ))}
+    </View>
+  );
+});
+
+/* ─── Leaf Seal (small warm avatar for chat stream) ─────────── */
+
+const LeafSeal = React.memo(function LeafSeal({
+  size = 24,
+  isDark = false,
+}: {
+  size?: number;
+  isDark?: boolean;
+}) {
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: isDark ? Brand.greenDark : Brand.greenLight,
+      }}
+    >
+      <Text style={{ fontSize: size * 0.48 }}>🌿</Text>
+    </View>
+  );
+});
+
+/* ─── Message Bubble ────────────────────────────────────────── */
+
+const MessageBubble = React.memo(function MessageBubble({
+  item,
+  colors,
+  isDark,
+  isFirstInGroup,
+  paperTint,
+}: {
+  item: Message;
+  colors: (typeof Colors)["light"];
+  isDark: boolean;
+  isFirstInGroup: boolean;
+  paperTint: PaperTint;
+}) {
+  const isUser = item.role === "user";
+
+  if (isUser) {
+    return (
+      <View
+        style={[
+          styles.messageRow,
+          styles.userRow,
+          { marginTop: isFirstInGroup ? 18 : 4 },
+        ]}
+      >
+        <View style={[styles.userBubble, { backgroundColor: Brand.green }]}>
+          <Text style={styles.userText}>{item.content}</Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.assistantBlock, { marginTop: isFirstInGroup ? 24 : 10 }]}
+    >
+      {isFirstInGroup && (
+        <View style={styles.assistantMeta}>
+          <LeafSeal size={22} isDark={isDark} />
+          <Text
+            style={[styles.assistantMetaLabel, { color: paperTint.eyebrow }]}
+          >
+            EE ASSISTANT
+          </Text>
+        </View>
+      )}
+      <View style={styles.assistantBody}>
+        <MarkdownDisplay
+          style={{
+            body: {
+              color: colors.text,
+              fontFamily: FontFamily.regular,
+              fontSize: 15.5,
+              lineHeight: 24,
+            },
+            strong: { fontFamily: FontFamily.semiBold },
+            em: { fontFamily: FontFamily.regular, fontStyle: "italic" },
+            bullet_list: { marginVertical: 6 },
+            ordered_list: { marginVertical: 6 },
+            list_item: { marginVertical: 2 },
+            link: {
+              color: isDark ? Brand.greenLight : Brand.green,
+              fontFamily: FontFamily.semiBold,
+            },
+            paragraph: { marginTop: 0, marginBottom: 10 },
+            heading1: {
+              fontFamily: FontFamily.headingBold,
+              fontSize: 20,
+              marginBottom: 8,
+              marginTop: 14,
+              color: colors.text,
+              letterSpacing: -0.3,
+            },
+            heading2: {
+              fontFamily: FontFamily.headingBold,
+              fontSize: 17,
+              marginBottom: 6,
+              marginTop: 12,
+              color: colors.text,
+            },
+            heading3: {
+              fontFamily: FontFamily.semiBold,
+              fontSize: 14,
+              textTransform: "uppercase",
+              letterSpacing: 1.2,
+              marginBottom: 4,
+              marginTop: 10,
+              color: paperTint.eyebrow,
+            },
+            blockquote: {
+              borderLeftWidth: 2,
+              borderLeftColor: paperTint.eyebrow,
+              paddingLeft: 12,
+              marginVertical: 8,
+              backgroundColor: "transparent",
+            },
+            code_inline: {
+              backgroundColor: isDark ? "#252830" : "rgba(14,58,35,0.06)",
+              color: colors.text,
+              fontSize: 14,
+              paddingHorizontal: 4,
+              paddingVertical: 1,
+              borderRadius: 4,
+            },
+          }}
+        >
+          {item.content}
+        </MarkdownDisplay>
+      </View>
+    </View>
+  );
+});
+
+/* ─── Welcome Hero — Editorial ─────────────────────────────── */
+
+function WelcomeHero({
+  colors,
+  isDark,
+  onSuggestionPress,
+  questions,
+  paperTint,
+  topInset,
+}: {
+  colors: (typeof Colors)["light"];
+  isDark: boolean;
+  onSuggestionPress: (text: string) => void;
+  questions: Question[];
+  paperTint: PaperTint;
+  topInset: number;
+}) {
+  return (
+    <ScrollView
+      contentContainerStyle={[
+        styles.welcomeContainer,
+        {
+          paddingTop: topInset + 36,
+          paddingBottom: FLOATING_BAR_HEIGHT + 80,
+        },
+      ]}
+      showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+    >
+      {/* Hero block */}
+      <View style={styles.heroBlock}>
+        <Text style={styles.heroLine}>
+          <Text style={[styles.hero, { color: paperTint.ink }]}>Kia ora</Text>
+          <Text style={[styles.hero, { color: paperTint.accent }]}>.</Text>
+        </Text>
+        <Text style={[styles.heroSubtitle, { color: paperTint.inkSoft }]}>
+          What would you like to know{"\n"}about volunteering with us?
+        </Text>
+      </View>
+
+      {/* Hairline divider */}
+      <View style={[styles.hairline, { backgroundColor: paperTint.rule }]} />
+
+      {/* Suggestions header */}
+      <Text
+        style={[
+          styles.eyebrow,
+          { color: paperTint.eyebrow, marginTop: 28, marginBottom: 4 },
+        ]}
+      >
+        TRY ASKING
+      </Text>
+
+      {/* Numbered editorial list */}
+      <View style={styles.questionList}>
+        {questions.map((q, i) => (
+          <Pressable
+            key={q.label}
+            onPress={() => {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              onSuggestionPress(q.label);
+            }}
+            style={({ pressed }) => [
+              styles.questionRow,
+              {
+                borderBottomColor: paperTint.rule,
+                borderBottomWidth: StyleSheet.hairlineWidth,
+                opacity: pressed ? 0.55 : 1,
+              },
+              i === 0 && {
+                borderTopColor: paperTint.rule,
+                borderTopWidth: StyleSheet.hairlineWidth,
+              },
+            ]}
+            accessibilityLabel={q.label}
+            accessibilityRole="button"
+          >
+            <Text style={[styles.questionNumber, { color: paperTint.eyebrow }]}>
+              {String(i + 1).padStart(2, "0")}
+            </Text>
+            <Text
+              style={[styles.questionLabel, { color: colors.text }]}
+              numberOfLines={2}
+            >
+              {q.label}
+            </Text>
+            <Ionicons
+              name="arrow-forward"
+              size={16}
+              color={paperTint.eyebrow}
+              style={styles.questionArrow}
+            />
+          </Pressable>
+        ))}
+      </View>
+
+      {/* Footer colophon */}
+      <View style={styles.welcomeFooter}>
+        <View
+          style={[
+            styles.hairline,
+            { backgroundColor: paperTint.rule, marginBottom: 14 },
+          ]}
+        />
+        <Text style={[styles.eyebrowCentered, { color: colors.textSecondary }]}>
+          NGĀ MIHI · POWERED BY THE RESOURCE HUB
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+/* ─── Main Screen ───────────────────────────────────────────── */
+
+export default function ChatScreen() {
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme];
+  const isDark = colorScheme === "dark";
+  const insets = useSafeAreaInsets();
+  const paperTint = usePaperTint(isDark, colors);
+  const router = useRouter();
+
+  const [messages, setMessages] = useState<Message[]>([WELCOME_MESSAGE]);
+  const [input, setInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [suggestedQuestions, setSuggestedQuestions] = useState<Question[]>(
+    DEFAULT_SUGGESTED_QUESTIONS
+  );
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const [composerHeight, setComposerHeight] = useState(FLOATING_BAR_HEIGHT);
+  const flatListRef = useRef<FlatList>(null);
+  const inputRef = useRef<TextInput>(null);
+  const pendingScrollIndexRef = useRef<number | null>(null);
+  const scrollMetricsRef = useRef({
+    offset: 0,
+    contentHeight: 0,
+    layoutHeight: 0,
+  });
+
+  const showWelcome = messages.length <= 1;
+  const keyboardVisible = keyboardHeight > 0;
+
+  /* ── Keyboard tracking with smooth LayoutAnimation ── */
+  useEffect(() => {
+    const showSub = Keyboard.addListener(
+      Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow",
+      (e) => {
+        if (Platform.OS === "ios") {
+          LayoutAnimation.configureNext({
+            duration: e.duration,
+            update: { type: LayoutAnimation.Types.keyboard },
+          });
+        }
+        setKeyboardHeight(e.endCoordinates.height);
+      }
+    );
+    const hideSub = Keyboard.addListener(
+      Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide",
+      (e) => {
+        if (Platform.OS === "ios" && e?.duration) {
+          LayoutAnimation.configureNext({
+            duration: e.duration,
+            update: { type: LayoutAnimation.Types.keyboard },
+          });
+        }
+        setKeyboardHeight(0);
+      }
+    );
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  /* ── Fetch suggested questions from API ── */
+  useEffect(() => {
+    api<{ suggestedQuestions: Question[] }>("/api/mobile/chat/config")
+      .then((data) => {
+        if (data.suggestedQuestions?.length > 0) {
+          setSuggestedQuestions(data.suggestedQuestions);
+        }
+      })
+      .catch(() => {
+        // Keep defaults on error
+      });
+  }, []);
+
+  /* ── Reset ── */
+  const resetChat = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    setMessages([WELCOME_MESSAGE]);
+    setInput("");
+    setIsLoading(false);
+    setShowScrollToBottom(false);
+    pendingScrollIndexRef.current = null;
+  }, []);
+
+  /* ── Send ── */
+  const sendMessage = useCallback(
+    async (text?: string) => {
+      const content = (text ?? input).trim();
+      if (!content || isLoading) return;
+
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+
+      const userMessage: Message = {
+        id: Date.now().toString(),
+        role: "user",
+        content,
+      };
+
+      setInput("");
+      setIsLoading(true);
+
+      const assistantId = (Date.now() + 1).toString();
+      const allMessages = [...messages, userMessage]
+        .filter((m) => m.id !== "welcome")
+        .map((m) => ({ role: m.role, content: m.content }));
+      pendingScrollIndexRef.current = messages.length;
+      setMessages((prev) => [...prev, userMessage]);
+
+      try {
+        await chatWithAssistant(allMessages, {
+          onStart: () => {
+            setIsLoading(false);
+            setMessages((prev) => [
+              ...prev,
+              { id: assistantId, role: "assistant", content: "" },
+            ]);
+          },
+          onToken: (token: string) => {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === assistantId ? { ...m, content: m.content + token } : m
+              )
+            );
+          },
+          onFinish: () => {
+            setIsLoading(false);
+          },
+          onError: (error: string) => {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === assistantId
+                  ? {
+                      ...m,
+                      content:
+                        "Sorry, I had trouble responding. Please try again — or contact the team directly if you need help right away 🌿",
+                    }
+                  : m
+              )
+            );
+            setIsLoading(false);
+            console.error("Chat error:", error);
+          },
+        });
+      } catch {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: assistantId,
+            role: "assistant" as const,
+            content:
+              "Sorry, I couldn't connect right now. Please check your connection and try again 🌿",
+          },
+        ]);
+        setIsLoading(false);
+      }
+    },
+    [input, isLoading, messages]
+  );
+
+  /* ── Floating bar vertical position ── */
+  const floatingBottom = keyboardVisible
+    ? keyboardHeight + 8
+    : insets.bottom + 8;
+
+  /* ── Scroll tracking: show button when not at bottom and list is scrollable ── */
+  const updateScrollButton = useCallback(() => {
+    const { offset, contentHeight, layoutHeight } = scrollMetricsRef.current;
+    if (layoutHeight === 0) return;
+    const distanceFromBottom = contentHeight - (offset + layoutHeight);
+    const scrollable = contentHeight > layoutHeight + 20;
+    setShowScrollToBottom(scrollable && distanceFromBottom > 40);
+  }, []);
+
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollMetricsRef.current.offset = e.nativeEvent.contentOffset.y;
+      scrollMetricsRef.current.contentHeight = e.nativeEvent.contentSize.height;
+      scrollMetricsRef.current.layoutHeight =
+        e.nativeEvent.layoutMeasurement.height;
+      updateScrollButton();
+    },
+    [updateScrollButton]
+  );
+
+  const handleContentSizeChange = useCallback(
+    (_w: number, h: number) => {
+      scrollMetricsRef.current.contentHeight = h;
+      // If a send was just triggered, pin the user's message to the top.
+      if (pendingScrollIndexRef.current !== null) {
+        const idx = pendingScrollIndexRef.current;
+        pendingScrollIndexRef.current = null;
+        requestAnimationFrame(() => {
+          flatListRef.current?.scrollToIndex({
+            index: idx,
+            viewPosition: 0,
+            animated: true,
+          });
+        });
+        return;
+      }
+      updateScrollButton();
+    },
+    [updateScrollButton]
+  );
+
+  const scrollToBottom = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    // Force-scroll to the exact bottom using tracked metrics (RN's
+    // scrollToEnd can be off when content is still settling).
+    const { contentHeight, layoutHeight } = scrollMetricsRef.current;
+    const target = Math.max(0, contentHeight - layoutHeight);
+    flatListRef.current?.scrollToOffset({ offset: target, animated: true });
+  }, []);
+
+  /* ── Render message with grouping awareness ── */
+  const renderMessage = useCallback(
+    ({ item, index }: { item: Message; index: number }) => {
+      const prev = messages[index - 1];
+      return (
+        <MessageBubble
+          item={item}
+          colors={colors}
+          isDark={isDark}
+          isFirstInGroup={!prev || prev.role !== item.role}
+          paperTint={paperTint}
+        />
+      );
+    },
+    [messages, colors, isDark, paperTint]
+  );
+
+  /* ── Composer state ── */
+  const sendBtnInactive = isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.06)";
+  const hasInput = input.trim().length > 0 && !isLoading;
+  const useNativeGlass = isLiquidGlassAvailable();
+
+  const inputContents = (
+    <>
+      <View style={styles.glassInputField}>
+        <TextInput
+          ref={inputRef}
+          style={[
+            styles.glassInputText,
+            { color: colors.text, fontFamily: FontFamily.regular },
+          ]}
+          value={input}
+          onChangeText={setInput}
+          placeholder="Ask anything about volunteering…"
+          placeholderTextColor={colors.textSecondary}
+          multiline
+          maxLength={1000}
+          onSubmitEditing={() => sendMessage()}
+          returnKeyType="send"
+          editable={!isLoading}
+          accessibilityLabel="Message input"
+        />
+      </View>
+      <Pressable
+        onPress={() => sendMessage()}
+        disabled={!hasInput}
+        style={({ pressed }) => [
+          styles.glassSendBtn,
+          {
+            backgroundColor: hasInput ? Brand.green : sendBtnInactive,
+            transform: [{ scale: pressed && hasInput ? 0.9 : 1 }],
+          },
+        ]}
+        accessibilityLabel="Send message"
+        accessibilityRole="button"
+      >
+        <Ionicons
+          name="arrow-up"
+          size={18}
+          color={hasInput ? "#ffffff" : colors.textSecondary}
+        />
+      </Pressable>
+    </>
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: paperTint.paper }]}>
+      {/* ── Persistent header with back button ── */}
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + 12,
+            borderBottomColor: showWelcome ? "transparent" : paperTint.rule,
+          },
+        ]}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          style={styles.backBtn}
+          accessibilityLabel="Back to Help"
+          accessibilityRole="button"
+        >
+          <Ionicons name="chevron-back" size={22} color={paperTint.eyebrow} />
+        </Pressable>
+        <View style={styles.headerCenter}>
+          <View style={styles.headerCenterRow}>
+            <LeafSeal size={20} isDark={isDark} />
+            <Text style={[styles.headerTitle, { color: paperTint.eyebrow }]}>
+              EE ASSISTANT
+            </Text>
+            <View style={[styles.statusDot, { backgroundColor: "#22c55e" }]} />
+          </View>
+        </View>
+        <View style={styles.headerRight}>
+          {!showWelcome ? (
+            <Pressable
+              onPress={resetChat}
+              style={({ pressed }) => [
+                styles.newChatBtn,
+                { opacity: pressed ? 0.55 : 1 },
+              ]}
+              accessibilityLabel="Start new conversation"
+              accessibilityRole="button"
+              hitSlop={12}
+            >
+              <Ionicons
+                name="create-outline"
+                size={16}
+                color={paperTint.eyebrow}
+              />
+              <Text style={[styles.newChatLabel, { color: paperTint.eyebrow }]}>
+                NEW
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+
+      {/* ── Content area ── */}
+      {showWelcome ? (
+        <WelcomeHero
+          colors={colors}
+          isDark={isDark}
+          onSuggestionPress={sendMessage}
+          questions={suggestedQuestions}
+          paperTint={paperTint}
+          topInset={0}
+        />
+      ) : (
+        <FlatList
+          ref={flatListRef}
+          data={messages}
+          renderItem={renderMessage}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={[
+            styles.messageList,
+            { paddingBottom: composerHeight + floatingBottom },
+          ]}
+          keyboardShouldPersistTaps="handled"
+          onScroll={handleScroll}
+          scrollEventThrottle={32}
+          onContentSizeChange={handleContentSizeChange}
+          onLayout={(e) => {
+            scrollMetricsRef.current.layoutHeight = e.nativeEvent.layout.height;
+            updateScrollButton();
+          }}
+          onScrollToIndexFailed={(info) => {
+            setTimeout(() => {
+              flatListRef.current?.scrollToIndex({
+                index: Math.min(info.index, info.highestMeasuredFrameIndex),
+                viewPosition: 0,
+                animated: true,
+              });
+            }, 80);
+          }}
+          ListFooterComponent={
+            isLoading ? (
+              <View style={[styles.assistantBlock, { marginTop: 24 }]}>
+                <View style={styles.assistantMeta}>
+                  <LeafSeal size={22} isDark={isDark} />
+                  <Text
+                    style={[
+                      styles.assistantMetaLabel,
+                      { color: paperTint.eyebrow },
+                    ]}
+                  >
+                    EE ASSISTANT
+                  </Text>
+                </View>
+                <View style={[styles.assistantBody, styles.typingBody]}>
+                  <TypingDots color={colors.textSecondary} />
+                </View>
+              </View>
+            ) : null
+          }
+          ListFooterComponentStyle={styles.listFooter}
+        />
+      )}
+
+      {/* ── Floating scroll-to-bottom button ── */}
+      {!showWelcome && showScrollToBottom && (
+        <Pressable
+          onPress={scrollToBottom}
+          style={({ pressed }) => [
+            styles.scrollToBottomBtn,
+            {
+              bottom: floatingBottom + FLOATING_BAR_HEIGHT + 14,
+              backgroundColor: isDark ? "#1a1d21" : "#ffffff",
+              borderColor: isDark
+                ? "rgba(255,255,255,0.14)"
+                : "rgba(14,58,35,0.14)",
+              transform: [{ scale: pressed ? 0.9 : 1 }],
+            },
+          ]}
+          accessibilityLabel="Scroll to latest message"
+          accessibilityRole="button"
+          hitSlop={8}
+        >
+          <Ionicons name="arrow-down" size={18} color={paperTint.eyebrow} />
+        </Pressable>
+      )}
+
+      {/* ── Floating composer ── */}
+      <View
+        onLayout={(e) => {
+          const h = e.nativeEvent.layout.height;
+          if (h > 0 && Math.abs(h - composerHeight) > 0.5) {
+            setComposerHeight(h);
+          }
+        }}
+        style={[
+          styles.floatingWrap,
+          { bottom: floatingBottom },
+          Platform.OS === "ios" && {
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: 4 },
+            shadowOpacity: isDark ? 0.3 : 0.1,
+            shadowRadius: 16,
+          },
+          Platform.OS === "android" && { elevation: 8 },
+        ]}
+      >
+        {showWelcome ? (
+          <View
+            style={[
+              styles.glassBar,
+              styles.glassBarFallback,
+              {
+                backgroundColor: isDark ? "#1a1d21" : "#ffffff",
+                borderColor: isDark
+                  ? "rgba(255,255,255,0.12)"
+                  : "rgba(14, 58, 35, 0.14)",
+                borderWidth: StyleSheet.hairlineWidth,
+              },
+            ]}
+          >
+            {inputContents}
+          </View>
+        ) : useNativeGlass ? (
+          <GlassView glassEffectStyle="regular" style={styles.glassBar}>
+            {inputContents}
+          </GlassView>
+        ) : (
+          <View style={[styles.glassBar, styles.glassBarFallback]}>
+            <BlurView
+              intensity={isDark ? 60 : 80}
+              tint={isDark ? "dark" : "light"}
+              style={[StyleSheet.absoluteFill, { borderRadius: 22 }]}
+            />
+            <View
+              style={[
+                StyleSheet.absoluteFill,
+                {
+                  backgroundColor: isDark
+                    ? "rgba(40,44,52,0.55)"
+                    : "rgba(255,253,247,0.78)",
+                  borderColor: isDark
+                    ? "rgba(255,255,255,0.18)"
+                    : "rgba(14, 58, 35, 0.14)",
+                  borderWidth: StyleSheet.hairlineWidth,
+                  borderRadius: 22,
+                },
+              ]}
+            />
+            {inputContents}
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}
+
+/* ─── Styles ────────────────────────────────────────────────── */
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+
+  /* Persistent header */
+  header: {
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    flexDirection: "row",
+    alignItems: "center",
+    zIndex: 2,
+  },
+  backBtn: {
+    width: 60,
+    alignItems: "flex-start",
+    justifyContent: "center",
+  },
+  headerCenter: { flex: 1, alignItems: "center" },
+  headerCenterRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  headerRight: {
+    width: 60,
+    alignItems: "flex-end",
+    justifyContent: "center",
+  },
+  headerTitle: {
+    fontFamily: FontFamily.semiBold,
+    fontSize: 12,
+    letterSpacing: 2.2,
+  },
+  statusDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    marginLeft: 2,
+  },
+  newChatBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+  },
+  newChatLabel: {
+    fontFamily: FontFamily.semiBold,
+    fontSize: 11,
+    letterSpacing: 1.8,
+  },
+
+  /* Welcome — editorial */
+  welcomeContainer: {
+    flexGrow: 1,
+    paddingHorizontal: 24,
+  },
+  eyebrow: {
+    fontFamily: FontFamily.semiBold,
+    fontSize: 11,
+    letterSpacing: 2,
+    marginBottom: 20,
+  },
+  eyebrowCentered: {
+    fontFamily: FontFamily.semiBold,
+    fontSize: 10.5,
+    letterSpacing: 1.8,
+    textAlign: "center",
+  },
+  heroBlock: {
+    marginBottom: 28,
+  },
+  heroLine: {
+    marginBottom: 18,
+  },
+  hero: {
+    fontFamily: FontFamily.headingBold,
+    fontSize: 64,
+    lineHeight: 66,
+    letterSpacing: -1.2,
+  },
+  heroSubtitle: {
+    fontFamily: FontFamily.regular,
+    fontSize: 17,
+    lineHeight: 26,
+    maxWidth: 320,
+  },
+  hairline: {
+    height: StyleSheet.hairlineWidth,
+    width: "100%",
+  },
+  questionList: {
+    marginTop: 4,
+  },
+  questionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 18,
+    gap: 14,
+  },
+  questionNumber: {
+    fontFamily: FontFamily.headingBold,
+    fontSize: 15,
+    width: 28,
+    letterSpacing: 0.5,
+  },
+  questionLabel: {
+    flex: 1,
+    fontFamily: FontFamily.medium,
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  questionArrow: {
+    marginLeft: 4,
+  },
+  welcomeFooter: {
+    marginTop: 44,
+  },
+
+  /* Message list */
+  messageList: {
+    paddingHorizontal: 22,
+    paddingTop: 8,
+  },
+  listFooter: {
+    paddingBottom: 8,
+  },
+  messageRow: {
+    flexDirection: "row",
+  },
+  userRow: {
+    justifyContent: "flex-end",
+  },
+  userBubble: {
+    maxWidth: "80%",
+    paddingHorizontal: 16,
+    paddingVertical: 11,
+    borderRadius: 20,
+    borderBottomRightRadius: 6,
+  },
+  userText: {
+    color: "#ffffff",
+    fontFamily: FontFamily.regular,
+    fontSize: 15.5,
+    lineHeight: 22,
+  },
+
+  /* Assistant — editorial prose */
+  assistantBlock: {
+    flexDirection: "column",
+  },
+  assistantMeta: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 10,
+  },
+  assistantMetaLabel: {
+    fontFamily: FontFamily.semiBold,
+    fontSize: 11,
+    letterSpacing: 1.8,
+  },
+  assistantBody: {
+    paddingLeft: 32,
+    paddingRight: 8,
+  },
+  typingBody: {
+    paddingTop: 4,
+    paddingBottom: 4,
+  },
+
+  /* Typing indicator */
+  dotsRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    height: 22,
+  },
+  dot: {
+    width: 7,
+    height: 7,
+    borderRadius: 3.5,
+  },
+
+  /* Floating composer */
+  floatingWrap: {
+    position: "absolute",
+    left: 14,
+    right: 14,
+    zIndex: 10,
+  },
+  glassBar: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    borderRadius: 22,
+    padding: 6,
+    gap: 6,
+  },
+  glassBarFallback: {
+    overflow: "hidden",
+  },
+  glassInputField: {
+    flex: 1,
+    borderRadius: 18,
+    paddingHorizontal: 14,
+    paddingVertical: Platform.OS === "ios" ? 10 : 6,
+    minHeight: 40,
+    justifyContent: "center",
+    backgroundColor: "transparent",
+  },
+  glassInputText: {
+    fontSize: 15.5,
+    lineHeight: 20,
+    maxHeight: 100,
+    paddingTop: 0,
+    paddingBottom: 0,
+    textAlignVertical: "center",
+  },
+  glassSendBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  /* Scroll-to-bottom floating button */
+  scrollToBottomBtn: {
+    position: "absolute",
+    alignSelf: "center",
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: StyleSheet.hairlineWidth,
+    zIndex: 11,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.14,
+    shadowRadius: 10,
+    elevation: 6,
+  },
+});

--- a/mobile/app/help/team.tsx
+++ b/mobile/app/help/team.tsx
@@ -1,0 +1,645 @@
+import { Ionicons } from "@expo/vector-icons";
+import { BlurView } from "expo-blur";
+import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect";
+import * as Haptics from "expo-haptics";
+import { useFocusEffect, useRouter } from "expo-router";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Keyboard,
+  LayoutAnimation,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { Brand, Colors, FontFamily } from "@/constants/theme";
+import { useColorScheme } from "@/hooks/use-color-scheme";
+import {
+  fetchTeamThread,
+  markTeamThreadRead,
+  sendTeamMessage,
+  type HoursStatus,
+  type TeamMessage,
+} from "@/lib/messages";
+
+const FLOATING_BAR_HEIGHT = 60;
+const REFRESH_ON_FOCUS_INTERVAL_MS = 15000;
+
+type PaperTint = {
+  paper: string;
+  ink: string;
+  inkSoft: string;
+  rule: string;
+  accent: string;
+  eyebrow: string;
+};
+
+function usePaperTint(
+  isDark: boolean,
+  colors: (typeof Colors)["light"]
+): PaperTint {
+  return {
+    paper: colors.background,
+    ink: isDark ? colors.text : Brand.green,
+    inkSoft: isDark ? colors.textSecondary : "#4a5a4f",
+    rule: isDark ? "rgba(232,245,232,0.12)" : "rgba(14,58,35,0.14)",
+    accent: Brand.accent,
+    eyebrow: isDark ? Brand.greenLight : Brand.green,
+  };
+}
+
+/* ─── Bubble ────────────────────────────────────────────────── */
+
+const Bubble = React.memo(function Bubble({
+  item,
+  isFirstInGroup,
+  colors,
+  isDark,
+  paperTint,
+}: {
+  item: TeamMessage;
+  isFirstInGroup: boolean;
+  colors: (typeof Colors)["light"];
+  isDark: boolean;
+  paperTint: PaperTint;
+}) {
+  const isAdmin = item.senderRole === "ADMIN";
+  const senderName =
+    [item.sender.firstName, item.sender.lastName].filter(Boolean).join(" ") ||
+    item.sender.name ||
+    "";
+
+  if (!isAdmin) {
+    return (
+      <View
+        style={[
+          styles.row,
+          styles.rowEnd,
+          { marginTop: isFirstInGroup ? 18 : 4 },
+        ]}
+      >
+        <View style={[styles.userBubble, { backgroundColor: Brand.green }]}>
+          <Text style={styles.userBubbleText}>{item.body}</Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.assistantBlock, { marginTop: isFirstInGroup ? 24 : 8 }]}>
+      {isFirstInGroup && (
+        <View style={styles.assistantMeta}>
+          <View
+            style={[
+              styles.adminAvatar,
+              {
+                backgroundColor: isDark ? Brand.greenDark : Brand.greenLight,
+              },
+            ]}
+          >
+            <Text style={styles.adminAvatarText}>🌿</Text>
+          </View>
+          <Text style={[styles.assistantMetaLabel, { color: paperTint.eyebrow }]}>
+            {senderName ? senderName.toUpperCase() : "EE TEAM"} · TEAM
+          </Text>
+          <Text style={[styles.timeLabel, { color: paperTint.inkSoft }]}>
+            {formatTime(item.createdAt)}
+          </Text>
+        </View>
+      )}
+      <View style={styles.assistantBody}>
+        <Text style={[styles.assistantBubbleText, { color: colors.text }]}>
+          {item.body}
+        </Text>
+      </View>
+    </View>
+  );
+});
+
+/* ─── Screen ────────────────────────────────────────────────── */
+
+export default function TeamThreadScreen() {
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme];
+  const isDark = colorScheme === "dark";
+  const insets = useSafeAreaInsets();
+  const paperTint = usePaperTint(isDark, colors);
+  const router = useRouter();
+
+  const [messages, setMessages] = useState<TeamMessage[]>([]);
+  const [hours, setHours] = useState<HoursStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [composerHeight, setComposerHeight] = useState(FLOATING_BAR_HEIGHT);
+  const flatListRef = useRef<FlatList<TeamMessage>>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refresh = useCallback(async (markRead: boolean = true) => {
+    try {
+      const data = await fetchTeamThread();
+      setMessages(data.messages);
+      setHours(data.hours);
+      if (markRead && data.thread.unread) {
+        markTeamThreadRead().catch(() => {});
+      }
+    } catch (err) {
+      console.warn("[help/team] refresh failed", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void refresh();
+      const tick = () => {
+        pollTimerRef.current = setTimeout(() => {
+          void refresh(false).finally(tick);
+        }, REFRESH_ON_FOCUS_INTERVAL_MS);
+      };
+      tick();
+      return () => {
+        if (pollTimerRef.current) clearTimeout(pollTimerRef.current);
+      };
+    }, [refresh])
+  );
+
+  /* Keyboard tracking with smooth LayoutAnimation. */
+  useEffect(() => {
+    const showSub = Keyboard.addListener(
+      Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow",
+      (e) => {
+        if (Platform.OS === "ios") {
+          LayoutAnimation.configureNext({
+            duration: e.duration,
+            update: { type: LayoutAnimation.Types.keyboard },
+          });
+        }
+        setKeyboardHeight(e.endCoordinates.height);
+      }
+    );
+    const hideSub = Keyboard.addListener(
+      Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide",
+      (e) => {
+        if (Platform.OS === "ios" && e?.duration) {
+          LayoutAnimation.configureNext({
+            duration: e.duration,
+            update: { type: LayoutAnimation.Types.keyboard },
+          });
+        }
+        setKeyboardHeight(0);
+      }
+    );
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  const send = useCallback(async () => {
+    const body = input.trim();
+    if (!body || sending) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setSending(true);
+    setInput("");
+    try {
+      const { message } = await sendTeamMessage(body);
+      setMessages((prev) => [...prev, message]);
+      requestAnimationFrame(() => {
+        flatListRef.current?.scrollToEnd({ animated: true });
+      });
+    } catch (err) {
+      setInput(body);
+      console.warn("[help/team] send failed", err);
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+    } finally {
+      setSending(false);
+    }
+  }, [input, sending]);
+
+  const renderMessage = useCallback(
+    ({ item, index }: { item: TeamMessage; index: number }) => {
+      const prev = messages[index - 1];
+      return (
+        <Bubble
+          item={item}
+          isFirstInGroup={
+            !prev ||
+            prev.senderRole !== item.senderRole ||
+            new Date(item.createdAt).getTime() -
+              new Date(prev.createdAt).getTime() >
+              5 * 60 * 1000
+          }
+          colors={colors}
+          isDark={isDark}
+          paperTint={paperTint}
+        />
+      );
+    },
+    [messages, colors, isDark, paperTint]
+  );
+
+  const floatingBottom = keyboardHeight > 0
+    ? keyboardHeight + 8
+    : insets.bottom + 8;
+
+  const useNativeGlass = isLiquidGlassAvailable();
+  const sendBtnInactive = isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.06)";
+  const hasInput = input.trim().length > 0 && !sending;
+
+  const composerInner = (
+    <>
+      <View style={styles.glassInputField}>
+        <TextInput
+          style={[
+            styles.glassInputText,
+            { color: colors.text, fontFamily: FontFamily.regular },
+          ]}
+          value={input}
+          onChangeText={setInput}
+          placeholder="Message the team…"
+          placeholderTextColor={colors.textSecondary}
+          multiline
+          maxLength={4000}
+          returnKeyType="default"
+          editable={!sending}
+          accessibilityLabel="Message input"
+        />
+      </View>
+      <Pressable
+        onPress={send}
+        disabled={!hasInput}
+        style={({ pressed }) => [
+          styles.glassSendBtn,
+          {
+            backgroundColor: hasInput ? Brand.green : sendBtnInactive,
+            transform: [{ scale: pressed && hasInput ? 0.9 : 1 }],
+          },
+        ]}
+        accessibilityLabel="Send message"
+        accessibilityRole="button"
+      >
+        {sending ? (
+          <ActivityIndicator color={hasInput ? "#ffffff" : colors.textSecondary} />
+        ) : (
+          <Ionicons
+            name="arrow-up"
+            size={18}
+            color={hasInput ? "#ffffff" : colors.textSecondary}
+          />
+        )}
+      </Pressable>
+    </>
+  );
+
+  return (
+    <View style={[styles.container, { backgroundColor: paperTint.paper }]}>
+      {/* Header */}
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + 14,
+            borderBottomColor: paperTint.rule,
+          },
+        ]}
+      >
+        <Pressable
+          onPress={() => router.back()}
+          hitSlop={12}
+          style={styles.backBtn}
+          accessibilityLabel="Back"
+          accessibilityRole="button"
+        >
+          <Ionicons name="chevron-back" size={22} color={paperTint.eyebrow} />
+        </Pressable>
+        <View style={styles.headerCenter}>
+          <Text style={[styles.headerTitle, { color: paperTint.eyebrow }]}>
+            EE TEAM
+          </Text>
+          <Text
+            style={[styles.headerSubtitle, { color: paperTint.inkSoft }]}
+            numberOfLines={1}
+          >
+            {hoursSubtitle(hours)}
+          </Text>
+        </View>
+        <View style={styles.backBtn} />
+      </View>
+
+      {/* Messages */}
+      {loading ? (
+        <View style={styles.loadingState}>
+          <ActivityIndicator color={paperTint.eyebrow} />
+        </View>
+      ) : messages.length === 0 ? (
+        <EmptyState paperTint={paperTint} colors={colors} />
+      ) : (
+        <FlatList
+          ref={flatListRef}
+          data={messages}
+          renderItem={renderMessage}
+          keyExtractor={(m) => m.id}
+          contentContainerStyle={[
+            styles.messageList,
+            { paddingBottom: composerHeight + floatingBottom + 16 },
+          ]}
+          keyboardShouldPersistTaps="handled"
+          onContentSizeChange={() => {
+            requestAnimationFrame(() => {
+              flatListRef.current?.scrollToEnd({ animated: false });
+            });
+          }}
+        />
+      )}
+
+      {/* Off-hours hint */}
+      {hours && !hours.isOpenNow && (
+        <View
+          style={[
+            styles.offHoursHint,
+            {
+              bottom: floatingBottom + composerHeight + 12,
+              backgroundColor: isDark
+                ? "rgba(255,255,255,0.06)"
+                : "rgba(14,58,35,0.05)",
+              borderColor: paperTint.rule,
+            },
+          ]}
+          pointerEvents="none"
+        >
+          <Text style={[styles.offHoursText, { color: paperTint.inkSoft }]}>
+            {hours.nextOpenLabel
+              ? `Team is offline · ${hours.nextOpenLabel.toLowerCase()}`
+              : "Team is offline · we'll reply when we're around"}
+          </Text>
+        </View>
+      )}
+
+      {/* Composer */}
+      <View
+        onLayout={(e) => {
+          const h = e.nativeEvent.layout.height;
+          if (h > 0 && Math.abs(h - composerHeight) > 0.5) {
+            setComposerHeight(h);
+          }
+        }}
+        style={[
+          styles.floatingWrap,
+          { bottom: floatingBottom },
+          Platform.OS === "ios" && {
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: 4 },
+            shadowOpacity: isDark ? 0.3 : 0.1,
+            shadowRadius: 16,
+          },
+          Platform.OS === "android" && { elevation: 8 },
+        ]}
+      >
+        {useNativeGlass ? (
+          <GlassView glassEffectStyle="regular" style={styles.glassBar}>
+            {composerInner}
+          </GlassView>
+        ) : (
+          <View style={[styles.glassBar, styles.glassBarFallback]}>
+            <BlurView
+              intensity={isDark ? 60 : 80}
+              tint={isDark ? "dark" : "light"}
+              style={[StyleSheet.absoluteFill, { borderRadius: 22 }]}
+            />
+            <View
+              style={[
+                StyleSheet.absoluteFill,
+                {
+                  backgroundColor: isDark
+                    ? "rgba(40,44,52,0.55)"
+                    : "rgba(255,253,247,0.78)",
+                  borderColor: paperTint.rule,
+                  borderWidth: StyleSheet.hairlineWidth,
+                  borderRadius: 22,
+                },
+              ]}
+            />
+            {composerInner}
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}
+
+/* ─── Empty state ───────────────────────────────────────────── */
+
+function EmptyState({
+  paperTint,
+  colors,
+}: {
+  paperTint: PaperTint;
+  colors: (typeof Colors)["light"];
+}) {
+  return (
+    <View style={styles.emptyState}>
+      <Text style={[styles.emptyEmoji]}>💬</Text>
+      <Text style={[styles.emptyTitle, { color: colors.text }]}>
+        Say kia ora to the team
+      </Text>
+      <Text style={[styles.emptyBody, { color: paperTint.inkSoft }]}>
+        Tell us what&apos;s up — running late, swapping a shift, a question,
+        anything. We&apos;ll get back as soon as we can.
+      </Text>
+    </View>
+  );
+}
+
+/* ─── Helpers ───────────────────────────────────────────────── */
+
+function formatTime(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  if (sameDay) {
+    return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  }
+  return date.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+function hoursSubtitle(hours: HoursStatus | null): string {
+  if (!hours) return "We reply during opening hours";
+  if (hours.isOpenNow) return "Online · usually replies quickly";
+  return hours.nextOpenLabel ?? "Currently offline";
+}
+
+/* ─── Styles ────────────────────────────────────────────────── */
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  backBtn: { width: 40, alignItems: "flex-start", justifyContent: "center" },
+  headerCenter: { flex: 1, alignItems: "center" },
+  headerTitle: {
+    fontFamily: FontFamily.semiBold,
+    fontSize: 12,
+    letterSpacing: 2.2,
+  },
+  headerSubtitle: {
+    fontFamily: FontFamily.regular,
+    fontSize: 12,
+    marginTop: 2,
+  },
+  loadingState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 36,
+    paddingBottom: FLOATING_BAR_HEIGHT * 2,
+  },
+  emptyEmoji: { fontSize: 44, marginBottom: 14 },
+  emptyTitle: {
+    fontFamily: FontFamily.headingBold,
+    fontSize: 24,
+    letterSpacing: -0.4,
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  emptyBody: {
+    fontFamily: FontFamily.regular,
+    fontSize: 14.5,
+    lineHeight: 21,
+    textAlign: "center",
+    maxWidth: 320,
+  },
+  messageList: {
+    paddingHorizontal: 22,
+    paddingTop: 12,
+  },
+  row: { flexDirection: "row" },
+  rowEnd: { justifyContent: "flex-end" },
+  userBubble: {
+    maxWidth: "80%",
+    paddingHorizontal: 16,
+    paddingVertical: 11,
+    borderRadius: 20,
+    borderBottomRightRadius: 6,
+  },
+  userBubbleText: {
+    color: "#ffffff",
+    fontFamily: FontFamily.regular,
+    fontSize: 15.5,
+    lineHeight: 22,
+  },
+  assistantBlock: { flexDirection: "column" },
+  assistantMeta: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 6,
+  },
+  adminAvatar: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  adminAvatarText: { fontSize: 11 },
+  assistantMetaLabel: {
+    fontFamily: FontFamily.semiBold,
+    fontSize: 11,
+    letterSpacing: 1.6,
+  },
+  timeLabel: {
+    fontFamily: FontFamily.regular,
+    fontSize: 11,
+    marginLeft: "auto",
+  },
+  assistantBody: {
+    paddingLeft: 32,
+    paddingRight: 8,
+  },
+  assistantBubbleText: {
+    fontFamily: FontFamily.regular,
+    fontSize: 15.5,
+    lineHeight: 23,
+  },
+  offHoursHint: {
+    position: "absolute",
+    left: 22,
+    right: 22,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    alignItems: "center",
+    zIndex: 5,
+  },
+  offHoursText: {
+    fontFamily: FontFamily.medium,
+    fontSize: 12,
+    letterSpacing: 0.2,
+  },
+  floatingWrap: {
+    position: "absolute",
+    left: 14,
+    right: 14,
+    zIndex: 10,
+  },
+  glassBar: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    borderRadius: 22,
+    padding: 6,
+    gap: 6,
+  },
+  glassBarFallback: { overflow: "hidden" },
+  glassInputField: {
+    flex: 1,
+    borderRadius: 18,
+    paddingHorizontal: 14,
+    paddingVertical: Platform.OS === "ios" ? 10 : 6,
+    minHeight: 40,
+    justifyContent: "center",
+    backgroundColor: "transparent",
+  },
+  glassInputText: {
+    fontSize: 15.5,
+    lineHeight: 20,
+    maxHeight: 120,
+    paddingTop: 0,
+    paddingBottom: 0,
+    textAlignVertical: "center",
+  },
+  glassSendBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/mobile/lib/messages.ts
+++ b/mobile/lib/messages.ts
@@ -1,0 +1,60 @@
+import { api } from "./api";
+
+export type Role = "VOLUNTEER" | "ADMIN";
+
+export interface TeamMessage {
+  id: string;
+  body: string;
+  senderId: string;
+  senderRole: Role;
+  createdAt: string;
+  sender: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    name: string | null;
+    profilePhotoUrl: string | null;
+  };
+}
+
+export interface DayHours {
+  dayOfWeek: number;
+  isOpen: boolean;
+  openTime: string;
+  closeTime: string;
+}
+
+export interface HoursStatus {
+  location: string | null;
+  isOpenNow: boolean;
+  todayHours: DayHours;
+  nextOpenLabel: string | null;
+}
+
+export interface ThreadFetchResult {
+  thread: {
+    id: string;
+    status: "OPEN" | "RESOLVED";
+    lastMessageAt: string;
+    unread: boolean;
+  };
+  messages: TeamMessage[];
+  hours: HoursStatus | null;
+}
+
+export function fetchTeamThread(): Promise<ThreadFetchResult> {
+  return api<ThreadFetchResult>("/api/mobile/messages/thread");
+}
+
+export function sendTeamMessage(body: string): Promise<{ message: TeamMessage }> {
+  return api<{ message: TeamMessage }>("/api/mobile/messages/thread/messages", {
+    method: "POST",
+    body: { body },
+  });
+}
+
+export function markTeamThreadRead(): Promise<{ ok: true }> {
+  return api<{ ok: true }>("/api/mobile/messages/thread", {
+    method: "POST",
+  });
+}

--- a/mobile/lib/notification-routing.ts
+++ b/mobile/lib/notification-routing.ts
@@ -37,6 +37,12 @@ export function navigateToNotificationTarget(actionUrl: unknown) {
     return;
   }
 
+  // /help/team -> volunteer ↔ team direct-message thread on the help tab
+  if (pathname === "/help/team") {
+    router.push("/help/team");
+    return;
+  }
+
   // /surveys/:token -> open the web survey page in an in-app browser.
   // Surveys aren't implemented natively on mobile, so we hand off to the
   // web experience rather than no-op.

--- a/web/prisma/migrations/20260430000000_add_direct_messaging/migration.sql
+++ b/web/prisma/migrations/20260430000000_add_direct_messaging/migration.sql
@@ -1,0 +1,72 @@
+-- CreateEnum
+CREATE TYPE "ThreadStatus" AS ENUM ('OPEN', 'RESOLVED');
+
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'DIRECT_MESSAGE';
+
+-- CreateTable
+CREATE TABLE "MessageThread" (
+    "id" TEXT NOT NULL,
+    "volunteerId" TEXT NOT NULL,
+    "status" "ThreadStatus" NOT NULL DEFAULT 'OPEN',
+    "lastMessageAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "volunteerLastReadAt" TIMESTAMP(3),
+    "teamLastReadAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MessageThread_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "senderRole" "Role" NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MessagingHours" (
+    "id" TEXT NOT NULL,
+    "location" TEXT NOT NULL,
+    "dayOfWeek" INTEGER NOT NULL,
+    "isOpen" BOOLEAN NOT NULL DEFAULT true,
+    "openTime" TEXT NOT NULL DEFAULT '09:00',
+    "closeTime" TEXT NOT NULL DEFAULT '17:00',
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "MessagingHours_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MessageThread_volunteerId_key" ON "MessageThread"("volunteerId");
+
+-- CreateIndex
+CREATE INDEX "MessageThread_status_lastMessageAt_idx" ON "MessageThread"("status", "lastMessageAt");
+
+-- CreateIndex
+CREATE INDEX "MessageThread_lastMessageAt_idx" ON "MessageThread"("lastMessageAt");
+
+-- CreateIndex
+CREATE INDEX "Message_threadId_createdAt_idx" ON "Message"("threadId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MessagingHours_location_idx" ON "MessagingHours"("location");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MessagingHours_location_dayOfWeek_key" ON "MessagingHours"("location", "dayOfWeek");
+
+-- AddForeignKey
+ALTER TABLE "MessageThread" ADD CONSTRAINT "MessageThread_volunteerId_fkey" FOREIGN KEY ("volunteerId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "MessageThread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -155,6 +155,10 @@ model User {
   // Mobile chat assistant conversations
   chatLogs ChatLog[]
 
+  // Direct messaging between volunteer and the team
+  messageThread MessageThread? @relation("VolunteerThread")
+  sentMessages  Message[]      @relation("MessageSender")
+
   // Analytics queries filter heavily on role + createdAt
   @@index([role, createdAt])
   // Archive filters and scheduled job queries
@@ -468,6 +472,7 @@ enum NotificationType {
   SURVEY_ASSIGNED // A new survey has been assigned to you
   SHIFT_SHORTAGE // Admin sent shortage alert for shifts that need more volunteers
   ANNOUNCEMENT // Admin published an announcement targeted at this volunteer
+  DIRECT_MESSAGE // Direct message in volunteer-team thread
 }
 
 model RestaurantManager {
@@ -1054,4 +1059,56 @@ model ArchiveLog {
   @@index([userId, createdAt])
   @@index([createdAt])
   @@index([eventType, createdAt])
+}
+
+// Direct-message thread between a volunteer and the EE team.
+// One thread per volunteer; any admin/manager can reply on it.
+model MessageThread {
+  id                  String        @id @default(cuid())
+  volunteerId         String        @unique
+  volunteer           User          @relation("VolunteerThread", fields: [volunteerId], references: [id], onDelete: Cascade)
+  status              ThreadStatus  @default(OPEN)
+  lastMessageAt       DateTime      @default(now())
+  volunteerLastReadAt DateTime?
+  teamLastReadAt      DateTime?
+  createdAt           DateTime      @default(now())
+  updatedAt           DateTime      @updatedAt
+  messages            Message[]
+
+  @@index([status, lastMessageAt])
+  @@index([lastMessageAt])
+}
+
+model Message {
+  id         String        @id @default(cuid())
+  threadId   String
+  thread     MessageThread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  senderId   String
+  sender     User          @relation("MessageSender", fields: [senderId], references: [id], onDelete: Cascade)
+  senderRole Role          // snapshot at send time so admin role demotion doesn't mislabel old messages
+  body       String
+  createdAt  DateTime      @default(now())
+
+  @@index([threadId, createdAt])
+}
+
+enum ThreadStatus {
+  OPEN
+  RESOLVED
+}
+
+// Per-day, per-location messaging hours shown to volunteers as a soft
+// expectation-setter. Off-hours messages are still delivered.
+model MessagingHours {
+  id        String   @id @default(cuid())
+  location  String   // matches Location.name
+  dayOfWeek Int      // 0=Sun ... 6=Sat (NZ time)
+  isOpen    Boolean  @default(true)
+  openTime  String   @default("09:00") // "HH:mm"
+  closeTime String   @default("17:00") // "HH:mm"
+  updatedAt DateTime @updatedAt
+  updatedBy String?
+
+  @@unique([location, dayOfWeek])
+  @@index([location])
 }

--- a/web/src/app/admin/layout.tsx
+++ b/web/src/app/admin/layout.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { isFeatureEnabled, FeatureFlag } from "@/lib/posthog-server";
+import { countUnreadForTeam } from "@/lib/services/messaging";
 
 import { AdminSidebar } from "@/components/admin-sidebar";
 import { AdminLayoutHeader } from "@/components/admin-layout-header";
@@ -60,7 +61,7 @@ export default async function AdminLayout({
 
   // Get pending parental consent count (volunteers requiring consent but not yet received)
   // Uses requiresParentalConsent flag for consistency with the table data
-  const [pendingParentalConsentCount, pendingReportCount, chatGuidesEnabled] = await Promise.all([
+  const [pendingParentalConsentCount, pendingReportCount, chatGuidesEnabled, unreadMessagesCount] = await Promise.all([
     prisma.user.count({
       where: {
         role: "VOLUNTEER",
@@ -71,6 +72,7 @@ export default async function AdminLayout({
     }),
     prisma.contentReport.count({ where: { status: "PENDING" } }),
     isFeatureEnabled(FeatureFlag.CHAT_GUIDES, session.user.id),
+    countUnreadForTeam(),
   ]);
 
   // Build list of nav items to hide based on feature flags
@@ -88,6 +90,7 @@ export default async function AdminLayout({
           displayName={displayName}
           pendingParentalConsentCount={pendingParentalConsentCount}
           pendingReportCount={pendingReportCount}
+          unreadMessagesCount={unreadMessagesCount}
           hiddenNavItems={hiddenNavItems}
         />
         <SidebarInset>

--- a/web/src/app/admin/messages/page.tsx
+++ b/web/src/app/admin/messages/page.tsx
@@ -1,0 +1,55 @@
+import { Metadata } from "next";
+import { connection } from "next/server";
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { MessagesInbox } from "@/components/admin/messages/messages-inbox";
+import { listThreadsForAdmin } from "@/lib/services/messaging";
+import { prisma } from "@/lib/prisma";
+
+export const metadata: Metadata = {
+  title: "Messages | Admin",
+  description: "Direct messages with volunteers",
+};
+
+export default async function AdminMessagesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ thread?: string }>;
+}) {
+  await connection();
+  const sp = await searchParams;
+
+  const [threads, locations] = await Promise.all([
+    listThreadsForAdmin({ status: "OPEN", limit: 50 }),
+    prisma.location.findMany({
+      where: { isActive: true },
+      select: { name: true },
+      orderBy: { name: "asc" },
+    }),
+  ]);
+
+  return (
+    <AdminPageWrapper
+      title="Messages"
+      description="Direct conversations with volunteers — any admin can reply"
+    >
+      <MessagesInbox
+        initialThreads={serializeThreads(threads)}
+        initialSelectedId={sp.thread ?? null}
+        locations={locations.map((l) => l.name)}
+      />
+    </AdminPageWrapper>
+  );
+}
+
+function serializeThreads(threads: Awaited<ReturnType<typeof listThreadsForAdmin>>) {
+  return threads.map((t) => ({
+    ...t,
+    lastMessageAt: t.lastMessageAt.toISOString(),
+    lastMessage: t.lastMessage
+      ? {
+          ...t.lastMessage,
+          createdAt: t.lastMessage.createdAt.toISOString(),
+        }
+      : null,
+  }));
+}

--- a/web/src/app/admin/site-settings/messaging-hours/page.tsx
+++ b/web/src/app/admin/site-settings/messaging-hours/page.tsx
@@ -1,0 +1,36 @@
+import { Metadata } from "next";
+import { connection } from "next/server";
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/lib/auth-options";
+
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { PageContainer } from "@/components/page-container";
+import { MessagingHoursEditor } from "@/components/admin/messages/messaging-hours-editor";
+import { getAllLocationHours } from "@/lib/services/messaging-hours";
+
+export const metadata: Metadata = {
+  title: "Messaging Hours | Admin",
+  description: "Set per-day messaging hours per location",
+};
+
+export default async function MessagingHoursPage() {
+  await connection();
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "ADMIN") {
+    redirect("/dashboard");
+  }
+
+  const locations = await getAllLocationHours();
+
+  return (
+    <AdminPageWrapper
+      title="Messaging Hours"
+      description="Configure when the team typically replies to volunteer messages — shown in the mobile app as a soft expectation-setter"
+    >
+      <PageContainer>
+        <MessagingHoursEditor initialLocations={locations} />
+      </PageContainer>
+    </AdminPageWrapper>
+  );
+}

--- a/web/src/app/admin/site-settings/page.tsx
+++ b/web/src/app/admin/site-settings/page.tsx
@@ -1,10 +1,13 @@
+import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { redirect } from "next/navigation";
+import { ArrowRight, Clock } from "lucide-react";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { SiteSettingsForm } from "@/components/site-settings-form";
+import { Card, CardContent } from "@/components/ui/card";
 
 export default async function SiteSettingsPage() {
   const session = await getServerSession(authOptions);
@@ -23,7 +26,25 @@ export default async function SiteSettingsPage() {
       description="Configure site-wide settings and URLs"
     >
       <PageContainer>
-        <SiteSettingsForm settings={settings} />
+        <div className="space-y-6">
+          <Card className="hover:bg-muted/30 transition-colors">
+            <Link href="/admin/site-settings/messaging-hours" className="block">
+              <CardContent className="py-5 flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3">
+                  <Clock className="w-5 h-5 text-emerald-700" />
+                  <div>
+                    <p className="font-medium">Messaging hours</p>
+                    <p className="text-sm text-muted-foreground">
+                      Per-day, per-location reply windows shown to volunteers
+                    </p>
+                  </div>
+                </div>
+                <ArrowRight className="w-4 h-4 text-muted-foreground" />
+              </CardContent>
+            </Link>
+          </Card>
+          <SiteSettingsForm settings={settings} />
+        </div>
       </PageContainer>
     </AdminPageWrapper>
   );

--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -41,6 +41,7 @@ import { UserCustomLabelsManager } from "@/components/user-custom-labels-manager
 import { type VolunteerGrade } from "@/generated/client";
 import { LOCATIONS, LocationOption } from "@/lib/locations";
 import { ImpersonateUserButton } from "@/components/impersonate-user-button";
+import { MessageVolunteerButton } from "@/components/admin/messages/message-volunteer-button";
 import { AdminContactInfoSection } from "@/components/admin-contact-info-section";
 import { GenerateAchievementsButton } from "@/components/generate-achievements-button";
 import { hearAboutUsOptions } from "@/lib/form-constants";
@@ -569,6 +570,21 @@ export default async function AdminVolunteerPage({
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
+                {volunteer.role === "VOLUNTEER" && (
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">
+                      Send a direct message
+                    </label>
+                    <div>
+                      <MessageVolunteerButton volunteerId={volunteer.id} />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Opens (or creates) a 1:1 conversation thread between this
+                      volunteer and the team
+                    </p>
+                  </div>
+                )}
+
                 <div className="space-y-2">
                   <label className="text-sm font-medium">
                     Impersonate User

--- a/web/src/app/api/admin/messages/threads/[id]/messages/route.ts
+++ b/web/src/app/api/admin/messages/threads/[id]/messages/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { sendMessage, MessagingError } from "@/lib/services/messaging";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN" || !session.user.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const { id: threadId } = await params;
+  let body: string;
+  try {
+    const json = (await req.json()) as { body?: unknown };
+    if (typeof json.body !== "string") {
+      return NextResponse.json({ error: "body is required" }, { status: 400 });
+    }
+    body = json.body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const message = await sendMessage({
+      threadId,
+      senderId: session.user.id,
+      senderRole: "ADMIN",
+      body,
+    });
+    return NextResponse.json({ message });
+  } catch (err) {
+    if (err instanceof MessagingError) {
+      const code = err.code === "NOT_FOUND" ? 404 : err.code === "FORBIDDEN" ? 403 : 400;
+      return NextResponse.json({ error: err.message }, { status: code });
+    }
+    console.error("[admin messages send]", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/admin/messages/threads/[id]/read/route.ts
+++ b/web/src/app/api/admin/messages/threads/[id]/read/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { markThreadRead } from "@/lib/services/messaging";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+  const { id } = await params;
+  await markThreadRead(id, "team");
+  return NextResponse.json({ ok: true });
+}

--- a/web/src/app/api/admin/messages/threads/[id]/resolve/route.ts
+++ b/web/src/app/api/admin/messages/threads/[id]/resolve/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { setThreadStatus } from "@/lib/services/messaging";
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+  const { id } = await params;
+
+  let status: "OPEN" | "RESOLVED" = "RESOLVED";
+  try {
+    const json = (await req.json().catch(() => ({}))) as { status?: unknown };
+    if (json.status === "OPEN" || json.status === "RESOLVED") {
+      status = json.status;
+    }
+  } catch {
+    // Default to RESOLVED if no body
+  }
+
+  await setThreadStatus(id, status);
+  return NextResponse.json({ ok: true, status });
+}

--- a/web/src/app/api/admin/messages/threads/[id]/route.ts
+++ b/web/src/app/api/admin/messages/threads/[id]/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+import { listMessages } from "@/lib/services/messaging";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const url = new URL(req.url);
+  const before = url.searchParams.get("before");
+  const limit = Number(url.searchParams.get("limit") ?? 50);
+
+  const thread = await prisma.messageThread.findUnique({
+    where: { id },
+    include: {
+      volunteer: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          name: true,
+          email: true,
+          phone: true,
+          profilePhotoUrl: true,
+          defaultLocation: true,
+          volunteerGrade: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+  if (!thread) {
+    return NextResponse.json({ error: "Thread not found" }, { status: 404 });
+  }
+
+  const messages = await listMessages({
+    threadId: id,
+    before: before ? new Date(before) : undefined,
+    limit,
+  });
+
+  // Count of upcoming shifts for the volunteer-context sidebar.
+  const upcomingShiftCount = await prisma.signup.count({
+    where: {
+      userId: thread.volunteerId,
+      status: { in: ["CONFIRMED", "PENDING", "WAITLISTED"] },
+      shift: { start: { gte: new Date() } },
+    },
+  });
+
+  return NextResponse.json({ thread, messages, upcomingShiftCount });
+}

--- a/web/src/app/api/admin/messages/threads/route.ts
+++ b/web/src/app/api/admin/messages/threads/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import {
+  getOrCreateThreadForVolunteer,
+  listThreadsForAdmin,
+  MessagingError,
+} from "@/lib/services/messaging";
+
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const status = (url.searchParams.get("status") ?? "OPEN").toUpperCase();
+  const unreadOnly = url.searchParams.get("unread") === "true";
+  const search = url.searchParams.get("q") ?? undefined;
+  const location = url.searchParams.get("location") ?? undefined;
+  const cursor = url.searchParams.get("cursor") ?? undefined;
+  const limit = Number(url.searchParams.get("limit") ?? 30);
+
+  if (status !== "OPEN" && status !== "RESOLVED" && status !== "ALL") {
+    return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  try {
+    const threads = await listThreadsForAdmin({
+      status: status as "OPEN" | "RESOLVED" | "ALL",
+      unreadOnly,
+      search,
+      location,
+      cursor,
+      limit,
+    });
+    return NextResponse.json({ threads });
+  } catch (err) {
+    console.error("[admin/messages/threads GET]", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  let volunteerId: string;
+  try {
+    const body = (await req.json()) as { volunteerId?: unknown };
+    if (typeof body.volunteerId !== "string" || !body.volunteerId) {
+      return NextResponse.json(
+        { error: "volunteerId is required" },
+        { status: 400 }
+      );
+    }
+    volunteerId = body.volunteerId;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    const thread = await getOrCreateThreadForVolunteer(volunteerId);
+    return NextResponse.json({ thread });
+  } catch (err) {
+    if (err instanceof MessagingError) {
+      const code = err.code === "NOT_FOUND" ? 404 : 400;
+      return NextResponse.json({ error: err.message }, { status: code });
+    }
+    console.error("[admin/messages/threads POST]", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/admin/messages/unread-count/route.ts
+++ b/web/src/app/api/admin/messages/unread-count/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { countUnreadForTeam } from "@/lib/services/messaging";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+  const count = await countUnreadForTeam();
+  return NextResponse.json({ count });
+}

--- a/web/src/app/api/admin/messaging-hours/route.ts
+++ b/web/src/app/api/admin/messaging-hours/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import {
+  getAllLocationHours,
+  upsertHoursForLocation,
+} from "@/lib/services/messaging-hours";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+  const locations = await getAllLocationHours();
+  return NextResponse.json({ locations });
+}
+
+interface UpsertBody {
+  location?: unknown;
+  hours?: unknown;
+}
+
+export async function PUT(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN" || !session.user.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  let body: UpsertBody;
+  try {
+    body = (await req.json()) as UpsertBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (typeof body.location !== "string" || !body.location) {
+    return NextResponse.json({ error: "location is required" }, { status: 400 });
+  }
+  if (!Array.isArray(body.hours)) {
+    return NextResponse.json({ error: "hours[] is required" }, { status: 400 });
+  }
+
+  const hours = body.hours as Array<{
+    dayOfWeek: number;
+    isOpen: boolean;
+    openTime: string;
+    closeTime: string;
+  }>;
+
+  try {
+    const result = await upsertHoursForLocation({
+      location: body.location,
+      hours,
+      updatedBy: session.user.id,
+    });
+    return NextResponse.json({ location: result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Internal error";
+    console.error("[admin messaging-hours PUT]", err);
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/web/src/app/api/mobile/messages/thread/messages/route.ts
+++ b/web/src/app/api/mobile/messages/thread/messages/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { requireMobileUser } from "@/lib/mobile-auth";
+import {
+  getOrCreateThreadForVolunteer,
+  sendMessage,
+  MessagingError,
+} from "@/lib/services/messaging";
+
+export async function POST(request: Request) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: string;
+  try {
+    const json = (await request.json()) as { body?: unknown };
+    if (typeof json.body !== "string") {
+      return NextResponse.json({ error: "body is required" }, { status: 400 });
+    }
+    body = json.body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  try {
+    // Auto-create thread on first send.
+    const thread = await getOrCreateThreadForVolunteer(auth.userId);
+    const message = await sendMessage({
+      threadId: thread.id,
+      senderId: auth.userId,
+      senderRole: "VOLUNTEER",
+      body,
+    });
+    return NextResponse.json({ message });
+  } catch (err) {
+    if (err instanceof MessagingError) {
+      const code =
+        err.code === "NOT_FOUND" ? 404 : err.code === "FORBIDDEN" ? 403 : 400;
+      return NextResponse.json({ error: err.message }, { status: code });
+    }
+    console.error("[mobile messages send]", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/web/src/app/api/mobile/messages/thread/route.ts
+++ b/web/src/app/api/mobile/messages/thread/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { requireMobileUser } from "@/lib/mobile-auth";
+import {
+  getOrCreateThreadForVolunteer,
+  isUnreadForVolunteer,
+  listMessages,
+  MessagingError,
+} from "@/lib/services/messaging";
+import {
+  evaluateOpenStatus,
+  getHoursForLocation,
+  getPrimaryLocationForVolunteer,
+} from "@/lib/services/messaging-hours";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/mobile/messages/thread
+ *
+ * Returns the volunteer's team thread + recent messages + an off-hours hint
+ * for their primary location. Auto-creates the thread on first hit so the
+ * mobile UI never has to handle a "no thread yet" state explicitly.
+ */
+export async function GET(request: Request) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const thread = await getOrCreateThreadForVolunteer(auth.userId);
+
+    const messages = await listMessages({ threadId: thread.id, limit: 50 });
+
+    const primaryLocation = await getPrimaryLocationForVolunteer(auth.userId);
+    const hoursStatus = primaryLocation
+      ? evaluateOpenStatus(await getHoursForLocation(primaryLocation))
+      : null;
+
+    const lastForUnread = messages.length > 0 ? messages[messages.length - 1] : null;
+    const unread = lastForUnread
+      ? isUnreadForVolunteer({
+          volunteerLastReadAt: thread.volunteerLastReadAt,
+          lastMessageAt: thread.lastMessageAt,
+          messages: [{ senderRole: lastForUnread.senderRole }],
+        })
+      : false;
+
+    return NextResponse.json({
+      thread: {
+        id: thread.id,
+        status: thread.status,
+        lastMessageAt: thread.lastMessageAt,
+        unread,
+      },
+      messages,
+      hours: hoursStatus
+        ? {
+            location: primaryLocation,
+            isOpenNow: hoursStatus.isOpenNow,
+            todayHours: hoursStatus.todayHours,
+            nextOpenLabel: hoursStatus.nextOpenLabel ?? null,
+          }
+        : null,
+    });
+  } catch (err) {
+    if (err instanceof MessagingError) {
+      const code = err.code === "VOLUNTEER_REQUIRED" ? 403 : 400;
+      return NextResponse.json({ error: err.message }, { status: code });
+    }
+    console.error("[mobile messages thread GET]", err);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/mobile/messages/thread/read — clears volunteer-side unread.
+ */
+export async function POST(request: Request) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  await prisma.messageThread.updateMany({
+    where: { volunteerId: auth.userId },
+    data: { volunteerLastReadAt: new Date() },
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/web/src/components/admin-sidebar.tsx
+++ b/web/src/components/admin-sidebar.tsx
@@ -37,6 +37,7 @@ interface AdminSidebarProps {
   displayName: string;
   pendingParentalConsentCount: number;
   pendingReportCount?: number;
+  unreadMessagesCount?: number;
   hiddenNavItems?: string[];
 }
 
@@ -46,6 +47,7 @@ export function AdminSidebar({
   displayName,
   pendingParentalConsentCount,
   pendingReportCount = 0,
+  unreadMessagesCount = 0,
   hiddenNavItems = [],
 }: AdminSidebarProps) {
   const pathname = usePathname();
@@ -150,6 +152,15 @@ export function AdminSidebar({
                             data-testid="moderation-badge"
                           >
                             {pendingReportCount}
+                          </SidebarMenuBadge>
+                        )}
+                      {item.href === "/admin/messages" &&
+                        unreadMessagesCount > 0 && (
+                          <SidebarMenuBadge
+                            className="bg-emerald-600 text-white"
+                            data-testid="messages-badge"
+                          >
+                            {unreadMessagesCount}
                           </SidebarMenuBadge>
                         )}
                     </SidebarMenuItem>

--- a/web/src/components/admin/messages/compose-button.tsx
+++ b/web/src/components/admin/messages/compose-button.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { ReactNode, useCallback, useEffect, useState } from "react";
+import { Loader2, Search } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+interface ComposeButtonProps {
+  children: ReactNode;
+  onCreated: (threadId: string) => void;
+}
+
+interface VolunteerHit {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export function ComposeButton({ children, onCreated }: ComposeButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<VolunteerHit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      return;
+    }
+    const ctrl = new AbortController();
+    setLoading(true);
+    fetch(`/api/admin/users?q=${encodeURIComponent(trimmed)}&limit=20`, {
+      signal: ctrl.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("search failed");
+        const data = (await res.json()) as Array<{
+          id: string;
+          name?: string | null;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+          role: "VOLUNTEER" | "ADMIN";
+        }>;
+        setResults(
+          data
+            .filter((u) => u.role === "VOLUNTEER")
+            .slice(0, 10)
+            .map((u) => ({
+              id: u.id,
+              email: u.email,
+              name:
+                [u.firstName, u.lastName].filter(Boolean).join(" ") ||
+                u.name ||
+                u.email,
+            }))
+        );
+      })
+      .catch(() => {
+        // ignore aborted
+      })
+      .finally(() => setLoading(false));
+    return () => ctrl.abort();
+  }, [query, open]);
+
+  const start = useCallback(
+    async (volunteerId: string) => {
+      setCreating(true);
+      try {
+        const res = await fetch("/api/admin/messages/threads", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ volunteerId }),
+        });
+        if (!res.ok) {
+          const err = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          alert(err.error ?? "Failed to start conversation");
+          return;
+        }
+        const data = (await res.json()) as { thread: { id: string } };
+        onCreated(data.thread.id);
+        setOpen(false);
+        setQuery("");
+      } finally {
+        setCreating(false);
+      }
+    },
+    [onCreated]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm">{children}</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Start a conversation</DialogTitle>
+        </DialogHeader>
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <Input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search volunteers by name or email…"
+            className="pl-9"
+          />
+        </div>
+        <div className="mt-3 max-h-72 overflow-y-auto">
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+            </div>
+          ) : results.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-6">
+              {query.trim().length < 2
+                ? "Type at least 2 characters to search."
+                : "No volunteers found."}
+            </p>
+          ) : (
+            <ul className="divide-y">
+              {results.map((r) => (
+                <li key={r.id}>
+                  <button
+                    type="button"
+                    disabled={creating}
+                    onClick={() => start(r.id)}
+                    className="w-full text-left px-2 py-2.5 hover:bg-muted/60 transition-colors flex items-center justify-between gap-2 disabled:opacity-60"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">{r.name}</p>
+                      <p className="text-xs text-muted-foreground truncate">
+                        {r.email}
+                      </p>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/admin/messages/message-volunteer-button.tsx
+++ b/web/src/components/admin/messages/message-volunteer-button.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Loader2, MessageSquare } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface MessageVolunteerButtonProps {
+  volunteerId: string;
+}
+
+export function MessageVolunteerButton({
+  volunteerId,
+}: MessageVolunteerButtonProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/messages/threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ volunteerId }),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        alert(err.error ?? "Failed to start conversation");
+        return;
+      }
+      const data = (await res.json()) as { thread: { id: string } };
+      router.push(`/admin/messages?thread=${data.thread.id}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [volunteerId, router]);
+
+  return (
+    <Button onClick={handleClick} disabled={loading} variant="outline" size="sm">
+      {loading ? (
+        <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+      ) : (
+        <MessageSquare className="w-4 h-4 mr-1.5" />
+      )}
+      Message
+    </Button>
+  );
+}

--- a/web/src/components/admin/messages/messages-inbox.tsx
+++ b/web/src/components/admin/messages/messages-inbox.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Bell, BellOff, MessageSquarePlus, Search } from "lucide-react";
+
+import { useNotificationStream } from "@/hooks/use-notification-stream";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+import { ThreadList } from "./thread-list";
+import { ThreadView } from "./thread-view";
+import { ComposeButton } from "./compose-button";
+import type { InboxRealtimeEvent, SerializedThread } from "./types";
+
+interface MessagesInboxProps {
+  initialThreads: SerializedThread[];
+  initialSelectedId: string | null;
+  locations: string[];
+}
+
+export function MessagesInbox({
+  initialThreads,
+  initialSelectedId,
+  locations,
+}: MessagesInboxProps) {
+  const router = useRouter();
+  const [threads, setThreads] = useState<SerializedThread[]>(initialThreads);
+  const [selectedId, setSelectedId] = useState<string | null>(
+    initialSelectedId ?? initialThreads[0]?.id ?? null
+  );
+  const [statusFilter, setStatusFilter] = useState<"OPEN" | "RESOLVED" | "ALL">(
+    "OPEN"
+  );
+  const [unreadOnly, setUnreadOnly] = useState(false);
+  const [locationFilter, setLocationFilter] = useState<string>("");
+  const [search, setSearch] = useState("");
+  const [browserNotificationsOn, setBrowserNotificationsOn] = useState(false);
+
+  // Reload threads when filters change.
+  const fetchThreads = useCallback(async () => {
+    const params = new URLSearchParams();
+    params.set("status", statusFilter);
+    if (unreadOnly) params.set("unread", "true");
+    if (locationFilter) params.set("location", locationFilter);
+    if (search.trim()) params.set("q", search.trim());
+    const res = await fetch(`/api/admin/messages/threads?${params}`);
+    if (!res.ok) return;
+    const data = (await res.json()) as { threads: SerializedThread[] };
+    setThreads(data.threads);
+  }, [statusFilter, unreadOnly, locationFilter, search]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    const run = async () => {
+      try {
+        const params = new URLSearchParams();
+        params.set("status", statusFilter);
+        if (unreadOnly) params.set("unread", "true");
+        if (locationFilter) params.set("location", locationFilter);
+        if (search.trim()) params.set("q", search.trim());
+        const res = await fetch(`/api/admin/messages/threads?${params}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error("fetch failed");
+        const data = (await res.json()) as { threads: SerializedThread[] };
+        if (!cancelled) setThreads(data.threads);
+      } catch {
+        // ignore aborted/failed
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [statusFilter, unreadOnly, locationFilter, search]);
+
+  // Sync selected thread to URL.
+  useEffect(() => {
+    if (!selectedId) return;
+    const url = new URL(window.location.href);
+    if (url.searchParams.get("thread") !== selectedId) {
+      url.searchParams.set("thread", selectedId);
+      router.replace(url.pathname + url.search, { scroll: false });
+    }
+  }, [selectedId, router]);
+
+  // Realtime: when a new message arrives in a thread, bump it to the top
+  // and show as unread. If we're not currently viewing it, surface a
+  // browser notification.
+  const onNewNotification = useCallback(
+    (raw: Record<string, unknown>) => {
+      const evt = raw as Partial<InboxRealtimeEvent>;
+      if (evt.kind !== "direct_message" || !evt.threadId || !evt.directMessage) {
+        return;
+      }
+      setThreads((prev) => {
+        const idx = prev.findIndex((t) => t.id === evt.threadId);
+        const isVolunteerSender = evt.directMessage!.senderRole === "VOLUNTEER";
+        if (idx === -1) {
+          // New thread we haven't seen yet — refetch the list.
+          void fetchThreads();
+          return prev;
+        }
+        const updated: SerializedThread = {
+          ...prev[idx],
+          lastMessageAt: evt.directMessage!.createdAt,
+          unreadForTeam: isVolunteerSender
+            ? selectedId !== evt.threadId
+            : prev[idx].unreadForTeam,
+          lastMessage: {
+            body: evt.directMessage!.body,
+            senderRole: evt.directMessage!.senderRole,
+            createdAt: evt.directMessage!.createdAt,
+          },
+          status: "OPEN",
+        };
+        const next = [updated, ...prev.filter((_, i) => i !== idx)];
+        return next;
+      });
+
+      const isVolunteerSender = evt.directMessage!.senderRole === "VOLUNTEER";
+      if (
+        browserNotificationsOn &&
+        isVolunteerSender &&
+        document.visibilityState !== "visible" &&
+        evt.threadId !== selectedId
+      ) {
+        showBrowserNotification(
+          evt.volunteer?.name ?? "Volunteer",
+          evt.directMessage!.body
+        );
+      }
+    },
+    [browserNotificationsOn, fetchThreads, selectedId]
+  );
+
+  useNotificationStream({
+    onNewNotification,
+    enabled: true,
+  });
+
+  const handleSelect = useCallback((id: string) => {
+    setSelectedId(id);
+  }, []);
+
+  // Mark selected thread as read on open.
+  const lastReadRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedId) return;
+    if (lastReadRef.current === selectedId) return;
+    lastReadRef.current = selectedId;
+    void fetch(`/api/admin/messages/threads/${selectedId}/read`, {
+      method: "POST",
+    }).then(() => {
+      setThreads((prev) =>
+        prev.map((t) =>
+          t.id === selectedId ? { ...t, unreadForTeam: false } : t
+        )
+      );
+    });
+  }, [selectedId]);
+
+  const handleMessageSent = useCallback(
+    (threadId: string, body: string, createdAt: string) => {
+      setThreads((prev) => {
+        const idx = prev.findIndex((t) => t.id === threadId);
+        if (idx === -1) return prev;
+        const updated: SerializedThread = {
+          ...prev[idx],
+          lastMessageAt: createdAt,
+          lastMessage: { body, senderRole: "ADMIN", createdAt },
+          unreadForTeam: false,
+          status: "OPEN",
+        };
+        return [updated, ...prev.filter((_, i) => i !== idx)];
+      });
+    },
+    []
+  );
+
+  const handleResolve = useCallback(
+    async (threadId: string, status: "OPEN" | "RESOLVED") => {
+      await fetch(`/api/admin/messages/threads/${threadId}/resolve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      setThreads((prev) =>
+        prev.map((t) => (t.id === threadId ? { ...t, status } : t))
+      );
+    },
+    []
+  );
+
+  const handleNewThread = useCallback((threadId: string) => {
+    setSelectedId(threadId);
+    void fetchThreads();
+  }, [fetchThreads]);
+
+  const toggleBrowserNotifications = useCallback(async () => {
+    if (browserNotificationsOn) {
+      setBrowserNotificationsOn(false);
+      return;
+    }
+    if (typeof Notification === "undefined") {
+      alert("This browser doesn't support notifications.");
+      return;
+    }
+    if (Notification.permission === "denied") {
+      alert("Notifications are blocked. Enable them in your browser settings.");
+      return;
+    }
+    const result =
+      Notification.permission === "granted"
+        ? "granted"
+        : await Notification.requestPermission();
+    setBrowserNotificationsOn(result === "granted");
+  }, [browserNotificationsOn]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative flex-1 min-w-[220px] max-w-md">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by name or email…"
+            className="pl-9"
+          />
+        </div>
+        <Select
+          value={statusFilter}
+          onValueChange={(v) => setStatusFilter(v as typeof statusFilter)}
+        >
+          <SelectTrigger className="w-[140px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="OPEN">Open</SelectItem>
+            <SelectItem value="RESOLVED">Resolved</SelectItem>
+            <SelectItem value="ALL">All</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={locationFilter || "ALL"}
+          onValueChange={(v) => setLocationFilter(v === "ALL" ? "" : v)}
+        >
+          <SelectTrigger className="w-[170px]">
+            <SelectValue placeholder="All locations" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="ALL">All locations</SelectItem>
+            {locations.map((l) => (
+              <SelectItem key={l} value={l}>
+                {l}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          variant={unreadOnly ? "default" : "outline"}
+          size="sm"
+          onClick={() => setUnreadOnly((v) => !v)}
+        >
+          Unread
+        </Button>
+
+        <div className="flex items-center gap-2 ml-auto">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleBrowserNotifications}
+            title={
+              browserNotificationsOn
+                ? "Notifications on"
+                : "Get desktop notifications"
+            }
+          >
+            {browserNotificationsOn ? (
+              <Bell className="w-4 h-4" />
+            ) : (
+              <BellOff className="w-4 h-4" />
+            )}
+            <span className="ml-1.5 hidden sm:inline">
+              {browserNotificationsOn ? "Notifications on" : "Notify me"}
+            </span>
+          </Button>
+          <ComposeButton onCreated={handleNewThread}>
+            <MessageSquarePlus className="w-4 h-4 mr-1.5" />
+            New message
+          </ComposeButton>
+        </div>
+      </div>
+
+      {/* Two-pane */}
+      <div className="grid grid-cols-1 lg:grid-cols-[340px_1fr] xl:grid-cols-[360px_1fr] gap-4 min-h-[70vh]">
+        <div className="border rounded-lg bg-card overflow-hidden flex flex-col max-h-[78vh]">
+          <ThreadList
+            threads={threads}
+            selectedId={selectedId}
+            onSelect={handleSelect}
+          />
+        </div>
+        <div className="border rounded-lg bg-card overflow-hidden flex flex-col min-h-[60vh] max-h-[78vh]">
+          {selectedId ? (
+            <ThreadView
+              key={selectedId}
+              threadId={selectedId}
+              onMessageSent={handleMessageSent}
+              onResolve={handleResolve}
+            />
+          ) : (
+            <EmptyPane />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyPane() {
+  return (
+    <div className="flex-1 flex items-center justify-center text-center px-6 py-16">
+      <div>
+        <p className="text-lg font-medium mb-1">No conversation selected</p>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          Pick a conversation on the left, or start a new one with the
+          <span className="font-medium"> New message</span> button.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function showBrowserNotification(title: string, body: string) {
+  try {
+    const n = new Notification(`${title} · Everybody Eats`, { body });
+    n.onclick = () => {
+      window.focus();
+      n.close();
+    };
+  } catch (err) {
+    console.warn("[messages] Failed to show browser notification", err);
+  }
+}

--- a/web/src/components/admin/messages/messaging-hours-editor.tsx
+++ b/web/src/components/admin/messages/messaging-hours-editor.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Loader2, Save } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+
+interface DayHours {
+  dayOfWeek: number;
+  isOpen: boolean;
+  openTime: string;
+  closeTime: string;
+}
+
+interface LocationHours {
+  location: string;
+  hours: DayHours[];
+}
+
+interface MessagingHoursEditorProps {
+  initialLocations: LocationHours[];
+}
+
+const DAYS = [
+  { idx: 1, label: "Monday" },
+  { idx: 2, label: "Tuesday" },
+  { idx: 3, label: "Wednesday" },
+  { idx: 4, label: "Thursday" },
+  { idx: 5, label: "Friday" },
+  { idx: 6, label: "Saturday" },
+  { idx: 0, label: "Sunday" },
+];
+
+export function MessagingHoursEditor({
+  initialLocations,
+}: MessagingHoursEditorProps) {
+  const [locations, setLocations] = useState(initialLocations);
+  const [savingFor, setSavingFor] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+
+  const updateDay = useCallback(
+    (
+      location: string,
+      dayOfWeek: number,
+      patch: Partial<DayHours>
+    ) => {
+      setLocations((prev) =>
+        prev.map((loc) =>
+          loc.location !== location
+            ? loc
+            : {
+                ...loc,
+                hours: loc.hours.map((d) =>
+                  d.dayOfWeek === dayOfWeek ? { ...d, ...patch } : d
+                ),
+              }
+        )
+      );
+    },
+    []
+  );
+
+  const save = useCallback(
+    async (location: string, hours: DayHours[]) => {
+      setSavingFor(location);
+      setSaved(null);
+      try {
+        const res = await fetch("/api/admin/messaging-hours", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ location, hours }),
+        });
+        if (!res.ok) {
+          const err = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          alert(err.error ?? "Failed to save");
+          return;
+        }
+        setSaved(location);
+        setTimeout(() => setSaved(null), 1800);
+      } finally {
+        setSavingFor(null);
+      }
+    },
+    []
+  );
+
+  if (locations.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center text-sm text-muted-foreground">
+          No active locations. Configure locations under Restaurants →
+          Restaurant Locations first.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {locations.map((loc) => (
+        <Card key={loc.location}>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle>{loc.location}</CardTitle>
+            <div className="flex items-center gap-2">
+              {saved === loc.location && (
+                <span className="text-xs text-emerald-700">Saved</span>
+              )}
+              <Button
+                size="sm"
+                onClick={() => save(loc.location, loc.hours)}
+                disabled={savingFor === loc.location}
+              >
+                {savingFor === loc.location ? (
+                  <Loader2 className="w-4 h-4 mr-1.5 animate-spin" />
+                ) : (
+                  <Save className="w-4 h-4 mr-1.5" />
+                )}
+                Save
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {DAYS.map(({ idx, label }) => {
+                const day = loc.hours.find((h) => h.dayOfWeek === idx)!;
+                return (
+                  <li
+                    key={idx}
+                    className="grid grid-cols-[120px_70px_1fr_auto_1fr] items-center gap-3 py-2 border-b last:border-b-0"
+                  >
+                    <span className="text-sm font-medium">{label}</span>
+                    <div className="flex items-center gap-2">
+                      <Switch
+                        checked={day.isOpen}
+                        onCheckedChange={(checked) =>
+                          updateDay(loc.location, idx, { isOpen: checked })
+                        }
+                        aria-label={`${label} open`}
+                      />
+                      <span
+                        className={cn(
+                          "text-xs",
+                          day.isOpen
+                            ? "text-emerald-700"
+                            : "text-muted-foreground"
+                        )}
+                      >
+                        {day.isOpen ? "Open" : "Closed"}
+                      </span>
+                    </div>
+                    <Input
+                      type="time"
+                      value={day.openTime}
+                      onChange={(e) =>
+                        updateDay(loc.location, idx, {
+                          openTime: e.target.value,
+                        })
+                      }
+                      disabled={!day.isOpen}
+                      className="w-32"
+                    />
+                    <span className="text-xs text-muted-foreground">to</span>
+                    <Input
+                      type="time"
+                      value={day.closeTime}
+                      onChange={(e) =>
+                        updateDay(loc.location, idx, {
+                          closeTime: e.target.value,
+                        })
+                      }
+                      disabled={!day.isOpen}
+                      className="w-32"
+                    />
+                  </li>
+                );
+              })}
+            </ul>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/admin/messages/thread-list.tsx
+++ b/web/src/components/admin/messages/thread-list.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn } from "@/lib/utils";
+import type { SerializedThread } from "./types";
+
+interface ThreadListProps {
+  threads: SerializedThread[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+export function ThreadList({ threads, selectedId, onSelect }: ThreadListProps) {
+  if (threads.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center px-6 py-16 text-center">
+        <div>
+          <p className="text-sm font-medium mb-1">No conversations</p>
+          <p className="text-xs text-muted-foreground">
+            Volunteer messages will appear here.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex-1 overflow-y-auto divide-y">
+      {threads.map((t) => (
+        <li key={t.id}>
+          <button
+            type="button"
+            onClick={() => onSelect(t.id)}
+            className={cn(
+              "w-full text-left px-4 py-3 flex gap-3 items-start transition-colors hover:bg-muted/60",
+              selectedId === t.id && "bg-muted"
+            )}
+          >
+            <Avatar className="size-10 shrink-0">
+              <AvatarImage
+                src={t.volunteer.profilePhotoUrl ?? undefined}
+                alt={t.volunteer.name}
+              />
+              <AvatarFallback>{getInitials(t.volunteer.name)}</AvatarFallback>
+            </Avatar>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center justify-between gap-2">
+                <span
+                  className={cn(
+                    "text-sm truncate",
+                    t.unreadForTeam ? "font-semibold" : "font-medium"
+                  )}
+                >
+                  {t.volunteer.name}
+                </span>
+                <span className="text-[11px] text-muted-foreground shrink-0">
+                  {formatRelative(t.lastMessageAt)}
+                </span>
+              </div>
+              <p
+                className={cn(
+                  "text-xs text-muted-foreground truncate mt-0.5",
+                  t.unreadForTeam && "text-foreground"
+                )}
+              >
+                {t.lastMessage
+                  ? prefixForRole(t.lastMessage.senderRole) + t.lastMessage.body
+                  : "No messages yet"}
+              </p>
+              <div className="flex items-center gap-2 mt-1.5">
+                {t.volunteer.defaultLocation && (
+                  <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    {t.volunteer.defaultLocation}
+                  </span>
+                )}
+                {t.status === "RESOLVED" && (
+                  <span className="text-[10px] uppercase tracking-wide text-muted-foreground bg-muted-foreground/10 rounded px-1.5 py-0.5">
+                    Resolved
+                  </span>
+                )}
+                {t.unreadForTeam && (
+                  <span className="ml-auto inline-block size-2 rounded-full bg-emerald-600" />
+                )}
+              </div>
+            </div>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function prefixForRole(role: "VOLUNTEER" | "ADMIN"): string {
+  return role === "ADMIN" ? "You: " : "";
+}
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function formatRelative(iso: string): string {
+  const date = new Date(iso);
+  const now = Date.now();
+  const diff = now - date.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return "just now";
+  if (diff < hour) return `${Math.floor(diff / minute)}m`;
+  if (diff < day) return `${Math.floor(diff / hour)}h`;
+  if (diff < 7 * day) return `${Math.floor(diff / day)}d`;
+  return date.toLocaleDateString("en-NZ", { day: "numeric", month: "short" });
+}

--- a/web/src/components/admin/messages/thread-view.tsx
+++ b/web/src/components/admin/messages/thread-view.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { Archive, ArchiveRestore, ExternalLink, Loader2, Send } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useNotificationStream } from "@/hooks/use-notification-stream";
+import { cn } from "@/lib/utils";
+
+import type {
+  InboxRealtimeEvent,
+  SerializedMessage,
+  ThreadDetail,
+} from "./types";
+
+interface ThreadViewProps {
+  threadId: string;
+  onMessageSent: (threadId: string, body: string, createdAt: string) => void;
+  onResolve: (threadId: string, status: "OPEN" | "RESOLVED") => void;
+}
+
+export function ThreadView({ threadId, onMessageSent, onResolve }: ThreadViewProps) {
+  const [thread, setThread] = useState<ThreadDetail | null>(null);
+  const [messages, setMessages] = useState<SerializedMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [body, setBody] = useState("");
+  const [sending, setSending] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const refresh = useCallback(async () => {
+    const res = await fetch(`/api/admin/messages/threads/${threadId}`);
+    if (!res.ok) return;
+    const data = (await res.json()) as {
+      thread: ThreadDetail & {
+        lastMessageAt: string;
+        teamLastReadAt: string | null;
+        volunteerLastReadAt: string | null;
+      };
+      messages: SerializedMessage[];
+      upcomingShiftCount: number;
+    };
+    setThread({ ...data.thread, upcomingShiftCount: data.upcomingShiftCount });
+    setMessages(data.messages);
+  }, [threadId]);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh().finally(() => setLoading(false));
+  }, [refresh]);
+
+  // Auto-scroll to bottom on new messages.
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [messages.length]);
+
+  // Realtime: append messages for this thread without refetching.
+  useNotificationStream({
+    onNewNotification: useCallback(
+      (raw: Record<string, unknown>) => {
+        const evt = raw as Partial<InboxRealtimeEvent>;
+        if (
+          evt.kind !== "direct_message" ||
+          evt.threadId !== threadId ||
+          !evt.directMessage
+        ) {
+          return;
+        }
+        // Avoid duplicating our own optimistic send.
+        setMessages((prev) => {
+          if (prev.some((m) => m.id === evt.directMessage!.id)) return prev;
+          return [
+            ...prev,
+            {
+              id: evt.directMessage!.id,
+              body: evt.directMessage!.body,
+              senderId: evt.directMessage!.senderId,
+              senderRole: evt.directMessage!.senderRole,
+              createdAt: evt.directMessage!.createdAt,
+              sender: {
+                id: evt.directMessage!.senderId,
+                firstName: null,
+                lastName: null,
+                name: evt.volunteer?.name ?? null,
+                profilePhotoUrl: null,
+              },
+            },
+          ];
+        });
+        // Mark thread as read on receipt while it's open.
+        void fetch(`/api/admin/messages/threads/${threadId}/read`, {
+          method: "POST",
+        });
+      },
+      [threadId]
+    ),
+  });
+
+  const send = useCallback(async () => {
+    const trimmed = body.trim();
+    if (!trimmed || sending) return;
+    setSending(true);
+    try {
+      const res = await fetch(
+        `/api/admin/messages/threads/${threadId}/messages`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ body: trimmed }),
+        }
+      );
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        alert(err.error ?? "Failed to send");
+        return;
+      }
+      const data = (await res.json()) as { message: SerializedMessage };
+      setMessages((prev) => [...prev, data.message]);
+      setBody("");
+      onMessageSent(threadId, trimmed, data.message.createdAt);
+    } finally {
+      setSending(false);
+    }
+  }, [body, sending, threadId, onMessageSent]);
+
+  const handleResolveClick = useCallback(() => {
+    if (!thread) return;
+    const next = thread.status === "OPEN" ? "RESOLVED" : "OPEN";
+    onResolve(threadId, next);
+    setThread({ ...thread, status: next });
+  }, [thread, threadId, onResolve]);
+
+  if (loading || !thread) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const volunteerName =
+    [thread.volunteer.firstName, thread.volunteer.lastName]
+      .filter(Boolean)
+      .join(" ") ||
+    thread.volunteer.name ||
+    thread.volunteer.email;
+
+  return (
+    <div className="flex-1 grid grid-cols-1 xl:grid-cols-[1fr_280px] min-h-0">
+      <div className="flex flex-col min-h-0">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b">
+          <div className="flex items-center gap-3 min-w-0">
+            <Avatar className="size-9">
+              <AvatarImage
+                src={thread.volunteer.profilePhotoUrl ?? undefined}
+                alt={volunteerName}
+              />
+              <AvatarFallback>
+                {volunteerName.slice(0, 2).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold truncate">{volunteerName}</span>
+                {thread.status === "RESOLVED" && (
+                  <Badge variant="secondary" className="text-[10px]">
+                    Resolved
+                  </Badge>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground truncate">
+                {thread.volunteer.email}
+                {thread.volunteer.defaultLocation
+                  ? ` · ${thread.volunteer.defaultLocation}`
+                  : ""}
+              </p>
+            </div>
+          </div>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={handleResolveClick}
+            title={
+              thread.status === "OPEN" ? "Mark resolved" : "Reopen thread"
+            }
+          >
+            {thread.status === "OPEN" ? (
+              <>
+                <Archive className="w-4 h-4 mr-1.5" />
+                Resolve
+              </>
+            ) : (
+              <>
+                <ArchiveRestore className="w-4 h-4 mr-1.5" />
+                Reopen
+              </>
+            )}
+          </Button>
+        </div>
+
+        {/* Messages */}
+        <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+          {messages.length === 0 ? (
+            <div className="text-center text-sm text-muted-foreground py-12">
+              No messages yet — say kia ora to {volunteerName.split(" ")[0]}.
+            </div>
+          ) : (
+            messages.map((m, i) => (
+              <MessageBubble
+                key={m.id}
+                message={m}
+                showSender={i === 0 || messages[i - 1].senderId !== m.senderId}
+              />
+            ))
+          )}
+        </div>
+
+        {/* Composer */}
+        <div className="border-t p-3 flex items-end gap-2">
+          <Textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder={`Reply to ${volunteerName.split(" ")[0]}…`}
+            rows={2}
+            className="resize-none flex-1"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                void send();
+              }
+            }}
+          />
+          <Button onClick={send} disabled={!body.trim() || sending}>
+            {sending ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Send className="w-4 h-4" />
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* Sidebar context */}
+      <aside className="hidden xl:block border-l p-4 overflow-y-auto bg-muted/20">
+        <p className="text-[10px] uppercase tracking-wider font-semibold text-muted-foreground mb-3">
+          Volunteer context
+        </p>
+        <dl className="space-y-2.5 text-sm">
+          <ContextRow label="Email" value={thread.volunteer.email} />
+          <ContextRow label="Phone" value={thread.volunteer.phone ?? "—"} />
+          <ContextRow
+            label="Home location"
+            value={thread.volunteer.defaultLocation ?? "—"}
+          />
+          <ContextRow
+            label="Grade"
+            value={
+              <Badge variant="outline" className="text-[10px]">
+                {thread.volunteer.volunteerGrade}
+              </Badge>
+            }
+          />
+          <ContextRow
+            label="Upcoming shifts"
+            value={String(thread.upcomingShiftCount)}
+          />
+        </dl>
+        <Link
+          href={`/admin/users/${thread.volunteer.id}`}
+          className="mt-4 inline-flex items-center text-xs font-medium text-emerald-700 hover:underline"
+        >
+          Open full profile <ExternalLink className="w-3 h-3 ml-1" />
+        </Link>
+      </aside>
+    </div>
+  );
+}
+
+function ContextRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col">
+      <dt className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="text-sm">{value}</dd>
+    </div>
+  );
+}
+
+function MessageBubble({
+  message,
+  showSender,
+}: {
+  message: SerializedMessage;
+  showSender: boolean;
+}) {
+  const isAdmin = message.senderRole === "ADMIN";
+  const senderName =
+    [message.sender.firstName, message.sender.lastName]
+      .filter(Boolean)
+      .join(" ") || message.sender.name || "";
+
+  return (
+    <div className={cn("flex flex-col", isAdmin ? "items-end" : "items-start")}>
+      {showSender && (
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground mb-1 px-1">
+          {isAdmin
+            ? `${senderName || "Admin"} · ${formatTime(message.createdAt)}`
+            : `${senderName || "Volunteer"} · ${formatTime(message.createdAt)}`}
+        </span>
+      )}
+      <div
+        className={cn(
+          "max-w-[75%] px-3.5 py-2 rounded-2xl text-sm whitespace-pre-wrap break-words",
+          isAdmin
+            ? "bg-emerald-700 text-white rounded-br-sm"
+            : "bg-muted rounded-bl-sm"
+        )}
+      >
+        {message.body}
+      </div>
+    </div>
+  );
+}
+
+function formatTime(iso: string): string {
+  const date = new Date(iso);
+  return date.toLocaleString("en-NZ", {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/web/src/components/admin/messages/types.ts
+++ b/web/src/components/admin/messages/types.ts
@@ -1,0 +1,73 @@
+import type { Role } from "@/generated/client";
+
+export interface SerializedThread {
+  id: string;
+  status: "OPEN" | "RESOLVED";
+  lastMessageAt: string;
+  unreadForTeam: boolean;
+  lastMessage: {
+    body: string;
+    senderRole: Role;
+    createdAt: string;
+  } | null;
+  volunteer: {
+    id: string;
+    name: string;
+    firstName: string | null;
+    lastName: string | null;
+    email: string;
+    profilePhotoUrl: string | null;
+    defaultLocation: string | null;
+  };
+}
+
+export interface SerializedMessage {
+  id: string;
+  body: string;
+  senderId: string;
+  senderRole: Role;
+  createdAt: string;
+  sender: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    name: string | null;
+    profilePhotoUrl: string | null;
+  };
+}
+
+export interface ThreadDetail {
+  id: string;
+  status: "OPEN" | "RESOLVED";
+  volunteerLastReadAt: string | null;
+  teamLastReadAt: string | null;
+  volunteer: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    name: string | null;
+    email: string;
+    phone: string | null;
+    profilePhotoUrl: string | null;
+    defaultLocation: string | null;
+    volunteerGrade: string;
+    createdAt: string;
+  };
+  upcomingShiftCount: number;
+}
+
+export interface InboxRealtimeEvent {
+  kind: "direct_message";
+  threadId: string;
+  directMessage: {
+    id: string;
+    body: string;
+    senderId: string;
+    senderRole: Role;
+    createdAt: string;
+  };
+  volunteer: {
+    id: string;
+    name: string;
+  };
+}

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -201,6 +201,13 @@ export const adminNavCategories: AdminNavCategory[] = [
     label: "Communications",
     items: [
       {
+        title: "Messages",
+        href: "/admin/messages",
+        icon: MessageSquare,
+        description: "Direct messages with volunteers",
+        commandKey: "messages",
+      },
+      {
         title: "Announcements",
         href: "/admin/announcements",
         icon: Megaphone,
@@ -352,6 +359,7 @@ export const getIconColor = (
     "Restaurant Managers": "text-orange-600",
 
     // Communications
+    Messages: "text-emerald-600",
     Announcements: "text-orange-500",
     "Shortage Notifications": "text-amber-600",
     "Newsletter Lists": "text-cyan-600",

--- a/web/src/lib/messaging-notify.ts
+++ b/web/src/lib/messaging-notify.ts
@@ -1,0 +1,97 @@
+import type { Message, Role, User } from "@/generated/client";
+import { createNotification } from "./notifications";
+import { notificationSSEManager } from "./notification-sse-manager";
+
+/**
+ * Realtime + push notification helpers for the volunteer ↔ team direct
+ * messaging system.
+ *
+ * Volunteers receive a normal Notification row + mobile push so the bell
+ * badge and OS badge stay in sync. The bell SSE event already carries the
+ * threadId in metadata, so the open mobile thread screen can refetch on
+ * receipt — no duplicate event is needed.
+ *
+ * Admins are web-only and would drown in DB notifications if every new
+ * message created one — they get a live SSE event only with the full
+ * message body, and their inbox UI keeps unread state from the thread's
+ * `teamLastReadAt` column.
+ */
+
+const MESSAGE_PREVIEW_LIMIT = 140;
+
+function preview(body: string): string {
+  if (body.length <= MESSAGE_PREVIEW_LIMIT) return body;
+  return body.slice(0, MESSAGE_PREVIEW_LIMIT - 1).trimEnd() + "…";
+}
+
+function senderDisplayName(sender: Pick<User, "firstName" | "name">): string {
+  return sender.firstName || sender.name || "Everybody Eats";
+}
+
+interface NotifyVolunteerArgs {
+  threadId: string;
+  volunteerId: string;
+  body: string;
+  sender: Pick<User, "id" | "firstName" | "name">;
+}
+
+export async function notifyVolunteerOfTeamMessage(
+  args: NotifyVolunteerArgs
+): Promise<void> {
+  const title = `${senderDisplayName(args.sender)} from Everybody Eats`;
+  await createNotification({
+    userId: args.volunteerId,
+    type: "DIRECT_MESSAGE",
+    title,
+    message: preview(args.body),
+    actionUrl: "/help/team",
+    relatedId: args.threadId,
+  }).catch((err) =>
+    console.error("[messaging-notify] notifyVolunteerOfTeamMessage:", err)
+  );
+}
+
+interface BroadcastToAdminsArgs {
+  threadId: string;
+  message: Pick<Message, "id" | "body" | "senderId" | "createdAt"> & {
+    senderRole: Role;
+  };
+  volunteer: Pick<User, "id" | "firstName" | "lastName" | "name" | "email">;
+}
+
+export async function broadcastNewMessageToAdmins(
+  args: BroadcastToAdminsArgs
+): Promise<void> {
+  const volunteerName =
+    [args.volunteer.firstName, args.volunteer.lastName]
+      .filter(Boolean)
+      .join(" ") ||
+    args.volunteer.name ||
+    args.volunteer.email;
+
+  await notificationSSEManager
+    .broadcastToAdmins({
+      type: "notification",
+      timestamp: Date.now(),
+      data: {
+        notification: {
+          kind: "direct_message",
+          threadId: args.threadId,
+          directMessage: {
+            id: args.message.id,
+            body: args.message.body,
+            senderId: args.message.senderId,
+            senderRole: args.message.senderRole,
+            createdAt: args.message.createdAt,
+          },
+          volunteer: {
+            id: args.volunteer.id,
+            name: volunteerName,
+          },
+        },
+      },
+    })
+    .catch((err) =>
+      console.error("[messaging-notify] broadcastNewMessageToAdmins:", err)
+    );
+}

--- a/web/src/lib/services/messaging-hours.ts
+++ b/web/src/lib/services/messaging-hours.ts
@@ -1,0 +1,213 @@
+import { prisma } from "@/lib/prisma";
+import { nowInNZT } from "@/lib/timezone";
+
+export interface DayHours {
+  dayOfWeek: number; // 0=Sun .. 6=Sat
+  isOpen: boolean;
+  openTime: string; // "HH:mm"
+  closeTime: string;
+}
+
+export interface LocationHours {
+  location: string;
+  hours: DayHours[]; // length 7, indexed by dayOfWeek
+}
+
+const DEFAULT_OPEN = "09:00";
+const DEFAULT_CLOSE = "17:00";
+
+function defaultDay(dayOfWeek: number): DayHours {
+  // Closed on weekends by default; open weekdays.
+  const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+  return {
+    dayOfWeek,
+    isOpen: !isWeekend,
+    openTime: DEFAULT_OPEN,
+    closeTime: DEFAULT_CLOSE,
+  };
+}
+
+function fillWeek(rows: { dayOfWeek: number; isOpen: boolean; openTime: string; closeTime: string }[]): DayHours[] {
+  const byDay = new Map(rows.map((r) => [r.dayOfWeek, r]));
+  return Array.from({ length: 7 }, (_, i) => byDay.get(i) ?? defaultDay(i));
+}
+
+export async function getHoursForLocation(
+  location: string
+): Promise<LocationHours> {
+  const rows = await prisma.messagingHours.findMany({
+    where: { location },
+    orderBy: { dayOfWeek: "asc" },
+  });
+  return { location, hours: fillWeek(rows) };
+}
+
+export async function getAllLocationHours(): Promise<LocationHours[]> {
+  const locations = await prisma.location.findMany({
+    where: { isActive: true },
+    orderBy: { name: "asc" },
+    select: { name: true },
+  });
+  const all = await prisma.messagingHours.findMany({
+    orderBy: [{ location: "asc" }, { dayOfWeek: "asc" }],
+  });
+  const grouped = new Map<string, typeof all>();
+  for (const row of all) {
+    const list = grouped.get(row.location) ?? [];
+    list.push(row);
+    grouped.set(row.location, list);
+  }
+  return locations.map((loc) => ({
+    location: loc.name,
+    hours: fillWeek(grouped.get(loc.name) ?? []),
+  }));
+}
+
+interface UpsertHoursArgs {
+  location: string;
+  hours: Pick<DayHours, "dayOfWeek" | "isOpen" | "openTime" | "closeTime">[];
+  updatedBy?: string;
+}
+
+export async function upsertHoursForLocation(
+  args: UpsertHoursArgs
+): Promise<LocationHours> {
+  for (const h of args.hours) {
+    if (!isValidTime(h.openTime) || !isValidTime(h.closeTime)) {
+      throw new Error(
+        `Invalid time on day ${h.dayOfWeek}: ${h.openTime}–${h.closeTime}`
+      );
+    }
+    if (h.dayOfWeek < 0 || h.dayOfWeek > 6) {
+      throw new Error(`Invalid dayOfWeek: ${h.dayOfWeek}`);
+    }
+  }
+
+  await prisma.$transaction(
+    args.hours.map((h) =>
+      prisma.messagingHours.upsert({
+        where: {
+          location_dayOfWeek: {
+            location: args.location,
+            dayOfWeek: h.dayOfWeek,
+          },
+        },
+        update: {
+          isOpen: h.isOpen,
+          openTime: h.openTime,
+          closeTime: h.closeTime,
+          updatedBy: args.updatedBy,
+        },
+        create: {
+          location: args.location,
+          dayOfWeek: h.dayOfWeek,
+          isOpen: h.isOpen,
+          openTime: h.openTime,
+          closeTime: h.closeTime,
+          updatedBy: args.updatedBy,
+        },
+      })
+    )
+  );
+
+  return getHoursForLocation(args.location);
+}
+
+function isValidTime(t: string): boolean {
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(t);
+}
+
+function timeToMinutes(t: string): number {
+  const [h, m] = t.split(":").map(Number);
+  return h * 60 + m;
+}
+
+export interface OpenStatus {
+  isOpenNow: boolean;
+  todayHours: DayHours;
+  nextOpenLabel?: string;
+}
+
+/**
+ * Returns whether messaging is "open" right now in NZ time, plus a
+ * human-readable hint for off-hours (e.g. "Opens 9 am tomorrow").
+ */
+export function evaluateOpenStatus(hours: LocationHours): OpenStatus {
+  const now = nowInNZT();
+  const dayOfWeek = now.getDay();
+  const today = hours.hours[dayOfWeek];
+  const minutesNow = now.getHours() * 60 + now.getMinutes();
+
+  let isOpenNow = false;
+  if (today.isOpen) {
+    const open = timeToMinutes(today.openTime);
+    const close = timeToMinutes(today.closeTime);
+    isOpenNow = minutesNow >= open && minutesNow < close;
+  }
+
+  let nextOpenLabel: string | undefined;
+  if (!isOpenNow) {
+    nextOpenLabel = formatNextOpen(hours.hours, dayOfWeek, minutesNow);
+  }
+
+  return { isOpenNow, todayHours: today, nextOpenLabel };
+}
+
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+function formatNextOpen(
+  week: DayHours[],
+  todayIdx: number,
+  minutesNow: number
+): string | undefined {
+  // Today before open?
+  const today = week[todayIdx];
+  if (today.isOpen && timeToMinutes(today.openTime) > minutesNow) {
+    return `Opens ${humanTime(today.openTime)} today`;
+  }
+
+  for (let offset = 1; offset <= 7; offset++) {
+    const idx = (todayIdx + offset) % 7;
+    const day = week[idx];
+    if (!day.isOpen) continue;
+    if (offset === 1) return `Opens ${humanTime(day.openTime)} tomorrow`;
+    return `Opens ${humanTime(day.openTime)} ${DAY_NAMES[idx]}`;
+  }
+  return undefined;
+}
+
+function humanTime(t: string): string {
+  const [h, m] = t.split(":").map(Number);
+  const period = h < 12 ? "am" : "pm";
+  const hour12 = h % 12 === 0 ? 12 : h % 12;
+  return m === 0 ? `${hour12} ${period}` : `${hour12}:${String(m).padStart(2, "0")} ${period}`;
+}
+
+/**
+ * Resolve a volunteer's "primary" location used for the off-hours hint.
+ * Prefers their `defaultLocation`, falling back to the most recent shift.
+ */
+export async function getPrimaryLocationForVolunteer(
+  volunteerId: string
+): Promise<string | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: volunteerId },
+    select: { defaultLocation: true },
+  });
+  if (user?.defaultLocation) return user.defaultLocation;
+
+  const recent = await prisma.signup.findFirst({
+    where: { userId: volunteerId },
+    orderBy: { createdAt: "desc" },
+    select: { shift: { select: { location: true } } },
+  });
+  return recent?.shift?.location ?? null;
+}

--- a/web/src/lib/services/messaging.ts
+++ b/web/src/lib/services/messaging.ts
@@ -1,0 +1,407 @@
+import { prisma } from "@/lib/prisma";
+import type { Prisma, Role } from "@/generated/client";
+import {
+  broadcastNewMessageToAdmins,
+  notifyVolunteerOfTeamMessage,
+} from "@/lib/messaging-notify";
+
+const MAX_MESSAGE_LENGTH = 4000;
+
+export class MessagingError extends Error {
+  constructor(
+    public code:
+      | "NOT_FOUND"
+      | "FORBIDDEN"
+      | "EMPTY_BODY"
+      | "BODY_TOO_LONG"
+      | "VOLUNTEER_REQUIRED",
+    message: string
+  ) {
+    super(message);
+    this.name = "MessagingError";
+  }
+}
+
+const messageInclude = {
+  sender: {
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      name: true,
+      profilePhotoUrl: true,
+    },
+  },
+} satisfies Prisma.MessageInclude;
+
+const threadInclude = {
+  volunteer: {
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      name: true,
+      email: true,
+      profilePhotoUrl: true,
+      defaultLocation: true,
+      volunteerGrade: true,
+    },
+  },
+} satisfies Prisma.MessageThreadInclude;
+
+export type ThreadWithVolunteer = Prisma.MessageThreadGetPayload<{
+  include: typeof threadInclude;
+}>;
+
+export type MessageWithSender = Prisma.MessageGetPayload<{
+  include: typeof messageInclude;
+}>;
+
+function validateBody(raw: unknown): string {
+  if (typeof raw !== "string") {
+    throw new MessagingError("EMPTY_BODY", "Message body is required");
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    throw new MessagingError("EMPTY_BODY", "Message body is required");
+  }
+  if (trimmed.length > MAX_MESSAGE_LENGTH) {
+    throw new MessagingError(
+      "BODY_TOO_LONG",
+      `Message must be at most ${MAX_MESSAGE_LENGTH} characters`
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Get-or-create a thread for a volunteer. Used by both volunteer-initiated
+ * sends (mobile) and admin-initiated "Message volunteer" buttons (web).
+ */
+export async function getOrCreateThreadForVolunteer(
+  volunteerId: string
+): Promise<ThreadWithVolunteer> {
+  const volunteer = await prisma.user.findUnique({
+    where: { id: volunteerId },
+    select: { id: true, role: true },
+  });
+  if (!volunteer) {
+    throw new MessagingError("NOT_FOUND", "Volunteer not found");
+  }
+  if (volunteer.role !== "VOLUNTEER") {
+    throw new MessagingError(
+      "VOLUNTEER_REQUIRED",
+      "Threads are only created for volunteers"
+    );
+  }
+
+  const existing = await prisma.messageThread.findUnique({
+    where: { volunteerId },
+    include: threadInclude,
+  });
+  if (existing) return existing;
+
+  return prisma.messageThread.create({
+    data: { volunteerId },
+    include: threadInclude,
+  });
+}
+
+interface ListMessagesOptions {
+  threadId: string;
+  before?: Date;
+  limit?: number;
+}
+
+export async function listMessages({
+  threadId,
+  before,
+  limit = 50,
+}: ListMessagesOptions): Promise<MessageWithSender[]> {
+  const messages = await prisma.message.findMany({
+    where: {
+      threadId,
+      ...(before ? { createdAt: { lt: before } } : {}),
+    },
+    orderBy: { createdAt: "desc" },
+    take: Math.min(limit, 100),
+    include: messageInclude,
+  });
+  return messages.reverse();
+}
+
+interface SendMessageArgs {
+  threadId: string;
+  senderId: string;
+  senderRole: Role;
+  body: string;
+}
+
+export async function sendMessage(
+  args: SendMessageArgs
+): Promise<MessageWithSender> {
+  const body = validateBody(args.body);
+  const sentByVolunteer = args.senderRole === "VOLUNTEER";
+
+  const thread = await prisma.messageThread.findUnique({
+    where: { id: args.threadId },
+    include: { volunteer: { select: { id: true } } },
+  });
+  if (!thread) {
+    throw new MessagingError("NOT_FOUND", "Thread not found");
+  }
+  if (sentByVolunteer && thread.volunteerId !== args.senderId) {
+    throw new MessagingError("FORBIDDEN", "You can only send to your own thread");
+  }
+
+  const now = new Date();
+
+  // Sender's own write also clears their unread marker.
+  const readMarker: Prisma.MessageThreadUpdateInput = sentByVolunteer
+    ? { volunteerLastReadAt: now }
+    : { teamLastReadAt: now };
+
+  const [message] = await prisma.$transaction([
+    prisma.message.create({
+      data: {
+        threadId: args.threadId,
+        senderId: args.senderId,
+        senderRole: args.senderRole,
+        body,
+      },
+      include: messageInclude,
+    }),
+    prisma.messageThread.update({
+      where: { id: args.threadId },
+      data: {
+        lastMessageAt: now,
+        // Re-open if a previously resolved thread gets a new message.
+        status: "OPEN",
+        ...readMarker,
+      },
+    }),
+  ]);
+
+  // Fan-out notifications outside the transaction.
+  if (sentByVolunteer) {
+    const volunteer = await prisma.user.findUnique({
+      where: { id: thread.volunteerId },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        name: true,
+        email: true,
+      },
+    });
+    if (volunteer) {
+      void broadcastNewMessageToAdmins({
+        threadId: args.threadId,
+        message: {
+          id: message.id,
+          body: message.body,
+          senderId: message.senderId,
+          senderRole: message.senderRole,
+          createdAt: message.createdAt,
+        },
+        volunteer,
+      });
+    }
+  } else {
+    void notifyVolunteerOfTeamMessage({
+      threadId: args.threadId,
+      volunteerId: thread.volunteerId,
+      body,
+      sender: {
+        id: args.senderId,
+        firstName: message.sender.firstName,
+        name: message.sender.name,
+      },
+    });
+  }
+
+  return message;
+}
+
+/**
+ * Mark the thread read for the volunteer or for the admin team. Idempotent.
+ */
+export async function markThreadRead(
+  threadId: string,
+  side: "volunteer" | "team"
+): Promise<void> {
+  await prisma.messageThread.update({
+    where: { id: threadId },
+    data:
+      side === "volunteer"
+        ? { volunteerLastReadAt: new Date() }
+        : { teamLastReadAt: new Date() },
+  });
+}
+
+export async function setThreadStatus(
+  threadId: string,
+  status: "OPEN" | "RESOLVED"
+): Promise<void> {
+  await prisma.messageThread.update({
+    where: { id: threadId },
+    data: { status },
+  });
+}
+
+export interface ThreadListItem {
+  id: string;
+  status: "OPEN" | "RESOLVED";
+  lastMessageAt: Date;
+  unreadForTeam: boolean;
+  lastMessage: {
+    body: string;
+    senderRole: Role;
+    createdAt: Date;
+  } | null;
+  volunteer: {
+    id: string;
+    name: string;
+    firstName: string | null;
+    lastName: string | null;
+    email: string;
+    profilePhotoUrl: string | null;
+    defaultLocation: string | null;
+  };
+}
+
+interface ListThreadsOptions {
+  status?: "OPEN" | "RESOLVED" | "ALL";
+  unreadOnly?: boolean;
+  search?: string;
+  location?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export async function listThreadsForAdmin(
+  opts: ListThreadsOptions = {}
+): Promise<ThreadListItem[]> {
+  const {
+    status = "OPEN",
+    unreadOnly,
+    search,
+    location,
+    limit = 30,
+    cursor,
+  } = opts;
+
+  const where: Prisma.MessageThreadWhereInput = {};
+  if (status !== "ALL") where.status = status;
+  const volunteerFilters: Prisma.UserWhereInput[] = [];
+  if (location) volunteerFilters.push({ defaultLocation: location });
+  if (search) {
+    volunteerFilters.push({
+      OR: [
+        { firstName: { contains: search, mode: "insensitive" } },
+        { lastName: { contains: search, mode: "insensitive" } },
+        { name: { contains: search, mode: "insensitive" } },
+        { email: { contains: search, mode: "insensitive" } },
+      ],
+    });
+  }
+  if (volunteerFilters.length > 0) {
+    where.volunteer = { AND: volunteerFilters };
+  }
+
+  const threads = await prisma.messageThread.findMany({
+    where,
+    orderBy: [{ lastMessageAt: "desc" }],
+    take: Math.min(limit, 100),
+    ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+    include: {
+      ...threadInclude,
+      messages: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        select: {
+          body: true,
+          senderRole: true,
+          createdAt: true,
+        },
+      },
+    },
+  });
+
+  const items: ThreadListItem[] = threads.map((t) => {
+    const last = t.messages[0] ?? null;
+    const unreadForTeam = isUnreadForTeam(t.teamLastReadAt, t.lastMessageAt, last);
+    return {
+      id: t.id,
+      status: t.status,
+      lastMessageAt: t.lastMessageAt,
+      unreadForTeam,
+      lastMessage: last
+        ? {
+            body: last.body,
+            senderRole: last.senderRole,
+            createdAt: last.createdAt,
+          }
+        : null,
+      volunteer: {
+        id: t.volunteer.id,
+        firstName: t.volunteer.firstName,
+        lastName: t.volunteer.lastName,
+        name:
+          [t.volunteer.firstName, t.volunteer.lastName]
+            .filter(Boolean)
+            .join(" ") ||
+          t.volunteer.name ||
+          t.volunteer.email,
+        email: t.volunteer.email,
+        profilePhotoUrl: t.volunteer.profilePhotoUrl,
+        defaultLocation: t.volunteer.defaultLocation,
+      },
+    };
+  });
+
+  return unreadOnly ? items.filter((t) => t.unreadForTeam) : items;
+}
+
+function isUnreadForTeam(
+  teamLastReadAt: Date | null,
+  lastMessageAt: Date,
+  lastMessage: { senderRole: Role } | null
+): boolean {
+  if (!lastMessage) return false;
+  if (lastMessage.senderRole !== "VOLUNTEER") return false;
+  if (!teamLastReadAt) return true;
+  return lastMessageAt.getTime() > teamLastReadAt.getTime();
+}
+
+export function isUnreadForVolunteer(thread: {
+  volunteerLastReadAt: Date | null;
+  lastMessageAt: Date;
+  messages: Array<{ senderRole: Role }>;
+}): boolean {
+  const last = thread.messages[thread.messages.length - 1];
+  if (!last || last.senderRole === "VOLUNTEER") return false;
+  if (!thread.volunteerLastReadAt) return true;
+  return thread.lastMessageAt.getTime() > thread.volunteerLastReadAt.getTime();
+}
+
+export async function countUnreadForTeam(): Promise<number> {
+  // Open threads where the latest message is from a volunteer and after the
+  // team's last-read marker (or never read).
+  const threads = await prisma.messageThread.findMany({
+    where: { status: "OPEN" },
+    select: {
+      id: true,
+      teamLastReadAt: true,
+      lastMessageAt: true,
+      messages: {
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        select: { senderRole: true },
+      },
+    },
+  });
+  return threads.filter((t) =>
+    isUnreadForTeam(t.teamLastReadAt, t.lastMessageAt, t.messages[0] ?? null)
+  ).length;
+}


### PR DESCRIPTION
## Summary

- Adds a 1:1 message thread per volunteer that any admin or restaurant manager can reply on. Either side can initiate.
- Web admin gets a new `/admin/messages` two-pane inbox with realtime SSE updates, browser-notification opt-in, and a "Message" button on the volunteer detail page. Sidebar shows an unread badge.
- Mobile Help tab is now a landing screen with two channels: the existing AI assistant (moved to `/help/ai` with a persistent back button) and a new `/help/team` thread that talks to the team with off-hours hint, push deep-linking, and a refresh-on-focus loop.
- Per-day, per-location messaging hours admin page at `/admin/site-settings/messaging-hours` — surfaces in the mobile composer as a soft expectation-setter (does not block sends).

## Architecture

- New Prisma models: `MessageThread`, `Message`, `MessagingHours`; `ThreadStatus` enum; `DIRECT_MESSAGE` added to `NotificationType`. Migration: `20260430000000_add_direct_messaging`.
- Shared messaging service in `web/src/lib/services/messaging.ts` is consumed by both admin and mobile route handlers.
- Realtime fan-out (`web/src/lib/messaging-notify.ts`) reuses the existing notification SSE channel + Expo push: volunteers get a DB notification + push (so the bell + OS badge stay in sync); admins are web-only and get live SSE only — the inbox derives its unread state from `MessageThread.teamLastReadAt`, avoiding bell flooding when many volunteers message at once.
- One thread per volunteer, all admins see it; admin replies render with the real first name + role label so volunteers know who they're talking to.

## Test plan

- [ ] Admin lands on `/admin/messages`, sees existing threads (none on a fresh DB), filters by status / location / search, and toggles "Unread only".
- [ ] Admin clicks "New message", searches a volunteer, opens (creates) the thread.
- [ ] Admin types and sends — bubble appears, thread bumps to top of list.
- [ ] Volunteer (mobile) opens Help tab, sees the new editorial landing with AI / team rows.
- [ ] Tap "Message the team" → thread loads, off-hours hint shows when current NZ time is outside configured hours.
- [ ] Volunteer sends a message → admin's open inbox updates live without refresh; thread bumps and shows unread dot if not currently open.
- [ ] Admin replies → volunteer receives push notification; tapping it deep-links to `/help/team`.
- [ ] AI chat (`/help/ai`) still works exactly as before, with new persistent back button and "NEW" reset action.
- [ ] Resolve a thread → drops out of the default Open filter; reopen restores it.
- [ ] Configure messaging hours per location, verify mobile composer hint reflects them.
- [ ] Browser-notifications opt-in toggle in admin inbox prompts permission and surfaces native notifications when tab is backgrounded.

## Notes

- Email fallback for off-hours admin notifications was intentionally skipped (per user direction). Easy follow-up if needed.
- Attachments / broadcasts intentionally cut from v1 — single-thread human chat only.
- E2E tests not included in this PR; happy to add as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)