### PR TITLE
feat: subscribe users to newsletter lists during registration

### DIFF
--- a/web/src/app/api/auth/complete-migration/route.ts
+++ b/web/src/app/api/auth/complete-migration/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import { syncNewsletterSubscriptions } from "@/lib/newsletter-sync";
 
 /**
  * Complete migration for OAuth users
@@ -106,6 +107,19 @@ export async function GET(request: NextRequest) {
     }
 
     console.log(`Migration completed for user ${migrationUser.email} via OAuth`);
+
+    // Subscribe migrated user to the newsletter lists they picked on the
+    // migration form. save-migration-data persisted those prefs to the
+    // migration user record before OAuth started.
+    await syncNewsletterSubscriptions({
+      email: migrationUser.email,
+      name: `${migrationUser.firstName || ""} ${migrationUser.lastName || ""}`,
+      oldLists: [],
+      newLists: migrationUser.emailNewsletterSubscription
+        ? migrationUser.newsletterLists ?? []
+        : [],
+      emailNewsletterSubscription: migrationUser.emailNewsletterSubscription,
+    });
 
     // Redirect to dashboard
     return NextResponse.redirect(new URL("/dashboard", request.url));

--- a/web/src/app/api/auth/register/route.ts
+++ b/web/src/app/api/auth/register/route.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/lib/prisma";
 import { autoLabelUnder16User } from "@/lib/auto-label-utils";
 import { createVerificationToken } from "@/lib/email-verification";
 import { getEmailService } from "@/lib/email-service";
+import { syncNewsletterSubscriptions } from "@/lib/newsletter-sync";
 import { validatePassword } from "@/lib/utils/password-validation";
 import { checkForBot } from "@/lib/bot-protection";
 import { calculateAge, getBaseUrl } from "@/lib/utils";
@@ -68,6 +69,7 @@ const registerSchema = z
 
     // Communication & agreements
     emailNewsletterSubscription: z.boolean().optional(),
+    newsletterLists: z.array(z.string()).optional(),
     notificationPreference: z.enum(["EMAIL", "SMS", "BOTH", "NONE"]).optional(),
     volunteerAgreementAccepted: z.boolean(),
     healthSafetyPolicyAccepted: z.boolean(),
@@ -124,18 +126,19 @@ export async function POST(req: Request) {
     const validatedData = registerSchema.parse(dataToValidate);
 
     // For migration, find existing user by ID; otherwise check if email exists
+    let priorNewsletterLists: string[] = [];
     if (isMigration && userId) {
       const migratingUser = await prisma.user.findUnique({
         where: { id: userId },
       });
-      
+
       if (!migratingUser) {
         return NextResponse.json(
           { error: "Invalid migration request" },
           { status: 400 }
         );
       }
-      
+
       // Verify the email matches for security
       if (migratingUser.email !== validatedData.email) {
         return NextResponse.json(
@@ -143,6 +146,8 @@ export async function POST(req: Request) {
           { status: 400 }
         );
       }
+
+      priorNewsletterLists = migratingUser.newsletterLists ?? [];
     } else {
       // Check if user already exists for new registrations
       const existingUser = await prisma.user.findUnique({
@@ -222,6 +227,10 @@ export async function POST(req: Request) {
       // Communication & agreements
       emailNewsletterSubscription:
         validatedData.emailNewsletterSubscription ?? true,
+      newsletterLists:
+        validatedData.emailNewsletterSubscription === false
+          ? []
+          : validatedData.newsletterLists ?? [],
       notificationPreference: validatedData.notificationPreference || "EMAIL",
       volunteerAgreementAccepted: validatedData.volunteerAgreementAccepted,
       healthSafetyPolicyAccepted: validatedData.healthSafetyPolicyAccepted,
@@ -342,6 +351,22 @@ export async function POST(req: Request) {
         // Don't fail registration if email sending fails, just log the error
       }
     }
+
+    // Campaign Monitor newsletter sync — opt-in only, defaults to no lists
+    // when the user did not select any. Failures are swallowed inside the
+    // helper so registration succeeds even if Campaign Monitor is down.
+    await syncNewsletterSubscriptions({
+      email: user.email,
+      name:
+        user.name ||
+        `${validatedData.firstName} ${validatedData.lastName}`.trim(),
+      oldLists: priorNewsletterLists,
+      newLists:
+        validatedData.emailNewsletterSubscription === false
+          ? []
+          : validatedData.newsletterLists ?? [],
+      emailNewsletterSubscription: validatedData.emailNewsletterSubscription,
+    });
 
     // Funnel attribution: stitch the anonymous distinct_id (eea_phid cookie)
     // onto the new user so their experiment exposure → conversion path is

--- a/web/src/app/api/auth/save-migration-data/route.ts
+++ b/web/src/app/api/auth/save-migration-data/route.ts
@@ -84,6 +84,12 @@ export async function POST(request: NextRequest) {
             ? data.defaultLocation
             : null,
         emailNewsletterSubscription: data.emailNewsletterSubscription,
+        newsletterLists:
+          data.emailNewsletterSubscription === false
+            ? []
+            : Array.isArray(data.newsletterLists)
+              ? data.newsletterLists
+              : [],
         notificationPreference: data.notificationPreference,
         receiveShortageNotifications: data.receiveShortageNotifications,
         excludedShortageNotificationTypes: Array.isArray(data.excludedShortageNotificationTypes) 

--- a/web/src/app/api/profile/route.ts
+++ b/web/src/app/api/profile/route.ts
@@ -8,6 +8,7 @@ import { safeParseAvailability } from "@/lib/parse-availability";
 import { autoLabelUnder16User, isUserUnder16 } from "@/lib/auto-label-utils";
 import { checkForBot } from "@/lib/bot-protection";
 import { CampaignMonitorService } from "@/lib/services/campaign-monitor";
+import { syncNewsletterSubscriptions } from "@/lib/newsletter-sync";
 import { getEmailService } from "@/lib/email-service";
 import { isProfileComplete } from "@/lib/profile-completion";
 
@@ -419,40 +420,23 @@ export async function PUT(req: Request) {
     }
 
     // Campaign Monitor newsletter sync
-    if (validatedData.emailNewsletterSubscription !== undefined || validatedData.newsletterLists !== undefined) {
-      try {
-        const campaignMonitor = new CampaignMonitorService();
-        const userEmail = updatedUser.email;
-        const userName = `${updatedUser.firstName || ''} ${updatedUser.lastName || ''}`.trim() || userEmail;
-
-        const oldLists = user.newsletterLists || [];
-        const newLists = validatedData.newsletterLists !== undefined
+    if (
+      validatedData.emailNewsletterSubscription !== undefined ||
+      validatedData.newsletterLists !== undefined
+    ) {
+      const oldLists = user.newsletterLists || [];
+      const newLists =
+        validatedData.newsletterLists !== undefined
           ? validatedData.newsletterLists
           : oldLists;
 
-        if (validatedData.emailNewsletterSubscription === false) {
-          // Unsubscribe from all lists
-          for (const listId of oldLists) {
-            await campaignMonitor.unsubscribeFromList(listId, userEmail);
-          }
-        } else if (validatedData.emailNewsletterSubscription === true || validatedData.newsletterLists !== undefined) {
-          // Subscribe to new lists
-          const listsToAdd = newLists.filter((id: string) => !oldLists.includes(id));
-          for (const listId of listsToAdd) {
-            await campaignMonitor.subscribeToList(listId, userEmail, userName, {});
-          }
-
-          // Unsubscribe from removed lists
-          const listsToRemove = oldLists.filter((id: string) => !newLists.includes(id));
-          for (const listId of listsToRemove) {
-            await campaignMonitor.unsubscribeFromList(listId, userEmail);
-          }
-        }
-      } catch (error) {
-        // Log error but don't fail profile update
-        console.error('Campaign Monitor sync error:', error);
-        // Could optionally add a warning to the response
-      }
+      await syncNewsletterSubscriptions({
+        email: updatedUser.email,
+        name: `${updatedUser.firstName || ""} ${updatedUser.lastName || ""}`,
+        oldLists,
+        newLists,
+        emailNewsletterSubscription: validatedData.emailNewsletterSubscription,
+      });
     }
 
     // Parse JSON fields for response safely

--- a/web/src/app/register/migrate/migration-registration-form.tsx
+++ b/web/src/app/register/migrate/migration-registration-form.tsx
@@ -68,6 +68,12 @@ interface MigrationRegistrationFormProps {
   token: string;
   locationOptions: Array<{ value: string; label: string }>;
   shiftTypes: Array<{ id: string; name: string }>;
+  newsletterLists: Array<{
+    id: string;
+    name: string;
+    campaignMonitorId: string;
+    description: string | null;
+  }>;
 }
 
 /**
@@ -311,6 +317,7 @@ export function MigrationRegistrationForm({
   user,
   token,
   locationOptions,
+  newsletterLists,
 }: MigrationRegistrationFormProps) {
   const router = useRouter();
   const { toast } = useToast();
@@ -361,7 +368,9 @@ export function MigrationRegistrationForm({
 
     // Communication & agreements
     emailNewsletterSubscription: true,
-    newsletterLists: [],
+    // Pre-select every active list — users opt out by unticking, matching the
+    // "include people in the newsletter on signup" intent.
+    newsletterLists: newsletterLists.map((list) => list.campaignMonitorId),
     notificationPreference: "EMAIL",
     receiveShortageNotifications: true,
     excludedShortageNotificationTypes: [],
@@ -693,6 +702,7 @@ export function MigrationRegistrationForm({
             setVolunteerAgreementOpen={setVolunteerAgreementOpen}
             healthSafetyPolicyOpen={healthSafetyPolicyOpen}
             setHealthSafetyPolicyOpen={setHealthSafetyPolicyOpen}
+            newsletterLists={newsletterLists}
           />
         );
       case 4: // Account setup (Password)

--- a/web/src/app/register/migrate/page.tsx
+++ b/web/src/app/register/migrate/page.tsx
@@ -61,6 +61,19 @@ async function getShiftTypes() {
   return shiftTypes;
 }
 
+async function getNewsletterLists() {
+  return prisma.newsletterList.findMany({
+    where: { active: true },
+    select: {
+      id: true,
+      name: true,
+      campaignMonitorId: true,
+      description: true,
+    },
+    orderBy: [{ displayOrder: "asc" }, { name: "asc" }],
+  });
+}
+
 async function validateToken(token: string) {
   if (!token) return null;
 
@@ -163,10 +176,11 @@ export default async function MigrationRegistrationPage({ searchParams }: PagePr
     );
   }
 
-  const [user, locationOptions, shiftTypes] = await Promise.all([
+  const [user, locationOptions, shiftTypes, newsletterLists] = await Promise.all([
     validateToken(token),
     getLocationOptions(),
     getShiftTypes(),
+    getNewsletterLists(),
   ]);
 
   if (!user) {
@@ -218,6 +232,7 @@ export default async function MigrationRegistrationPage({ searchParams }: PagePr
             token={token}
             locationOptions={locationOptions}
             shiftTypes={shiftTypes}
+            newsletterLists={newsletterLists}
           />
         </Suspense>
       </div>

--- a/web/src/app/register/page.tsx
+++ b/web/src/app/register/page.tsx
@@ -70,14 +70,31 @@ async function getShiftTypes() {
   return shiftTypes;
 }
 
+async function getNewsletterLists() {
+  "use cache";
+  cacheLife("hours");
+
+  return prisma.newsletterList.findMany({
+    where: { active: true },
+    select: {
+      id: true,
+      name: true,
+      campaignMonitorId: true,
+      description: true,
+    },
+    orderBy: [{ displayOrder: "asc" }, { name: "asc" }],
+  });
+}
+
 /**
  * Multi-step volunteer registration page
  * Collects comprehensive user profile information during signup
  */
 export default async function RegisterPage() {
-  const [locationOptions, shiftTypes, phid] = await Promise.all([
+  const [locationOptions, shiftTypes, newsletterLists, phid] = await Promise.all([
     getLocationOptions(),
     getShiftTypes(),
+    getNewsletterLists(),
     getPhidFromCookies(),
   ]);
 
@@ -91,6 +108,7 @@ export default async function RegisterPage() {
       <RegisterForm
         locationOptions={locationOptions}
         shiftTypes={shiftTypes}
+        newsletterLists={newsletterLists}
       />
     </Suspense>
   );

--- a/web/src/app/register/register-client.tsx
+++ b/web/src/app/register/register-client.tsx
@@ -45,9 +45,19 @@ interface Provider {
 interface RegisterClientProps {
   locationOptions: Array<{ value: string; label: string }>;
   shiftTypes: Array<{ id: string; name: string }>;
+  newsletterLists: Array<{
+    id: string;
+    name: string;
+    campaignMonitorId: string;
+    description: string | null;
+  }>;
 }
 
-export default function RegisterClient({ locationOptions, shiftTypes }: RegisterClientProps) {
+export default function RegisterClient({
+  locationOptions,
+  shiftTypes,
+  newsletterLists,
+}: RegisterClientProps) {
   const [loading, setLoading] = useState(false);
   const [currentStep, setCurrentStep] = useState(0);
   const [oauthLoading, setOauthLoading] = useState<string | null>(null);
@@ -126,7 +136,9 @@ export default function RegisterClient({ locationOptions, shiftTypes }: Register
 
     // Communication & agreements
     emailNewsletterSubscription: true,
-    newsletterLists: [],
+    // Pre-select every active list — users opt out by unticking, matching the
+    // "include people in the newsletter on signup" intent.
+    newsletterLists: newsletterLists.map((list) => list.campaignMonitorId),
     notificationPreference: "EMAIL",
     receiveShortageNotifications: true,
     excludedShortageNotificationTypes: [],
@@ -628,6 +640,7 @@ export default function RegisterClient({ locationOptions, shiftTypes }: Register
             healthSafetyPolicyOpen={healthSafetyPolicyOpen}
             setHealthSafetyPolicyOpen={setHealthSafetyPolicyOpen}
             shiftTypes={shiftTypes}
+            newsletterLists={newsletterLists}
           />
         );
       default:

--- a/web/src/app/register/register-form.tsx
+++ b/web/src/app/register/register-form.tsx
@@ -10,13 +10,24 @@ const RegisterClient = dynamic(() => import("./register-client"), {
 interface RegisterFormProps {
   locationOptions: Array<{ value: string; label: string }>;
   shiftTypes: Array<{ id: string; name: string }>;
+  newsletterLists: Array<{
+    id: string;
+    name: string;
+    campaignMonitorId: string;
+    description: string | null;
+  }>;
 }
 
-export function RegisterForm({ locationOptions, shiftTypes }: RegisterFormProps) {
+export function RegisterForm({
+  locationOptions,
+  shiftTypes,
+  newsletterLists,
+}: RegisterFormProps) {
   return (
     <RegisterClient
       locationOptions={locationOptions}
       shiftTypes={shiftTypes}
+      newsletterLists={newsletterLists}
     />
   );
 }

--- a/web/src/lib/newsletter-sync.ts
+++ b/web/src/lib/newsletter-sync.ts
@@ -1,0 +1,52 @@
+import { CampaignMonitorService } from "@/lib/services/campaign-monitor";
+
+interface SyncOptions {
+  email: string;
+  name: string;
+  oldLists: string[];
+  newLists: string[];
+  emailNewsletterSubscription?: boolean;
+}
+
+/**
+ * Reconcile a user's Campaign Monitor subscriptions with the desired state.
+ *
+ * - When `emailNewsletterSubscription` is explicitly false, every list in
+ *   `oldLists` is unsubscribed and `newLists` is ignored.
+ * - Otherwise, lists added since `oldLists` are subscribed and lists removed
+ *   are unsubscribed.
+ *
+ * Errors are swallowed (Campaign Monitor outages should not block registration
+ * or profile updates), but the sync is still attempted for every list.
+ */
+export async function syncNewsletterSubscriptions({
+  email,
+  name,
+  oldLists,
+  newLists,
+  emailNewsletterSubscription,
+}: SyncOptions): Promise<void> {
+  try {
+    const campaignMonitor = new CampaignMonitorService();
+    const displayName = name.trim() || email;
+
+    if (emailNewsletterSubscription === false) {
+      for (const listId of oldLists) {
+        await campaignMonitor.unsubscribeFromList(listId, email);
+      }
+      return;
+    }
+
+    const listsToAdd = newLists.filter((id) => !oldLists.includes(id));
+    for (const listId of listsToAdd) {
+      await campaignMonitor.subscribeToList(listId, email, displayName, {});
+    }
+
+    const listsToRemove = oldLists.filter((id) => !newLists.includes(id));
+    for (const listId of listsToRemove) {
+      await campaignMonitor.unsubscribeFromList(listId, email);
+    }
+  } catch (error) {
+    console.error("Campaign Monitor sync error:", error);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a shared `syncNewsletterSubscriptions` helper (`web/src/lib/newsletter-sync.ts`) extracted from the profile PUT handler and reuses it in `/api/auth/register` and the OAuth `complete-migration` path.
- Persists `newsletterLists` on the email-register and `save-migration-data` endpoints (defaults to no lists when the user opts out of the newsletter checkbox).
- Loads active newsletter lists in `/register` and `/register/migrate`, passes them into `CommunicationStep`, and pre-ticks every list so opt-out is the explicit action.

OAuth-only signups (web and mobile) are intentionally unchanged — those users still pick lists via profile-edit, which already syncs through the same helper.

## Test plan

- [ ] Email registration with newsletter checkbox on subscribes the user to every active list in Campaign Monitor.
- [ ] Email registration with the newsletter checkbox off subscribes to nothing and stores `newsletterLists: []`.
- [ ] Migration via password (POST `/api/auth/register?isMigration=true`) subscribes to the picked lists.
- [ ] Migration via OAuth (`save-migration-data` → OAuth → `complete-migration`) subscribes to the picked lists after the redirect.
- [ ] Profile edit page newsletter behaviour is unchanged (regression).
- [ ] `npm run typecheck` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)