### PR TITLE
fix(web): defer heic2any import to avoid SSR window crash

### DIFF
--- a/web/src/components/ui/profile-image-upload.tsx
+++ b/web/src/components/ui/profile-image-upload.tsx
@@ -7,7 +7,6 @@ import ReactCrop, {
   centerCrop,
   makeAspectCrop,
 } from "react-image-crop";
-import heic2any from "heic2any";
 import { Button } from "@/components/ui/button";
 import {
   MotionDialog,
@@ -225,8 +224,11 @@ export function ProfileImageUpload({
           return;
         }
 
-        // Browser can't render it (likely HEIC) — convert with heic2any
+        // Browser can't render it (likely HEIC) — convert with heic2any.
+        // Dynamically imported because heic2any touches `window` at module
+        // evaluation time, which crashes Next.js SSR.
         URL.revokeObjectURL(objectUrl);
+        const { default: heic2any } = await import("heic2any");
         const convertedBlob = await heic2any({
           blob: file,
           toType: "image/jpeg",


### PR DESCRIPTION
## Summary
- The `heic2any` package references `window` at module evaluation time, which crashed Next.js SSR (Turbopack dev) when the profile image upload component was imported on the server — 46 occurrences across 6 users in the last 24h.
- Replaced the static top-level import with a dynamic `await import("heic2any")` inside the HEIC fallback branch, so the module is only loaded in the browser when it's actually needed.

Fixes #903

## Test plan
- [ ] Load any page that includes `ProfileImageUpload` and confirm no SSR `ReferenceError: window is not defined` in dev server logs
- [ ] Upload a non-HEIC image (JPG/PNG) — flows through `URL.createObjectURL` path, no conversion needed
- [ ] Upload a HEIC image — `heic2any` lazy-loads and converts to JPEG successfully
- [ ] Monitor PostHog error tracking issue `019e48f9-740e-7533-ad24-965cf21e4ceb` for occurrence drop after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)