### PR TITLE
feat: capture exceptions with PostHog error tracking

### DIFF
--- a/mobile/lib/posthog.ts
+++ b/mobile/lib/posthog.ts
@@ -15,5 +15,15 @@ export const posthog = apiKey
       // Autocapture app open/close/background transitions so we get
       // basic engagement without per-screen instrumentation.
       captureAppLifecycleEvents: true,
+      // Capture unhandled JS errors and promise rejections so we can
+      // monitor them in PostHog's error tracking. `console` is left off
+      // to avoid duplicates from React's automatic error logging.
+      errorTracking: {
+        autocapture: {
+          uncaughtExceptions: true,
+          unhandledRejections: true,
+          console: [],
+        },
+      },
     })
   : null;

--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -1,0 +1,42 @@
+import type { Instrumentation } from "next";
+
+export function register() {
+  // No-op for initialization. PostHog server client is lazily created in
+  // src/lib/posthog-server.ts on first use.
+}
+
+export const onRequestError: Instrumentation.onRequestError = async (
+  err,
+  request,
+) => {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return;
+
+  const { getPostHogServer } = await import("./src/lib/posthog-server");
+  const posthog = getPostHogServer();
+
+  // Pull PostHog's anonymous distinct_id from the cookie so the exception
+  // is attributed to the same person as their browser events.
+  let distinctId: string | undefined;
+  const cookieHeader = request.headers.cookie;
+  if (cookieHeader) {
+    const cookieString = Array.isArray(cookieHeader)
+      ? cookieHeader.join("; ")
+      : cookieHeader;
+    const match = cookieString.match(/ph_phc_.*?_posthog=([^;]+)/);
+    if (match?.[1]) {
+      try {
+        const decoded = decodeURIComponent(match[1]);
+        const parsed = JSON.parse(decoded) as { distinct_id?: string };
+        distinctId = parsed.distinct_id;
+      } catch {
+        // Malformed cookie — fall through and capture without a distinct id.
+      }
+    }
+  }
+
+  posthog.captureException(
+    err instanceof Error ? err : new Error(String(err)),
+    distinctId,
+  );
+};

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useEffect } from "react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    posthog.captureException(error, {
+      digest: error.digest,
+    });
+  }, [error]);
+
+  return (
+    <div className="container mx-auto flex min-h-[60vh] flex-col items-center justify-center px-4 py-12 text-center">
+      <h1 className="font-fraunces text-4xl font-bold tracking-tight">
+        Kia ora — something went wrong
+      </h1>
+      <p className="mt-4 max-w-prose text-muted-foreground">
+        We&apos;ve been notified and will look into it. You can try again, or
+        head back to the dashboard.
+      </p>
+      <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+        <Button onClick={reset}>Try again</Button>
+        <Button variant="outline" asChild>
+          <Link href="/dashboard">Back to dashboard</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/global-error.tsx
+++ b/web/src/app/global-error.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react";
 
 export default function GlobalError({
   error,
+  reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
@@ -34,21 +35,24 @@ export default function GlobalError({
             Something went wrong
           </h1>
           <p style={{ color: "#666", marginBottom: "1.5rem" }}>
-            Kia ora — we hit an unexpected error. Please try reloading the page.
+            Kia ora — we hit an unexpected error. Please try again.
           </p>
-          <a
-            href="/"
+          <button
+            type="button"
+            onClick={() => reset()}
             style={{
               display: "inline-block",
               padding: "0.625rem 1.25rem",
               borderRadius: "0.5rem",
               background: "#111",
               color: "#fff",
-              textDecoration: "none",
+              border: 0,
+              cursor: "pointer",
+              font: "inherit",
             }}
           >
-            Reload
-          </a>
+            Try again
+          </button>
         </div>
       </body>
     </html>

--- a/web/src/app/global-error.tsx
+++ b/web/src/app/global-error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    posthog.captureException(error, {
+      digest: error.digest,
+      scope: "global-error",
+    });
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: "2rem",
+          fontFamily: "system-ui, -apple-system, sans-serif",
+          textAlign: "center",
+        }}
+      >
+        <div style={{ maxWidth: "32rem" }}>
+          <h1 style={{ fontSize: "2rem", fontWeight: 700, marginBottom: "1rem" }}>
+            Something went wrong
+          </h1>
+          <p style={{ color: "#666", marginBottom: "1.5rem" }}>
+            Kia ora — we hit an unexpected error. Please try reloading the page.
+          </p>
+          <a
+            href="/"
+            style={{
+              display: "inline-block",
+              padding: "0.625rem 1.25rem",
+              borderRadius: "0.5rem",
+              background: "#111",
+              color: "#fff",
+              textDecoration: "none",
+            }}
+          >
+            Reload
+          </a>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Description
Wire PostHog error tracking into both the web app and mobile app so unhandled errors show up in the Error Tracking dashboard. PostHog itself is already installed in both projects — this PR only adds the boundaries and autocapture config needed to surface exceptions.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## What changed

### Web (Next.js)
- **`web/src/app/error.tsx`** — route-level error boundary. Calls `posthog.captureException(error, { digest })` on mount and renders a friendly NZ-flavored fallback with "Try again" / "Back to dashboard" actions.
- **`web/src/app/global-error.tsx`** — root error boundary catching crashes inside `app/layout.tsx`. Tags captures with `scope: "global-error"` so the more severe class can be filtered separately.
- **`web/instrumentation.ts`** — Next.js `onRequestError` hook for server-side errors (Server Components, route handlers, server actions). Reuses the existing `getPostHogServer()` singleton, runtime-gates to `nodejs`, and extracts the `ph_phc_*_posthog` cookie so the exception attributes to the right PostHog person.

### Mobile (Expo / React Native)
- **`mobile/lib/posthog.ts`** — enabled `errorTracking.autocapture` with `uncaughtExceptions: true` and `unhandledRejections: true`. `console: []` is set explicitly to avoid duplicate captures from React's own error logging.

### Already in place — no changes needed
- Source-map uploads via `@posthog/nextjs-config` are already wired into `web/next.config.ts`.
- `NEXT_PUBLIC_POSTHOG_KEY` and `EXPO_PUBLIC_POSTHOG_KEY` env vars already configured.

## Follow-up (manual, not in this PR)
To capture **browser** unhandled errors (the global `window.onerror` / `unhandledrejection` path), enable exception autocapture in PostHog: [Project settings → Error tracking → Exception autocapture](https://us.posthog.com/settings/project-error-tracking#exception-autocapture). The error boundaries in this PR cover React's render path; the global handlers are gated by remote config.

## Testing
- [x] Type check passes for the new files (verified locally — pre-existing errors in this branch are unrelated, in `admin/locations` and `notifications.ts`).
- [ ] Manual smoke test in preview: trigger a render error → confirm `$exception` event in PostHog.

## Version Bump
`version:minor` — adds new error-tracking instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)