### PR TITLE
Use lastMobileLoginAt for mobile-app gate (fix #897 false positives)

### DIFF
--- a/web/prisma/migrations/20260521000000_add_user_last_mobile_login_at/migration.sql
+++ b/web/prisma/migrations/20260521000000_add_user_last_mobile_login_at/migration.sql
@@ -1,0 +1,21 @@
+-- AlterTable: track when a user last authenticated on the mobile app.
+-- Used by the admin UI to gate the 1:1 "Message" action — push tokens alone
+-- are too strict because they require OS notification permission, so a user
+-- can have the app installed but no PushToken row.
+ALTER TABLE "User"
+  ADD COLUMN "lastMobileLoginAt" TIMESTAMP(3);
+
+-- Backfill from existing push tokens so users we already know are on mobile
+-- don't have to re-open the app before the admin "Message" button reappears.
+-- The most-recent PushToken row's lastUsedAt (or createdAt as fallback) is a
+-- reasonable proxy for their previous mobile activity.
+UPDATE "User"
+SET "lastMobileLoginAt" = sub.last_seen
+FROM (
+  SELECT
+    "userId",
+    MAX(COALESCE("lastUsedAt", "createdAt")) AS last_seen
+  FROM "PushToken"
+  GROUP BY "userId"
+) AS sub
+WHERE "User".id = sub."userId";

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -84,6 +84,12 @@ model User {
   archiveExtensionToken         String?   @unique
   archiveExtensionTokenExpiresAt DateTime?
 
+  // Most recent successful mobile auth event (login, OAuth, passkey, or
+  // cold-start session restore). Used as the "has the mobile app" signal —
+  // more reliable than PushToken presence, which is also gated on the user
+  // having granted OS notification permission.
+  lastMobileLoginAt DateTime?
+
   createdAt            DateTime          @default(now())
   updatedAt            DateTime          @updatedAt
   signups              Signup[]

--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -125,12 +125,13 @@ export default async function AdminVolunteerPage({
       createdAt: true,
       archivedAt: true,
       archiveReason: true,
-      // Mobile-app presence: 1:1 messages reach the volunteer via push only,
-      // so we gate the "Message" admin action on whether they've signed in on
-      // mobile (which is the only way a PushToken row gets created).
-      _count: {
-        select: { pushTokens: true },
-      },
+      // Mobile-app presence signal: the "Message" admin action is only useful
+      // for volunteers currently on the mobile app. Use lastMobileLoginAt
+      // (stamped on every mobile login / cold-start session restore) rather
+      // than PushToken rows, because tokens additionally require OS
+      // notification permission — a user who declined the prompt has the app
+      // but no token.
+      lastMobileLoginAt: true,
       regularVolunteers: {
         include: {
           shiftType: true,
@@ -577,7 +578,7 @@ export default async function AdminVolunteerPage({
               </CardHeader>
               <CardContent className="space-y-4">
                 {volunteer.role === "VOLUNTEER" &&
-                  volunteer._count.pushTokens > 0 && (
+                  volunteer.lastMobileLoginAt !== null && (
                     <div className="space-y-2">
                       <label className="text-sm font-medium">
                         Send a direct message

--- a/web/src/app/api/admin/messages/threads/[id]/route.ts
+++ b/web/src/app/api/admin/messages/threads/[id]/route.ts
@@ -38,12 +38,10 @@ export async function GET(
           defaultLocation: true,
           volunteerGrade: true,
           createdAt: true,
-          // Used by the inbox UI to surface a "no mobile app" hint —
-          // outbound replies only push to mobile, so a volunteer with no
-          // PushToken rows won't get the interrupt notification.
-          _count: {
-            select: { pushTokens: true },
-          },
+          // Powers the "no mobile app" inbox hint. Stamped on every mobile
+          // auth event (login + cold-start /me), so null means the volunteer
+          // has never opened the app while signed in.
+          lastMobileLoginAt: true,
         },
       },
     },
@@ -52,13 +50,13 @@ export async function GET(
     return NextResponse.json({ error: "Thread not found" }, { status: 404 });
   }
 
-  // Flatten the count into a friendlier boolean for the client.
-  const { _count, ...volunteerRest } = thread.volunteer;
+  // Flatten the timestamp into a friendlier boolean for the client.
+  const { lastMobileLoginAt, ...volunteerRest } = thread.volunteer;
   const threadForClient = {
     ...thread,
     volunteer: {
       ...volunteerRest,
-      hasMobileApp: _count.pushTokens > 0,
+      hasMobileApp: lastMobileLoginAt !== null,
     },
   };
 

--- a/web/src/app/api/auth/mobile/login/route.ts
+++ b/web/src/app/api/auth/mobile/login/route.ts
@@ -52,6 +52,18 @@ export async function POST(request: Request) {
       );
     }
 
+    // Stamp the mobile-login marker so admin UI can tell who's actually on
+    // mobile (more reliable than push tokens, which require notification
+    // permission). Fire-and-forget — failure here shouldn't block login.
+    void prisma.user
+      .update({
+        where: { id: user.id },
+        data: { lastMobileLoginAt: new Date() },
+      })
+      .catch((err) =>
+        console.error("Failed to stamp lastMobileLoginAt on login:", err)
+      );
+
     const token = await signMobileToken(user.id, user.email);
 
     return NextResponse.json({

--- a/web/src/app/api/auth/mobile/me/route.ts
+++ b/web/src/app/api/auth/mobile/me/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getMobileUser } from "@/lib/mobile-auth";
+import { prisma } from "@/lib/prisma";
 import { archiveAndAnonymizeUser } from "@/lib/user-service";
 
 export async function GET(request: Request) {
@@ -11,6 +12,21 @@ export async function GET(request: Request) {
       { status: 401 }
     );
   }
+
+  // The mobile app calls this on cold start to restore the session — so this
+  // is the most reliable "is this user actively on mobile?" signal we have.
+  // Fire-and-forget so a flaky write never breaks app startup.
+  void prisma.user
+    .update({
+      where: { id: user.id },
+      data: { lastMobileLoginAt: new Date() },
+    })
+    .catch((err) =>
+      console.error(
+        "Failed to stamp lastMobileLoginAt on session restore:",
+        err
+      )
+    );
 
   return NextResponse.json(user);
 }

--- a/web/src/app/api/auth/mobile/oauth/route.ts
+++ b/web/src/app/api/auth/mobile/oauth/route.ts
@@ -131,6 +131,17 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "User not found after upsert" }, { status: 500 });
     }
 
+    // Mark this user as currently on mobile — used by admin UI to gate the
+    // 1:1 "Message" action. Fire-and-forget; login flow shouldn't block on it.
+    void prisma.user
+      .update({
+        where: { id: freshUser.id },
+        data: { lastMobileLoginAt: new Date() },
+      })
+      .catch((err) =>
+        console.error("Failed to stamp lastMobileLoginAt on OAuth login:", err)
+      );
+
     const token = await signMobileToken(freshUser.id, freshUser.email);
     return NextResponse.json({ token, user: toMobileUser(freshUser) });
   } catch (error) {

--- a/web/src/app/api/auth/mobile/passkey/verify/route.ts
+++ b/web/src/app/api/auth/mobile/passkey/verify/route.ts
@@ -134,6 +134,20 @@ export async function POST(req: NextRequest) {
       data: { counter: BigInt(newCounter), lastUsedAt: new Date() },
     });
 
+    // Stamp the mobile-login marker so admin UI can tell this user is on
+    // mobile. Fire-and-forget — failure shouldn't block a successful auth.
+    void prisma.user
+      .update({
+        where: { id: passkey.user.id },
+        data: { lastMobileLoginAt: new Date() },
+      })
+      .catch((err) =>
+        console.error(
+          "Failed to stamp lastMobileLoginAt on passkey login:",
+          err
+        )
+      );
+
     const token = await signMobileToken(passkey.user.id, passkey.user.email);
     return NextResponse.json({ token, user: toMobileUser(passkey.user) });
   } catch (error) {


### PR DESCRIPTION
## Description

Follow-up to #897 — the "Message" admin action was being hidden / the inbox banner shown for volunteers who **do** have the mobile app, because the gate used `PushToken` row presence as the signal. `PushToken` is only created when the user *also* grants OS notification permission (see [`mobile/lib/push-notifications.ts:71`](mobile/lib/push-notifications.ts)) — so a volunteer who installed the app and tapped "Don't Allow" gets flagged as having no mobile app.

This PR switches the signal to a new `User.lastMobileLoginAt` timestamp that's stamped on every successful mobile auth event, regardless of notification permissions.

### What changed

- **`prisma/schema.prisma`** — new nullable `User.lastMobileLoginAt DateTime?`.
- **`prisma/migrations/20260521000000_add_user_last_mobile_login_at/`** — adds the column and **backfills** it from the most recent `PushToken.lastUsedAt` (falling back to `createdAt`) per user, so volunteers we already know are on mobile don't have to re-open the app before the admin button reappears.
- **`web/src/app/api/auth/mobile/{login,oauth,passkey/verify,me}/route.ts`** — fire-and-forget `prisma.user.update({ lastMobileLoginAt: new Date() })` after each successful auth. The `me` endpoint is the most important — it fires on every cold-start session restore, so an active mobile user gets their timestamp refreshed every app open.
- **`web/src/app/admin/volunteers/[id]/page.tsx`** — gate `<MessageVolunteerButton />` on `lastMobileLoginAt !== null` instead of `_count.pushTokens > 0`.
- **`web/src/app/api/admin/messages/threads/[id]/route.ts`** — derive `hasMobileApp` from `lastMobileLoginAt !== null`. The client-facing `ThreadDetail.volunteer.hasMobileApp` boolean shape is unchanged, so the existing banner in `ThreadView` continues to work without further changes.

### Why fire-and-forget on the auth endpoints

Stamping `lastMobileLoginAt` is purely advisory for an admin UI affordance — if the write fails or is slow, we never want it to block a real login, OAuth handshake, or app cold-start. Errors are logged but swallowed.

### Why backfill from PushToken

Without the backfill, every volunteer currently on mobile would lose the "Message" button until they next open the app after this ships. The most-recent `PushToken.lastUsedAt` per user is a perfect proxy — anyone with at least one token row was demonstrably on mobile recently.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
Suggest `version:patch` — fixes a false negative in a recently-shipped feature.

## Testing
- [ ] `npm run prisma:generate` after pull (new field needs to be in the generated client).
- [ ] `npm run prisma:migrate` locally to confirm the migration applies cleanly and backfills.
- [ ] Manual sanity check:
  - Volunteer with **no** mobile sign-in history (and no push tokens) → Message button hidden, inbox banner shown.
  - Volunteer with prior push tokens but never opened post-deploy → `lastMobileLoginAt` populated by the backfill, Message button visible.
  - Volunteer who declined notifications but does open the app → after cold start, `lastMobileLoginAt` set by `/api/auth/mobile/me`, Message button visible.

## Additional Notes

`PushToken` is still used by the actual push delivery path (`sendPushToUser`) — this PR doesn't touch how pushes are sent, just how we decide whether to expose the messaging affordance. So a volunteer with `lastMobileLoginAt` set but no `PushToken` rows will still see the message in the in-app inbox + web bell, just not as an OS push. The banner copy ("replies won't send a push notification — they'll only see it when they next open the web portal") slightly understates that case (they'd also see it next time they open the mobile app), but it's close enough; happy to refine in a follow-up if reviewers want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)