### PR TITLE
fix(shifts): count unregistered volunteers toward capacity everywhere

### DIFF
--- a/web/src/app/api/admin/messages/threads/[id]/route.ts
+++ b/web/src/app/api/admin/messages/threads/[id]/route.ts
@@ -4,6 +4,10 @@ import type { Prisma } from "@/generated/client";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { listMessages } from "@/lib/services/messaging";
+import {
+  getShiftEffectiveCount,
+  shiftCapacityCountSelect,
+} from "@/lib/placeholder-utils";
 
 export async function GET(
   req: Request,
@@ -73,7 +77,7 @@ export async function GET(
             notes: true,
             capacity: true,
             shiftType: { select: { name: true } },
-            _count: { select: { signups: { where: { status: "CONFIRMED" } } } },
+            _count: shiftCapacityCountSelect(["CONFIRMED"]),
           },
         },
       },
@@ -90,7 +94,7 @@ export async function GET(
         location: nextSignup.shift.location,
         notes: nextSignup.shift.notes,
         capacity: nextSignup.shift.capacity,
-        confirmedCount: nextSignup.shift._count.signups,
+        confirmedCount: getShiftEffectiveCount(nextSignup.shift),
         shiftTypeName: nextSignup.shift.shiftType.name,
       }
     : null;

--- a/web/src/app/api/admin/notifications/send-shortage/route.ts
+++ b/web/src/app/api/admin/notifications/send-shortage/route.ts
@@ -5,6 +5,10 @@ import { prisma } from "@/lib/prisma";
 import { getEmailService } from "@/lib/email-service";
 import { formatInNZT } from "@/lib/timezone";
 import { createNotificationsForUsers } from "@/lib/notifications";
+import {
+  getShiftEffectiveCount,
+  shiftCapacityCountSelect,
+} from "@/lib/placeholder-utils";
 
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
@@ -30,17 +34,7 @@ export async function POST(request: Request) {
       where: { id: { in: shiftIds } },
       include: {
         shiftType: true,
-        _count: {
-          select: {
-            signups: {
-              where: {
-                status: {
-                  in: ["CONFIRMED", "REGULAR_PENDING"],
-                },
-              },
-            },
-          },
-        },
+        _count: shiftCapacityCountSelect(["CONFIRMED", "REGULAR_PENDING"]),
       },
       orderBy: { start: "asc" },
     });
