### PR TITLE
fix(mobile): show shifts calendar dot only when friends are going

### DIFF
--- a/mobile/app/(tabs)/shifts.tsx
+++ b/mobile/app/(tabs)/shifts.tsx
@@ -277,13 +277,16 @@ export default function ShiftsScreen() {
     return map;
   }, [filteredAvailable, filteredMyShifts, filteredPast]);
 
-  /* Calendar friend dots — only count shifts visible under the active location filter */
+  /* Calendar friend dots — only count shifts visible under the active location
+     filter, AND only when at least one actual friend is going. Public-profile
+     volunteers also appear in shiftFriends but shouldn't trigger the dot. */
   const friendDates = useMemo(() => {
     const set = new Set<string>();
     const visible = [...filteredMyShifts, ...filteredPast, ...filteredAvailable];
     for (const shift of visible) {
       const friends = shiftFriends[shift.id];
       if (!friends || friends.length === 0) continue;
+      if (!friends.some((f) => f.isFriend)) continue;
       set.add(formatDateKey(new Date(shift.start)));
     }
     return set;

--- a/mobile/components/shift-month-calendar.tsx
+++ b/mobile/components/shift-month-calendar.tsx
@@ -233,7 +233,7 @@ export function ShiftMonthCalendar({
         <View style={styles.legendItem}>
           <View style={[styles.legendDot, { backgroundColor: "#f5c518" }]} />
           <Text style={[styles.legendText, { color: colors.textSecondary }]}>
-            Volunteers going
+            Friends going
           </Text>
         </View>
       </View>
@@ -326,7 +326,7 @@ function DayCell({
       ]}
       accessibilityLabel={`${formatNZT(day, "EEEE, d MMMM")}${
         shiftCount > 0 ? `, ${shiftCount} shifts` : ", no shifts"
-      }${hasFriends ? ", volunteers going" : ""}${
+      }${hasFriends ? ", friends going" : ""}${
         isSignedUp ? ", you're signed up" : ""
       }${isPastAttended ? ", shift attended" : ""}`}
       accessibilityRole="button"


### PR DESCRIPTION
## Summary
- The Shifts tab calendar's gold dot was firing whenever **any** volunteer was going on that day, including users with PUBLIC profile visibility — not just actual friends.
- `shiftFriends` already distinguishes the two via `PeriodFriend.isFriend` ([use-shifts.ts:14](mobile/hooks/use-shifts.ts#L14)), so this filters `friendDates` to require at least one entry with `isFriend === true`.
- Updated the legend "Volunteers going" → "Friends going" and the day-cell accessibility label to match.

Closes #892

## Test plan
- [ ] Open the Shifts tab as a user with no friends going on date X but PUBLIC volunteers signed up that day — the gold dot should no longer appear.
- [ ] Open the Shifts tab as a user with at least one friend signed up that day — the gold dot still appears.
- [ ] Confirm the calendar legend now reads "Friends going".
- [ ] VoiceOver/TalkBack: day cells with friends going now announce ", friends going".

🤖 Generated with [Claude Code](https://claude.com/claude-code)