### PR TITLE
feat(friends): slot-based suggestions + mobile parity

### DIFF
--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -28,6 +28,10 @@ import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useFriends } from "@/hooks/use-friends";
 import { useProfile } from "@/hooks/use-profile";
 import {
+  useRecommendedFriends,
+  type RecommendedFriend,
+} from "@/hooks/use-recommended-friends";
+import {
   isCalendarSyncEnabled,
   setCalendarSyncEnabled,
 } from "@/lib/calendar-sync";
@@ -90,11 +94,54 @@ export default function ProfileScreen() {
     refresh,
   } = useProfile();
   const { friends, refresh: refreshFriends } = useFriends();
+  const {
+    recommended,
+    refresh: refreshRecommended,
+    sendRequest,
+    isSending,
+    acceptRequest,
+    isAccepting,
+  } = useRecommendedFriends();
 
   useFocusEffect(
     useCallback(() => {
       refreshFriends();
-    }, [refreshFriends])
+      refreshRecommended();
+    }, [refreshFriends, refreshRecommended])
+  );
+
+  const handleSendRequest = useCallback(
+    async (toUserId: string) => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      try {
+        await sendRequest(toUserId);
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      } catch (err) {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+        Alert.alert(
+          "Couldn't send request",
+          err instanceof Error ? err.message : "Please try again."
+        );
+      }
+    },
+    [sendRequest]
+  );
+
+  const handleAcceptRequest = useCallback(
+    async (requestId: string, fromUserId: string) => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      try {
+        await acceptRequest(requestId, fromUserId);
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      } catch (err) {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+        Alert.alert(
+          "Couldn't accept request",
+          err instanceof Error ? err.message : "Please try again."
+        );
+      }
+    },
+    [acceptRequest]
   );
   const logout = useAuth((s) => s.logout);
   const showOnboarding = useOnboarding((s) => s.show);
