### PR TITLE
feat(mobile): show public-profile volunteers alongside friends on shifts

### DIFF
--- a/mobile/app/(tabs)/shifts.tsx
+++ b/mobile/app/(tabs)/shifts.tsx
@@ -1102,7 +1102,7 @@ function PeriodHeader({
           <Text
             style={[styles.periodMetaText, { color: colors.textSecondary }]}
           >
-            {friends.length === 1 ? "1 friend" : `${friends.length} friends`}
+            {friends.length === 1 ? "1 volunteer" : `${friends.length} volunteers`}
           </Text>
         </View>
       ) : (
@@ -1142,7 +1142,7 @@ function friendsLine(friends: PeriodFriend[], hasStatus: boolean): string {
   }
   return hasStatus
     ? `With ${firstName} + ${friends.length - 1} more`
-    : `${firstName} + ${friends.length - 1} friends going`;
+    : `${firstName} + ${friends.length - 1} others going`;
 }
 
 function ShiftCard({

--- a/mobile/app/shift/[id].tsx
+++ b/mobile/app/shift/[id].tsx
@@ -176,26 +176,29 @@ export default function ShiftDetailScreen() {
     );
   }, [shift, refresh]);
 
-  // Split period friends into "on your shift" vs "same session, different role"
-  const yourShiftFriendIds = useMemo(
-    () => new Set(shiftSignups.filter((su) => su.isFriend).map((su) => su.id)),
+  // Split period friends into "on your shift" vs "same session, different role".
+  // The shift detail signups list contains every active signup (friends, public,
+  // and strangers), so intersecting it with periodFriends correctly identifies
+  // which periodFriends are on this exact shift — including PUBLIC users.
+  const thisShiftSignupIds = useMemo(
+    () => new Set(shiftSignups.map((su) => su.id)),
     [shiftSignups]
   );
   const thisShiftName = shift?.shiftType.name;
   const friendsOnYourShift = useMemo(
     () =>
       periodFriends.filter(
-        (f) => yourShiftFriendIds.has(f.id) || f.shiftTypeName === thisShiftName
+        (f) => thisShiftSignupIds.has(f.id) || f.shiftTypeName === thisShiftName
       ),
-    [periodFriends, yourShiftFriendIds, thisShiftName]
+    [periodFriends, thisShiftSignupIds, thisShiftName]
   );
   const friendsInSession = useMemo(
     () =>
       periodFriends.filter(
         (f) =>
-          !yourShiftFriendIds.has(f.id) && f.shiftTypeName !== thisShiftName
+          !thisShiftSignupIds.has(f.id) && f.shiftTypeName !== thisShiftName
       ),
-    [periodFriends, yourShiftFriendIds, thisShiftName]
+    [periodFriends, thisShiftSignupIds, thisShiftName]
   );
 
   if (isLoading) {
@@ -695,7 +698,7 @@ function FriendsSection({
     <View style={s.section}>
       <SectionHeader
         label=""
-        title={`${total} friend${total !== 1 ? "s" : ""} on this shift`}
+        title={`${total} volunteer${total !== 1 ? "s" : ""} you can see`}
         caption={""}
         colors={colors}
       />

--- a/mobile/components/shift-month-calendar.tsx
+++ b/mobile/components/shift-month-calendar.tsx
@@ -233,7 +233,7 @@ export function ShiftMonthCalendar({
         <View style={styles.legendItem}>
           <View style={[styles.legendDot, { backgroundColor: "#f5c518" }]} />
           <Text style={[styles.legendText, { color: colors.textSecondary }]}>
-            Friends going
+            Volunteers going
           </Text>
         </View>
       </View>
@@ -326,7 +326,7 @@ function DayCell({
       ]}
       accessibilityLabel={`${formatNZT(day, "EEEE, d MMMM")}${
         shiftCount > 0 ? `, ${shiftCount} shifts` : ", no shifts"
-      }${hasFriends ? ", friends going" : ""}${
+      }${hasFriends ? ", volunteers going" : ""}${
         isSignedUp ? ", you're signed up" : ""
       }${isPastAttended ? ", shift attended" : ""}`}
       accessibilityRole="button"

--- a/mobile/components/shift-signup-sheet.tsx
+++ b/mobile/components/shift-signup-sheet.tsx
@@ -46,6 +46,8 @@ type FriendOnPeriod = {
   profilePhotoUrl: string | null;
   /** The shift type they're signed up for (may differ from this shift) */
   shiftTypeName: string | null;
+  /** True for actual friends; false for users with PUBLIC profile visibility. */
+  isFriend: boolean;
 };
 
 type ConcurrentResponse = {
@@ -287,13 +289,13 @@ export function ShiftSignupSheet({
             </View>
           </View>
 
-          {/* Friends volunteering this period */}
+          {/* Volunteers signed up for this period (friends + public profiles) */}
           {periodFriends.length > 0 && (
             <View style={[ss.friendsSection, { backgroundColor: isDark ? 'rgba(14,58,35,0.15)' : Brand.greenLight }]}>
               <View style={ss.friendsHeader}>
                 <Ionicons name="people" size={16} color={isDark ? '#86efac' : Brand.green} />
                 <Text style={[ss.friendsTitle, { color: isDark ? '#86efac' : Brand.green }]}>
-                  {periodFriends.length} friend{periodFriends.length !== 1 ? 's' : ''} volunteering this shift
+                  {periodFriends.length} volunteer{periodFriends.length !== 1 ? 's' : ''} going
                 </Text>
               </View>
               <View style={ss.friendsList}>

--- a/mobile/hooks/use-shift-detail.ts
+++ b/mobile/hooks/use-shift-detail.ts
@@ -39,6 +39,7 @@ type ConcurrentResponse = {
     name: string;
     profilePhotoUrl: string | null;
     shiftTypeName: string | null;
+    isFriend: boolean;
   }[];
 };
 
@@ -48,6 +49,8 @@ export type PeriodFriend = {
   profilePhotoUrl: string | null;
   /** The role/shift-type name the friend is signed up for */
   shiftTypeName: string | null;
+  /** True for actual friends; false for users with PUBLIC profile visibility. */
+  isFriend: boolean;
 };
 
 type UseShiftDetailReturn = {
@@ -111,6 +114,7 @@ export function useShiftDetail(shiftId: string | undefined): UseShiftDetailRetur
           name: f.name,
           profilePhotoUrl: f.profilePhotoUrl,
           shiftTypeName: f.shiftTypeName,
+          isFriend: f.isFriend ?? true,
         }),
       );
 

--- a/mobile/hooks/use-shifts.ts
+++ b/mobile/hooks/use-shifts.ts
@@ -8,6 +8,8 @@ export type PeriodFriend = {
   id: string;
   name: string;
   profilePhotoUrl: string | null;
+  /** True for actual friends; false for users with PUBLIC profile visibility. */
+  isFriend: boolean;
 };
 
 type ShiftsResponse = {

--- a/web/src/app/api/mobile/shifts/[id]/concurrent/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/concurrent/route.ts
@@ -71,16 +71,27 @@ export async function GET(
       friendIds.add(f.userId === userId ? f.friendId : f.userId);
     }
 
-    if (friendIds.size === 0) {
-      return NextResponse.json({ concurrentShifts, friends: [] });
-    }
-
-    // Find signups by friends on any of these period shifts
-    const friendSignups = await prisma.signup.findMany({
+    // Find signups visible to this user on any of these period shifts.
+    // Visibility rules (matching the web shifts page): include actual friends
+    // (FRIENDS_ONLY visibility) OR anyone whose profile is PUBLIC.
+    const visibleSignups = await prisma.signup.findMany({
       where: {
         shiftId: { in: periodShiftIds.map((s) => s.id) },
-        userId: { in: Array.from(friendIds) },
         status: { in: ["CONFIRMED", "PENDING", "REGULAR_PENDING"] },
+        userId: { not: userId },
+        user: {
+          OR: [
+            { friendVisibility: "PUBLIC" },
+            ...(friendIds.size > 0
+              ? [
+                  {
+                    friendVisibility: "FRIENDS_ONLY" as const,
+                    id: { in: Array.from(friendIds) },
+                  },
+                ]
+              : []),
+          ],
+        },
       },
       select: {
         shiftId: true,
@@ -99,9 +110,9 @@ export async function GET(
     // Build a map of shiftId → shiftTypeName for labelling
     const shiftTypeMap = new Map(periodShiftIds.map((s) => [s.id, s.shiftTypeName]));
 
-    // Deduplicate friends (a friend might be on multiple shifts theoretically)
+    // Deduplicate (a user might be on multiple shifts theoretically)
     const seen = new Set<string>();
-    const friends = friendSignups
+    const friends = visibleSignups
       .filter((s) => {
         if (seen.has(s.user.id)) return false;
         seen.add(s.user.id);
@@ -115,6 +126,7 @@ export async function GET(
           "Volunteer",
         profilePhotoUrl: s.user.profilePhotoUrl,
         shiftTypeName: shiftTypeMap.get(s.shiftId) ?? null,
+        isFriend: friendIds.has(s.user.id),
       }));
 
     return NextResponse.json({ concurrentShifts, friends });

--- a/web/src/app/api/mobile/shifts/route.ts
+++ b/web/src/app/api/mobile/shifts/route.ts
@@ -170,17 +170,38 @@ export async function GET(request: Request) {
     friendIds.add(f.userId === userId ? f.friendId : f.userId);
   }
 
-  type FriendSummary = { id: string; name: string; profilePhotoUrl: string | null };
+  type FriendSummary = {
+    id: string;
+    name: string;
+    profilePhotoUrl: string | null;
+    isFriend: boolean;
+  };
 
   let periodFriends: Record<string, FriendSummary[]> = {};
   let shiftFriends: Record<string, FriendSummary[]> = {};
 
-  if (friendIds.size > 0 && allUpcomingShiftIds.length > 0) {
-    const friendSignups = await prisma.signup.findMany({
+  if (allUpcomingShiftIds.length > 0) {
+    // Include signups by either: actual friends (any non-PRIVATE visibility)
+    // OR users who set their profile to PUBLIC visibility. This matches the
+    // web shifts page logic.
+    const visibleSignups = await prisma.signup.findMany({
       where: {
         shiftId: { in: allUpcomingShiftIds },
-        userId: { in: Array.from(friendIds) },
         status: { in: ["CONFIRMED", "PENDING", "REGULAR_PENDING"] },
+        userId: { not: userId },
+        user: {
+          OR: [
+            { friendVisibility: "PUBLIC" },
+            ...(friendIds.size > 0
+              ? [
+                  {
+                    friendVisibility: "FRIENDS_ONLY" as const,
+                    id: { in: Array.from(friendIds) },
+                  },
+                ]
+              : []),
+          ],
+        },
       },
       select: {
         shiftId: true,
@@ -199,7 +220,7 @@ export async function GET(request: Request) {
     const periodMap = new Map<string, Map<string, FriendSummary>>();
     const shiftMap = new Map<string, Map<string, FriendSummary>>();
 
-    for (const signup of friendSignups) {
+    for (const signup of visibleSignups) {
       const friend: FriendSummary = {
         id: signup.user.id,
         name:
@@ -207,6 +228,7 @@ export async function GET(request: Request) {
           [signup.user.firstName, signup.user.lastName].filter(Boolean).join(" ") ??
           "Volunteer",
         profilePhotoUrl: signup.user.profilePhotoUrl,
+        isFriend: friendIds.has(signup.user.id),
       };
 
       if (!shiftMap.has(signup.shiftId)) {


### PR DESCRIPTION
## Summary
- Mobile shift surfaces only showed actual friends signed up for shifts. The web shifts calendar already included users with `friendVisibility = PUBLIC` in the same UI — this brings mobile to parity.
- Updated `/api/mobile/shifts` and `/api/mobile/shifts/[id]/concurrent` to return signups by friends **or** users whose profile visibility is `PUBLIC`, mirroring the logic in `web/src/app/shifts/page.tsx:249-275`.
- Each returned entry now carries an `isFriend` flag so the UI can layer in a friend-only badge later without backend changes.
- Fixed dedup in `mobile/app/shift/[id].tsx` so PUBLIC users appearing in `periodFriends` get correctly grouped under "on your shift" vs "different role". Now keys off all signup IDs instead of only friend-flagged ones.
- Copy updated from "X friends" to "X volunteers" / "others" so the count accurately describes the mixed set (signup sheet, shifts tab card + period header, calendar legend + a11y label, shift detail section header).

## Test plan
- [ ] Sign in on mobile as a user with at least one friend going to a shift — confirm the friend still appears in the calendar dot, period header, signup sheet, and shift detail.
- [ ] Sign in as a user with **no** friends but where another volunteer with `friendVisibility = PUBLIC` is signed up to a visible shift — confirm that volunteer appears in the same surfaces.
- [ ] Verify a `PRIVATE` user is **not** shown in any of the above surfaces.
- [ ] Verify the shift-detail "X volunteers you can see" section splits correctly into SAME ROLE / DIFFERENT ROLE for both friends and PUBLIC users.
- [ ] Web typecheck passes (`npm run typecheck` in `web/`).
- [ ] Mobile typecheck passes (`npx tsc --noEmit` in `mobile/`).
- [ ] Web unit tests pass (`npm run test:run` in `web/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)