### PR TITLE
fix(flaky): admin-notes waitForTimeout race conditions

### DIFF
--- a/web/tests/e2e/admin-notes.spec.ts
+++ b/web/tests/e2e/admin-notes.spec.ts
@@ -6,7 +6,6 @@ import { createTestUser, getUserByEmail } from "./helpers/test-helpers";
 // Helper function to wait for page to load completely
 async function waitForPageLoad(page: Page) {
   await page.waitForLoadState("load");
-  await page.waitForTimeout(500); // Small buffer for animations
 }
 
 // Helper function to navigate to a volunteer profile
@@ -104,15 +103,12 @@ test.describe("Admin Notes Management", () => {
     const saveButton = page.getByTestId("save-note-button");
     await saveButton.click();
 
-    // Wait for the note to appear
-    await page.waitForTimeout(2000);
-
     // Check that the note appears in the list
     const notesList = page.getByTestId("notes-list");
     await expect(notesList).toBeVisible();
 
     // The note content should be visible
-    await expect(page.getByText(noteContent)).toBeVisible();
+    await expect(page.getByText(noteContent)).toBeVisible({ timeout: 10000 });
   });
 
   test("should edit an existing admin note", async ({ page }) => {
@@ -125,13 +121,13 @@ test.describe("Admin Notes Management", () => {
     await noteTextarea.fill("Note to be edited");
     const saveButton = page.getByTestId("save-note-button");
     await saveButton.click();
-    await page.waitForTimeout(2000);
 
     // Find the first note and click edit
     const firstNote = page
       .getByTestId("notes-list")
       .locator('[data-testid^="note-"]')
       .first();
+    await expect(firstNote).toBeVisible({ timeout: 10000 });
     const editButton = firstNote.getByTestId(/edit-note-button-/);
     await editButton.click();
 
@@ -145,13 +141,10 @@ test.describe("Admin Notes Management", () => {
     const saveEditButton = firstNote.getByTestId(/save-edit-button-/);
     await saveEditButton.click();
 
-    // Wait for the update to complete
-    await page.waitForTimeout(2000);
-
     // Check that the updated content is visible
     await expect(
       page.getByText("Updated note content for e2e testing")
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 10000 });
   });
 
   test("should delete an admin note with confirmation dialog", async ({
@@ -166,11 +159,10 @@ test.describe("Admin Notes Management", () => {
     await noteTextarea.fill("Note to be deleted in e2e test");
     const saveButton = page.getByTestId("save-note-button");
     await saveButton.click();
-    await page.waitForTimeout(2000);
 
     // Now delete it
     const notesToDelete = page.getByText("Note to be deleted in e2e test");
-    await expect(notesToDelete).toBeVisible();
+    await expect(notesToDelete).toBeVisible({ timeout: 10000 });
 
     // Click the delete button for this note
     const noteContainer = notesToDelete
@@ -185,13 +177,10 @@ test.describe("Admin Notes Management", () => {
     await expect(deleteConfirmButton).toBeVisible();
     await deleteConfirmButton.click();
 
-    // Wait for deletion to complete
-    await page.waitForTimeout(2000);
-
     // Check that the note is no longer visible
     await expect(
       page.getByText("Note to be deleted in e2e test")
-    ).not.toBeVisible();
+    ).not.toBeVisible({ timeout: 10000 });
   });
 
   test("should cancel note deletion when clicking cancel", async ({ page }) => {
@@ -204,13 +193,13 @@ test.describe("Admin Notes Management", () => {
     await noteTextarea.fill("Note for cancel test");
     const saveButton = page.getByTestId("save-note-button");
     await saveButton.click();
-    await page.waitForTimeout(2000);
 
     // Find the note and click delete
     const firstNote = page
       .getByTestId("notes-list")
       .locator('[data-testid^="note-"]')
       .first();
+    await expect(firstNote).toBeVisible({ timeout: 10000 });
     const deleteButton = firstNote.getByTestId(/delete-note-button-/);
     await deleteButton.click();
 
@@ -222,7 +211,7 @@ test.describe("Admin Notes Management", () => {
     // The note should still be visible
     const notesList = page.getByTestId("notes-list");
     await expect(notesList).toBeVisible();
-    await expect(page.getByText("Note for cancel test")).toBeVisible();
+    await expect(page.getByText("Note for cancel test")).toBeVisible({ timeout: 10000 });
   });
 
   test("should cancel adding a new note", async ({ page }) => {


### PR DESCRIPTION
## Root-cause analysis

**Context:** Weekly flaky-test scan (2026-05-11 → 2026-05-18, 33 merged PRs, ~22 Playwright test runs).

The confirmed #1 flaky test this week — `Playwright Tests (14)` shard — was fixed by PR #882 (merged 2026-05-18), which addressed `waitForTimeout` race conditions in `notifications.spec.ts` and `my-shifts.spec.ts`. A strict-mode violation in `admin-shift-edit-delete.spec.ts` was fixed by PR #884 (merged 2026-05-18).

**This PR** fixes the next-highest-risk pattern: `admin-notes.spec.ts` had **seven** `waitForTimeout` calls (six at 2000 ms, one at 500 ms) that are all timing guesses around API mutations and page loads. Under CI load — identical to the conditions that caused shard-14 failures — these fixed waits race against actual server response times.

## Anti-patterns removed

| Location | Old pattern | Risk |
|---|---|---|
| `waitForPageLoad` helper | `waitForTimeout(500)` after `waitForLoadState("load")` | Unnecessary; animations disabled in test env |
| "create note" test | `waitForTimeout(2000)` before asserting note text | Fails if POST `/api/admin/admin-notes` > 2 s |
| "edit note" test (×2) | `waitForTimeout(2000)` before operating on created note; before asserting updated text | Same |
| "delete note" test (×2) | `waitForTimeout(2000)` before asserting note to delete is visible; before asserting note gone | Same |
| "cancel delete" test | `waitForTimeout(2000)` before acting on newly-created note | Same |

## Fix

Every post-mutation `waitForTimeout` replaced with a condition Playwright retries automatically:

```typescript
// OLD — races against slow API under CI load
await saveButton.click();
await page.waitForTimeout(2000);
await expect(page.getByText(noteContent)).toBeVisible();

// NEW — passes immediately when ready, fails fast if not ready within 10 s
await saveButton.click();
await expect(page.getByText(noteContent)).toBeVisible({ timeout: 10000 });
```

For "note must appear before we can click it" (edit/cancel-delete tests), an explicit `expect(firstNote).toBeVisible({ timeout: 10000 })` precedes further interaction, replacing the blind wait.

## Scope

Test-file changes only — no application code modified.

## Test plan

- [x] All `waitForTimeout` calls removed from `admin-notes.spec.ts` (verified with `grep`)
- [ ] Run `npx playwright test admin-notes --project=chromium` locally several times (requires running DB — not available in this environment; CI will validate)

https://claude.ai/code/session_01GL5YD9TZJZ8tN1fLoUeCWb

---
_Generated by [Claude Code](https://claude.ai/code/session_01GL5YD9TZJZ8tN1fLoUeCWb)_