### PR TITLE
fix(shifts): prevent HierarchyRequestError on rapid date navigation

### DIFF
--- a/web/src/app/shifts/details/page.tsx
+++ b/web/src/app/shifts/details/page.tsx
@@ -143,8 +143,14 @@ export default async function ShiftDetailsPage({
         <ShiftsProfileCompletionBanner />
       </Suspense>
 
-      {/* Shift cards stream in when data is ready */}
+      {/* Shift cards stream in when data is ready.
+          Key forces a clean unmount/remount on navigation between dates or
+          locations — without it, rapid prev/next clicks can put React's
+          reconciler into a state where it tries to re-parent a portal-using
+          subtree (Radix Dialog/Drawer inside ShiftSignupButton) into one of
+          its own descendants, throwing HierarchyRequestError during commit. */}
       <Suspense
+        key={`${dateParam}-${selectedLocation ?? "all"}`}
         fallback={
           <div className="space-y-8">
             <div className="space-y-4">


### PR DESCRIPTION
## Summary

- Adds a stable `key` to the `<Suspense>` boundary that wraps `ShiftDetailsContent` on `/shifts/details`, derived from the current `date` and `location` search params.
- Prevents `DOMException: HierarchyRequestError: Failed to execute 'insertBefore' on 'Node': The new child element contains the parent.` thrown during React commit when users navigate prev/next day rapidly.

## Why

[Issue #902](https://github.com/everybody-eats-nz/volunteer-portal/issues/902) — PostHog captured 13 occurrences from 3 users over 24h, all during rapid date navigation on `/shifts/details?location=Onehunga`. The crash happens inside React's `commitMutationEffects` (the internal `$RV` frame).

Without a key, the same `<Suspense>` instance is reused across navigations. Its subtree contains Radix `Dialog`/`Drawer` portals (inside every `ShiftSignupButton`/`CancelSignupButton`), and the surrounding page is wrapped in animated `motion.div` containers. When `searchParams` change rapidly, React tries to reconcile the old portal-using subtree into the new tree and, in some interleavings, ends up scheduling a DOM insert that would place a node inside one of its own descendants — the browser rejects this with `HierarchyRequestError`.

Forcing a clean unmount/remount via `key={\`\${dateParam}-\${selectedLocation ?? "all"}\`}` sidesteps the reconciliation conflict entirely. The admin-side `animated-shift-cards-wrapper.tsx` already uses the same `${dateString}-${selectedLocation}` keying pattern (via `AnimatePresence mode="wait"`) for the same scenario.

## Test plan

- [ ] Open `/shifts/details?date=YYYY-MM-DD&location=Onehunga` (or any location).
- [ ] Click the prev/next day buttons rapidly several times in a row.
- [ ] Confirm no `HierarchyRequestError` appears in the browser console.
- [ ] Confirm the shift list updates correctly for each date and the skeleton fallback appears briefly between navigations.
- [ ] Open a `ShiftSignupButton` or `CancelSignupButton` dialog on a shift card and confirm it still opens/closes normally.
- [ ] Repeat on mobile width to confirm the Drawer variant still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)