### PR TITLE
refactor(mobile): migrate data fetching to TanStack Query

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -2,10 +2,7 @@ import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import { ThemeProvider, DarkTheme, DefaultTheme } from '@react-navigation/native';
 
 import { useColorScheme } from '@/hooks/use-color-scheme';
-import {
-  useTeamUnreadPolling,
-  useTeamUnreadStore,
-} from '@/hooks/use-team-unread';
+import { useTeamUnreadCount } from '@/hooks/use-team-unread';
 import { useAuth } from '@/lib/auth';
 import { Brand } from '@/constants/theme';
 import LoginScreen from '@/app/(auth)/login';
@@ -13,8 +10,7 @@ import LoginScreen from '@/app/(auth)/login';
 export default function TabLayout() {
   const colorScheme = useColorScheme();
   const { isAuthenticated, isLoading } = useAuth();
-  const teamUnreadCount = useTeamUnreadStore((s) => s.count);
-  useTeamUnreadPolling(isAuthenticated);
+  const teamUnreadCount = useTeamUnreadCount(isAuthenticated);
 
   const eeLight = {
     ...DefaultTheme,

--- a/mobile/app/(tabs)/chat.tsx
+++ b/mobile/app/(tabs)/chat.tsx
@@ -13,7 +13,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { Brand, Colors, FontFamily } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
-import { useTeamUnreadStore } from "@/hooks/use-team-unread";
+import { useTeamUnreadCount } from "@/hooks/use-team-unread";
 import { fetchTeamThread } from "@/lib/messages";
 
 /* ─── Editorial palette ─────────────────────────────────────── */
@@ -56,7 +56,7 @@ export default function HelpScreen() {
   const [latestAdminMessage, setLatestAdminMessage] = useState<string | null>(
     null
   );
-  const teamUnreadCount = useTeamUnreadStore((s) => s.count);
+  const teamUnreadCount = useTeamUnreadCount();
 
   const loadStatus = useCallback(async () => {
     try {

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -37,7 +37,10 @@ import { Brand, Colors, FontFamily } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { ImageViewer } from "@/components/image-viewer";
 import { useFeed } from "@/hooks/use-feed";
-import { useFeedInteractions } from "@/hooks/use-feed-interactions";
+import {
+  useFeedComments,
+  useFeedInteractions,
+} from "@/hooks/use-feed-interactions";
 import { useNotifications } from "@/hooks/use-notifications";
 import { usePendingFeedItemStore } from "@/hooks/use-pending-feed-item";
 import { useProfile } from "@/hooks/use-profile";
@@ -75,11 +78,9 @@ export default function HomeScreen() {
 
   const {
     toggleLike: apiToggleLike,
-    loadComments,
     addComment: apiAddComment,
     editComment: apiEditComment,
     deleteComment: apiDeleteComment,
-    getCommentState,
     reportItem,
     hasReported,
     blockUser,
@@ -111,6 +112,10 @@ export default function HomeScreen() {
   const likesSheetItem = likesSheetItemId
     ? feedItems.find((i) => i.id === likesSheetItemId) ?? null
     : null;
+  // Subscribe to the open item's comments. The query is gated on
+  // likesSheetItemId so it only fires when the sheet is open, but the cache
+  // sticks around — re-opening the same sheet shows comments instantly.
+  const sheetComments = useFeedComments(likesSheetItemId);
   const [viewerImages, setViewerImages] = useState<string[] | null>(null);
   const [viewerIndex, setViewerIndex] = useState(0);
 
@@ -168,20 +173,9 @@ export default function HomeScreen() {
     [ME_AS_LIKER, profile?.id]
   );
 
-  const getCommentsForItem = useCallback(
-    (itemId: string): FeedComment[] => {
-      return getCommentState(itemId).comments;
-    },
-    [getCommentState]
-  );
-
-  const handleOpenSheet = useCallback(
-    (item: FeedItem) => {
-      setLikesSheetItemId(item.id);
-      loadComments(item.id);
-    },
-    [loadComments]
-  );
+  const handleOpenSheet = useCallback((item: FeedItem) => {
+    setLikesSheetItemId(item.id);
+  }, []);
 
   // Notification deep link: when a tap stashes a feed item id (e.g. an
   // announcement push), open that item's sheet as soon as the feed has
@@ -538,8 +532,8 @@ export default function HomeScreen() {
           onClose={() => setLikesSheetItemId(null)}
           colors={colors}
           isDark={colorScheme === "dark"}
-          comments={getCommentsForItem(likesSheetItem.id)}
-          isLoadingComments={getCommentState(likesSheetItem.id).isLoading}
+          comments={sheetComments.comments}
+          isLoadingComments={sheetComments.isLoading}
           onAddComment={(text) => addComment(likesSheetItem.id, text)}
           onEditComment={(commentId, text) =>
             editComment(likesSheetItem.id, commentId, text)

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { useFonts } from 'expo-font';
 import * as Notifications from 'expo-notifications';
 import { Stack } from 'expo-router';
@@ -21,7 +22,10 @@ import {
 
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useAuth } from '@/lib/auth';
-import { useNotificationsStore } from '@/hooks/use-notifications';
+import {
+  getUnreadCount,
+  subscribeToNotificationsUnread,
+} from '@/hooks/use-notifications';
 import { Brand } from '@/constants/theme';
 import { AchievementCelebration } from '@/components/achievement-celebration';
 import { AuthGate } from '@/components/auth-gate';
@@ -29,6 +33,7 @@ import { OnboardingFlow } from '@/components/onboarding-flow';
 import { useInitAchievementCelebration } from '@/hooks/use-achievement-celebration';
 import { navigateToNotificationTarget } from '@/lib/notification-routing';
 import { posthog } from '@/lib/posthog';
+import { queryClient, setupFocusManager } from '@/lib/query-client';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -49,6 +54,8 @@ export default function RootLayout() {
   useEffect(() => {
     restoreSession();
   }, [restoreSession]);
+
+  useEffect(() => setupFocusManager(), []);
 
   // Tap handling: navigate when the user taps a push notification (both
   // the runtime listener and any notification that launched the app from
@@ -90,17 +97,15 @@ export default function RootLayout() {
     };
   }, [isLoading, fontsLoaded, isAuthenticated]);
 
-  // Keep the OS app-icon badge in sync with the store's unreadCount.
+  // Keep the OS app-icon badge in sync with the notifications query cache.
   // Push notifications increment the badge; only we can clear it once the
   // user reads things in-app.
   useEffect(() => {
     const applyBadge = (count: number) => {
       Notifications.setBadgeCountAsync(count).catch(() => {});
     };
-    applyBadge(useNotificationsStore.getState().unreadCount);
-    return useNotificationsStore.subscribe((state, prev) => {
-      if (state.unreadCount !== prev.unreadCount) applyBadge(state.unreadCount);
-    });
+    applyBadge(getUnreadCount(queryClient));
+    return subscribeToNotificationsUnread(queryClient, applyBadge);
   }, []);
 
   useEffect(() => {
@@ -184,9 +189,13 @@ export default function RootLayout() {
     </ThemeProvider>
   );
 
-  if (!posthog) {
-    return appTree;
-  }
+  const withPosthog = posthog ? (
+    <PostHogProvider client={posthog}>{appTree}</PostHogProvider>
+  ) : (
+    appTree
+  );
 
-  return <PostHogProvider client={posthog}>{appTree}</PostHogProvider>;
+  return (
+    <QueryClientProvider client={queryClient}>{withPosthog}</QueryClientProvider>
+  );
 }

--- a/mobile/app/help/team.tsx
+++ b/mobile/app/help/team.tsx
@@ -20,7 +20,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { Brand, Colors, FontFamily } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
-import { useTeamUnreadStore } from "@/hooks/use-team-unread";
+import { clearTeamUnreadCount } from "@/hooks/use-team-unread";
+import { queryClient } from "@/lib/query-client";
 import {
   fetchTeamThread,
   markTeamThreadRead,
@@ -170,10 +171,10 @@ export default function TeamThreadScreen() {
       setHours(data.hours);
       if (markRead && data.thread.unread) {
         markTeamThreadRead()
-          .then(() => useTeamUnreadStore.getState().setCount(0))
+          .then(() => clearTeamUnreadCount(queryClient))
           .catch(() => {});
       } else if (markRead) {
-        useTeamUnreadStore.getState().setCount(0);
+        clearTeamUnreadCount(queryClient);
       }
     } catch (err) {
       console.warn("[help/team] refresh failed", err);

--- a/mobile/hooks/use-feed-interactions.ts
+++ b/mobile/hooks/use-feed-interactions.ts
@@ -1,6 +1,9 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
+
 import { api } from "@/lib/api";
 import type { FeedComment } from "@/lib/dummy-data";
+import { queryKeys } from "@/lib/query-keys";
 
 type LikeResponse = {
   liked: boolean;
@@ -30,9 +33,6 @@ type UseFeedInteractionsReturn = {
   /** Toggle like on a feed item. Returns the new liked state and count. */
   toggleLike: (itemId: string) => Promise<LikeResponse | null>;
 
-  /** Load all comments for a feed item (call when the sheet opens). */
-  loadComments: (itemId: string) => Promise<void>;
-
   /** Add a comment to a feed item. Returns the new comment. */
   addComment: (itemId: string, text: string, currentUserId: string, currentUserName: string, currentUserPhoto?: string) => Promise<FeedComment | null>;
 
@@ -41,9 +41,6 @@ type UseFeedInteractionsReturn = {
 
   /** Delete a comment you authored. Optimistic removal. */
   deleteComment: (itemId: string, commentId: string) => Promise<boolean>;
-
-  /** Get cached comment state for an item. */
-  getCommentState: (itemId: string) => CommentState;
 
   /** Report a feed item as objectionable content. */
   reportItem: (targetType: string, targetId: string, reason: string) => Promise<boolean>;
@@ -62,22 +59,54 @@ type UseFeedInteractionsReturn = {
 };
 
 /**
- * Manages real-time like/comment interactions on feed items.
+ * Subscribe to a single item's comments. The sheet calls this once with the
+ * open item id; the cache survives the sheet closing, so re-opening the same
+ * item shows comments instantly while a background revalidation runs.
+ */
+export function useFeedComments(itemId: string | null | undefined): CommentState {
+  const query = useQuery({
+    queryKey: itemId ? queryKeys.feedComments.forItem(itemId) : queryKeys.feedComments.all,
+    queryFn: () =>
+      api<CommentsResponse>(
+        `/api/mobile/feed/${encodeURIComponent(itemId ?? "")}/comments`
+      ).then((r) => r.comments),
+    enabled: Boolean(itemId),
+  });
+  return {
+    comments: query.data ?? [],
+    isLoading: query.isPending && Boolean(itemId),
+    error: query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : "Failed to load comments"
+      : null,
+  };
+}
+
+/**
+ * Manages mutations on feed items: likes, comments (add/edit/delete),
+ * reports, and blocks. Comment lists themselves live in the React Query
+ * cache — read them via {@link useFeedComments}.
  *
- * Likes: optimistic toggle — updates local state immediately, then calls API.
- * Comments: loaded lazily when the sheet opens, then appended optimistically on add.
+ * Likes: optimistic toggle done by the caller against the feed item.
+ * Comments: optimistic patches against the per-item comments cache.
  */
 export function useFeedInteractions(): UseFeedInteractionsReturn {
-  // Map of itemId → comment state
-  const [commentStates, setCommentStates] = useState<
-    Record<string, CommentState>
-  >({});
+  const queryClient = useQueryClient();
 
   // Track items reported this session so the UI can reflect the reported state
   const [reportedIds, setReportedIds] = useState<Set<string>>(new Set());
 
   // Track users blocked this session for instant UI feedback
   const [blockedUserIds, setBlockedUserIds] = useState<Set<string>>(new Set());
+
+  const patchComments = useCallback(
+    (itemId: string, updater: (prev: FeedComment[]) => FeedComment[]) => {
+      const key = queryKeys.feedComments.forItem(itemId);
+      queryClient.setQueryData<FeedComment[]>(key, (prev) => updater(prev ?? []));
+    },
+    [queryClient]
+  );
 
   const toggleLike = useCallback(
     async (itemId: string): Promise<LikeResponse | null> => {
@@ -94,36 +123,6 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
     []
   );
 
-  const loadComments = useCallback(async (itemId: string) => {
-    // Skip if already loaded
-    const existing = commentStates[itemId];
-    if (existing?.comments.length > 0) return;
-
-    setCommentStates((prev) => ({
-      ...prev,
-      [itemId]: { comments: [], isLoading: true, error: null },
-    }));
-
-    try {
-      const result = await api<CommentsResponse>(
-        `/api/mobile/feed/${encodeURIComponent(itemId)}/comments`
-      );
-      setCommentStates((prev) => ({
-        ...prev,
-        [itemId]: { comments: result.comments, isLoading: false, error: null },
-      }));
-    } catch (err) {
-      setCommentStates((prev) => ({
-        ...prev,
-        [itemId]: {
-          comments: [],
-          isLoading: false,
-          error: err instanceof Error ? err.message : "Failed to load comments",
-        },
-      }));
-    }
-  }, [commentStates]);
-
   const addComment = useCallback(
     async (
       itemId: string,
@@ -132,7 +131,6 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
       currentUserName: string,
       currentUserPhoto?: string
     ): Promise<FeedComment | null> => {
-      // Optimistic comment
       const optimistic: FeedComment = {
         id: `optimistic-${Date.now()}`,
         userId: currentUserId,
@@ -142,54 +140,25 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
         timestamp: new Date().toISOString(),
       };
 
-      setCommentStates((prev) => {
-        const existing = prev[itemId] ?? { comments: [], isLoading: false, error: null };
-        return {
-          ...prev,
-          [itemId]: {
-            ...existing,
-            comments: [...existing.comments, optimistic],
-          },
-        };
-      });
+      patchComments(itemId, (prev) => [...prev, optimistic]);
 
       try {
         const result = await api<AddCommentResponse>(
           `/api/mobile/feed/${encodeURIComponent(itemId)}/comments`,
           { method: "POST", body: { text } }
         );
-
-        // Replace optimistic with real comment
-        setCommentStates((prev) => {
-          const existing = prev[itemId] ?? { comments: [], isLoading: false, error: null };
-          return {
-            ...prev,
-            [itemId]: {
-              ...existing,
-              comments: existing.comments.map((c) =>
-                c.id === optimistic.id ? result.comment : c
-              ),
-            },
-          };
-        });
-
+        patchComments(itemId, (prev) =>
+          prev.map((c) => (c.id === optimistic.id ? result.comment : c))
+        );
         return result.comment;
       } catch {
-        // Remove optimistic comment on failure
-        setCommentStates((prev) => {
-          const existing = prev[itemId] ?? { comments: [], isLoading: false, error: null };
-          return {
-            ...prev,
-            [itemId]: {
-              ...existing,
-              comments: existing.comments.filter((c) => c.id !== optimistic.id),
-            },
-          };
-        });
+        patchComments(itemId, (prev) =>
+          prev.filter((c) => c.id !== optimistic.id)
+        );
         return null;
       }
     },
-    []
+    [patchComments]
   );
 
   const editComment = useCallback(
@@ -198,80 +167,44 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
       commentId: string,
       text: string
     ): Promise<FeedComment | null> => {
-      // Snapshot the previous comment so we can revert on failure
-      let previous: FeedComment | undefined;
-      setCommentStates((prev) => {
-        const existing = prev[itemId];
-        if (!existing) return prev;
-        previous = existing.comments.find((c) => c.id === commentId);
-        return {
-          ...prev,
-          [itemId]: {
-            ...existing,
-            comments: existing.comments.map((c) =>
-              c.id === commentId ? { ...c, text } : c
-            ),
-          },
-        };
-      });
+      const key = queryKeys.feedComments.forItem(itemId);
+      const previous = queryClient
+        .getQueryData<FeedComment[]>(key)
+        ?.find((c) => c.id === commentId);
+
+      patchComments(itemId, (prev) =>
+        prev.map((c) => (c.id === commentId ? { ...c, text } : c))
+      );
 
       try {
         const result = await api<EditCommentResponse>(
           `/api/mobile/feed/comments/${encodeURIComponent(commentId)}`,
           { method: "PATCH", body: { text } }
         );
-        setCommentStates((prev) => {
-          const existing = prev[itemId];
-          if (!existing) return prev;
-          return {
-            ...prev,
-            [itemId]: {
-              ...existing,
-              comments: existing.comments.map((c) =>
-                c.id === commentId ? result.comment : c
-              ),
-            },
-          };
-        });
+        patchComments(itemId, (prev) =>
+          prev.map((c) => (c.id === commentId ? result.comment : c))
+        );
         return result.comment;
       } catch {
-        // Revert optimistic edit
-        setCommentStates((prev) => {
-          const existing = prev[itemId];
-          if (!existing || !previous) return prev;
-          return {
-            ...prev,
-            [itemId]: {
-              ...existing,
-              comments: existing.comments.map((c) =>
-                c.id === commentId ? (previous as FeedComment) : c
-              ),
-            },
-          };
-        });
+        if (previous) {
+          patchComments(itemId, (prev) =>
+            prev.map((c) => (c.id === commentId ? previous : c))
+          );
+        }
         return null;
       }
     },
-    []
+    [patchComments, queryClient]
   );
 
   const deleteComment = useCallback(
     async (itemId: string, commentId: string): Promise<boolean> => {
-      let removed: FeedComment | undefined;
-      let removedIndex = -1;
-      setCommentStates((prev) => {
-        const existing = prev[itemId];
-        if (!existing) return prev;
-        removedIndex = existing.comments.findIndex((c) => c.id === commentId);
-        removed = existing.comments[removedIndex];
-        return {
-          ...prev,
-          [itemId]: {
-            ...existing,
-            comments: existing.comments.filter((c) => c.id !== commentId),
-          },
-        };
-      });
+      const key = queryKeys.feedComments.forItem(itemId);
+      const snapshot = queryClient.getQueryData<FeedComment[]>(key) ?? [];
+      const removedIndex = snapshot.findIndex((c) => c.id === commentId);
+      const removed = snapshot[removedIndex];
+
+      patchComments(itemId, (prev) => prev.filter((c) => c.id !== commentId));
 
       try {
         await api<DeleteCommentResponse>(
@@ -280,27 +213,17 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
         );
         return true;
       } catch {
-        // Revert by re-inserting at the original position
-        setCommentStates((prev) => {
-          const existing = prev[itemId];
-          if (!existing || !removed || removedIndex < 0) return prev;
-          const next = [...existing.comments];
-          next.splice(removedIndex, 0, removed);
-          return { ...prev, [itemId]: { ...existing, comments: next } };
-        });
+        if (removed && removedIndex >= 0) {
+          patchComments(itemId, (prev) => {
+            const next = [...prev];
+            next.splice(removedIndex, 0, removed);
+            return next;
+          });
+        }
         return false;
       }
     },
-    []
-  );
-
-  const getCommentState = useCallback(
-    (itemId: string): CommentState => {
-      return (
-        commentStates[itemId] ?? { comments: [], isLoading: false, error: null }
-      );
-    },
-    [commentStates]
+    [patchComments, queryClient]
   );
 
   const reportItem = useCallback(
@@ -345,26 +268,29 @@ export function useFeedInteractions(): UseFeedInteractionsReturn {
     [blockedUserIds]
   );
 
-  const removeCommentsByUser = useCallback((userId: string) => {
-    setCommentStates((prev) => {
-      const next: Record<string, CommentState> = {};
-      for (const [itemId, state] of Object.entries(prev)) {
-        next[itemId] = {
-          ...state,
-          comments: state.comments.filter((c) => c.userId !== userId),
-        };
+  // After a block, scrub the blocked user's comments from every cached
+  // per-item list so the feed/comment sheet updates instantly.
+  const removeCommentsByUser = useCallback(
+    (userId: string) => {
+      const cache = queryClient.getQueryCache();
+      const matches = cache.findAll({ queryKey: queryKeys.feedComments.all });
+      for (const entry of matches) {
+        const data = entry.state.data as FeedComment[] | undefined;
+        if (!data) continue;
+        queryClient.setQueryData<FeedComment[]>(
+          entry.queryKey,
+          data.filter((c) => c.userId !== userId)
+        );
       }
-      return next;
-    });
-  }, []);
+    },
+    [queryClient]
+  );
 
   return {
     toggleLike,
-    loadComments,
     addComment,
     editComment,
     deleteComment,
-    getCommentState,
     reportItem,
     hasReported,
     blockUser,

--- a/mobile/hooks/use-feed.ts
+++ b/mobile/hooks/use-feed.ts
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
 
 import { api } from "@/lib/api";
 import type { FeedItem } from "@/lib/dummy-data";
+import { queryKeys } from "@/lib/query-keys";
 
 type FeedResponse = {
   items: FeedItem[];
@@ -21,68 +23,76 @@ type UseFeedReturn = {
   removeItemsByUser: (userId: string) => void;
 };
 
+const hasAuthor = (item: FeedItem): item is FeedItem & { userId?: string } =>
+  item.type === "achievement" ||
+  item.type === "friend_signup" ||
+  item.type === "photo_post";
+
 export function useFeed(): UseFeedReturn {
-  const [realItems, setRealItems] = useState<FeedItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const queryKey = queryKeys.feed.list();
 
-  const fetchFeed = useCallback(async () => {
-    try {
-      setError(null);
-      const result = await api<FeedResponse>("/api/mobile/feed");
-      setRealItems(result.items);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load feed");
-      setRealItems([]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchFeed();
-  }, [fetchFeed]);
-
-  const refresh = useCallback(async () => {
-    setIsLoading(true);
-    await fetchFeed();
-  }, [fetchFeed]);
+  const query = useQuery({
+    queryKey,
+    queryFn: () => api<FeedResponse>("/api/mobile/feed"),
+  });
 
   const updateItem = useCallback(
     (
       id: string,
       patch: Partial<Pick<FeedItem, "likeCount" | "likedByMe" | "commentCount">>
     ) => {
-      setRealItems((prev) =>
-        prev.map((item) => (item.id === id ? { ...item, ...patch } : item))
-      );
+      queryClient.setQueryData<FeedResponse>(queryKey, (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          items: prev.items.map((item) =>
+            item.id === id ? { ...item, ...patch } : item
+          ),
+        };
+      });
     },
-    []
+    [queryClient, queryKey]
   );
 
-  const [locallyBlockedUserIds, setLocallyBlockedUserIds] = useState<
-    Set<string>
-  >(new Set());
+  const removeItemsByUser = useCallback(
+    (userId: string) => {
+      queryClient.setQueryData<FeedResponse>(queryKey, (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          items: prev.items.filter((item) => {
+            if (!hasAuthor(item)) return true;
+            const uid = (item as { userId?: string }).userId;
+            return !uid || uid !== userId;
+          }),
+        };
+      });
+    },
+    [queryClient, queryKey]
+  );
 
-  const removeItemsByUser = useCallback((userId: string) => {
-    setLocallyBlockedUserIds((prev) => new Set(prev).add(userId));
-  }, []);
+  const items = useMemo(
+    () =>
+      [...(query.data?.items ?? [])].sort(
+        (a, b) =>
+          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      ),
+    [query.data?.items]
+  );
 
-  const hasAuthor = (item: FeedItem): item is FeedItem & { userId?: string } =>
-    item.type === "achievement" ||
-    item.type === "friend_signup" ||
-    item.type === "photo_post";
-
-  const items = realItems
-    .filter((item) => {
-      if (!hasAuthor(item)) return true;
-      const uid = (item as { userId?: string }).userId;
-      return !uid || !locallyBlockedUserIds.has(uid);
-    })
-    .sort(
-      (a, b) =>
-        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-    );
-
-  return { items, isLoading, error, refresh, updateItem, removeItemsByUser };
+  return {
+    items,
+    isLoading: query.isPending,
+    error: query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : "Failed to load feed"
+      : null,
+    refresh: async () => {
+      await query.refetch();
+    },
+    updateItem,
+    removeItemsByUser,
+  };
 }

--- a/mobile/hooks/use-friends.ts
+++ b/mobile/hooks/use-friends.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import type { Friend } from "@/lib/dummy-data";
+import { queryKeys } from "@/lib/query-keys";
 
 type FriendsResponse = {
   friends: Friend[];
@@ -15,35 +16,22 @@ type UseFriendsReturn = {
 };
 
 export function useFriends(): UseFriendsReturn {
-  const [friends, setFriends] = useState<Friend[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchFriends = useCallback(async () => {
-    try {
-      setError(null);
-      const result = await api<FriendsResponse>("/api/mobile/friends");
-      setFriends(result.friends);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load friends");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchFriends();
-  }, [fetchFriends]);
-
-  const refresh = useCallback(async () => {
-    setIsLoading(true);
-    await fetchFriends();
-  }, [fetchFriends]);
+  const query = useQuery({
+    queryKey: queryKeys.friends.list(),
+    queryFn: () => api<FriendsResponse>("/api/mobile/friends"),
+    select: (data) => data.friends,
+  });
 
   return {
-    friends,
-    isLoading,
-    error,
-    refresh,
+    friends: query.data ?? [],
+    isLoading: query.isPending,
+    error: query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : "Failed to load friends"
+      : null,
+    refresh: async () => {
+      await query.refetch();
+    },
   };
 }

--- a/mobile/hooks/use-notifications.ts
+++ b/mobile/hooks/use-notifications.ts
@@ -1,7 +1,12 @@
-import { useEffect } from 'react';
-import { create } from 'zustand';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type QueryClient,
+} from '@tanstack/react-query';
 
 import { api } from '@/lib/api';
+import { queryKeys } from '@/lib/query-keys';
 
 export type NotificationType =
   | 'FRIEND_REQUEST_RECEIVED'
@@ -44,151 +49,154 @@ type UseNotificationsReturn = {
   remove: (id: string) => Promise<void>;
 };
 
-type NotificationState = {
-  notifications: AppNotification[];
-  unreadCount: number;
-  isLoading: boolean;
-  error: string | null;
-  hasFetched: boolean;
-  fetch: () => Promise<void>;
-  refresh: () => Promise<void>;
-  markAsRead: (id: string) => Promise<void>;
-  markAllAsRead: () => Promise<void>;
-  remove: (id: string) => Promise<void>;
-};
+const NOTIFICATIONS_KEY = queryKeys.notifications.list();
 
-export const useNotificationsStore = create<NotificationState>((set, get) => ({
-  notifications: [],
-  unreadCount: 0,
-  isLoading: true,
-  error: null,
-  hasFetched: false,
-
-  fetch: async () => {
-    try {
-      set({ error: null });
-      const result = await api<ListResponse>('/api/mobile/notifications');
-      set({
-        notifications: result.notifications,
-        unreadCount: result.unreadCount,
-        hasFetched: true,
-      });
-    } catch (err) {
-      set({
-        error:
-          err instanceof Error ? err.message : 'Failed to load notifications',
-      });
-    } finally {
-      set({ isLoading: false });
-    }
-  },
-
-  refresh: async () => {
-    set({ isLoading: true });
-    await get().fetch();
-  },
-
-  markAsRead: async (id) => {
-    const target = get().notifications.find((n) => n.id === id);
-    if (!target) return;
-    const wasUnread = !target.isRead;
-
-    set((state) => ({
-      notifications: state.notifications.map((n) =>
-        n.id === id ? { ...n, isRead: true } : n,
-      ),
-      unreadCount: wasUnread
-        ? Math.max(0, state.unreadCount - 1)
-        : state.unreadCount,
-    }));
-
-    try {
-      await api(`/api/mobile/notifications/${id}`, {
-        method: 'PUT',
-        body: { action: 'mark_read' },
-      });
-    } catch (err) {
-      console.warn('[NOTIFICATIONS] mark-as-read failed:', err);
-      set((state) => ({
-        notifications: state.notifications.map((n) =>
-          n.id === id ? { ...n, isRead: false } : n,
-        ),
-        unreadCount: wasUnread ? state.unreadCount + 1 : state.unreadCount,
-      }));
-    }
-  },
-
-  markAllAsRead: async () => {
-    const previous = get().notifications;
-    const previousUnread = get().unreadCount;
-
-    set((state) => ({
-      notifications: state.notifications.map((n) => ({ ...n, isRead: true })),
-      unreadCount: 0,
-    }));
-
-    try {
-      await api('/api/mobile/notifications', {
-        method: 'PUT',
-        body: { action: 'mark_all_read' },
-      });
-    } catch (err) {
-      console.warn('[NOTIFICATIONS] mark-all-read failed:', err);
-      set({ notifications: previous, unreadCount: previousUnread });
-    }
-  },
-
-  remove: async (id) => {
-    const removed = get().notifications.find((n) => n.id === id);
-    if (!removed) return;
-
-    set((state) => ({
-      notifications: state.notifications.filter((n) => n.id !== id),
-      unreadCount: !removed.isRead
-        ? Math.max(0, state.unreadCount - 1)
-        : state.unreadCount,
-    }));
-
-    try {
-      await api(`/api/mobile/notifications/${id}`, { method: 'DELETE' });
-    } catch (err) {
-      console.warn('[NOTIFICATIONS] delete failed:', err);
-      set((state) => ({
-        notifications: [removed, ...state.notifications],
-        unreadCount: !removed.isRead
-          ? state.unreadCount + 1
-          : state.unreadCount,
-      }));
-    }
-  },
-}));
+function patchList(
+  client: QueryClient,
+  patch: (prev: ListResponse) => ListResponse
+) {
+  client.setQueryData<ListResponse>(NOTIFICATIONS_KEY, (prev) =>
+    prev ? patch(prev) : prev
+  );
+}
 
 export function useNotifications(): UseNotificationsReturn {
-  const notifications = useNotificationsStore((s) => s.notifications);
-  const unreadCount = useNotificationsStore((s) => s.unreadCount);
-  const isLoading = useNotificationsStore((s) => s.isLoading);
-  const error = useNotificationsStore((s) => s.error);
-  const hasFetched = useNotificationsStore((s) => s.hasFetched);
-  const fetchNotifications = useNotificationsStore((s) => s.fetch);
-  const refresh = useNotificationsStore((s) => s.refresh);
-  const markAsRead = useNotificationsStore((s) => s.markAsRead);
-  const markAllAsRead = useNotificationsStore((s) => s.markAllAsRead);
-  const remove = useNotificationsStore((s) => s.remove);
+  const queryClient = useQueryClient();
 
-  useEffect(() => {
-    if (!hasFetched) {
-      void fetchNotifications();
-    }
-  }, [hasFetched, fetchNotifications]);
+  const query = useQuery({
+    queryKey: NOTIFICATIONS_KEY,
+    queryFn: () => api<ListResponse>('/api/mobile/notifications'),
+  });
+
+  const markRead = useMutation({
+    mutationFn: (id: string) =>
+      api(`/api/mobile/notifications/${id}`, {
+        method: 'PUT',
+        body: { action: 'mark_read' },
+      }),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: NOTIFICATIONS_KEY });
+      const snapshot = queryClient.getQueryData<ListResponse>(NOTIFICATIONS_KEY);
+      const target = snapshot?.notifications.find((n) => n.id === id);
+      if (!target || target.isRead) return { snapshot };
+      patchList(queryClient, (prev) => ({
+        ...prev,
+        notifications: prev.notifications.map((n) =>
+          n.id === id ? { ...n, isRead: true } : n
+        ),
+        unreadCount: Math.max(0, prev.unreadCount - 1),
+      }));
+      return { snapshot };
+    },
+    onError: (err, _id, ctx) => {
+      console.warn('[NOTIFICATIONS] mark-as-read failed:', err);
+      if (ctx?.snapshot) {
+        queryClient.setQueryData(NOTIFICATIONS_KEY, ctx.snapshot);
+      }
+    },
+  });
+
+  const markAllRead = useMutation({
+    mutationFn: () =>
+      api('/api/mobile/notifications', {
+        method: 'PUT',
+        body: { action: 'mark_all_read' },
+      }),
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: NOTIFICATIONS_KEY });
+      const snapshot = queryClient.getQueryData<ListResponse>(NOTIFICATIONS_KEY);
+      patchList(queryClient, (prev) => ({
+        ...prev,
+        notifications: prev.notifications.map((n) => ({ ...n, isRead: true })),
+        unreadCount: 0,
+      }));
+      return { snapshot };
+    },
+    onError: (err, _vars, ctx) => {
+      console.warn('[NOTIFICATIONS] mark-all-read failed:', err);
+      if (ctx?.snapshot) {
+        queryClient.setQueryData(NOTIFICATIONS_KEY, ctx.snapshot);
+      }
+    },
+  });
+
+  const removeNotification = useMutation({
+    mutationFn: (id: string) =>
+      api(`/api/mobile/notifications/${id}`, { method: 'DELETE' }),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: NOTIFICATIONS_KEY });
+      const snapshot = queryClient.getQueryData<ListResponse>(NOTIFICATIONS_KEY);
+      const removed = snapshot?.notifications.find((n) => n.id === id);
+      if (!removed) return { snapshot };
+      patchList(queryClient, (prev) => ({
+        ...prev,
+        notifications: prev.notifications.filter((n) => n.id !== id),
+        unreadCount: removed.isRead
+          ? prev.unreadCount
+          : Math.max(0, prev.unreadCount - 1),
+      }));
+      return { snapshot };
+    },
+    onError: (err, _id, ctx) => {
+      console.warn('[NOTIFICATIONS] delete failed:', err);
+      if (ctx?.snapshot) {
+        queryClient.setQueryData(NOTIFICATIONS_KEY, ctx.snapshot);
+      }
+    },
+  });
 
   return {
-    notifications,
-    unreadCount,
-    isLoading,
-    error,
-    refresh,
-    markAsRead,
-    markAllAsRead,
-    remove,
+    notifications: query.data?.notifications ?? [],
+    unreadCount: query.data?.unreadCount ?? 0,
+    isLoading: query.isPending,
+    error: query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : 'Failed to load notifications'
+      : null,
+    refresh: async () => {
+      await query.refetch();
+    },
+    markAsRead: async (id) => {
+      await markRead.mutateAsync(id).catch(() => {});
+    },
+    markAllAsRead: async () => {
+      await markAllRead.mutateAsync().catch(() => {});
+    },
+    remove: async (id) => {
+      await removeNotification.mutateAsync(id).catch(() => {});
+    },
   };
+}
+
+/**
+ * Read the current unread count straight from the cache. Used by the OS
+ * badge sync in `_layout.tsx` — it doesn't need to subscribe to the hook,
+ * just react to cache updates via {@link subscribeToNotificationsUnread}.
+ */
+export function getUnreadCount(client: QueryClient): number {
+  return (
+    client.getQueryData<ListResponse>(NOTIFICATIONS_KEY)?.unreadCount ?? 0
+  );
+}
+
+/**
+ * Subscribe to unreadCount changes in the notifications query. Fires the
+ * callback only when the count actually changes (deduped). Returns an
+ * unsubscribe function.
+ */
+export function subscribeToNotificationsUnread(
+  client: QueryClient,
+  onChange: (count: number) => void
+): () => void {
+  let last = getUnreadCount(client);
+  return client.getQueryCache().subscribe((event) => {
+    const key = event.query.queryKey;
+    if (key[0] !== 'notifications') return;
+    const next = getUnreadCount(client);
+    if (next !== last) {
+      last = next;
+      onChange(next);
+    }
+  });
 }

--- a/mobile/hooks/use-profile.ts
+++ b/mobile/hooks/use-profile.ts
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 
 import { api } from "@/lib/api";
 import type { Achievement, ProfileStats, UserProfile } from "@/lib/dummy-data";
+import { queryKeys } from "@/lib/query-keys";
 import { useAchievementCelebrationStore } from "./use-achievement-celebration";
 
 type ProfileResponse = {
@@ -52,37 +54,23 @@ type UseProfileReturn = {
 };
 
 export function useProfile(): UseProfileReturn {
-  const [data, setData] = useState<ProfileResponse | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const query = useQuery({
+    queryKey: queryKeys.profile.me,
+    queryFn: () => api<ProfileResponse>("/api/mobile/profile"),
+  });
 
-  const fetchProfile = useCallback(async () => {
-    try {
-      setError(null);
-      const result = await api<ProfileResponse>("/api/mobile/profile");
-      setData(result);
-      // The mobile profile route runs checkAndUnlockAchievements server-side,
-      // so any new unlock shows up in this payload — queue it for celebration.
-      useAchievementCelebrationStore
-        .getState()
-        .queueIfNew(result.achievements ?? []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load profile");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
+  // The mobile profile route runs checkAndUnlockAchievements server-side, so
+  // any new unlock arrives in this payload — queue it for celebration each
+  // time fresh data lands. Keyed on dataUpdatedAt so a refetch with no new
+  // achievements still passes the dedup inside `queueIfNew`.
+  const achievements = query.data?.achievements;
+  const dataUpdatedAt = query.dataUpdatedAt;
   useEffect(() => {
-    fetchProfile();
-  }, [fetchProfile]);
+    if (!achievements) return;
+    useAchievementCelebrationStore.getState().queueIfNew(achievements);
+  }, [achievements, dataUpdatedAt]);
 
-  const refresh = useCallback(async () => {
-    setIsLoading(true);
-    await fetchProfile();
-  }, [fetchProfile]);
-
-  // Map API response to the shapes the screens expect
+  const data = query.data;
   const profile: UserProfile | null = data
     ? {
         id: data.profile.id,
@@ -121,8 +109,14 @@ export function useProfile(): UseProfileReturn {
     achievements: data?.achievements ?? [],
     totalPoints: data?.totalPoints ?? 0,
     totalVolunteers: data?.totalVolunteers ?? 0,
-    isLoading,
-    error,
-    refresh,
+    isLoading: query.isPending,
+    error: query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : "Failed to load profile"
+      : null,
+    refresh: async () => {
+      await query.refetch();
+    },
   };
 }

--- a/mobile/hooks/use-shift-detail.ts
+++ b/mobile/hooks/use-shift-detail.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import type { Shift, ShiftSignup } from "@/lib/dummy-data";
+import { queryKeys } from "@/lib/query-keys";
 
 /** Raw shape returned by GET /api/mobile/shifts/[id] */
 type ShiftDetailResponse = {
@@ -64,28 +65,28 @@ type UseShiftDetailReturn = {
 };
 
 export function useShiftDetail(shiftId: string | undefined): UseShiftDetailReturn {
-  const [shift, setShift] = useState<Shift | null>(null);
-  const [signups, setSignups] = useState<ShiftSignup[]>([]);
-  const [periodFriends, setPeriodFriends] = useState<PeriodFriend[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const enabled = Boolean(shiftId);
 
-  const fetchDetail = useCallback(async () => {
-    if (!shiftId) {
-      setIsLoading(false);
-      return;
-    }
+  const detail = useQuery({
+    queryKey: shiftId ? queryKeys.shifts.detail(shiftId) : ["shifts", "detail", "noop"],
+    queryFn: () => api<ShiftDetailResponse>(`/api/mobile/shifts/${shiftId}`),
+    enabled,
+  });
 
-    try {
-      setError(null);
-      const [data, concurrent] = await Promise.all([
-        api<ShiftDetailResponse>(`/api/mobile/shifts/${shiftId}`),
-        api<ConcurrentResponse>(`/api/mobile/shifts/${shiftId}/concurrent`).catch(
-          () => null,
-        ),
-      ]);
+  // Concurrent friends/shifts is best-effort — render the detail even if it fails.
+  const concurrent = useQuery({
+    queryKey: shiftId
+      ? queryKeys.shifts.concurrent(shiftId)
+      : ["shifts", "concurrent", "noop"],
+    queryFn: () =>
+      api<ConcurrentResponse>(`/api/mobile/shifts/${shiftId}/concurrent`),
+    enabled,
+    retry: false,
+  });
 
-      const mappedShift: Shift = {
+  const data = detail.data;
+  const shift: Shift | null = data
+    ? {
         id: data.id,
         shiftType: {
           id: data.shiftType.id,
@@ -99,52 +100,38 @@ export function useShiftDetail(shiftId: string | undefined): UseShiftDetailRetur
         signedUp: data.signedUp,
         status: data.status === "REGULAR_PENDING" ? "PENDING" : data.status,
         notes: data.notes ?? undefined,
-      };
+      }
+    : null;
 
-      const mappedSignups: ShiftSignup[] = data.signups.map((s) => ({
-        id: s.id,
-        name: s.name,
-        profilePhotoUrl: s.profilePhotoUrl ?? undefined,
-        isFriend: s.isFriend,
-      }));
+  const signups: ShiftSignup[] = (data?.signups ?? []).map((s) => ({
+    id: s.id,
+    name: s.name,
+    profilePhotoUrl: s.profilePhotoUrl ?? undefined,
+    isFriend: s.isFriend,
+  }));
 
-      const mappedPeriodFriends: PeriodFriend[] = (concurrent?.friends ?? []).map(
-        (f) => ({
-          id: f.id,
-          name: f.name,
-          profilePhotoUrl: f.profilePhotoUrl,
-          shiftTypeName: f.shiftTypeName,
-          isFriend: f.isFriend ?? true,
-        }),
-      );
-
-      setShift(mappedShift);
-      setSignups(mappedSignups);
-      setPeriodFriends(mappedPeriodFriends);
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Failed to load shift details"
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  }, [shiftId]);
-
-  useEffect(() => {
-    fetchDetail();
-  }, [fetchDetail]);
-
-  const refresh = useCallback(async () => {
-    setIsLoading(true);
-    await fetchDetail();
-  }, [fetchDetail]);
+  const periodFriends: PeriodFriend[] = (concurrent.data?.friends ?? []).map(
+    (f) => ({
+      id: f.id,
+      name: f.name,
+      profilePhotoUrl: f.profilePhotoUrl,
+      shiftTypeName: f.shiftTypeName,
+      isFriend: f.isFriend ?? true,
+    })
+  );
 
   return {
     shift,
     signups,
     periodFriends,
-    isLoading,
-    error,
-    refresh,
+    isLoading: enabled ? detail.isPending : false,
+    error: detail.error
+      ? detail.error instanceof Error
+        ? detail.error.message
+        : "Failed to load shift details"
+      : null,
+    refresh: async () => {
+      await Promise.all([detail.refetch(), concurrent.refetch()]);
+    },
   };
 }

--- a/mobile/hooks/use-shifts.ts
+++ b/mobile/hooks/use-shifts.ts
@@ -1,8 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
 
 import { api } from "@/lib/api";
 import { syncShifts } from "@/lib/calendar-sync";
 import type { Shift } from "@/lib/dummy-data";
+import { queryKeys } from "@/lib/query-keys";
 
 export type PeriodFriend = {
   id: string;
@@ -40,85 +42,60 @@ type UseShiftsReturn = {
 };
 
 export function useShifts(): UseShiftsReturn {
-  const [myShifts, setMyShifts] = useState<Shift[]>([]);
-  const [available, setAvailable] = useState<Shift[]>([]);
-  const [past, setPast] = useState<Shift[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [userDefaultLocation, setUserDefaultLocation] = useState<string | null>(null);
-  const [periodFriends, setPeriodFriends] = useState<Record<string, PeriodFriend[]>>({});
-  const [shiftFriends, setShiftFriends] = useState<Record<string, PeriodFriend[]>>({});
+  const query = useInfiniteQuery({
+    queryKey: queryKeys.shifts.list(),
+    queryFn: ({ pageParam }) => {
+      const path = pageParam
+        ? `/api/mobile/shifts?pastCursor=${encodeURIComponent(pageParam)}`
+        : "/api/mobile/shifts";
+      return api<ShiftsResponse>(path);
+    },
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.pastNextCursor,
+  });
 
-  const pastCursorRef = useRef<string | null>(null);
-  const isLoadingMoreRef = useRef(false);
+  const firstPage = query.data?.pages[0];
 
-  const fetchShifts = useCallback(async () => {
-    try {
-      setError(null);
-      const result = await api<ShiftsResponse>("/api/mobile/shifts");
-      setMyShifts(result.myShifts);
-      setAvailable(result.available);
-      setPast(result.past);
-      setUserDefaultLocation(result.userDefaultLocation ?? null);
-      setPeriodFriends(result.periodFriends ?? {});
-      setShiftFriends(result.shiftFriends ?? {});
-      pastCursorRef.current = result.pastNextCursor;
+  // First page carries myShifts/available/userDefaultLocation/periodFriends/shiftFriends;
+  // later pages only extend `past`. Fold all `past` arrays into one list.
+  const past = useMemo(
+    () => (query.data?.pages ?? []).flatMap((page) => page.past),
+    [query.data?.pages]
+  );
 
-      // Reconcile device calendar with fresh shift data (picks up web signups
-      // and cancellations). No-op unless the user opted in.
-      syncShifts(result.myShifts).catch(() => {
-        // Swallow: calendar sync is best-effort, never block the UI on it.
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load shifts");
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
-
+  // Reconcile device calendar with fresh shift data on every successful first
+  // page (picks up web signups and cancellations). No-op unless the user
+  // opted in. Keyed on dataUpdatedAt so refetches re-sync.
+  const myShifts = firstPage?.myShifts ?? [];
+  const dataUpdatedAt = query.dataUpdatedAt;
   useEffect(() => {
-    fetchShifts();
-  }, [fetchShifts]);
-
-  const refresh = useCallback(async () => {
-    setIsLoading(true);
-    await fetchShifts();
-  }, [fetchShifts]);
-
-  const loadMorePast = useCallback(async () => {
-    if (!pastCursorRef.current || isLoadingMoreRef.current) return;
-    isLoadingMoreRef.current = true;
-    setIsLoadingMore(true);
-    try {
-      const params = new URLSearchParams({
-        pastCursor: pastCursorRef.current,
-      });
-      const result = await api<ShiftsResponse>(
-        `/api/mobile/shifts?${params}`
-      );
-      setPast((prev) => [...prev, ...result.past]);
-      pastCursorRef.current = result.pastNextCursor;
-    } catch {
-      // Silently fail — user can retry by scrolling again
-    } finally {
-      isLoadingMoreRef.current = false;
-      setIsLoadingMore(false);
-    }
-  }, []);
+    if (!firstPage) return;
+    syncShifts(firstPage.myShifts).catch(() => {
+      // Swallow: calendar sync is best-effort, never block the UI on it.
+    });
+  }, [firstPage, dataUpdatedAt]);
 
   return {
     myShifts,
-    available,
+    available: firstPage?.available ?? [],
     past,
-    isLoading,
-    error,
-    refresh,
-    loadMorePast,
-    hasMorePast: pastCursorRef.current !== null,
-    isLoadingMore,
-    userDefaultLocation,
-    periodFriends,
-    shiftFriends,
+    isLoading: query.isPending,
+    error: query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : "Failed to load shifts"
+      : null,
+    refresh: async () => {
+      await query.refetch();
+    },
+    loadMorePast: async () => {
+      if (!query.hasNextPage || query.isFetchingNextPage) return;
+      await query.fetchNextPage();
+    },
+    hasMorePast: query.hasNextPage,
+    isLoadingMore: query.isFetchingNextPage,
+    userDefaultLocation: firstPage?.userDefaultLocation ?? null,
+    periodFriends: firstPage?.periodFriends ?? {},
+    shiftFriends: firstPage?.shiftFriends ?? {},
   };
 }

--- a/mobile/hooks/use-team-unread.ts
+++ b/mobile/hooks/use-team-unread.ts
@@ -1,51 +1,28 @@
-import { useEffect } from "react";
-import { AppState } from "react-native";
-import { create } from "zustand";
+import { useQuery, type QueryClient } from "@tanstack/react-query";
 
 import { fetchTeamUnreadCount } from "@/lib/messages";
+import { queryKeys } from "@/lib/query-keys";
 
-const POLL_INTERVAL_MS = 30000;
-
-type TeamUnreadState = {
-  count: number;
-  fetch: () => Promise<void>;
-  setCount: (count: number) => void;
-};
-
-export const useTeamUnreadStore = create<TeamUnreadState>((set) => ({
-  count: 0,
-  fetch: async () => {
-    try {
-      const { count } = await fetchTeamUnreadCount();
-      set({ count });
-    } catch {
-      // Silent — badge just won't update on this tick.
-    }
-  },
-  setCount: (count) => set({ count }),
-}));
+const POLL_INTERVAL_MS = 30_000;
+const KEY = queryKeys.team.unreadCount();
 
 /**
- * Polls the team unread count and refreshes when the app returns to the
- * foreground. Mount once at the tab layout level.
+ * Read (and poll) the team-help unread count. Mount in any component that
+ * needs the count — extra mounts are deduped by React Query and share the
+ * same 30s refetch schedule.
  */
-export function useTeamUnreadPolling(enabled: boolean = true) {
-  const fetchCount = useTeamUnreadStore((s) => s.fetch);
+export function useTeamUnreadCount(enabled: boolean = true): number {
+  const query = useQuery({
+    queryKey: KEY,
+    queryFn: () => fetchTeamUnreadCount().then((r) => r.count),
+    refetchInterval: enabled ? POLL_INTERVAL_MS : false,
+    refetchIntervalInBackground: false,
+    enabled,
+  });
+  return query.data ?? 0;
+}
 
-  useEffect(() => {
-    if (!enabled) return;
-    void fetchCount();
-    const interval = setInterval(() => {
-      void fetchCount();
-    }, POLL_INTERVAL_MS);
-
-    const sub = AppState.addEventListener("change", (state) => {
-      if (state === "active") void fetchCount();
-    });
-
-    return () => {
-      clearInterval(interval);
-      sub.remove();
-    };
-  }, [enabled, fetchCount]);
+/** Imperatively clear the count after the user reads the thread. */
+export function clearTeamUnreadCount(client: QueryClient) {
+  client.setQueryData<number>(KEY, 0);
 }

--- a/mobile/hooks/use-user-profile.ts
+++ b/mobile/hooks/use-user-profile.ts
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 
 export type UserFriendshipStatus =
   | "SELF"
@@ -67,39 +69,41 @@ type UseUserProfileReturn = {
 };
 
 export function useUserProfile(userId: string): UseUserProfileReturn {
-  const [profile, setProfileState] = useState<UserProfile | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const queryKey = queryKeys.profile.user(userId);
 
-  const fetchProfile = useCallback(async () => {
-    try {
-      setError(null);
-      const result = await api<UserProfileResponse>(
+  const query = useQuery({
+    queryKey,
+    queryFn: () =>
+      api<UserProfileResponse>(
         `/api/mobile/users/${encodeURIComponent(userId)}`
-      );
-      setProfileState(result.profile);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load profile");
-    } finally {
-      setIsLoading(false);
-    }
-  }, [userId]);
-
-  useEffect(() => {
-    fetchProfile();
-  }, [fetchProfile]);
-
-  const refresh = useCallback(async () => {
-    setIsLoading(true);
-    await fetchProfile();
-  }, [fetchProfile]);
+      ),
+    select: (data) => data.profile,
+    enabled: Boolean(userId),
+  });
 
   const setProfile = useCallback(
     (updater: (prev: UserProfile | null) => UserProfile | null) => {
-      setProfileState((prev) => updater(prev));
+      queryClient.setQueryData<UserProfileResponse>(queryKey, (prev) => {
+        const next = updater(prev?.profile ?? null);
+        if (!next) return prev;
+        return { profile: next };
+      });
     },
-    []
+    [queryClient, queryKey]
   );
 
-  return { profile, isLoading, error, refresh, setProfile };
+  return {
+    profile: query.data ?? null,
+    isLoading: query.isPending,
+    error: query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : "Failed to load profile"
+      : null,
+    refresh: async () => {
+      await query.refetch();
+    },
+    setProfile,
+  };
 }

--- a/mobile/lib/query-client.ts
+++ b/mobile/lib/query-client.ts
@@ -1,0 +1,49 @@
+import { focusManager, onlineManager, QueryClient } from '@tanstack/react-query';
+import type { AppStateStatus } from 'react-native';
+import { AppState, Platform } from 'react-native';
+
+import { ApiError } from './api';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Mobile networks are flaky; one silent retry covers most blips.
+      retry: (failureCount, error) => {
+        if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+          return false;
+        }
+        return failureCount < 1;
+      },
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      refetchOnReconnect: true,
+      refetchOnMount: true,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});
+
+/**
+ * Wire React Query's `focusManager` to React Native's AppState so queries
+ * revalidate when the user foregrounds the app — the RN equivalent of
+ * web's `window.focus`.
+ */
+export function setupFocusManager() {
+  const onAppStateChange = (status: AppStateStatus) => {
+    if (Platform.OS !== 'web') {
+      focusManager.setFocused(status === 'active');
+    }
+  };
+  const subscription = AppState.addEventListener('change', onAppStateChange);
+  return () => subscription.remove();
+}
+
+/**
+ * Tell React Query the app is always "online" — RN doesn't ship a NetInfo
+ * adapter by default, and we'd rather let requests fire and fail than
+ * silently park them. Swap in @react-native-community/netinfo later if we
+ * want true offline handling.
+ */
+onlineManager.setOnline(true);

--- a/mobile/lib/query-keys.ts
+++ b/mobile/lib/query-keys.ts
@@ -1,0 +1,38 @@
+/**
+ * Central registry of React Query keys. Keep all keys here so that
+ * `queryClient.invalidateQueries({ queryKey: queryKeys.shifts.all })`
+ * stays type-safe and grep-able as the cache surface grows.
+ */
+export const queryKeys = {
+  shifts: {
+    all: ['shifts'] as const,
+    list: () => [...queryKeys.shifts.all, 'list'] as const,
+    detail: (id: string) => [...queryKeys.shifts.all, 'detail', id] as const,
+    concurrent: (id: string) =>
+      [...queryKeys.shifts.all, 'concurrent', id] as const,
+  },
+  profile: {
+    me: ['profile', 'me'] as const,
+    user: (id: string) => ['profile', 'user', id] as const,
+  },
+  friends: {
+    all: ['friends'] as const,
+    list: () => [...queryKeys.friends.all, 'list'] as const,
+  },
+  feed: {
+    all: ['feed'] as const,
+    list: () => [...queryKeys.feed.all, 'list'] as const,
+  },
+  notifications: {
+    all: ['notifications'] as const,
+    list: () => [...queryKeys.notifications.all, 'list'] as const,
+  },
+  team: {
+    all: ['team'] as const,
+    unreadCount: () => [...queryKeys.team.all, 'unread-count'] as const,
+  },
+  feedComments: {
+    all: ['feed', 'comments'] as const,
+    forItem: (itemId: string) => [...queryKeys.feedComments.all, itemId] as const,
+  },
+} as const;

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -17,6 +17,7 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
+        "@tanstack/react-query": "^5.100.9",
         "date-fns": "^4.1.0",
         "expo": "~55.0.17",
         "expo-apple-authentication": "~55.0.13",
@@ -3476,6 +3477,32 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz",
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
+      "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -26,6 +26,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "@tanstack/react-query": "^5.100.9",
     "date-fns": "^4.1.0",
     "expo": "~55.0.17",
     "expo-apple-authentication": "~55.0.13",


### PR DESCRIPTION
## Summary

- Replaces hand-rolled `useState`/`useEffect` data hooks and Zustand polling stores in the mobile app with `@tanstack/react-query`. Adds a shared `QueryClient` + `AppState`→`focusManager` bridge so foregrounding the app revalidates queries.
- Public APIs of every hook are preserved, so consuming screens render unchanged. The only call-site changes are in the three files that previously read from Zustand stores (`useNotificationsStore`, `useTeamUnreadStore`) and one feed sheet consumer that switched to the new `useFeedComments(itemId)` hook.
- Net diff is essentially flat (`+648 / -662`) because the boilerplate the hooks used to carry is now handled by the library.

## What's migrated

| Hook | Strategy |
|---|---|
| `useFriends` | `useQuery` |
| `useProfile` | `useQuery` + `useEffect` for the achievement-celebration side effect |
| `useUserProfile` | `useQuery` + `setQueryData` for the existing `setProfile` updater |
| `useShiftDetail` | Two parallel `useQuery`s (detail + concurrent friends) — concurrent fetch is best-effort with no retries |
| `useFeed` | `useQuery` + `setQueryData` for `updateItem` / `removeItemsByUser` |
| `useShifts` | `useInfiniteQuery` for cursor-based `loadMorePast`; first page carries the non-paginated fields |
| `useNotifications` | `useQuery` + three `useMutation`s with optimistic updates and rollback. Removes the Zustand store. |
| `useTeamUnreadCount` | `useQuery` with `refetchInterval`. Removes the Zustand store + manual `setInterval` / AppState listener. |
| `useFeedInteractions` | Per-item comments moved into the React Query cache; mutations patch the cache. New `useFeedComments(itemId)` hook for the comment sheet. Session-only `reportedIds` / `blockedUserIds` stay as local state. |

## Why TanStack Query

- Cache survives unmounts — re-opening a shift detail modal or comment sheet is instant.
- Request dedup across screens that mount the same hook.
- Foreground revalidation via the new `AppState`→`focusManager` bridge in `mobile/lib/query-client.ts`.
- Single source of truth for polling (team unread).
- Optimistic mutations with rollback on error (notifications, comments).
- Built-in retry policy: one silent retry on transient errors, no retry on 4xx.

Setup lives in `mobile/lib/query-client.ts` (singleton + focus manager) and `mobile/lib/query-keys.ts` (typed key registry so future `invalidateQueries` stays grep-able).

## Test plan

- [ ] Cold-launch the app and verify the feed, shifts, and profile tabs render the same data as before.
- [ ] Open a shift detail, close it, re-open the same shift — content should appear instantly (cache hit) with a background revalidation.
- [ ] Background the app for ~10s, foreground — shifts/feed/notifications should refetch.
- [ ] Open the notifications screen, tap mark-as-read on one item, confirm the badge decrement is immediate and persists.
- [ ] Tap mark-all-read and confirm rollback if offline.
- [ ] Open the comment sheet on a feed item, post a comment, close, re-open — comment should still be there from cache.
- [ ] Like / unlike a feed item, confirm count updates.
- [ ] Verify the help/chat tab badge updates within ~30s when the team replies, and clears when you open the thread.
- [ ] Scroll past-shifts list, confirm `loadMorePast` continues to paginate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)