### PR TITLE
fix(auth): hide broken Facebook login on web and mobile

### DIFF
--- a/mobile/app/(auth)/login.tsx
+++ b/mobile/app/(auth)/login.tsx
@@ -32,7 +32,7 @@ import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useAuth } from "@/lib/auth";
 import { ApiError } from "@/lib/api";
 import { isPasskeySupported, signInWithPasskey } from "@/lib/passkey-client";
-import { signInWithApple, useFacebookAuth, useGoogleAuth } from "@/lib/oauth";
+import { signInWithApple, useGoogleAuth } from "@/lib/oauth";
 import { posthog } from "@/lib/posthog";
 
 const HERO_IMAGES = [
@@ -40,7 +40,8 @@ const HERO_IMAGES = [
   require("@/assets/photos/66da3c585f61f1e0ba83fbcc_03.png"),
 ];
 
-type OAuthProvider = "apple" | "google" | "facebook";
+// Facebook login is disabled — the integration has been broken for a while.
+type OAuthProvider = "apple" | "google";
 
 export default function LoginScreen() {
   const colorScheme = useColorScheme();
@@ -64,15 +65,11 @@ export default function LoginScreen() {
   const [passkeyReady, setPasskeyReady] = useState(false);
   const passwordRef = useRef<TextInput>(null);
   const [googleRequest, googleResponse, promptGoogle] = useGoogleAuth();
-  const [facebookRequest, facebookResponse, promptFacebook] = useFacebookAuth();
   // On native, the Google provider uses the auth-code flow and exchanges the
   // code for tokens in a post-prompt effect — so `promptAsync` resolves before
   // the id_token is available. This ref tracks an in-flight sign-in so the
   // effect below can finish the login once the exchanged response lands.
   const googleInFlight = useRef(false);
-  // Facebook returns an access token via the implicit/code flow; same
-  // post-prompt landing pattern as Google.
-  const facebookInFlight = useRef(false);
 
   useEffect(() => {
     isPasskeySupported().then(setPasskeyReady);
@@ -108,36 +105,6 @@ export default function LoginScreen() {
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [googleResponse]);
-
-  useEffect(() => {
-    if (!facebookResponse || !facebookInFlight.current) return;
-
-    if (facebookResponse.type !== "success") {
-      facebookInFlight.current = false;
-      setBusyProvider(null);
-      return;
-    }
-
-    const accessToken =
-      facebookResponse.authentication?.accessToken ??
-      (facebookResponse.params as Record<string, string>)?.access_token;
-
-    if (!accessToken) return;
-
-    facebookInFlight.current = false;
-
-    (async () => {
-      try {
-        await loginWithOAuth("facebook", { accessToken });
-      } catch (error) {
-        handleError(error, "Couldn't sign in with Facebook. Please try again.");
-        posthog?.capture("login_failed", { method: "oauth_facebook" });
-      } finally {
-        setBusyProvider(null);
-      }
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [facebookResponse]);
 
   const anyBusy = isSubmitting || busyProvider !== null;
 
@@ -215,28 +182,6 @@ export default function LoginScreen() {
       handleError(error, "Couldn't sign in with Apple. Please try again.");
       posthog?.capture("login_failed", { method: "oauth_apple" });
     } finally {
-      setBusyProvider(null);
-    }
-  }
-
-  async function handleFacebook() {
-    if (anyBusy) return;
-    if (!facebookRequest) {
-      Alert.alert(
-        "Sign in failed",
-        "Facebook sign-in isn't ready yet — try again in a moment."
-      );
-      return;
-    }
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setBusyProvider("facebook");
-    facebookInFlight.current = true;
-    try {
-      await promptFacebook();
-    } catch (error) {
-      facebookInFlight.current = false;
-      handleError(error, "Couldn't sign in with Facebook. Please try again.");
-      posthog?.capture("login_failed", { method: "oauth_facebook" });
       setBusyProvider(null);
     }
   }
@@ -424,13 +369,6 @@ export default function LoginScreen() {
                 onPress={handleGoogle}
                 isDark={isDark}
               />
-              <OAuthCircle
-                provider="facebook"
-                isBusy={busyProvider === "facebook"}
-                disabled={anyBusy || !facebookRequest}
-                onPress={handleFacebook}
-                isDark={isDark}
-              />
             </Animated.View>
 
             {/* Divider before email */}
@@ -604,13 +542,6 @@ function OAuthCircle({
           icon: isDark ? "#0b0d10" : "#ffffff",
           label: "Apple",
         }
-      : provider === "facebook"
-      ? {
-          bg: "#1877F2",
-          border: "transparent",
-          icon: "#ffffff",
-          label: "Facebook",
-        }
       : {
           bg: "#ffffff",
           border: "rgba(0,0,0,0.08)",
@@ -638,8 +569,6 @@ function OAuthCircle({
         <Ionicons name="ellipsis-horizontal" size={22} color={style.icon} />
       ) : provider === "apple" ? (
         <Ionicons name="logo-apple" size={26} color={style.icon} />
-      ) : provider === "facebook" ? (
-        <Ionicons name="logo-facebook" size={26} color={style.icon} />
       ) : (
         <Ionicons name="logo-google" size={26} color="#4285F4" />
       )}

--- a/mobile/lib/auth.ts
+++ b/mobile/lib/auth.ts
@@ -23,7 +23,8 @@ export type User = {
 
 type AuthResponse = { token: string; user: User };
 
-type LoginMethod = 'email' | 'oauth_apple' | 'oauth_google' | 'oauth_facebook' | 'passkey';
+// 'oauth_facebook' omitted — Facebook login is disabled (broken integration).
+type LoginMethod = 'email' | 'oauth_apple' | 'oauth_google' | 'passkey';
 
 function identifyInPostHog(user: User) {
   posthog?.identify(user.id, {
@@ -40,7 +41,7 @@ type AuthState = {
 
   loginWithEmail: (email: string, password: string) => Promise<void>;
   loginWithOAuth: (
-    provider: 'apple' | 'google' | 'facebook',
+    provider: 'apple' | 'google',
     token: OAuthToken,
   ) => Promise<void>;
   loginWithPasskey: (response: PasskeyAuthResponse) => Promise<void>;

--- a/mobile/lib/oauth.ts
+++ b/mobile/lib/oauth.ts
@@ -1,6 +1,8 @@
 import * as AppleAuthentication from 'expo-apple-authentication';
 import * as Google from 'expo-auth-session/providers/google';
-import * as Facebook from 'expo-auth-session/providers/facebook';
+// Facebook login is disabled — the integration has been broken for a while.
+// Kept commented for a one-line re-enable once the Facebook app is fixed.
+// import * as Facebook from 'expo-auth-session/providers/facebook';
 import * as WebBrowser from 'expo-web-browser';
 import { Platform } from 'react-native';
 
@@ -64,14 +66,14 @@ export function useGoogleAuth() {
 }
 
 /**
- * Facebook sign-in hook — mirrors the Google pattern. Facebook returns an
- * access token (not an id_token) which the server exchanges for a profile
- * via the Graph API. Must be called at the top of a component; use the
- * returned `promptAsync` from event handlers.
+ * Facebook sign-in hook — disabled (broken integration). Re-enable this
+ * function and the import above once the Facebook OAuth app is working again.
+ * Facebook returns an access token (not an id_token) which the server
+ * exchanges for a profile via the Graph API.
  */
-export function useFacebookAuth() {
-  return Facebook.useAuthRequest({
-    clientId: process.env.EXPO_PUBLIC_FACEBOOK_APP_ID,
-    scopes: ['public_profile', 'email'],
-  });
-}
+// export function useFacebookAuth() {
+//   return Facebook.useAuthRequest({
+//     clientId: process.env.EXPO_PUBLIC_FACEBOOK_APP_ID,
+//     scopes: ['public_profile', 'email'],
+//   });
+// }

--- a/web/src/lib/auth-options.ts
+++ b/web/src/lib/auth-options.ts
@@ -2,9 +2,12 @@ import type { NextAuthOptions } from "next-auth";
 import type { JWT } from "next-auth/jwt";
 import Credentials from "next-auth/providers/credentials";
 import GoogleProvider from "next-auth/providers/google";
-import FacebookProvider, {
-  FacebookProfile,
-} from "next-auth/providers/facebook";
+// Facebook login is temporarily disabled — the integration has been broken
+// for a while. Keep the import commented so it's a one-line re-enable once the
+// Facebook OAuth app is fixed.
+// import FacebookProvider, {
+//   FacebookProfile,
+// } from "next-auth/providers/facebook";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcrypt";
 import { unarchiveUser } from "@/lib/archive-service";
@@ -73,21 +76,25 @@ export const authOptions: NextAuthOptions = {
         };
       },
     }),
-    FacebookProvider({
-      clientId: process.env.FACEBOOK_CLIENT_ID!,
-      clientSecret: process.env.FACEBOOK_CLIENT_SECRET!,
-      // Request highest quality profile picture (800x800)
-      profileUrl:
-        "https://graph.facebook.com/me?fields=id,name,email,picture.width(800).height(800)",
-      profile(profile: FacebookProfile) {
-        return {
-          id: profile.id,
-          name: profile.name,
-          email: profile.email,
-          image: profile.picture?.data?.url,
-        };
-      },
-    }),
+    // Facebook login disabled (broken integration). Re-enable this block and
+    // the import above once the Facebook OAuth app is working again. Removing
+    // it here hides "Continue with Facebook" from the login, register, and
+    // migration screens, since they all derive providers from this list.
+    // FacebookProvider({
+    //   clientId: process.env.FACEBOOK_CLIENT_ID!,
+    //   clientSecret: process.env.FACEBOOK_CLIENT_SECRET!,
+    //   // Request highest quality profile picture (800x800)
+    //   profileUrl:
+    //     "https://graph.facebook.com/me?fields=id,name,email,picture.width(800).height(800)",
+    //   profile(profile: FacebookProfile) {
+    //     return {
+    //       id: profile.id,
+    //       name: profile.name,
+    //       email: profile.email,
+    //       image: profile.picture?.data?.url,
+    //     };
+    //   },
+    // }),
 
     // Credentials Provider
     Credentials({


### PR DESCRIPTION
## Description

The Facebook OAuth integration has been broken for a while. This PR hides the "Continue with Facebook" option from every sign-in surface across both apps.

**Web** — commented out `FacebookProvider` (and its import) in `web/src/lib/auth-options.ts`. The login, register, and migration screens all derive their OAuth buttons from `authOptions.providers`, so disabling the provider in this one place removes the button everywhere on web. The dead `case "facebook"` branches in the login/register UI are intentionally left in place so re-enabling is a one-line uncomment.

**Mobile** — removed the hardcoded Facebook `OAuthCircle` from `mobile/app/(auth)/login.tsx` along with its now-dead supporting code (the `useFacebookAuth` hook, in-flight state/ref, post-prompt `useEffect`, `handleFacebook` handler, and the `"facebook"` entries in the `OAuthProvider` type and `OAuthCircle` styling/icon branches) so the file stays lint/type-clean.

The mobile backend Facebook token-verification path (`web/src/app/api/auth/mobile/oauth/route.ts`) is intentionally left intact — no client can reach it now, and keeping it makes re-enabling simple. Both changes are documented inline.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
`version:patch`

## Testing
- [x] Manual review / static verification: no remaining live references to `FacebookProvider`/`FacebookProfile` (web) or `facebook` (mobile login screen); the web change is one fewer element in a typed provider array (type-safe by inspection).
- [ ] `npm run typecheck`/`lint` not run locally — this git worktree has no `node_modules`; CI will run both.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes
To re-enable once Facebook OAuth is fixed: uncomment the import + `FacebookProvider` block in `auth-options.ts`, and restore the mobile button (available in git history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)