@@ -80,7 +74,7 @@ export async function POST(request: Request) {
 
     // Build shift data for emails
     const shiftsForEmail = shifts.map((shift) => {
-      const currentVolunteers = shift._count.signups;
+      const currentVolunteers = getShiftEffectiveCount(shift);
       const neededVolunteers = shift.capacity - currentVolunteers;
       return {
         shiftId: shift.id,

--- a/web/src/app/api/admin/shifts/available/route.ts
+++ b/web/src/app/api/admin/shifts/available/route.ts
@@ -3,6 +3,10 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { startOfDay, endOfDay } from "date-fns";
+import {
+  getShiftEffectiveCount,
+  shiftCapacityCountSelect,
+} from "@/lib/placeholder-utils";
 
 // GET /api/admin/shifts/available - Get available shifts with capacity for a specific date/location
 export async function GET(request: Request) {
@@ -47,11 +51,7 @@ export async function GET(request: Request) {
       },
       include: {
         shiftType: true,
-        signups: {
-          where: {
-            status: "CONFIRMED",
-          },
-        },
+        _count: shiftCapacityCountSelect(["CONFIRMED"]),
       },
       orderBy: {
         start: "asc",
@@ -66,7 +66,7 @@ export async function GET(request: Request) {
         end: shift.end.toISOString(),
         location: shift.location,
         capacity: shift.capacity,
-        confirmedCount: shift.signups.length,
+        confirmedCount: getShiftEffectiveCount(shift),
         shiftType: {
           id: shift.shiftType.id,
           name: shift.shiftType.name,

--- a/web/src/app/api/mobile/shifts/[id]/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireMobileUser } from "@/lib/mobile-auth";
+import {
+  getShiftEffectiveCount,
+  shiftCapacityCountSelect,
+} from "@/lib/placeholder-utils";
 
 /**
  * GET /api/mobile/shifts/[id]
@@ -46,6 +50,7 @@ export async function GET(
           },
         },
       },
+      _count: shiftCapacityCountSelect(["CONFIRMED"]),
     },
   });
 
@@ -79,10 +84,8 @@ export async function GET(
   const userSignup = shift.signups.find((s) => s.userId === userId);
   const userStatus = userSignup?.status ?? null;
 
-  // Count confirmed signups
-  const signedUpCount = shift.signups.filter(
-    (s) => s.status === "CONFIRMED"
-  ).length;
+  // Count confirmed signups + unregistered placeholders
+  const signedUpCount = getShiftEffectiveCount(shift);
 
   // Build signups list (all active signups) for the "Who's on this mahi" section
   const signups = shift.signups.map((s) => {

--- a/web/src/app/api/mobile/shifts/route.ts
+++ b/web/src/app/api/mobile/shifts/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireMobileUser } from "@/lib/mobile-auth";
 import { getShiftDate, isAMShift } from "@/lib/concurrent-shifts";
+import {
+  getShiftEffectiveCount,
+  shiftCapacityCountSelect,
+} from "@/lib/placeholder-utils";
 
 const DEFAULT_PAGE_SIZE = 15;
 
@@ -57,7 +61,7 @@ export async function GET(request: Request) {
       shift: {
         include: {
           shiftType: true,
-          signups: { where: { status: "CONFIRMED" } },
+          _count: shiftCapacityCountSelect(["CONFIRMED"]),
         },
       },
     },
@@ -77,7 +81,7 @@ export async function GET(request: Request) {
     },
     include: {
       shiftType: true,
-      signups: { where: { status: "CONFIRMED" } },
+      _count: shiftCapacityCountSelect(["CONFIRMED"]),
     },
     orderBy: { start: "asc" },
   });
@@ -93,7 +97,7 @@ export async function GET(request: Request) {
       shift: {
         include: {
           shiftType: true,
-          signups: { where: { status: "CONFIRMED" } },
+          _count: shiftCapacityCountSelect(["CONFIRMED"]),
         },
       },
     },
@@ -117,7 +121,7 @@ export async function GET(request: Request) {
       capacity: number;
       notes: string | null;
       shiftType: { id: string; name: string; description: string | null };
-      signups: { id: string }[];
+      _count: { signups: number; placeholders: number };
     },
     status?: string | null
   ) => ({
@@ -131,7 +135,7 @@ export async function GET(request: Request) {
     end: shift.end.toISOString(),
     location: shift.location ?? "TBC",
     capacity: shift.capacity,
-    signedUp: shift.signups.length,
+    signedUp: getShiftEffectiveCount(shift),
     status: status ?? null,
     notes: shift.notes,
   });

--- a/web/src/app/api/shifts/route.ts
+++ b/web/src/app/api/shifts/route.ts
@@ -1,5 +1,9 @@
 import { prisma } from "@/lib/prisma";
 import { getBaseUrl } from "@/lib/utils";
+import {
+  getShiftEffectiveCount,
+  shiftCapacityCountSelect,
+} from "@/lib/placeholder-utils";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest) {
@@ -17,7 +21,10 @@ export async function GET(request: NextRequest) {
   const shifts = await prisma.shift.findMany({
     where,
     orderBy: { start: "asc" },
-    include: { shiftType: true, signups: true },
+    include: {
+      shiftType: true,
+      _count: shiftCapacityCountSelect(["CONFIRMED"]),
+    },
   });
 
   type ShiftItem = {
@@ -34,26 +41,18 @@ export async function GET(request: NextRequest) {
   };
 
   const baseUrl = getBaseUrl();
-  const result: ShiftItem[] = [];
-  for (const s of shifts) {
-    let confirmedCount = 0;
-    for (const signup of s.signups) {
-      if (signup.status === "CONFIRMED") confirmedCount += 1;
-    }
-
-    result.push({
-      id: s.id,
-      start: s.start,
-      end: s.end,
-      location: s.location,
-      notes: s.notes,
-      capacity: s.capacity,
-      remaining: Math.max(0, s.capacity - confirmedCount),
-      shiftType: { id: s.shiftType.id, name: s.shiftType.name },
-      url: `${baseUrl}/shifts/${s.id}`,
-      image: `${baseUrl}/og-image.png`,
-    });
-  }
+  const result: ShiftItem[] = shifts.map((s) => ({
+    id: s.id,
+    start: s.start,
+    end: s.end,
+    location: s.location,
+    notes: s.notes,
+    capacity: s.capacity,
+    remaining: Math.max(0, s.capacity - getShiftEffectiveCount(s)),
+    shiftType: { id: s.shiftType.id, name: s.shiftType.name },
+    url: `${baseUrl}/shifts/${s.id}`,
+    image: `${baseUrl}/og-image.png`,
+  }));
 
   return NextResponse.json(result);
 }

--- a/web/src/components/animated-shift-cards.tsx
+++ b/web/src/components/animated-shift-cards.tsx
@@ -672,9 +672,7 @@ export function AnimatedShiftCards({ shifts, shiftIdToTypeName }: AnimatedShiftC
                             data-testid={`shift-capacity-${shift.id}`}
                             className={`${staffingStatus.color} text-white text-base px-3 py-1.5 font-bold shadow-sm`}
                           >
-                            {unregisteredCount > 0
-                              ? `${confirmedSignups}+${unregisteredCount}/${shift.capacity}`
-                              : `${confirmed}/${shift.capacity}`}
+                            {`${confirmed}/${shift.capacity}`}
                           </Badge>
                           {!isCompleted && (
                             <span className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide">

--- a/web/src/lib/concurrent-shifts.ts
+++ b/web/src/lib/concurrent-shifts.ts
@@ -1,6 +1,10 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@/generated/client";
 import { formatInNZT, toNZT } from "@/lib/timezone";
+import {
+  getShiftEffectiveCount,
+  shiftCapacityCountSelect,
+} from "@/lib/placeholder-utils";
 
 /** Hour cutoff (NZ time) — shifts starting before this are "Day", at or after are "Evening" */
 export const DAY_EVENING_CUTOFF_HOUR = 16;
@@ -76,17 +80,7 @@ export async function getConcurrentShifts(shiftId: string) {
           description: true,
         },
       },
-      _count: {
-        select: {
-          signups: {
-            where: {
-              status: {
-                in: ["CONFIRMED", "REGULAR_PENDING"],
-              },
-            },
-          },
-        },
-      },
+      _count: shiftCapacityCountSelect(["CONFIRMED", "REGULAR_PENDING"]),
     },
     orderBy: {
       start: "asc",
@@ -104,6 +98,6 @@ export async function getConcurrentShifts(shiftId: string) {
     id: s.id,
     shiftTypeName: s.shiftType.name,
     shiftTypeDescription: s.shiftType.description,
-    spotsRemaining: Math.max(0, s.capacity - s._count.signups),
+    spotsRemaining: Math.max(0, s.capacity - getShiftEffectiveCount(s)),
   }));
 }

--- a/web/src/lib/home-stats.ts
+++ b/web/src/lib/home-stats.ts
@@ -1,4 +1,8 @@
 import { prisma } from "@/lib/prisma";
+import {
+  getShiftEffectiveCount,
+  shiftCapacityCountSelect,
+} from "@/lib/placeholder-utils";
 
 export type HomeStats = {
   volunteers: number;
@@ -99,10 +103,7 @@ export async function getHomeStats(): Promise<HomeStats> {
         id: true,
         capacity: true,
         location: true,
-        signups: {
-          where: { status: "CONFIRMED" },
-          select: { id: true },
-        },
+        _count: shiftCapacityCountSelect(["CONFIRMED"]),
       },
     }),
     prisma.location.count({ where: { isActive: true } }),
@@ -112,10 +113,7 @@ export async function getHomeStats(): Promise<HomeStats> {
       take: 6,
       include: {
         shiftType: { select: { name: true } },
-        signups: {
-          where: { status: "CONFIRMED" },
-          select: { id: true },
-        },
+        _count: shiftCapacityCountSelect(["CONFIRMED"]),
       },
     }),
     prisma.signup.findMany({
@@ -154,10 +152,10 @@ export async function getHomeStats(): Promise<HomeStats> {
 
   // Open shifts derived
   const openShiftsCount = openShiftsRaw.filter(
-    (s) => s.signups.length < s.capacity
+    (s) => getShiftEffectiveCount(s) < s.capacity
   ).length;
   const openSpots = openShiftsRaw.reduce(
-    (sum, s) => sum + Math.max(0, s.capacity - s.signups.length),
+    (sum, s) => sum + Math.max(0, s.capacity - getShiftEffectiveCount(s)),
     0
   );
 
@@ -168,9 +166,9 @@ export async function getHomeStats(): Promise<HomeStats> {
     activeNames.has(n)
   ).map((name) => {
     const shifts = openShiftsRaw.filter((s) => s.location === name);
-    const open = shifts.filter((s) => s.signups.length < s.capacity).length;
+    const open = shifts.filter((s) => getShiftEffectiveCount(s) < s.capacity).length;
     const spots = shifts.reduce(
-      (sum, s) => sum + Math.max(0, s.capacity - s.signups.length),
+      (sum, s) => sum + Math.max(0, s.capacity - getShiftEffectiveCount(s)),
       0
     );
     return { name, openShifts: open, spotsLeft: spots };
@@ -183,8 +181,8 @@ export async function getHomeStats(): Promise<HomeStats> {
     location: s.location,
     shiftType: s.shiftType.name,
     capacity: s.capacity,
-    confirmed: s.signups.length,
-    spotsLeft: Math.max(0, s.capacity - s.signups.length),
+    confirmed: getShiftEffectiveCount(s),
+    spotsLeft: Math.max(0, s.capacity - getShiftEffectiveCount(s)),
   }));
 
   const activity: RecentActivityItem[] = recentSignups.map((s) => {

--- a/web/src/lib/placeholder-utils.test.ts
+++ b/web/src/lib/placeholder-utils.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   getEffectiveConfirmedCount,
   getShiftConfirmedCount,
+  getShiftEffectiveCount,
+  shiftCapacityCountSelect,
 } from "./placeholder-utils";
 
 describe("getEffectiveConfirmedCount", () => {
@@ -61,5 +63,59 @@ describe("getShiftConfirmedCount", () => {
     expect(
       getShiftConfirmedCount({ signups: [], _count: { placeholders: 0 } })
     ).toBe(0);
+  });
+});
+
+describe("getShiftEffectiveCount", () => {
+  it("sums _count.signups and _count.placeholders", () => {
+    expect(
+      getShiftEffectiveCount({ _count: { signups: 4, placeholders: 2 } })
+    ).toBe(6);
+  });
+
+  it("returns just signups when placeholders are 0", () => {
+    expect(
+      getShiftEffectiveCount({ _count: { signups: 3, placeholders: 0 } })
+    ).toBe(3);
+  });
+
+  it("returns just placeholders when signups are 0", () => {
+    expect(
+      getShiftEffectiveCount({ _count: { signups: 0, placeholders: 5 } })
+    ).toBe(5);
+  });
+
+  it("returns 0 when both are 0", () => {
+    expect(
+      getShiftEffectiveCount({ _count: { signups: 0, placeholders: 0 } })
+    ).toBe(0);
+  });
+});
+
+describe("shiftCapacityCountSelect", () => {
+  it("filters signups by the provided statuses and always counts placeholders", () => {
+    expect(shiftCapacityCountSelect(["CONFIRMED"])).toEqual({
+      select: {
+        signups: { where: { status: { in: ["CONFIRMED"] } } },
+        placeholders: true,
+      },
+    });
+  });
+
+  it("supports multiple statuses", () => {
+    expect(shiftCapacityCountSelect(["CONFIRMED", "REGULAR_PENDING"])).toEqual({
+      select: {
+        signups: {
+          where: { status: { in: ["CONFIRMED", "REGULAR_PENDING"] } },
+        },
+        placeholders: true,
+      },
+    });
+  });
+
+  it("counts all signups (unfiltered) when no statuses are provided", () => {
+    expect(shiftCapacityCountSelect()).toEqual({
+      select: { signups: true, placeholders: true },
+    });
   });
 });

--- a/web/src/lib/placeholder-utils.ts
+++ b/web/src/lib/placeholder-utils.ts
@@ -1,3 +1,5 @@
+import type { SignupStatus } from "@/generated/client";
+
 /**
  * Returns the effective confirmed count including unregistered volunteers.
  * Unregistered volunteers don't have a Signup row — they live in the
@@ -27,4 +29,41 @@ export function getShiftConfirmedCount(shift: {
     (s) => s.status === "CONFIRMED"
   ).length;
   return getEffectiveConfirmedCount(confirmedSignups, shift._count.placeholders);
+}
+
+/**
+ * Canonical Prisma `_count` select for shift capacity. Counts registered
+ * signups (optionally filtered by status) plus unregistered placeholders.
+ *
+ * Use this in any Prisma query that needs to know how many spots a shift
+ * has filled, so unregistered volunteers can't be silently dropped from
+ * the count:
+ *
+ *   prisma.shift.findMany({
+ *     include: { _count: shiftCapacityCountSelect(["CONFIRMED"]) },
+ *   })
+ *
+ * Pair with `getShiftEffectiveCount` to read the result.
+ */
+export function shiftCapacityCountSelect(statuses?: readonly SignupStatus[]) {
+  return {
+    select: {
+      signups: statuses
+        ? { where: { status: { in: [...statuses] } } }
+        : true,
+      placeholders: true,
+    },
+  } as const;
+}
+
+/**
+ * Returns the effective volunteer count from a shift loaded with the
+ * standard `_count` shape: registered signups (already status-filtered by
+ * the query) plus unregistered placeholders. Pair with
+ * `shiftCapacityCountSelect` on the query side.
+ */
+export function getShiftEffectiveCount(shift: {
+  _count: { signups: number; placeholders: number };
+}): number {
+  return shift._count.signups + shift._count.placeholders;
 }


### PR DESCRIPTION
## Summary

- Admin roster badge: changes the volunteer-count chip from `2+2/6` (registered + unregistered / capacity) to a single combined `4/6` so it reads naturally as "4 of 6 spots filled" — per Nic's request.
- Capacity math: unregistered volunteers (`ShiftPlaceholder` rows entered by an admin for group members without accounts) were silently dropped from spots-remaining math in several APIs and shared utilities, causing the volunteer-facing "X spaces available" to overstate availability. Fixed across the mobile API, public `/api/shifts` feed, home dashboard, shortage email math, admin available-shifts picker, admin chat next-shift card, and concurrent-shifts util.
- Centralisation: introduces two small helpers in `web/src/lib/placeholder-utils.ts` so the pattern is hard to reintroduce next time:
  - `shiftCapacityCountSelect(statuses?)` — canonical Prisma `_count.select` block that always includes `placeholders`
  - `getShiftEffectiveCount(shift)` — reads `_count.signups + _count.placeholders` from a query result

## Files touched (web/)

| Surface | File |
|---|---|
| Roster badge display | `src/components/animated-shift-cards.tsx` |
| Public shifts feed | `src/app/api/shifts/route.ts` |
| Mobile shifts list | `src/app/api/mobile/shifts/route.ts` |
| Mobile shift detail | `src/app/api/mobile/shifts/[id]/route.ts` |
| Admin available-shifts picker | `src/app/api/admin/shifts/available/route.ts` |
| Shortage email math | `src/app/api/admin/notifications/send-shortage/route.ts` |
| Admin chat next-shift card | `src/app/api/admin/messages/threads/[id]/route.ts` |
| Concurrent-shifts util (linked from shift detail) | `src/lib/concurrent-shifts.ts` |
| Home dashboard panels (open shifts / spotsLeft) | `src/lib/home-stats.ts` |
| New helpers + tests | `src/lib/placeholder-utils.ts`, `src/lib/placeholder-utils.test.ts` |

Web pages already counting placeholders correctly (admin dashboard, `/admin/shifts`, `/shifts`, `/shifts/[id]`, etc.) were left untouched.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm run test:run` — 170/170 passing (7 new unit tests for the two new helpers)
- [ ] Manual smoke against a shift with mixed registered + placeholder signups:
  - [ ] `/admin/shifts` — badge reads `4/6`, not `2+2/6`
  - [ ] `/shifts/[id]` — "spots left" still correct (no regression)
  - [ ] `/` (home dashboard) — location panel and per-shift "open" counts now exclude placeholder-filled slots
  - [ ] Mobile Shifts tab — `X/Y volunteers` row reflects placeholders
  - [ ] Trigger shortage email for a shift with placeholders — "X more volunteers needed" reduced by placeholder count

🤖 Generated with [Claude Code](https://claude.com/claude-code)