### PR TITLE
fix(flaky): replace waitForTimeout race conditions in notification and my-shifts tests

### DIFF
--- a/web/tests/e2e/my-shifts.spec.ts
+++ b/web/tests/e2e/my-shifts.spec.ts
@@ -5,7 +5,8 @@ import { loginAsVolunteer } from "./helpers/auth";
 // Helper function to wait for page to load completely
 async function waitForPageLoad(page: Page) {
   await page.waitForLoadState("load");
-  await page.waitForTimeout(1000); // Small buffer for animations
+  // Wait for the page root element rather than an arbitrary animation buffer.
+  await expect(page.getByTestId("my-shifts-page")).toBeVisible();
 }
 
 // Helper function to get responsive element by viewport
@@ -191,7 +192,7 @@ test.describe("My Shifts Calendar Page", () => {
 
       // Click previous month button
       const prevButton = await getNavigationButton(page, "prev");
-      await page.waitForTimeout(500);
+      await expect(prevButton).toBeVisible();
       await prevButton.click();
       await page.waitForURL("/shifts/mine?*");
       await page.waitForLoadState("load");
@@ -209,7 +210,7 @@ test.describe("My Shifts Calendar Page", () => {
 
       // Click next month button
       const nextButton = await getNavigationButton(page, "next");
-      await page.waitForTimeout(500);
+      await expect(nextButton).toBeVisible();
       await nextButton.click();
       await page.waitForURL("/shifts/mine?*");
       await page.waitForLoadState("load");
@@ -224,8 +225,8 @@ test.describe("My Shifts Calendar Page", () => {
       page,
     }) => {
       // Navigate to next month
-      await page.waitForTimeout(500);
       const nextButton = await getNavigationButton(page, "next");
+      await expect(nextButton).toBeVisible();
       await nextButton.click();
       await page.waitForURL("/shifts/mine?*");
 
@@ -234,7 +235,7 @@ test.describe("My Shifts Calendar Page", () => {
       await expect(todayButton).toBeVisible();
 
       // Click today button to return to current month
-      await page.waitForTimeout(500);
+      await expect(todayButton).toBeEnabled();
       await todayButton.click();
       await page.waitForLoadState("load");
 
@@ -574,6 +575,7 @@ test.describe("My Shifts Calendar Page", () => {
 
       // Today button (only visible when not viewing current month)
       // Navigate to see if today button appears
+      await expect(nextButton).toBeVisible();
       await nextButton.click();
       await page.waitForLoadState("load");
 

--- a/web/tests/e2e/notifications.spec.ts
+++ b/web/tests/e2e/notifications.spec.ts
@@ -157,10 +157,8 @@ test.describe("Notification System", () => {
       // Click mark as read button
       await unreadNotification.getByTestId("mark-read-button").click();
 
-      // Wait for the action to complete
-      await page.waitForTimeout(500);
-
-      // Unread badge should be gone
+      // Unread badge should disappear — no arbitrary wait needed since
+      // Playwright's expect retries automatically until the assertion passes.
       await expect(
         unreadNotification.getByTestId("unread-badge")
       ).not.toBeVisible();
@@ -189,9 +187,6 @@ test.describe("Notification System", () => {
 
       // Click delete button
       await firstNotification.getByTestId("delete-notification-button").click();
-
-      // Wait for deletion to complete
-      await page.waitForTimeout(500);
 
       // Count should decrease by 1 or show empty state
       const newCount = await page
@@ -232,10 +227,7 @@ test.describe("Notification System", () => {
       await expect(markAllReadButton).toBeVisible();
       await markAllReadButton.click();
 
-      // Wait for the action to complete
-      await page.waitForTimeout(1000);
-
-      // All unread badges should be gone
+      // All unread badges should disappear — Playwright retries automatically.
       await expect(page.getByTestId("unread-badge")).not.toBeVisible();
 
       // Notification count badge should be gone from bell
@@ -327,21 +319,25 @@ test.describe("Notification System", () => {
       // Close dropdown
       await page.click("body", { position: { x: 50, y: 50 } });
 
-      // Wait for polling to update (up to 30 seconds, but should be immediate)
-      await page.waitForTimeout(2000);
-
-      // Check if badge count decreased
+      // Poll for the badge to reflect the updated read state instead of
+      // using a fixed timeout — SSE/polling delivery time is non-deterministic.
       if (initialCount > 1) {
-        const newBadge = page.getByTestId("notification-count-badge");
-        await expect(newBadge).toBeVisible();
-        const newBadgeText = await newBadge.textContent();
-        const newCount = parseInt(newBadgeText?.replace("+", "") || "0");
-        expect(newCount).toBeLessThan(initialCount);
+        await expect
+          .poll(
+            async () => {
+              const badge = page.getByTestId("notification-count-badge");
+              if (!(await badge.isVisible())) return 0;
+              const text = await badge.textContent();
+              return parseInt(text?.replace("+", "") || "0");
+            },
+            { timeout: 10000 }
+          )
+          .toBeLessThan(initialCount);
       } else if (initialCount === 1) {
-        // Badge should be gone
+        // Badge should disappear once the last unread is read
         await expect(
           page.getByTestId("notification-count-badge")
-        ).not.toBeVisible();
+        ).not.toBeVisible({ timeout: 10000 });
       }
     }
   });


### PR DESCRIPTION
## Root-cause analysis

**Flaky signal detected:** `Playwright Tests (14)` failed on workflow run [25696775983](https://github.com/everybody-eats-nz/volunteer-portal/actions/runs/25696775983) — both PR #861 and PR #864 reference this same run (they share a HEAD commit). The same shard passed on adjacent runs (PR #857 → run 25642349468, PR #865 → run 25696862595, PR #867 → run 25699917060). No re-run was performed, so these are cross-commit comparisons, but the code changes in those PRs (analytics tracking, admin pagination) are unrelated to the tests in the failing shard — making environmental/timing flakiness the only plausible cause.

**Observed failure pattern (7-day scan, ~31 PRs):**

| Check | Failures | Runs | Flake rate |
|---|---|---|---|
| `Playwright Tests (14)` | 2 | ~31 | ~6.5% |
| `merge-reports` (Vercel deploy) | 2 | ~31 | ~6.5% |
| `version-bump` | every web PR | every web PR | 100% (broken, not flaky) |

## Root causes fixed

### 1. `notifications.spec.ts` — "should update unread count in real-time" (line 331, primary)

`waitForTimeout(2000)` races against SSE/polling delivering the badge update:

```typescript
// OLD — fails if SSE is >2 s late (CI load, cold connection)
await page.waitForTimeout(2000);
if (initialCount > 1) {
  const newCount = parseInt(...);
  expect(newCount).toBeLessThan(initialCount); // hard assertion after fixed wait
}

// NEW — polls up to 10 s, passes immediately once the badge updates
await expect.poll(async () => {
  const badge = page.getByTestId("notification-count-badge");
  if (!(await badge.isVisible())) return 0;
  return parseInt((await badge.textContent())?.replace("+", "") || "0");
}, { timeout: 10000 }).toBeLessThan(initialCount);
```

### 2. `notifications.spec.ts` — mark-as-read / delete / mark-all-read tests

Removed `waitForTimeout(500)` and `waitForTimeout(1000)` guards that preceded state-change assertions Playwright already retries automatically. The fixed waits add flake risk (too short under load, too long normally) without providing any guarantee.

### 3. `my-shifts.spec.ts` — `waitForPageLoad` helper (beforeEach)

`waitForTimeout(1000)` is called for every test in the file. Replaced with `expect(page.getByTestId("my-shifts-page")).toBeVisible()` which is instantaneous once the page is ready and automatically retries until it is.

### 4. `my-shifts.spec.ts` — calendar navigation tests

`waitForTimeout(500)` before button clicks assumes the button is rendered in half a second. Under CI load this assumption fails. Replaced with `expect(button).toBeVisible()` / `expect(button).toBeEnabled()` which are deterministic conditions, not time guesses.

## Separate issues (not fixed here)

- **`version-bump`** fails on 100% of web PRs — consistently broken (likely a missing/expired `DEPLOY_KEY` secret), not a flaky test.
- **`merge-reports`** Vercel deployment failures (~6.5%) — infrastructure flakiness in the Vercel deploy step, not in any test assertion. Needs investigation of Vercel token/project config.

## Test plan

- [x] `notifications.spec.ts` — all 12 tests reviewed for `waitForTimeout` anti-patterns; 4 replaced
- [x] `my-shifts.spec.ts` — `waitForPageLoad` helper and 4 navigation click guards replaced
- [ ] Run `npx playwright test --shard=14/20 --project=chromium` locally several times to confirm no regression (requires running database)

https://claude.ai/code/session_0146ycVtrSeUKFvkBmSdyUGe

---
_Generated by [Claude Code](https://claude.ai/code/session_0146ycVtrSeUKFvkBmSdyUGe)_