### PR TITLE
Hide volunteer-profile Message button when volunteer has no mobile app

### DIFF
--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -125,6 +125,12 @@ export default async function AdminVolunteerPage({
       createdAt: true,
       archivedAt: true,
       archiveReason: true,
+      // Mobile-app presence: 1:1 messages reach the volunteer via push only,
+      // so we gate the "Message" admin action on whether they've signed in on
+      // mobile (which is the only way a PushToken row gets created).
+      _count: {
+        select: { pushTokens: true },
+      },
       regularVolunteers: {
         include: {
           shiftType: true,
@@ -570,20 +576,21 @@ export default async function AdminVolunteerPage({
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
-                {volunteer.role === "VOLUNTEER" && (
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium">
-                      Send a direct message
-                    </label>
-                    <div>
-                      <MessageVolunteerButton volunteerId={volunteer.id} />
+                {volunteer.role === "VOLUNTEER" &&
+                  volunteer._count.pushTokens > 0 && (
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium">
+                        Send a direct message
+                      </label>
+                      <div>
+                        <MessageVolunteerButton volunteerId={volunteer.id} />
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Opens (or creates) a 1:1 conversation thread between
+                        this volunteer and the team
+                      </p>
                     </div>
-                    <p className="text-xs text-muted-foreground">
-                      Opens (or creates) a 1:1 conversation thread between this
-                      volunteer and the team
-                    </p>
-                  </div>
-                )}
+                  )}
 
                 <div className="space-y-2">
                   <label className="text-sm font-medium">

--- a/web/src/app/api/admin/messages/threads/[id]/route.ts
+++ b/web/src/app/api/admin/messages/threads/[id]/route.ts
@@ -38,6 +38,12 @@ export async function GET(
           defaultLocation: true,
           volunteerGrade: true,
           createdAt: true,
+          // Used by the inbox UI to surface a "no mobile app" hint —
+          // outbound replies only push to mobile, so a volunteer with no
+          // PushToken rows won't get the interrupt notification.
+          _count: {
+            select: { pushTokens: true },
+          },
         },
       },
     },
@@ -45,6 +51,16 @@ export async function GET(
   if (!thread) {
     return NextResponse.json({ error: "Thread not found" }, { status: 404 });
   }
+
+  // Flatten the count into a friendlier boolean for the client.
+  const { _count, ...volunteerRest } = thread.volunteer;
+  const threadForClient = {
+    ...thread,
+    volunteer: {
+      ...volunteerRest,
+      hasMobileApp: _count.pushTokens > 0,
+    },
+  };
 
   const messages = await listMessages({
     threadId: id,
@@ -99,5 +115,10 @@ export async function GET(
       }
     : null;
 
-  return NextResponse.json({ thread, messages, upcomingShiftCount, nextShift });
+  return NextResponse.json({
+    thread: threadForClient,
+    messages,
+    upcomingShiftCount,
+    nextShift,
+  });
 }

--- a/web/src/components/admin/messages/thread-view.tsx
+++ b/web/src/components/admin/messages/thread-view.tsx
@@ -2,7 +2,14 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Archive, ArchiveRestore, ExternalLink, Loader2, Send } from "lucide-react";
+import {
+  Archive,
+  ArchiveRestore,
+  ExternalLink,
+  Info,
+  Loader2,
+  Send,
+} from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -208,6 +215,19 @@ export function ThreadView({ threadId, onMessageSent, onResolve }: ThreadViewPro
             )}
           </Button>
         </div>
+
+        {/* No-mobile-app hint: replies create a bell notification but won't
+            push, so flag it to admins before they compose. */}
+        {!thread.volunteer.hasMobileApp && (
+          <div className="flex items-start gap-2 border-b bg-amber-50 dark:bg-amber-950/30 px-4 py-2.5 text-xs text-amber-900 dark:text-amber-200">
+            <Info className="w-4 h-4 shrink-0 mt-px" />
+            <p>
+              {volunteerName.split(" ")[0]} hasn&apos;t signed in on the mobile
+              app, so replies won&apos;t send a push notification — they&apos;ll
+              only see it when they next open the web portal.
+            </p>
+          </div>
+        )}
 
         {/* Messages */}
         <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4 space-y-4">

--- a/web/src/components/admin/messages/types.ts
+++ b/web/src/components/admin/messages/types.ts
@@ -52,6 +52,12 @@ export interface ThreadDetail {
     defaultLocation: string | null;
     volunteerGrade: string;
     createdAt: string;
+    /**
+     * True if the volunteer has at least one registered Expo push token —
+     * i.e. they've signed in on the mobile app. Used to warn admins when a
+     * reply won't trigger a push.
+     */
+    hasMobileApp: boolean;
   };
   upcomingShiftCount: number;
   nextShift: NextShiftSummary | null;


### PR DESCRIPTION
## Description

The "Send a direct message" admin action on volunteer profiles delivers via push notification (Expo, via `PushToken` rows created on mobile sign-in). For volunteers who've never logged into the mobile app, the button currently exists but its primary delivery channel is a no-op — admins click it expecting the volunteer to be pinged, and nothing pings.

This PR gates the entry point on whether the volunteer has signed in on mobile, and adds an inline hint inside the inbox for the remaining cases where a thread already exists (e.g. the volunteer had the app and then logged out).

### What changed

- **`web/src/app/admin/volunteers/[id]/page.tsx`** — fetches `_count.pushTokens` for the volunteer and only renders `<MessageVolunteerButton />` when it's `> 0`. If the volunteer isn't on mobile, the Admin Actions card simply omits the messaging row.
- **`web/src/app/api/admin/messages/threads/[id]/route.ts`** — includes `_count.pushTokens` in the volunteer selection and flattens it to `volunteer.hasMobileApp: boolean` on the response payload.
- **`web/src/components/admin/messages/types.ts`** — adds `hasMobileApp: boolean` to `ThreadDetail.volunteer`.
- **`web/src/components/admin/messages/thread-view.tsx`** — renders an amber Info banner between the thread header and the messages list when `!thread.volunteer.hasMobileApp`, explaining the reply will only show up in the web portal.

### Why this layering

Hiding the button on the profile alone isn't enough — admins can still land on an existing thread through the inbox (Compose/search/etc.), so the hint inside `ThreadView` is the safety net for that path. The push channel still works for volunteers who do have the app, and the in-app `Notification` row is still created either way (so a volunteer logging into the web portal will see the message in the bell).

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
Suggest `version:minor` — it's a user-visible improvement to the admin UX, not a bug fix per se.

## Testing
- [x] No existing tests reference `MessageVolunteerButton`, the thread detail API, or `hasMobileApp`, so nothing should regress.
- [ ] Manual sanity check on a worktree was blocked by missing `node_modules` (worktree only); reviewer should run `npm run typecheck` and a quick smoke through:
  - Open an admin volunteer profile for a user with **no** `PushToken` rows → "Send a direct message" row should be gone.
  - Open an admin volunteer profile for a user **with** `PushToken` rows → button visible as before.
  - Open a thread in the inbox for a user with no `PushToken` rows → amber Info banner appears under the thread header.

## Screenshots
_Not included — change is a small UI toggle plus an info banner. Happy to add if the reviewer wants them._

## Additional Notes

A natural follow-up (not in this PR) would be deleting `PushToken` rows that come back as `DeviceNotRegistered` from Expo more aggressively, so the `hasMobileApp` signal stays accurate when users uninstall the app. The current expo-push service already prunes on send-failure, which covers most cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)