### PR TITLE
fix(admin): correct volunteer profile link from admin messages

### DIFF
--- a/web/src/components/admin/messages/thread-view.tsx
+++ b/web/src/components/admin/messages/thread-view.tsx
@@ -303,7 +303,7 @@ export function ThreadView({ threadId, onMessageSent, onResolve }: ThreadViewPro
         <NextShiftCard nextShift={thread.nextShift} />
 
         <Link
-          href={`/admin/users/${thread.volunteer.id}`}
+          href={`/admin/volunteers/${thread.volunteer.id}`}
           className="mt-4 inline-flex items-center text-xs font-medium text-emerald-700 hover:underline"
         >
           Open full profile <ExternalLink className="w-3 h-3 ml-1" />


### PR DESCRIPTION
## Summary
- The "Open full profile" link in the admin messages thread sidebar pointed at `/admin/users/<id>`, which 404s — there is no `[id]` route under `/admin/users` (only the listing page).
- Updated the link in [thread-view.tsx:306](web/src/components/admin/messages/thread-view.tsx#L306) to use `/admin/volunteers/<id>`, where the volunteer profile page actually lives.

## Test plan
- [ ] Open an admin message thread, click "Open full profile" in the sidebar, and confirm it loads the volunteer's profile instead of 404'ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)