@@ -461,6 +508,53 @@ export default function ProfileScreen() {
             }`}
             colors={colors}
           />
+
+          {recommended.length > 0 && (
+            <View style={styles.suggestedBlock}>
+              <View style={styles.suggestedHeaderRow}>
+                <Ionicons
+                  name="sparkles"
+                  size={14}
+                  color={Brand.green}
+                />
+                <Text
+                  style={[
+                    styles.suggestedHeader,
+                    { color: colors.textSecondary },
+                  ]}
+                >
+                  Volunteers you’ve worked alongside
+                </Text>
+              </View>
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.friendsScroll}
+              >
+                {recommended.map((suggestion) => (
+                  <SuggestedFriendCard
+                    key={suggestion.id}
+                    suggestion={suggestion}
+                    colors={colors}
+                    isDark={isDark}
+                    isSending={isSending(suggestion.id)}
+                    isAccepting={isAccepting(suggestion.id)}
+                    onAdd={() => handleSendRequest(suggestion.id)}
+                    onAccept={
+                      suggestion.requestId
+                        ? () =>
+                            handleAcceptRequest(
+                              suggestion.requestId!,
+                              suggestion.id
+                            )
+                        : undefined
+                    }
+                  />
+                ))}
+              </ScrollView>
+            </View>
+          )}
+
           {friends.length === 0 ? (
             <View
               style={[
@@ -1649,6 +1743,143 @@ function FriendCard({
   );
 }
 
+/* ── Suggested friend card (slot-matched volunteers) ── */
+
+function getSuggestedDisplayName(s: RecommendedFriend) {
+  if (s.firstName) return s.firstName;
+  if (s.name) return s.name.split(" ")[0];
+  return "Volunteer";
+}
+
+function getSuggestedInitial(s: RecommendedFriend) {
+  const name = getSuggestedDisplayName(s);
+  return name.charAt(0).toUpperCase();
+}
+
+function SuggestedFriendCard({
+  suggestion,
+  colors,
+  isDark,
+  isSending,
+  isAccepting,
+  onAdd,
+  onAccept,
+}: {
+  suggestion: RecommendedFriend;
+  colors: (typeof Colors)["light"];
+  isDark: boolean;
+  isSending: boolean;
+  isAccepting: boolean;
+  onAdd: () => void;
+  onAccept?: () => void;
+}) {
+  const displayName = getSuggestedDisplayName(suggestion);
+  const isPending = suggestion.isPendingRequest && !!onAccept;
+  const handlePress = isPending ? onAccept! : onAdd;
+  const isBusy = isPending ? isAccepting : isSending;
+  const buttonLabel = isPending
+    ? isBusy
+      ? "Accepting…"
+      : "Accept"
+    : isBusy
+    ? "Sending…"
+    : "Add";
+  const buttonIcon = isPending ? "checkmark" : "add";
+
+  return (
+    <View
+      style={[
+        styles.friendCard,
+        styles.suggestedCard,
+        {
+          backgroundColor: colors.card,
+          borderColor: isDark
+            ? "rgba(255,255,255,0.06)"
+            : "rgba(14,58,35,0.08)",
+          shadowColor: "#000",
+          shadowOpacity: isDark ? 0.06 : 0,
+          elevation: isDark ? 2 : 0,
+        },
+      ]}
+      accessible
+      accessibilityLabel={`${displayName}, ${suggestion.sharedShiftsCount} shared shifts. ${
+        isPending ? "Pending friend request" : "Suggested friend"
+      }`}
+    >
+      {suggestion.profilePhotoUrl ? (
+        <Image
+          source={{ uri: suggestion.profilePhotoUrl }}
+          style={styles.friendAvatar}
+        />
+      ) : (
+        <View
+          style={[styles.friendAvatarFallback, { backgroundColor: Brand.green }]}
+        >
+          <Text style={styles.friendAvatarInitial}>
+            {getSuggestedInitial(suggestion)}
+          </Text>
+        </View>
+      )}
+
+      <Text
+        style={[styles.friendName, { color: colors.text }]}
+        numberOfLines={1}
+      >
+        {displayName}
+      </Text>
+
+      <View style={styles.friendMetaRow}>
+        <Ionicons
+          name="people-outline"
+          size={12}
+          color={colors.textSecondary}
+        />
+        <Text
+          style={[styles.friendMeta, { color: colors.textSecondary }]}
+          numberOfLines={1}
+        >
+          {suggestion.sharedShiftsCount} shared
+        </Text>
+      </View>
+
+      {isPending && (
+        <View style={styles.suggestedPendingPill}>
+          <Text style={styles.suggestedPendingText}>Wants to connect</Text>
+        </View>
+      )}
+
+      <Pressable
+        onPress={handlePress}
+        disabled={isBusy}
+        accessibilityRole="button"
+        accessibilityLabel={
+          isPending
+            ? `Accept friend request from ${displayName}`
+            : `Send friend request to ${displayName}`
+        }
+        hitSlop={8}
+        style={({ pressed }) => [
+          styles.suggestedAddButton,
+          {
+            backgroundColor: isPending ? Brand.green : colors.text,
+            opacity: isBusy ? 0.6 : pressed ? 0.85 : 1,
+            transform: [{ scale: pressed && !isBusy ? 0.97 : 1 }],
+          },
+        ]}
+      >
+        {isBusy ? (
+          <ActivityIndicator size="small" color="#ffffff" />
+        ) : (
+          <>
+            <Ionicons name={buttonIcon} size={14} color="#ffffff" />
+            <Text style={styles.suggestedAddText}>{buttonLabel}</Text>
+          </>
+        )}
+      </Pressable>
+    </View>
+  );
+}
+
 /* ── Settings row ── */
 
 function SettingsRow({
@@ -2024,6 +2255,56 @@ const styles = StyleSheet.create({
   friendMeta: {
     fontSize: 11,
     fontFamily: FontFamily.medium,
+    letterSpacing: 0.1,
+  },
+  suggestedBlock: {
+    marginBottom: 16,
+  },
+  suggestedHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginBottom: 8,
+    paddingHorizontal: 2,
+  },
+  suggestedHeader: {
+    fontSize: 12,
+    fontFamily: FontFamily.semiBold,
+    letterSpacing: 0.2,
+    textTransform: "uppercase",
+  },
+  suggestedCard: {
+    paddingBottom: 14,
+    gap: 4,
+  },
+  suggestedPendingPill: {
+    marginTop: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 999,
+    backgroundColor: "rgba(255,196,87,0.18)",
+  },
+  suggestedPendingText: {
+    fontSize: 10,
+    fontFamily: FontFamily.semiBold,
+    letterSpacing: 0.2,
+    color: "#b87324",
+  },
+  suggestedAddButton: {
+    marginTop: 10,
+    minHeight: 32,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+    alignSelf: "stretch",
+  },
+  suggestedAddText: {
+    color: "#ffffff",
+    fontSize: 13,
+    fontFamily: FontFamily.semiBold,
     letterSpacing: 0.1,
   },
   emptyFriendsCard: {

--- a/mobile/hooks/use-recommended-friends.ts
+++ b/mobile/hooks/use-recommended-friends.ts
@@ -1,0 +1,113 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+
+/**
+ * Suggested friend payload returned by GET /api/mobile/friends/recommended.
+ * Mirrors the web `RecommendedFriend` shape.
+ */
+export type RecommendedFriend = {
+  id: string;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  profilePhotoUrl: string | null;
+  sharedShiftsCount: number;
+  recentSharedShifts: Array<{
+    id: string;
+    start: string;
+    shiftTypeName: string;
+    location: string | null;
+  }>;
+  isPendingRequest?: boolean;
+  requestId?: string;
+};
+
+type RecommendedResponse = {
+  recommendedFriends: RecommendedFriend[];
+};
+
+type UseRecommendedFriendsReturn = {
+  recommended: RecommendedFriend[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  sendRequest: (toUserId: string) => Promise<void>;
+  isSending: (toUserId: string) => boolean;
+  acceptRequest: (requestId: string, fromUserId: string) => Promise<void>;
+  isAccepting: (fromUserId: string) => boolean;
+};
+
+export function useRecommendedFriends(): UseRecommendedFriendsReturn {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: queryKeys.friends.recommended(),
+    queryFn: () =>
+      api<RecommendedResponse>("/api/mobile/friends/recommended"),
+    select: (data) => data.recommendedFriends,
+  });
+
+  const removeSuggestion = (userId: string) => {
+    queryClient.setQueryData<RecommendedResponse>(
+      queryKeys.friends.recommended(),
+      (prev) =>
+        prev
+          ? {
+              recommendedFriends: prev.recommendedFriends.filter(
+                (f) => f.id !== userId
+              ),
+            }
+          : prev
+    );
+  };
+
+  const sendMutation = useMutation({
+    mutationFn: (toUserId: string) =>
+      api<{ ok: true; requestId: string }>("/api/mobile/friends/requests", {
+        method: "POST",
+        body: { toUserId },
+      }),
+    onSuccess: (_, toUserId) => {
+      removeSuggestion(toUserId);
+    },
+  });
+
+  const acceptMutation = useMutation({
+    mutationFn: ({ requestId }: { requestId: string; fromUserId: string }) =>
+      api<{ ok: true; status: string }>(
+        `/api/mobile/friends/requests/${requestId}/accept`,
+        { method: "POST" }
+      ),
+    onSuccess: (_, { fromUserId }) => {
+      removeSuggestion(fromUserId);
+      // New friendship — refresh the existing friends list too.
+      queryClient.invalidateQueries({ queryKey: queryKeys.friends.list() });
+    },
+  });
+
+  return {
+    recommended: query.data ?? [],
+    isLoading: query.isPending,
+    error: query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : "Failed to load suggestions"
+      : null,
+    refresh: async () => {
+      await query.refetch();
+    },
+    sendRequest: async (toUserId: string) => {
+      await sendMutation.mutateAsync(toUserId);
+    },
+    isSending: (toUserId: string) =>
+      sendMutation.isPending && sendMutation.variables === toUserId,
+    acceptRequest: async (requestId: string, fromUserId: string) => {
+      await acceptMutation.mutateAsync({ requestId, fromUserId });
+    },
+    isAccepting: (fromUserId: string) =>
+      acceptMutation.isPending &&
+      acceptMutation.variables?.fromUserId === fromUserId,
+  };
+}

--- a/mobile/lib/query-keys.ts
+++ b/mobile/lib/query-keys.ts
@@ -18,6 +18,7 @@ export const queryKeys = {
   friends: {
     all: ['friends'] as const,
     list: () => [...queryKeys.friends.all, 'list'] as const,
+    recommended: () => [...queryKeys.friends.all, 'recommended'] as const,
   },
   feed: {
     all: ['feed'] as const,

--- a/web/src/app/api/mobile/friends/recommended/route.ts
+++ b/web/src/app/api/mobile/friends/recommended/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireMobileUser } from "@/lib/mobile-auth";
+import { getRecommendedFriendsForUser } from "@/lib/friends-data";
+
+/**
+ * GET /api/mobile/friends/recommended
+ *
+ * Mobile equivalent of /api/friends/recommended. Returns volunteers the
+ * authenticated user has shared at least N (day/evening) shift slots with
+ * over the recent window, plus any pending incoming friend requests.
+ */
+export async function GET(request: Request) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { userId } = auth;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const recommendedFriends = await getRecommendedFriendsForUser(
+    user.id,
+    user.email
+  );
+
+  return NextResponse.json({ recommendedFriends });
+}

--- a/web/src/app/api/mobile/friends/requests/route.ts
+++ b/web/src/app/api/mobile/friends/requests/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { requireMobileUser } from "@/lib/mobile-auth";
+import { sendFriendRequestFromUserToUser } from "@/lib/friend-request-service";
+
+/**
+ * POST /api/mobile/friends/requests
+ *
+ * Sends a friend request from the authenticated mobile user to the user
+ * identified by `toUserId` in the request body. Used by the mobile
+ * suggested-friends list.
+ */
+export async function POST(request: Request) {
+  const auth = await requireMobileUser(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const toUserId =
+    body && typeof body === "object" && "toUserId" in body
+      ? (body as { toUserId: unknown }).toUserId
+      : undefined;
+
+  if (typeof toUserId !== "string" || toUserId.length === 0) {
+    return NextResponse.json(
+      { error: "toUserId is required" },
+      { status: 400 }
+    );
+  }
+
+  const result = await sendFriendRequestFromUserToUser(auth.userId, toUserId);
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ ok: true, requestId: result.requestId });
+}

--- a/web/src/lib/friend-request-service.test.ts
+++ b/web/src/lib/friend-request-service.test.ts
@@ -1,0 +1,213 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    friendship: { findFirst: vi.fn() },
+    friendRequest: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  createFriendRequestNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { sendFriendRequestFromUserToUser } from "./friend-request-service";
+import { prisma } from "./prisma";
+
+type Mock = ReturnType<typeof vi.fn>;
+const userFind = prisma.user.findUnique as unknown as Mock;
+const friendshipFind = prisma.friendship.findFirst as unknown as Mock;
+const requestFind = prisma.friendRequest.findFirst as unknown as Mock;
+const requestCreate = prisma.friendRequest.create as unknown as Mock;
+const requestUpdate = prisma.friendRequest.update as unknown as Mock;
+
+const sender = {
+  id: "sender-1",
+  email: "sender@example.com",
+  name: "Sender",
+  firstName: "Send",
+  lastName: "Er",
+};
+
+const recipient = {
+  id: "recipient-1",
+  email: "recipient@example.com",
+  allowFriendRequests: true,
+};
+
+describe("sendFriendRequestFromUserToUser", () => {
+  beforeEach(() => {
+    userFind.mockReset();
+    friendshipFind.mockReset();
+    requestFind.mockReset();
+    requestCreate.mockReset();
+    requestUpdate.mockReset();
+  });
+
+  it("rejects self-friend requests without hitting the database", async () => {
+    const result = await sendFriendRequestFromUserToUser("user1", "user1");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("Cannot send friend request to yourself");
+    expect(result.status).toBe(400);
+    expect(userFind).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the sender is missing", async () => {
+    userFind.mockResolvedValueOnce(null); // sender lookup
+
+    const result = await sendFriendRequestFromUserToUser("missing", "other");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("Sender not found");
+    expect(result.status).toBe(404);
+  });
+
+  it("returns 404 when the recipient is missing", async () => {
+    userFind.mockResolvedValueOnce(sender);
+    userFind.mockResolvedValueOnce(null);
+
+    const result = await sendFriendRequestFromUserToUser(sender.id, "ghost");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("User not found");
+    expect(result.status).toBe(404);
+  });
+
+  it("returns 403 when the recipient has friend requests disabled", async () => {
+    userFind.mockResolvedValueOnce(sender);
+    userFind.mockResolvedValueOnce({ ...recipient, allowFriendRequests: false });
+
+    const result = await sendFriendRequestFromUserToUser(
+      sender.id,
+      recipient.id
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("User is not accepting friend requests");
+    expect(result.status).toBe(403);
+  });
+
+  it("returns 409 when an active friendship already exists", async () => {
+    userFind.mockResolvedValueOnce(sender);
+    userFind.mockResolvedValueOnce(recipient);
+    friendshipFind.mockResolvedValueOnce({ id: "f1" });
+
+    const result = await sendFriendRequestFromUserToUser(
+      sender.id,
+      recipient.id
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("Friendship already exists or is pending");
+    expect(result.status).toBe(409);
+  });
+
+  it("returns 409 when a pending unexpired request already exists", async () => {
+    userFind.mockResolvedValueOnce(sender);
+    userFind.mockResolvedValueOnce(recipient);
+    friendshipFind.mockResolvedValueOnce(null);
+    requestFind.mockResolvedValueOnce({
+      id: "r1",
+      status: "PENDING",
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+
+    const result = await sendFriendRequestFromUserToUser(
+      sender.id,
+      recipient.id
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("Friend request already sent");
+    expect(result.status).toBe(409);
+    expect(requestCreate).not.toHaveBeenCalled();
+    expect(requestUpdate).not.toHaveBeenCalled();
+  });
+
+  it("revives a previously declined/expired request rather than creating a duplicate", async () => {
+    userFind.mockResolvedValueOnce(sender);
+    userFind.mockResolvedValueOnce(recipient);
+    friendshipFind.mockResolvedValueOnce(null);
+    requestFind.mockResolvedValueOnce({
+      id: "r-old",
+      status: "DECLINED",
+      expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    });
+    requestUpdate.mockResolvedValueOnce({ id: "r-old" });
+
+    const result = await sendFriendRequestFromUserToUser(
+      sender.id,
+      recipient.id
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.requestId).toBe("r-old");
+    expect(requestUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "r-old" },
+        data: expect.objectContaining({ status: "PENDING" }),
+      })
+    );
+    expect(requestCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates a new request when none exists and returns the new id", async () => {
+    userFind.mockResolvedValueOnce(sender);
+    userFind.mockResolvedValueOnce(recipient);
+    friendshipFind.mockResolvedValueOnce(null);
+    requestFind.mockResolvedValueOnce(null);
+    requestCreate.mockResolvedValueOnce({ id: "r-new" });
+
+    const result = await sendFriendRequestFromUserToUser(
+      sender.id,
+      recipient.id
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.requestId).toBe("r-new");
+    expect(requestCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fromUserId: sender.id,
+          toEmail: recipient.email,
+        }),
+      })
+    );
+  });
+
+  it("still succeeds when the notification helper throws (notifications are best-effort)", async () => {
+    const { createFriendRequestNotification } = await import(
+      "@/lib/notifications"
+    );
+    (createFriendRequestNotification as unknown as Mock).mockRejectedValueOnce(
+      new Error("notif down")
+    );
+
+    userFind.mockResolvedValueOnce(sender);
+    userFind.mockResolvedValueOnce(recipient);
+    friendshipFind.mockResolvedValueOnce(null);
+    requestFind.mockResolvedValueOnce(null);
+    requestCreate.mockResolvedValueOnce({ id: "r-new" });
+
+    const result = await sendFriendRequestFromUserToUser(
+      sender.id,
+      recipient.id
+    );
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/web/src/lib/friend-request-service.ts
+++ b/web/src/lib/friend-request-service.ts
@@ -1,0 +1,142 @@
+import { prisma } from "@/lib/prisma";
+import { createFriendRequestNotification } from "@/lib/notifications";
+
+type SendResult =
+  | { ok: true; requestId: string }
+  | { ok: false; error: string; status: number };
+
+const REQUEST_EXPIRY_DAYS = 30;
+
+/**
+ * Shared core for "send friend request by userId" — used by both the web
+ * server action (`sendFriendRequestByUserId`) and the mobile API route
+ * (`POST /api/mobile/friends/requests`). Auth-agnostic: callers are
+ * responsible for resolving the authenticated `fromUserId`.
+ */
+export async function sendFriendRequestFromUserToUser(
+  fromUserId: string,
+  toUserId: string
+): Promise<SendResult> {
+  if (fromUserId === toUserId) {
+    return {
+      ok: false,
+      error: "Cannot send friend request to yourself",
+      status: 400,
+    };
+  }
+
+  const fromUser = await prisma.user.findUnique({
+    where: { id: fromUserId },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      firstName: true,
+      lastName: true,
+    },
+  });
+
+  if (!fromUser) {
+    return { ok: false, error: "Sender not found", status: 404 };
+  }
+
+  const toUser = await prisma.user.findUnique({
+    where: { id: toUserId },
+    select: {
+      id: true,
+      email: true,
+      allowFriendRequests: true,
+    },
+  });
+
+  if (!toUser) {
+    return { ok: false, error: "User not found", status: 404 };
+  }
+
+  if (!toUser.allowFriendRequests) {
+    return {
+      ok: false,
+      error: "User is not accepting friend requests",
+      status: 403,
+    };
+  }
+
+  const existingFriendship = await prisma.friendship.findFirst({
+    where: {
+      OR: [
+        { userId: fromUser.id, friendId: toUser.id },
+        { userId: toUser.id, friendId: fromUser.id },
+      ],
+    },
+  });
+
+  if (existingFriendship) {
+    return {
+      ok: false,
+      error: "Friendship already exists or is pending",
+      status: 409,
+    };
+  }
+
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + REQUEST_EXPIRY_DAYS);
+
+  const existingRequest = await prisma.friendRequest.findFirst({
+    where: { fromUserId: fromUser.id, toEmail: toUser.email },
+  });
+
+  let friendRequest;
+  if (existingRequest) {
+    if (
+      existingRequest.status === "PENDING" &&
+      existingRequest.expiresAt > new Date()
+    ) {
+      return {
+        ok: false,
+        error: "Friend request already sent",
+        status: 409,
+      };
+    }
+
+    friendRequest = await prisma.friendRequest.update({
+      where: { id: existingRequest.id },
+      data: {
+        status: "PENDING",
+        message: null,
+        expiresAt,
+        updatedAt: new Date(),
+      },
+    });
+  } else {
+    friendRequest = await prisma.friendRequest.create({
+      data: {
+        fromUserId: fromUser.id,
+        toEmail: toUser.email,
+        message: null,
+        expiresAt,
+      },
+    });
+  }
+
+  try {
+    const senderName =
+      fromUser.name ||
+      (fromUser.firstName && fromUser.lastName
+        ? `${fromUser.firstName} ${fromUser.lastName}`
+        : fromUser.email);
+
+    await createFriendRequestNotification(
+      toUser.id,
+      senderName,
+      friendRequest.id,
+      fromUser.id
+    );
+  } catch (notificationError) {
+    console.error(
+      "Error creating friend request notification:",
+      notificationError
+    );
+  }
+
+  return { ok: true, requestId: friendRequest.id };
+}

--- a/web/src/lib/friends-actions.ts
+++ b/web/src/lib/friends-actions.ts
@@ -9,6 +9,7 @@ import {
   createFriendRequestNotification,
   createFriendRequestAcceptedNotification,
 } from "@/lib/notifications";
+import { sendFriendRequestFromUserToUser } from "@/lib/friend-request-service";
 
 const sendFriendRequestSchema = z.object({
   email: z.string().email("Invalid email format"),
@@ -310,121 +311,20 @@ export async function sendFriendRequestByUserId(userId: string) {
 
   const user = await prisma.user.findUnique({
     where: { email: session.user.email },
+    select: { id: true },
   });
 
   if (!user) {
     return { error: "User not found" };
   }
 
-  try {
-    // Check if trying to add themselves
-    if (userId === user.id) {
-      return { error: "Cannot send friend request to yourself" };
-    }
-
-    // Check if user allows friend requests
-    const targetUser = await prisma.user.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        email: true,
-        allowFriendRequests: true,
-        name: true,
-        firstName: true,
-        lastName: true,
-      },
-    });
-
-    if (!targetUser) {
-      return { error: "User not found" };
-    }
-
-    if (!targetUser.allowFriendRequests) {
-      return { error: "User is not accepting friend requests" };
-    }
-
-    // Check if friendship already exists
-    const existingFriendship = await prisma.friendship.findFirst({
-      where: {
-        OR: [
-          { userId: user.id, friendId: targetUser.id },
-          { userId: targetUser.id, friendId: user.id },
-        ],
-      },
-    });
-
-    if (existingFriendship) {
-      return { error: "Friendship already exists or is pending" };
-    }
-
-    // Check if friend request already exists (any status)
-    const existingRequest = await prisma.friendRequest.findFirst({
-      where: {
-        fromUserId: user.id,
-        toEmail: targetUser.email,
-      },
-    });
-
-    // Calculate new expiry date
-    const expiresAt = new Date();
-    expiresAt.setDate(expiresAt.getDate() + 30); // 30 days expiry
-
-    let friendRequest;
-
-    if (existingRequest) {
-      // If there's a pending request that hasn't expired, don't allow resending
-      if (existingRequest.status === "PENDING" && existingRequest.expiresAt > new Date()) {
-        return { error: "Friend request already sent" };
-      }
-
-      // If request was previously accepted, declined, expired, or canceled, update it
-      // This handles the case where users removed each other as friends and want to reconnect
-      friendRequest = await prisma.friendRequest.update({
-        where: { id: existingRequest.id },
-        data: {
-          status: "PENDING",
-          message: null, // No message for suggested friends
-          expiresAt,
-          updatedAt: new Date(),
-        },
-      });
-    } else {
-      // Create new friend request
-      friendRequest = await prisma.friendRequest.create({
-        data: {
-          fromUserId: user.id,
-          toEmail: targetUser.email,
-          message: null, // No message for suggested friends
-          expiresAt,
-        },
-      });
-    }
-
-    // Create notification for the target user
-    try {
-      const senderName =
-        user.name ||
-        (user.firstName && user.lastName
-          ? `${user.firstName} ${user.lastName}`
-          : user.email);
-
-      await createFriendRequestNotification(
-        targetUser.id,
-        senderName,
-        friendRequest.id,
-        user.id
-      );
-    } catch (notificationError) {
-      // Don't fail the friend request if notification creation fails
-      console.error("Error creating friend request notification:", notificationError);
-    }
-
-    revalidatePath("/friends");
-    return { success: "Friend request sent successfully" };
-  } catch (error) {
-    console.error("Error sending friend request:", error);
-    return { error: "Internal server error" };
+  const result = await sendFriendRequestFromUserToUser(user.id, userId);
+  if (!result.ok) {
+    return { error: result.error };
   }
+
+  revalidatePath("/friends");
+  return { success: "Friend request sent successfully" };
 }
 
 export async function removeFriend(friendId: string) {

--- a/web/src/lib/friends-data.test.ts
+++ b/web/src/lib/friends-data.test.ts
@@ -1,0 +1,377 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+vi.mock("@/lib/auth-options", () => ({
+  authOptions: {},
+}));
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    signup: { findMany: vi.fn() },
+    friendship: { findMany: vi.fn() },
+    friendRequest: { findMany: vi.fn() },
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+import { getShiftSlotKey, getRecommendedFriendsForUser } from "./friends-data";
+import { prisma } from "./prisma";
+
+type SignupFindMany = ReturnType<typeof vi.fn>;
+type FriendshipFindMany = ReturnType<typeof vi.fn>;
+type FriendRequestFindMany = ReturnType<typeof vi.fn>;
+
+const mockedSignup = prisma.signup.findMany as unknown as SignupFindMany;
+const mockedFriendship = prisma.friendship.findMany as unknown as FriendshipFindMany;
+const mockedFriendRequest = prisma.friendRequest.findMany as unknown as FriendRequestFindMany;
+
+/**
+ * Build a signup payload matching the include shape expected by
+ * `getRecommendedFriendsForUser`'s second `signup.findMany` call.
+ */
+function candidateSignup(opts: {
+  userId: string;
+  email?: string;
+  firstName?: string;
+  shiftId: string;
+  start: Date;
+  location: string | null;
+  shiftTypeName?: string;
+}) {
+  return {
+    user: {
+      id: opts.userId,
+      name: null,
+      firstName: opts.firstName ?? "Cand",
+      lastName: null,
+      email: opts.email ?? `${opts.userId}@example.com`,
+      profilePhotoUrl: null,
+    },
+    shift: {
+      id: opts.shiftId,
+      start: opts.start,
+      shiftType: { name: opts.shiftTypeName ?? "Dishwasher" },
+      location: opts.location,
+    },
+  };
+}
+
+describe("getShiftSlotKey", () => {
+  it("generates the same key for two shifts in the same NZ evening slot at the same location", () => {
+    // 17:00 UTC on 2024-01-15 = 06:00 NZDT the next day — wait, NZDT is UTC+13
+    // in January. So pick a UTC time that lands in NZ evening.
+    // 2024-01-15 06:00 UTC = 19:00 NZDT 2024-01-15
+    // 2024-01-15 07:30 UTC = 20:30 NZDT 2024-01-15
+    const shift1 = {
+      start: new Date("2024-01-15T06:00:00Z"),
+      location: "Ponsonby",
+    };
+    const shift2 = {
+      start: new Date("2024-01-15T07:30:00Z"),
+      location: "Ponsonby",
+    };
+    expect(getShiftSlotKey(shift1)).toBe(getShiftSlotKey(shift2));
+    expect(getShiftSlotKey(shift1)).toContain("EVE");
+  });
+
+  it("generates different keys for Day vs Evening at the same location/date", () => {
+    // 02:00 UTC = 15:00 NZDT (before 16:00 cutoff → Day)
+    // 06:00 UTC = 19:00 NZDT (Evening)
+    const day = {
+      start: new Date("2024-01-15T02:00:00Z"),
+      location: "Ponsonby",
+    };
+    const evening = {
+      start: new Date("2024-01-15T06:00:00Z"),
+      location: "Ponsonby",
+    };
+    expect(getShiftSlotKey(day)).not.toBe(getShiftSlotKey(evening));
+    expect(getShiftSlotKey(day)).toContain("DAY");
+    expect(getShiftSlotKey(evening)).toContain("EVE");
+  });
+
+  it("generates different keys for different locations on the same slot", () => {
+    const ponsonby = {
+      start: new Date("2024-01-15T06:00:00Z"),
+      location: "Ponsonby",
+    };
+    const wellington = {
+      start: new Date("2024-01-15T06:00:00Z"),
+      location: "Wellington",
+    };
+    expect(getShiftSlotKey(ponsonby)).not.toBe(getShiftSlotKey(wellington));
+  });
+
+  it("treats a null location as its own bucket distinct from any named location", () => {
+    const nullLoc = {
+      start: new Date("2024-01-15T06:00:00Z"),
+      location: null,
+    };
+    const named = {
+      start: new Date("2024-01-15T06:00:00Z"),
+      location: "Ponsonby",
+    };
+    expect(getShiftSlotKey(nullLoc)).not.toBe(getShiftSlotKey(named));
+  });
+
+  it("buckets by NZ-local date, not UTC date", () => {
+    // 2024-01-15 11:30 UTC = 2024-01-16 00:30 NZDT
+    const lateUtc = {
+      start: new Date("2024-01-15T11:30:00Z"),
+      location: "Ponsonby",
+    };
+    // 2024-01-16 03:00 UTC = 2024-01-16 16:00 NZDT (start of Evening on 16th)
+    const nzNextDay = {
+      start: new Date("2024-01-16T03:00:00Z"),
+      location: "Ponsonby",
+    };
+    // Both NZ dates should be 2024-01-16
+    expect(getShiftSlotKey(lateUtc)).toContain("2024-01-16");
+    expect(getShiftSlotKey(nzNextDay)).toContain("2024-01-16");
+  });
+});
+
+describe("getRecommendedFriendsForUser", () => {
+  beforeEach(() => {
+    mockedSignup.mockReset();
+    mockedFriendship.mockReset();
+    mockedFriendRequest.mockReset();
+  });
+
+  it("returns an empty list when the user has no recent shifts", async () => {
+    mockedSignup.mockResolvedValueOnce([]); // userShifts
+
+    const result = await getRecommendedFriendsForUser("me", "me@example.com");
+
+    expect(result).toEqual([]);
+    // No further queries should run when there are no shifts
+    expect(mockedFriendship).not.toHaveBeenCalled();
+  });
+
+  it("suggests a candidate who shares 3+ slot matches even via different shift types", async () => {
+    // Three different evenings, three different ponsonby shifts the user attended.
+    const myShifts = [
+      { shift: { start: new Date("2024-01-15T06:00:00Z"), location: "Ponsonby" } },
+      { shift: { start: new Date("2024-01-22T06:00:00Z"), location: "Ponsonby" } },
+      { shift: { start: new Date("2024-01-29T06:00:00Z"), location: "Ponsonby" } },
+    ];
+    mockedSignup.mockResolvedValueOnce(myShifts);
+    mockedFriendship.mockResolvedValueOnce([]);
+    mockedFriendRequest.mockResolvedValueOnce([]); // sent
+    mockedFriendRequest.mockResolvedValueOnce([]); // received
+
+    // Candidate Aroha was on the SAME evenings at Ponsonby but a different
+    // shift type each time. Three distinct slot matches.
+    mockedSignup.mockResolvedValueOnce([
+      candidateSignup({
+        userId: "aroha",
+        shiftId: "s1",
+        start: new Date("2024-01-15T07:00:00Z"),
+        location: "Ponsonby",
+        shiftTypeName: "Dishwasher",
+      }),
+      candidateSignup({
+        userId: "aroha",
+        shiftId: "s2",
+        start: new Date("2024-01-22T07:00:00Z"),
+        location: "Ponsonby",
+        shiftTypeName: "FOH",
+      }),
+      candidateSignup({
+        userId: "aroha",
+        shiftId: "s3",
+        start: new Date("2024-01-29T07:00:00Z"),
+        location: "Ponsonby",
+        shiftTypeName: "Prep",
+      }),
+    ]);
+
+    const result = await getRecommendedFriendsForUser("me", "me@example.com");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("aroha");
+    expect(result[0].sharedShiftsCount).toBe(3);
+    expect(result[0].isPendingRequest).toBe(false);
+  });
+
+  it("excludes a candidate who only matches 2 slots (below threshold)", async () => {
+    mockedSignup.mockResolvedValueOnce([
+      { shift: { start: new Date("2024-01-15T06:00:00Z"), location: "Ponsonby" } },
+      { shift: { start: new Date("2024-01-22T06:00:00Z"), location: "Ponsonby" } },
+    ]);
+    mockedFriendship.mockResolvedValueOnce([]);
+    mockedFriendRequest.mockResolvedValueOnce([]);
+    mockedFriendRequest.mockResolvedValueOnce([]);
+
+    mockedSignup.mockResolvedValueOnce([
+      candidateSignup({
+        userId: "kai",
+        shiftId: "s1",
+        start: new Date("2024-01-15T07:00:00Z"),
+        location: "Ponsonby",
+      }),
+      candidateSignup({
+        userId: "kai",
+        shiftId: "s2",
+        start: new Date("2024-01-22T07:00:00Z"),
+        location: "Ponsonby",
+      }),
+    ]);
+
+    const result = await getRecommendedFriendsForUser("me", "me@example.com");
+
+    expect(result).toEqual([]);
+  });
+
+  it("dedupes when a candidate has multiple shifts in the same slot (counts as 1)", async () => {
+    // User attended 3 distinct evenings.
+    mockedSignup.mockResolvedValueOnce([
+      { shift: { start: new Date("2024-01-15T06:00:00Z"), location: "Ponsonby" } },
+      { shift: { start: new Date("2024-01-22T06:00:00Z"), location: "Ponsonby" } },
+      { shift: { start: new Date("2024-01-29T06:00:00Z"), location: "Ponsonby" } },
+    ]);
+    mockedFriendship.mockResolvedValueOnce([]);
+    mockedFriendRequest.mockResolvedValueOnce([]);
+    mockedFriendRequest.mockResolvedValueOnce([]);
+
+    // Candidate signed up for TWO shifts on the same evening (Jan 15) — should
+    // dedupe to one shared slot, leaving only 2 distinct matches → below threshold.
+    mockedSignup.mockResolvedValueOnce([
+      candidateSignup({
+        userId: "moana",
+        shiftId: "s1a",
+        start: new Date("2024-01-15T06:30:00Z"),
+        location: "Ponsonby",
+      }),
+      candidateSignup({
+        userId: "moana",
+        shiftId: "s1b",
+        start: new Date("2024-01-15T08:00:00Z"),
+        location: "Ponsonby",
+      }),
+      candidateSignup({
+        userId: "moana",
+        shiftId: "s2",
+        start: new Date("2024-01-22T07:00:00Z"),
+        location: "Ponsonby",
+      }),
+    ]);
+
+    const result = await getRecommendedFriendsForUser("me", "me@example.com");
+
+    // 2 distinct slots — below the 3-slot threshold.
+    expect(result).toEqual([]);
+  });
+
+  it("excludes a candidate whose only matches are at a different location", async () => {
+    mockedSignup.mockResolvedValueOnce([
+      { shift: { start: new Date("2024-01-15T06:00:00Z"), location: "Ponsonby" } },
+      { shift: { start: new Date("2024-01-22T06:00:00Z"), location: "Ponsonby" } },
+      { shift: { start: new Date("2024-01-29T06:00:00Z"), location: "Ponsonby" } },
+    ]);
+    mockedFriendship.mockResolvedValueOnce([]);
+    mockedFriendRequest.mockResolvedValueOnce([]);
+    mockedFriendRequest.mockResolvedValueOnce([]);
+
+    // Even though dates match, location does not.
+    mockedSignup.mockResolvedValueOnce([
+      candidateSignup({
+        userId: "tane",
+        shiftId: "s1",
+        start: new Date("2024-01-15T07:00:00Z"),
+        location: "Wellington",
+      }),
+      candidateSignup({
+        userId: "tane",
+        shiftId: "s2",
+        start: new Date("2024-01-22T07:00:00Z"),
+        location: "Wellington",
+      }),
+      candidateSignup({
+        userId: "tane",
+        shiftId: "s3",
+        start: new Date("2024-01-29T07:00:00Z"),
+        location: "Wellington",
+      }),
+    ]);
+
+    const result = await getRecommendedFriendsForUser("me", "me@example.com");
+
+    expect(result).toEqual([]);
+  });
+
+  it("surfaces an incoming pending friend request even when shared-shift count is zero", async () => {
+    mockedSignup.mockResolvedValueOnce([
+      { shift: { start: new Date("2024-01-15T06:00:00Z"), location: "Ponsonby" } },
+    ]);
+    mockedFriendship.mockResolvedValueOnce([]);
+    mockedFriendRequest.mockResolvedValueOnce([]); // sent
+
+    // Pending request from "nia" who has no shared shifts with us.
+    mockedFriendRequest.mockResolvedValueOnce([
+      {
+        id: "req-1",
+        fromUser: {
+          id: "nia",
+          name: "Nia",
+          firstName: "Nia",
+          lastName: null,
+          email: "nia@example.com",
+          profilePhotoUrl: null,
+        },
+      },
+    ]);
+
+    mockedSignup.mockResolvedValueOnce([]); // no shared signups
+
+    const result = await getRecommendedFriendsForUser("me", "me@example.com");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("nia");
+    expect(result[0].isPendingRequest).toBe(true);
+    expect(result[0].requestId).toBe("req-1");
+    expect(result[0].sharedShiftsCount).toBe(0);
+  });
+
+  it("excludes candidates the user has already sent a pending request to", async () => {
+    mockedSignup.mockResolvedValueOnce([
+      { shift: { start: new Date("2024-01-15T06:00:00Z"), location: "Ponsonby" } },
+      { shift: { start: new Date("2024-01-22T06:00:00Z"), location: "Ponsonby" } },
+      { shift: { start: new Date("2024-01-29T06:00:00Z"), location: "Ponsonby" } },
+    ]);
+    mockedFriendship.mockResolvedValueOnce([]);
+    mockedFriendRequest.mockResolvedValueOnce([
+      { toEmail: "aroha@example.com" },
+    ]); // sent to aroha
+    mockedFriendRequest.mockResolvedValueOnce([]); // received
+
+    mockedSignup.mockResolvedValueOnce([
+      candidateSignup({
+        userId: "aroha",
+        email: "aroha@example.com",
+        shiftId: "s1",
+        start: new Date("2024-01-15T07:00:00Z"),
+        location: "Ponsonby",
+      }),
+      candidateSignup({
+        userId: "aroha",
+        email: "aroha@example.com",
+        shiftId: "s2",
+        start: new Date("2024-01-22T07:00:00Z"),
+        location: "Ponsonby",
+      }),
+      candidateSignup({
+        userId: "aroha",
+        email: "aroha@example.com",
+        shiftId: "s3",
+        start: new Date("2024-01-29T07:00:00Z"),
+        location: "Ponsonby",
+      }),
+    ]);
+
+    const result = await getRecommendedFriendsForUser("me", "me@example.com");
+
+    expect(result).toEqual([]);
+  });
+});

--- a/web/src/lib/friends-data.ts
+++ b/web/src/lib/friends-data.ts
@@ -6,8 +6,12 @@ import { subMonths } from "date-fns";
 import type { RecommendedFriend } from "@/lib/friends-utils";
 import { getShiftDate, isAMShift } from "@/lib/concurrent-shifts";
 
-// Slot key: same NZ date + same period (Day/Evening) + same location
-function getShiftSlotKey(shift: { start: Date; location: string | null }): string {
+// Slot key: same NZ date + same period (Day/Evening) + same location.
+// Exported so tests can verify the matching logic directly.
+export function getShiftSlotKey(shift: {
+  start: Date;
+  location: string | null;
+}): string {
   const date = getShiftDate(shift.start);
   const period = isAMShift(shift.start) ? "DAY" : "EVE";
   return `${date}|${period}|${shift.location ?? ""}`;

--- a/web/src/lib/friends-data.ts
+++ b/web/src/lib/friends-data.ts
@@ -4,6 +4,14 @@ import { prisma } from "@/lib/prisma";
 import { cache } from "react";
 import { subMonths } from "date-fns";
 import type { RecommendedFriend } from "@/lib/friends-utils";
+import { getShiftDate, isAMShift } from "@/lib/concurrent-shifts";
+
+// Slot key: same NZ date + same period (Day/Evening) + same location
+function getShiftSlotKey(shift: { start: Date; location: string | null }): string {
+  const date = getShiftDate(shift.start);
+  const period = isAMShift(shift.start) ? "DAY" : "EVE";
+  return `${date}|${period}|${shift.location ?? ""}`;
+}
 
 export interface Friend {
   friendshipId: string;
@@ -176,56 +184,65 @@ export const getFriendsData = cache(async (): Promise<FriendsData | null> => {
 const SHARED_SHIFTS_THRESHOLD = 3;
 const MONTHS_TO_LOOK_BACK = 3;
 
-// Fetch recommended friends based on shared shifts
-export const getRecommendedFriends = cache(async (): Promise<RecommendedFriend[]> => {
-  const session = await getServerSession(authOptions);
-
-  if (!session?.user?.email) {
-    return [];
-  }
-
-  const user = await prisma.user.findUnique({
-    where: { email: session.user.email },
-  });
-
-  if (!user) {
-    return [];
-  }
-
+/**
+ * Core recommended-friends algorithm. Auth-agnostic so it can be reused by
+ * both the NextAuth web flow and the JWT-authenticated mobile API.
+ *
+ * A "shared shift" means both users were at the same location during the
+ * same NZ-time day/evening period — they don't need to have been on the
+ * exact same shift.
+ */
+export async function getRecommendedFriendsForUser(
+  userId: string,
+  userEmail: string
+): Promise<RecommendedFriend[]> {
   try {
     const cutoffDate = subMonths(new Date(), MONTHS_TO_LOOK_BACK);
 
     const userShifts = await prisma.signup.findMany({
       where: {
-        userId: user.id,
+        userId,
         status: "CONFIRMED",
         shift: { start: { gte: cutoffDate } },
       },
-      select: { shiftId: true },
+      select: {
+        shift: { select: { start: true, location: true } },
+      },
     });
 
-    const userShiftIds = userShifts.map((signup) => signup.shiftId);
-
-    if (userShiftIds.length === 0) {
+    if (userShifts.length === 0) {
       return [];
+    }
+
+    // Build the set of slots the current user attended (date + day/evening + location).
+    const userSlotKeys = new Set<string>();
+    const userLocations = new Set<string>();
+    let userHasNullLocation = false;
+    for (const signup of userShifts) {
+      userSlotKeys.add(getShiftSlotKey(signup.shift));
+      if (signup.shift.location === null) {
+        userHasNullLocation = true;
+      } else {
+        userLocations.add(signup.shift.location);
+      }
     }
 
     const existingFriends = await prisma.friendship.findMany({
       where: {
-        OR: [{ userId: user.id }, { friendId: user.id }],
+        OR: [{ userId }, { friendId: userId }],
         status: "ACCEPTED",
       },
       select: { userId: true, friendId: true },
     });
 
     const friendIds = existingFriends.map((f) =>
-      f.userId === user.id ? f.friendId : f.userId
+      f.userId === userId ? f.friendId : f.userId
     );
 
     // Get sent friend requests (to exclude from suggestions)
     const sentRequests = await prisma.friendRequest.findMany({
       where: {
-        fromUserId: user.id,
+        fromUserId: userId,
         status: "PENDING",
         expiresAt: { gt: new Date() },
       },
@@ -237,7 +254,7 @@ export const getRecommendedFriends = cache(async (): Promise<RecommendedFriend[]
     // Get received friend requests (to include in suggestions)
     const receivedRequests = await prisma.friendRequest.findMany({
       where: {
-        toEmail: user.email,
+        toEmail: userEmail,
         status: "PENDING",
         expiresAt: { gt: new Date() },
       },
@@ -255,11 +272,27 @@ export const getRecommendedFriends = cache(async (): Promise<RecommendedFriend[]
       },
     });
 
+    // Narrow the candidate pool to signups whose shift could match one of our
+    // slots: same date range + same location set. We then filter precisely by
+    // slot key in memory.
+    const locationFilter: Array<{ location: string | null } | { location: { in: string[] } }> = [];
+    if (userLocations.size > 0) {
+      locationFilter.push({ location: { in: [...userLocations] } });
+    }
+    if (userHasNullLocation) {
+      locationFilter.push({ location: null });
+    }
+
     const sharedSignups = await prisma.signup.findMany({
       where: {
-        shiftId: { in: userShiftIds },
-        userId: { not: user.id },
+        userId: { not: userId },
         status: "CONFIRMED",
+        shift: {
+          start: { gte: cutoffDate },
+          ...(locationFilter.length === 1
+            ? locationFilter[0]
+            : { OR: locationFilter }),
+        },
         user: {
           allowFriendSuggestions: true,
           archivedAt: null,
@@ -288,48 +321,68 @@ export const getRecommendedFriends = cache(async (): Promise<RecommendedFriend[]
       },
     });
 
+    // Aggregate by user, counting distinct shared slots. We keep one
+    // representative shift per slot (the other user's shift) so the UI can
+    // show what they typically work.
     const userShiftCounts = new Map<
       string,
       {
         user: (typeof sharedSignups)[0]["user"];
-        shifts: (typeof sharedSignups)[0]["shift"][];
+        shiftsBySlot: Map<string, (typeof sharedSignups)[0]["shift"]>;
       }
     >();
 
     sharedSignups.forEach((signup) => {
-      const userId = signup.user.id;
+      const slotKey = getShiftSlotKey(signup.shift);
+      if (!userSlotKeys.has(slotKey)) {
+        return;
+      }
 
       // Only exclude users we've sent requests to, not users who sent requests to us
       if (sentRequestEmails.includes(signup.user.email)) {
         return;
       }
 
-      if (!userShiftCounts.has(userId)) {
-        userShiftCounts.set(userId, { user: signup.user, shifts: [] });
+      const candidateUserId = signup.user.id;
+      if (!userShiftCounts.has(candidateUserId)) {
+        userShiftCounts.set(candidateUserId, {
+          user: signup.user,
+          shiftsBySlot: new Map(),
+        });
       }
 
-      userShiftCounts.get(userId)!.shifts.push(signup.shift);
+      const entry = userShiftCounts.get(candidateUserId)!;
+      const existing = entry.shiftsBySlot.get(slotKey);
+      // Prefer the most recent shift in the slot as the representative
+      if (!existing || signup.shift.start.getTime() > existing.start.getTime()) {
+        entry.shiftsBySlot.set(slotKey, signup.shift);
+      }
     });
+
+    const collectRecentSharedShifts = (
+      shiftsBySlot: Map<string, (typeof sharedSignups)[0]["shift"]> | undefined
+    ) =>
+      Array.from(shiftsBySlot?.values() ?? [])
+        .sort((a, b) => b.start.getTime() - a.start.getTime())
+        .slice(0, 3)
+        .map((shift) => ({
+          id: shift.id,
+          start: shift.start.toISOString(),
+          shiftTypeName: shift.shiftType.name,
+          location: shift.location,
+        }));
 
     // Map received friend requests to RecommendedFriend format
     const friendRequestSuggestions: RecommendedFriend[] = receivedRequests.map((req) => {
-      const userShifts = userShiftCounts.get(req.fromUser.id);
+      const data = userShiftCounts.get(req.fromUser.id);
       return {
         id: req.fromUser.id,
         name: req.fromUser.name,
         firstName: req.fromUser.firstName,
         lastName: req.fromUser.lastName,
         profilePhotoUrl: req.fromUser.profilePhotoUrl,
-        sharedShiftsCount: userShifts?.shifts.length || 0,
-        recentSharedShifts: userShifts?.shifts
-          .sort((a, b) => b.start.getTime() - a.start.getTime())
-          .slice(0, 3)
-          .map((shift) => ({
-            id: shift.id,
-            start: shift.start.toISOString(),
-            shiftTypeName: shift.shiftType.name,
-            location: shift.location,
-          })) || [],
+        sharedShiftsCount: data?.shiftsBySlot.size ?? 0,
+        recentSharedShifts: collectRecentSharedShifts(data?.shiftsBySlot),
         isPendingRequest: true,
         requestId: req.id,
       };
@@ -338,9 +391,9 @@ export const getRecommendedFriends = cache(async (): Promise<RecommendedFriend[]
     // Get shared-shift based suggestions (exclude users who sent friend requests)
     const receivedRequestUserIds = receivedRequests.map((req) => req.fromUser.id);
     const sharedShiftSuggestions: RecommendedFriend[] = Array.from(userShiftCounts.entries())
-      .filter(([userId, data]) =>
-        data.shifts.length >= SHARED_SHIFTS_THRESHOLD &&
-        !receivedRequestUserIds.includes(userId)
+      .filter(([candidateUserId, data]) =>
+        data.shiftsBySlot.size >= SHARED_SHIFTS_THRESHOLD &&
+        !receivedRequestUserIds.includes(candidateUserId)
       )
       .map(([, data]) => ({
         id: data.user.id,
@@ -348,16 +401,8 @@ export const getRecommendedFriends = cache(async (): Promise<RecommendedFriend[]
         firstName: data.user.firstName,
         lastName: data.user.lastName,
         profilePhotoUrl: data.user.profilePhotoUrl,
-        sharedShiftsCount: data.shifts.length,
-        recentSharedShifts: data.shifts
-          .sort((a, b) => b.start.getTime() - a.start.getTime())
-          .slice(0, 3)
-          .map((shift) => ({
-            id: shift.id,
-            start: shift.start.toISOString(),
-            shiftTypeName: shift.shiftType.name,
-            location: shift.location,
-          })),
+        sharedShiftsCount: data.shiftsBySlot.size,
+        recentSharedShifts: collectRecentSharedShifts(data.shiftsBySlot),
         isPendingRequest: false,
       }))
       .sort((a, b) => b.sharedShiftsCount - a.sharedShiftsCount);
@@ -368,6 +413,26 @@ export const getRecommendedFriends = cache(async (): Promise<RecommendedFriend[]
     console.error("Error fetching recommended friends:", error);
     return [];
   }
+}
+
+// Fetch recommended friends based on shared shifts (web NextAuth session)
+export const getRecommendedFriends = cache(async (): Promise<RecommendedFriend[]> => {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    return [];
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { id: true, email: true },
+  });
+
+  if (!user) {
+    return [];
+  }
+
+  return getRecommendedFriendsForUser(user.id, user.email);
 });
 
 // Get current user for server components


### PR DESCRIPTION
## Summary
- Replace exact-shift matching in friend suggestions with **(NZ date + Day/Evening + location)** slot matching, so a dishwasher at 5pm and a FOH at 6pm at the same restaurant on the same evening now count as a shared shift. Uses the existing `isAMShift` / `getShiftDate` helpers (4pm NZ cutoff) already used elsewhere in the app.
- Extract the algorithm into `getRecommendedFriendsForUser(userId, userEmail)` so both the NextAuth web flow and the JWT-authenticated mobile API call the same core.
- Add `GET /api/mobile/friends/recommended` and `POST /api/mobile/friends/requests`, plus a shared `friend-request-service.ts` so the existing `sendFriendRequestByUserId` server action and the new mobile route share request-creation logic.
- Add a mobile Suggested section to the profile Whānau row (horizontal scroll cards with avatar, shared-shift count, and an Add / Accept pill). Honours haptics, 44pt touch targets, dark mode, and pending-request state.

Closes #850.

## Test plan
- [ ] Web `/friends` page — confirm suggestions appear for users who share the same evening/day slot at the same location (not just identical shift IDs).
- [ ] Web — confirm the 3+ shared slots threshold and 3-month window still apply.
- [ ] Web — confirm pending incoming friend requests still surface in the suggestion list with Accept/Decline buttons.
- [ ] Mobile — open Profile tab; the "Volunteers you've worked alongside" row renders above the Whānau friends list when suggestions exist.
- [ ] Mobile — Add button on a suggestion sends a friend request (POST `/api/mobile/friends/requests`) and removes the card from the list.
- [ ] Mobile — Accept button on a pending incoming request promotes the user into the friends list and removes the suggestion card.
- [ ] Mobile — works in both light and dark mode; loading spinner replaces icon while sending/accepting.
- [ ] No regressions in `/api/mobile/friends` shifts-together counts (already used the same Day/Evening matching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)