### PR TITLE
fix(analytics): capture register_completed for OAuth signups

### DIFF
--- a/web/src/app/api/profile/route.ts
+++ b/web/src/app/api/profile/route.ts
@@ -11,6 +11,12 @@ import { CampaignMonitorService } from "@/lib/services/campaign-monitor";
 import { syncNewsletterSubscriptions } from "@/lib/newsletter-sync";
 import { getEmailService } from "@/lib/email-service";
 import { isProfileComplete } from "@/lib/profile-completion";
+import {
+  captureFunnelEvent,
+  FunnelEvent,
+  getPhidFromCookies,
+} from "@/lib/funnel";
+import { phAlias } from "@/lib/posthog-server";
 
 const updateProfileSchema = z.object({
   firstName: z.string().optional(),
@@ -403,6 +409,24 @@ export async function PUT(req: Request) {
       await prisma.user.update({
         where: { id: user.id },
         data: { profileCompleted: true },
+      });
+
+      // Funnel attribution for OAuth (social) signups — credentials users emit
+      // register_completed at form submission, but OAuth users land already
+      // logged-in and only finish the funnel once required profile fields are
+      // filled. Stitch the anonymous PHID onto the user id so homepage exposure
+      // and this conversion land on the same identity in PostHog.
+      const phid = await getPhidFromCookies();
+      if (phid) {
+        phAlias({ distinctId: user.id, alias: phid });
+      }
+      captureFunnelEvent({
+        event: FunnelEvent.REGISTER_COMPLETED,
+        userId: user.id,
+        phid,
+        properties: {
+          is_oauth: true,
+        },
       });
 
       // Send welcome email


### PR DESCRIPTION
## Summary

- Homepage A/B experiment was under-counting `register_completed` because the event only fired from `POST /api/auth/register` — the credentials (email/password) path. Google/Facebook signups go through NextAuth's `signIn` callback (`src/lib/auth-options.ts`) which silently creates the user with `volunteerAgreementAccepted: false`, never hitting the funnel.
- Per product semantics, the OAuth equivalent of "registered" is "profile is now complete" (all required fields set). Fire `register_completed` and `phAlias` the anonymous `eea_phid` cookie onto `user.id` at the `profileCompleted: false → true` transition in `PUT /api/profile`.
- Event tagged with `is_oauth: true` for optional segmentation; experiment totals just sum across the property.

## Why the conversion counts looked low

OAuth conversions were entirely missing from the funnel, AND anonymous homepage exposure (cookie id) wasn't being stitched to the new user identity for those users — so PostHog couldn't attribute their downstream events to the variant.

## Test plan

- [ ] New credentials registration still emits exactly one `register_completed` (no double-fire) — credentials users have `profileCompleted: true` from creation, so the new block is skipped.
- [ ] New Google signup → complete profile via `/profile` form → `register_completed` lands in PostHog with `is_oauth: true` on the user's identity.
- [ ] Same flow for Facebook.
- [ ] Subsequent `PUT /api/profile` updates after profile is already complete do NOT re-fire `register_completed`.
- [ ] PostHog person merges the anonymous `eea_phid` distinct_id and the authenticated `user.id` after the conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)