### PR TITLE
feat(shifts): shareable shift pages with dynamic OG images

### DIFF
--- a/web/src/app/shifts/[id]/opengraph-image.tsx
+++ b/web/src/app/shifts/[id]/opengraph-image.tsx
@@ -3,7 +3,6 @@ import { prisma } from "@/lib/prisma";
 import { formatInNZT } from "@/lib/timezone";
 import { getShiftTheme } from "@/lib/shift-themes";
 
-export const runtime = "nodejs";
 export const alt = "Volunteer shift at Everybody Eats";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";

--- a/web/src/app/shifts/[id]/opengraph-image.tsx
+++ b/web/src/app/shifts/[id]/opengraph-image.tsx
@@ -29,9 +29,9 @@ async function loadGoogleFont(family: string, weight: number): Promise<ArrayBuff
       `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:wght@${weight}&display=swap`,
       {
         headers: {
-          // UA pinned so Google returns a satori-compatible font format (TTF/WOFF).
+          // Pre-woff2 UA so Google returns TTF, which is what satori (next/og) supports.
           "User-Agent":
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko",
         },
       }
     ).then((r) => r.text());
@@ -334,7 +334,7 @@ export default async function ShiftOgImage({
             display: "flex",
             alignItems: "center",
             justifyContent: "space-between",
-            padding: "0 72px 56px",
+            padding: "32px 72px 56px",
           }}
         >
           <div

--- a/web/src/app/shifts/[id]/opengraph-image.tsx
+++ b/web/src/app/shifts/[id]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from "next/og";
 import { prisma } from "@/lib/prisma";
 import { formatInNZT } from "@/lib/timezone";
 import { getShiftTheme } from "@/lib/shift-themes";
+import { loadBrandFonts } from "@/lib/og-fonts";
 
 export const alt = "Volunteer shift at Everybody Eats";
 export const size = { width: 1200, height: 630 };
@@ -20,26 +21,6 @@ const THEME_PRESETS: Record<string, { from: string; to: string; accent: string }
 
 function resolveThemeColors(fullGradient: string) {
   return THEME_PRESETS[fullGradient] ?? THEME_PRESETS["from-gray-500 to-slate-500"];
-}
-
-async function loadGoogleFont(family: string, weight: number): Promise<ArrayBuffer | null> {
-  try {
-    const css = await fetch(
-      `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:wght@${weight}&display=swap`,
-      {
-        headers: {
-          // Pre-woff2 UA so Google returns TTF, which is what satori (next/og) supports.
-          "User-Agent":
-            "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko",
-        },
-      }
-    ).then((r) => r.text());
-    const url = css.match(/src:\s*url\((.+?)\)\s*format/)?.[1];
-    if (!url) return null;
-    return await fetch(url).then((r) => r.arrayBuffer());
-  } catch {
-    return null;
-  }
 }
 
 export default async function ShiftOgImage({
@@ -63,32 +44,7 @@ export default async function ShiftOgImage({
     },
   });
 
-  const [fraunces, libreFranklin, libreFranklinBold] = await Promise.all([
-    loadGoogleFont("Fraunces", 600),
-    loadGoogleFont("Libre Franklin", 400),
-    loadGoogleFont("Libre Franklin", 600),
-  ]);
-
-  const fonts = [
-    fraunces && { name: "Fraunces", data: fraunces, weight: 600 as const, style: "normal" as const },
-    libreFranklin && {
-      name: "Libre Franklin",
-      data: libreFranklin,
-      weight: 400 as const,
-      style: "normal" as const,
-    },
-    libreFranklinBold && {
-      name: "Libre Franklin",
-      data: libreFranklinBold,
-      weight: 600 as const,
-      style: "normal" as const,
-    },
-  ].filter(Boolean) as {
-    name: string;
-    data: ArrayBuffer;
-    weight: 400 | 600;
-    style: "normal";
-  }[];
+  const fonts = await loadBrandFonts();
 
   if (!shift) {
     return new ImageResponse(

--- a/web/src/app/shifts/[id]/opengraph-image.tsx
+++ b/web/src/app/shifts/[id]/opengraph-image.tsx
@@ -1,0 +1,374 @@
+import { ImageResponse } from "next/og";
+import { prisma } from "@/lib/prisma";
+import { formatInNZT } from "@/lib/timezone";
+import { getShiftTheme } from "@/lib/shift-themes";
+
+export const runtime = "nodejs";
+export const alt = "Volunteer shift at Everybody Eats";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const THEME_PRESETS: Record<string, { from: string; to: string; accent: string }> = {
+  "from-blue-500 to-cyan-500": { from: "#3b82f6", to: "#06b6d4", accent: "#22d3ee" },
+  "from-purple-500 to-pink-500": { from: "#a855f7", to: "#ec4899", accent: "#f472b6" },
+  "from-green-500 to-emerald-500": { from: "#22c55e", to: "#10b981", accent: "#34d399" },
+  "from-orange-500 to-amber-500": { from: "#f97316", to: "#f59e0b", accent: "#fbbf24" },
+  "from-red-500 to-pink-500": { from: "#ef4444", to: "#ec4899", accent: "#f472b6" },
+  "from-indigo-500 to-purple-500": { from: "#6366f1", to: "#a855f7", accent: "#c084fc" },
+  "from-pink-500 to-rose-500": { from: "#ec4899", to: "#f43f5e", accent: "#fb7185" },
+  "from-gray-500 to-slate-500": { from: "#6b7280", to: "#64748b", accent: "#94a3b8" },
+};
+
+function resolveThemeColors(fullGradient: string) {
+  return THEME_PRESETS[fullGradient] ?? THEME_PRESETS["from-gray-500 to-slate-500"];
+}
+
+async function loadGoogleFont(family: string, weight: number): Promise<ArrayBuffer | null> {
+  try {
+    const css = await fetch(
+      `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:wght@${weight}&display=swap`,
+      {
+        headers: {
+          // UA pinned so Google returns a satori-compatible font format (TTF/WOFF).
+          "User-Agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36",
+        },
+      }
+    ).then((r) => r.text());
+    const url = css.match(/src:\s*url\((.+?)\)\s*format/)?.[1];
+    if (!url) return null;
+    return await fetch(url).then((r) => r.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+export default async function ShiftOgImage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const shift = await prisma.shift.findUnique({
+    where: { id },
+    include: {
+      shiftType: true,
+      _count: {
+        select: {
+          signups: {
+            where: { status: { in: ["CONFIRMED", "PENDING", "REGULAR_PENDING"] } },
+          },
+          placeholders: true,
+        },
+      },
+    },
+  });
+
+  const [fraunces, libreFranklin, libreFranklinBold] = await Promise.all([
+    loadGoogleFont("Fraunces", 600),
+    loadGoogleFont("Libre Franklin", 400),
+    loadGoogleFont("Libre Franklin", 600),
+  ]);
+
+  const fonts = [
+    fraunces && { name: "Fraunces", data: fraunces, weight: 600 as const, style: "normal" as const },
+    libreFranklin && {
+      name: "Libre Franklin",
+      data: libreFranklin,
+      weight: 400 as const,
+      style: "normal" as const,
+    },
+    libreFranklinBold && {
+      name: "Libre Franklin",
+      data: libreFranklinBold,
+      weight: 600 as const,
+      style: "normal" as const,
+    },
+  ].filter(Boolean) as {
+    name: string;
+    data: ArrayBuffer;
+    weight: 400 | 600;
+    style: "normal";
+  }[];
+
+  if (!shift) {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "#0e3a23",
+            color: "#fff",
+            fontSize: 64,
+            fontFamily: "Fraunces, serif",
+          }}
+        >
+          Everybody Eats — Volunteer Portal
+        </div>
+      ),
+      { ...size, fonts }
+    );
+  }
+
+  const theme = getShiftTheme(shift.shiftType.name);
+  const colors = resolveThemeColors(theme.fullGradient);
+  const confirmedCount = shift._count.signups + shift._count.placeholders;
+  const spotsRemaining = Math.max(0, shift.capacity - confirmedCount);
+  const isPast = new Date(shift.end) < new Date();
+  const isFull = spotsRemaining === 0;
+
+  const dayLabel = formatInNZT(new Date(shift.start), "EEEE");
+  const dateLabel = formatInNZT(new Date(shift.start), "d MMM yyyy");
+  const timeLabel = `${formatInNZT(new Date(shift.start), "h:mma")} – ${formatInNZT(
+    new Date(shift.end),
+    "h:mma"
+  )}`.toLowerCase();
+
+  const statusLabel = isPast
+    ? "Shift complete"
+    : isFull
+      ? "Waitlist open"
+      : `${spotsRemaining} ${spotsRemaining === 1 ? "spot" : "spots"} left`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          background: "#fdf8f1",
+          fontFamily: "Libre Franklin, sans-serif",
+          color: "#1c1917",
+          position: "relative",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            top: -120,
+            right: -120,
+            width: 520,
+            height: 520,
+            borderRadius: "50%",
+            background: `linear-gradient(135deg, ${colors.from}, ${colors.to})`,
+            opacity: 0.18,
+            display: "flex",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            bottom: -180,
+            left: -120,
+            width: 460,
+            height: 460,
+            borderRadius: "50%",
+            background: `linear-gradient(135deg, ${colors.accent}, ${colors.from})`,
+            opacity: 0.12,
+            display: "flex",
+          }}
+        />
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "56px 72px 0",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+            <div
+              style={{
+                width: 56,
+                height: 56,
+                borderRadius: 14,
+                background: "#0e3a23",
+                color: "#fdf8f1",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontFamily: "Fraunces, serif",
+                fontSize: 30,
+                fontWeight: 600,
+              }}
+            >
+              EE
+            </div>
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              <div
+                style={{
+                  fontFamily: "Fraunces, serif",
+                  fontSize: 24,
+                  fontWeight: 600,
+                  color: "#0e3a23",
+                  lineHeight: 1,
+                }}
+              >
+                Everybody Eats
+              </div>
+              <div
+                style={{
+                  fontSize: 16,
+                  color: "#57534e",
+                  letterSpacing: 0.4,
+                  marginTop: 6,
+                  textTransform: "uppercase",
+                }}
+              >
+                Volunteer Portal
+              </div>
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              padding: "12px 22px",
+              borderRadius: 999,
+              background: isPast
+                ? "rgba(120, 113, 108, 0.15)"
+                : isFull
+                  ? "rgba(217, 119, 6, 0.18)"
+                  : "rgba(22, 101, 52, 0.15)",
+              color: isPast ? "#57534e" : isFull ? "#92400e" : "#166534",
+              fontSize: 22,
+              fontWeight: 600,
+            }}
+          >
+            {statusLabel}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            padding: "48px 72px 0",
+            flex: 1,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 22,
+              color: "#78716c",
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              fontWeight: 600,
+              display: "flex",
+            }}
+          >
+            Volunteer mahi · Aotearoa
+          </div>
+
+          <div
+            style={{
+              fontFamily: "Fraunces, serif",
+              fontWeight: 600,
+              fontSize: 96,
+              lineHeight: 1.02,
+              letterSpacing: -1.5,
+              color: "#0e3a23",
+              marginTop: 18,
+              display: "flex",
+              flexWrap: "wrap",
+              maxWidth: 980,
+            }}
+          >
+            {shift.shiftType.name}
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 18,
+              marginTop: 36,
+              fontSize: 34,
+              fontFamily: "Fraunces, serif",
+              fontWeight: 600,
+              color: "#1c1917",
+            }}
+          >
+            <span>{dayLabel}</span>
+            <span style={{ color: colors.from }}>·</span>
+            <span>{dateLabel}</span>
+            <span style={{ color: colors.from }}>·</span>
+            <span>{timeLabel}</span>
+          </div>
+
+          {shift.location && (
+            <div
+              style={{
+                marginTop: 22,
+                fontSize: 30,
+                color: "#44403c",
+                display: "flex",
+                alignItems: "center",
+                gap: 14,
+              }}
+            >
+              <div
+                style={{
+                  width: 14,
+                  height: 14,
+                  borderRadius: "50%",
+                  background: `linear-gradient(135deg, ${colors.from}, ${colors.to})`,
+                  display: "flex",
+                }}
+              />
+              {shift.location}
+            </div>
+          )}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "0 72px 56px",
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "Fraunces, serif",
+              fontWeight: 600,
+              fontStyle: "italic",
+              fontSize: 28,
+              color: "#0e3a23",
+            }}
+          >
+            Kia ora — join the whānau.
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: "#57534e",
+              fontWeight: 600,
+              letterSpacing: 0.4,
+            }}
+          >
+            volunteers.everybodyeats.nz
+          </div>
+        </div>
+
+        <div
+          style={{
+            height: 12,
+            background: `linear-gradient(90deg, ${colors.from}, ${colors.accent}, ${colors.to})`,
+            display: "flex",
+          }}
+        />
+      </div>
+    ),
+    { ...size, fonts }
+  );
+}

--- a/web/src/app/shifts/[id]/page.tsx
+++ b/web/src/app/shifts/[id]/page.tsx
@@ -25,8 +25,69 @@ import { ProfileCompletionBannerServer } from "@/components/profile-completion-b
 import { generateCalendarUrls } from "@/lib/calendar-utils";
 import { LOCATION_ADDRESSES, type Location } from "@/lib/locations";
 import { ShiftSignupButton } from "@/components/shift-signup-button";
+import { ShareShiftButton } from "@/components/share-shift-button";
 import { getShiftTheme } from "@/lib/shift-themes";
 import { Suspense } from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata, buildShiftEventSchema } from "@/lib/seo";
+import { getBaseUrl } from "@/lib/utils";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const shift = await prisma.shift.findUnique({
+    where: { id },
+    include: {
+      shiftType: { select: { name: true, description: true } },
+      _count: {
+        select: {
+          signups: {
+            where: { status: { in: ["CONFIRMED", "PENDING", "REGULAR_PENDING"] } },
+          },
+          placeholders: true,
+        },
+      },
+    },
+  });
+
+  if (!shift) {
+    return buildPageMetadata({
+      title: "Shift not found",
+      description: "This volunteer shift could not be found.",
+      path: `/shifts/${id}`,
+      noIndex: true,
+    });
+  }
+
+  const dayLabel = formatInNZT(new Date(shift.start), "EEEE d MMMM");
+  const timeLabel = `${formatInNZT(new Date(shift.start), "h:mma")}–${formatInNZT(
+    new Date(shift.end),
+    "h:mma"
+  )}`.toLowerCase();
+  const locationPart = shift.location ? ` · ${shift.location}` : "";
+  const title = `${shift.shiftType.name}${locationPart} · ${dayLabel}`;
+
+  const confirmedCount = shift._count.signups + shift._count.placeholders;
+  const spotsRemaining = Math.max(0, shift.capacity - confirmedCount);
+  const isPast = new Date(shift.end) < new Date();
+  const spotsLine = isPast
+    ? "This shift has finished."
+    : spotsRemaining === 0
+      ? "Currently full — join the waitlist."
+      : `${spotsRemaining} ${spotsRemaining === 1 ? "spot" : "spots"} still open.`;
+
+  const description = `Volunteer with Everybody Eats: ${shift.shiftType.name} on ${dayLabel}, ${timeLabel}${locationPart}. ${spotsLine}`;
+
+  return buildPageMetadata({
+    title,
+    description,
+    path: `/shifts/${id}`,
+    noIndex: isPast,
+  });
+}
 
 export default async function ShiftDetailPage({
   params,
@@ -495,39 +556,72 @@ export default async function ShiftDetailPage({
           )}
 
           {!isPastShift && (
-            <div className="pt-2 border-t">
-              <div className="text-sm font-medium text-muted-foreground mb-2">
-                Add to Calendar
+            <div className="pt-2 border-t space-y-4">
+              <div>
+                <div className="text-sm font-medium text-muted-foreground mb-2">
+                  Add to Calendar
+                </div>
+                <div className="flex gap-2 flex-wrap">
+                  {(() => {
+                    const urls = generateCalendarUrls(shift);
+                    return (
+                      <>
+                        <Button variant="outline" size="sm" className="gap-1.5" asChild>
+                          <a href={urls.google} target="_blank" rel="noopener noreferrer">
+                            <CalendarPlus className="h-3.5 w-3.5" />
+                            Google
+                          </a>
+                        </Button>
+                        <Button variant="outline" size="sm" className="gap-1.5" asChild>
+                          <a href={urls.outlook} target="_blank" rel="noopener noreferrer">
+                            <CalendarPlus className="h-3.5 w-3.5" />
+                            Outlook
+                          </a>
+                        </Button>
+                        <Button variant="outline" size="sm" className="gap-1.5" asChild>
+                          <a href={urls.ics} download={`shift-${shift.id}.ics`}>
+                            <CalendarPlus className="h-3.5 w-3.5" />
+                            .ics
+                          </a>
+                        </Button>
+                      </>
+                    );
+                  })()}
+                </div>
               </div>
-              <div className="flex gap-2 flex-wrap">
-                {(() => {
-                  const urls = generateCalendarUrls(shift);
-                  return (
-                    <>
-                      <Button variant="outline" size="sm" className="gap-1.5" asChild>
-                        <a href={urls.google} target="_blank" rel="noopener noreferrer">
-                          <CalendarPlus className="h-3.5 w-3.5" />
-                          Google
-                        </a>
-                      </Button>
-                      <Button variant="outline" size="sm" className="gap-1.5" asChild>
-                        <a href={urls.outlook} target="_blank" rel="noopener noreferrer">
-                          <CalendarPlus className="h-3.5 w-3.5" />
-                          Outlook
-                        </a>
-                      </Button>
-                      <Button variant="outline" size="sm" className="gap-1.5" asChild>
-                        <a href={urls.ics} download={`shift-${shift.id}.ics`}>
-                          <CalendarPlus className="h-3.5 w-3.5" />
-                          .ics
-                        </a>
-                      </Button>
-                    </>
-                  );
-                })()}
+
+              <div>
+                <div className="text-sm font-medium text-muted-foreground mb-2">
+                  Spread the word
+                </div>
+                <ShareShiftButton
+                  url={`${getBaseUrl()}/shifts/${shift.id}`}
+                  title={`Volunteer with Everybody Eats — ${shift.shiftType.name}`}
+                  text={`Kia ora! Come volunteer on ${shiftDate}, ${shiftTime}${
+                    shift.location ? ` at ${shift.location}` : ""
+                  }.`}
+                />
               </div>
             </div>
           )}
+
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(
+                buildShiftEventSchema({
+                  id: shift.id,
+                  name: shift.shiftType.name,
+                  description: shift.shiftType.description,
+                  startDate: new Date(shift.start),
+                  endDate: new Date(shift.end),
+                  location: shift.location,
+                  capacity: shift.capacity,
+                  spotsAvailable: spotsRemaining,
+                })
+              ),
+            }}
+          />
         </CardContent>
       </Card>
     </PageContainer>

--- a/web/src/app/shifts/details/og/route.tsx
+++ b/web/src/app/shifts/details/og/route.tsx
@@ -1,0 +1,533 @@
+import { ImageResponse } from "next/og";
+import { startOfDay, endOfDay } from "date-fns";
+import { prisma } from "@/lib/prisma";
+import { formatInNZT, parseISOInNZT, toUTC } from "@/lib/timezone";
+
+const SIZE = { width: 1200, height: 630 } as const;
+
+async function loadGoogleFont(family: string, weight: number): Promise<ArrayBuffer | null> {
+  try {
+    const css = await fetch(
+      `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:wght@${weight}&display=swap`,
+      {
+        headers: {
+          // Pre-woff2 UA so Google returns TTF, which satori (next/og) supports.
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko",
+        },
+      }
+    ).then((r) => r.text());
+    const url = css.match(/src:\s*url\((.+?)\)\s*format/)?.[1];
+    if (!url) return null;
+    return await fetch(url).then((r) => r.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+interface SessionStats {
+  count: number;
+  spots: number;
+}
+
+function fallbackImage(message: string, fonts: { name: string; data: ArrayBuffer; weight: 400 | 600; style: "normal" }[]) {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#0e3a23",
+          color: "#fdf8f1",
+          fontFamily: "Fraunces, serif",
+          fontSize: 56,
+          padding: 64,
+          textAlign: "center",
+        }}
+      >
+        {message}
+      </div>
+    ),
+    { ...SIZE, fonts }
+  );
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const dateParam = searchParams.get("date");
+  const location = searchParams.get("location") ?? undefined;
+  const rawSession = searchParams.get("session");
+  const session: "day" | "evening" | undefined =
+    rawSession === "day" || rawSession === "evening" ? rawSession : undefined;
+
+  const [fraunces, libreFranklin, libreFranklinBold] = await Promise.all([
+    loadGoogleFont("Fraunces", 600),
+    loadGoogleFont("Libre Franklin", 400),
+    loadGoogleFont("Libre Franklin", 600),
+  ]);
+
+  const fonts = [
+    fraunces && { name: "Fraunces", data: fraunces, weight: 600 as const, style: "normal" as const },
+    libreFranklin && {
+      name: "Libre Franklin",
+      data: libreFranklin,
+      weight: 400 as const,
+      style: "normal" as const,
+    },
+    libreFranklinBold && {
+      name: "Libre Franklin",
+      data: libreFranklinBold,
+      weight: 600 as const,
+      style: "normal" as const,
+    },
+  ].filter(Boolean) as {
+    name: string;
+    data: ArrayBuffer;
+    weight: 400 | 600;
+    style: "normal";
+  }[];
+
+  if (!dateParam) {
+    return fallbackImage("Everybody Eats — Volunteer Portal", fonts);
+  }
+
+  let selectedDate: Date;
+  try {
+    selectedDate = parseISOInNZT(dateParam);
+  } catch {
+    return fallbackImage("Everybody Eats — Volunteer Portal", fonts);
+  }
+
+  const startUTC = toUTC(startOfDay(selectedDate));
+  const endUTC = toUTC(endOfDay(selectedDate));
+
+  const shifts = await prisma.shift.findMany({
+    where: {
+      start: { gte: startUTC, lte: endUTC },
+      ...(location ? { location } : {}),
+    },
+    select: {
+      start: true,
+      capacity: true,
+      _count: {
+        select: {
+          signups: {
+            where: { status: { in: ["CONFIRMED", "PENDING", "REGULAR_PENDING"] } },
+          },
+          placeholders: true,
+        },
+      },
+    },
+  });
+
+  const stats: { day: SessionStats; evening: SessionStats } = {
+    day: { count: 0, spots: 0 },
+    evening: { count: 0, spots: 0 },
+  };
+  for (const s of shifts) {
+    const hour = Number(formatInNZT(s.start, "HH"));
+    const key = hour < 16 ? "day" : "evening";
+    const filled = s._count.signups + s._count.placeholders;
+    const remaining = Math.max(0, s.capacity - filled);
+    stats[key].count += 1;
+    stats[key].spots += remaining;
+  }
+
+  const dayLine = formatInNZT(selectedDate, "EEEE");
+  const dateLine = formatInNZT(selectedDate, "d MMMM yyyy");
+
+  const total = stats.day.count + stats.evening.count;
+  if (total === 0) {
+    return fallbackImage(
+      `No shifts on ${formatInNZT(selectedDate, "EEE d MMM")}${location ? ` · ${location}` : ""}`,
+      fonts
+    );
+  }
+
+  const showSingleSession = session !== undefined;
+
+  const singleSession = showSingleSession ? session : null;
+  const singleStats = singleSession ? stats[singleSession] : null;
+
+  const dayGradient = "linear-gradient(135deg, #f59e0b, #f97316)";
+  const eveningGradient = "linear-gradient(135deg, #6366f1, #8b5cf6)";
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          background: singleSession === "evening" ? "#0b1224" : "#fdf8f1",
+          color: singleSession === "evening" ? "#fdf8f1" : "#1c1917",
+          fontFamily: "Libre Franklin, sans-serif",
+          position: "relative",
+        }}
+      >
+        {/* Decorative blobs */}
+        <div
+          style={{
+            position: "absolute",
+            top: -160,
+            right: -120,
+            width: 560,
+            height: 560,
+            borderRadius: "50%",
+            background: singleSession === "evening" ? eveningGradient : dayGradient,
+            opacity: singleSession === "evening" ? 0.32 : 0.2,
+            display: "flex",
+          }}
+        />
+        {!singleSession && (
+          <div
+            style={{
+              position: "absolute",
+              bottom: -180,
+              left: -120,
+              width: 460,
+              height: 460,
+              borderRadius: "50%",
+              background: eveningGradient,
+              opacity: 0.14,
+              display: "flex",
+            }}
+          />
+        )}
+
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "56px 72px 0",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+            <div
+              style={{
+                width: 56,
+                height: 56,
+                borderRadius: 14,
+                background: singleSession === "evening" ? "#fdf8f1" : "#0e3a23",
+                color: singleSession === "evening" ? "#0e3a23" : "#fdf8f1",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontFamily: "Fraunces, serif",
+                fontSize: 30,
+                fontWeight: 600,
+              }}
+            >
+              EE
+            </div>
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              <div
+                style={{
+                  fontFamily: "Fraunces, serif",
+                  fontSize: 24,
+                  fontWeight: 600,
+                  color: singleSession === "evening" ? "#fdf8f1" : "#0e3a23",
+                  lineHeight: 1,
+                }}
+              >
+                Everybody Eats
+              </div>
+              <div
+                style={{
+                  fontSize: 16,
+                  color: singleSession === "evening" ? "#cbd5e1" : "#57534e",
+                  letterSpacing: 0.4,
+                  marginTop: 6,
+                  textTransform: "uppercase",
+                }}
+              >
+                Volunteer Portal
+              </div>
+            </div>
+          </div>
+
+          {location && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                padding: "12px 22px",
+                borderRadius: 999,
+                background:
+                  singleSession === "evening"
+                    ? "rgba(253, 248, 241, 0.15)"
+                    : "rgba(14, 58, 35, 0.12)",
+                color: singleSession === "evening" ? "#fdf8f1" : "#0e3a23",
+                fontSize: 22,
+                fontWeight: 600,
+              }}
+            >
+              📍 {location}
+            </div>
+          )}
+        </div>
+
+        {/* Body */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            padding: "44px 72px 0",
+            flex: 1,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 22,
+              color: singleSession === "evening" ? "#94a3b8" : "#78716c",
+              letterSpacing: 2,
+              textTransform: "uppercase",
+              fontWeight: 600,
+              display: "flex",
+            }}
+          >
+            {singleSession === "day"
+              ? "Day shifts · before 4pm"
+              : singleSession === "evening"
+                ? "Evening shifts · 4pm onwards"
+                : "Volunteer line-up · Aotearoa"}
+          </div>
+
+          <div
+            style={{
+              fontFamily: "Fraunces, serif",
+              fontWeight: 600,
+              fontSize: singleSession ? 96 : 88,
+              lineHeight: 1.02,
+              letterSpacing: -1.5,
+              color: singleSession === "evening" ? "#fdf8f1" : "#0e3a23",
+              marginTop: 18,
+              display: "flex",
+              alignItems: "baseline",
+              gap: 28,
+            }}
+          >
+            <span>{dayLine}</span>
+          </div>
+          <div
+            style={{
+              fontFamily: "Fraunces, serif",
+              fontSize: 44,
+              fontWeight: 600,
+              color: singleSession === "evening" ? "#cbd5e1" : "#44403c",
+              marginTop: 6,
+              display: "flex",
+            }}
+          >
+            {dateLine}
+          </div>
+
+          {singleSession && singleStats ? (
+            <div
+              style={{
+                marginTop: 36,
+                display: "flex",
+                gap: 22,
+                alignItems: "center",
+                fontSize: 32,
+                color: singleSession === "evening" ? "#fdf8f1" : "#1c1917",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 12,
+                  padding: "16px 26px",
+                  borderRadius: 999,
+                  background: singleSession === "evening" ? eveningGradient : dayGradient,
+                  color: "#fff",
+                  fontWeight: 600,
+                  fontSize: 28,
+                }}
+              >
+                {singleSession === "day" ? "☀️" : "🌙"} {singleStats.count} shift
+                {singleStats.count === 1 ? "" : "s"}
+              </div>
+              <div
+                style={{
+                  fontWeight: 600,
+                  display: "flex",
+                }}
+              >
+                {singleStats.spots > 0
+                  ? `${singleStats.spots} spot${singleStats.spots === 1 ? "" : "s"} open`
+                  : "Waitlist only"}
+              </div>
+            </div>
+          ) : (
+            <div
+              style={{
+                marginTop: 36,
+                display: "flex",
+                gap: 20,
+              }}
+            >
+              {stats.day.count > 0 && (
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    padding: "20px 28px",
+                    background: "rgba(245, 158, 11, 0.15)",
+                    borderRadius: 18,
+                    borderLeft: "6px solid #f59e0b",
+                    minWidth: 280,
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: 22,
+                      color: "#7c2d12",
+                      fontWeight: 600,
+                      letterSpacing: 0.4,
+                      textTransform: "uppercase",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                    }}
+                  >
+                    ☀️ Day · before 4pm
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: "Fraunces, serif",
+                      fontSize: 44,
+                      fontWeight: 600,
+                      color: "#7c2d12",
+                      marginTop: 8,
+                      display: "flex",
+                    }}
+                  >
+                    {stats.day.count} shift{stats.day.count === 1 ? "" : "s"}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 22,
+                      color: "#9a3412",
+                      marginTop: 4,
+                      display: "flex",
+                    }}
+                  >
+                    {stats.day.spots > 0
+                      ? `${stats.day.spots} spot${stats.day.spots === 1 ? "" : "s"} open`
+                      : "Waitlist only"}
+                  </div>
+                </div>
+              )}
+              {stats.evening.count > 0 && (
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    padding: "20px 28px",
+                    background: "rgba(99, 102, 241, 0.15)",
+                    borderRadius: 18,
+                    borderLeft: "6px solid #6366f1",
+                    minWidth: 280,
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: 22,
+                      color: "#3730a3",
+                      fontWeight: 600,
+                      letterSpacing: 0.4,
+                      textTransform: "uppercase",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                    }}
+                  >
+                    🌙 Evening · from 4pm
+                  </div>
+                  <div
+                    style={{
+                      fontFamily: "Fraunces, serif",
+                      fontSize: 44,
+                      fontWeight: 600,
+                      color: "#3730a3",
+                      marginTop: 8,
+                      display: "flex",
+                    }}
+                  >
+                    {stats.evening.count} shift{stats.evening.count === 1 ? "" : "s"}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 22,
+                      color: "#4338ca",
+                      marginTop: 4,
+                      display: "flex",
+                    }}
+                  >
+                    {stats.evening.spots > 0
+                      ? `${stats.evening.spots} spot${stats.evening.spots === 1 ? "" : "s"} open`
+                      : "Waitlist only"}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "32px 72px 56px",
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "Fraunces, serif",
+              fontWeight: 600,
+              fontStyle: "italic",
+              fontSize: 28,
+              color: singleSession === "evening" ? "#fdf8f1" : "#0e3a23",
+            }}
+          >
+            Kia ora — bring the whānau.
+          </div>
+          <div
+            style={{
+              fontSize: 22,
+              color: singleSession === "evening" ? "#cbd5e1" : "#57534e",
+              fontWeight: 600,
+              letterSpacing: 0.4,
+            }}
+          >
+            volunteers.everybodyeats.nz
+          </div>
+        </div>
+
+        <div
+          style={{
+            height: 12,
+            background:
+              singleSession === "evening"
+                ? eveningGradient
+                : singleSession === "day"
+                  ? dayGradient
+                  : "linear-gradient(90deg, #f59e0b, #f97316, #6366f1, #8b5cf6)",
+            display: "flex",
+          }}
+        />
+      </div>
+    ),
+    { ...SIZE, fonts, headers: { "content-type": "image/png" } }
+  );
+}

--- a/web/src/app/shifts/details/og/route.tsx
+++ b/web/src/app/shifts/details/og/route.tsx
@@ -2,35 +2,18 @@ import { ImageResponse } from "next/og";
 import { startOfDay, endOfDay } from "date-fns";
 import { prisma } from "@/lib/prisma";
 import { formatInNZT, parseISOInNZT, toUTC } from "@/lib/timezone";
+import { loadBrandFonts } from "@/lib/og-fonts";
 
 const SIZE = { width: 1200, height: 630 } as const;
-
-async function loadGoogleFont(family: string, weight: number): Promise<ArrayBuffer | null> {
-  try {
-    const css = await fetch(
-      `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:wght@${weight}&display=swap`,
-      {
-        headers: {
-          // Pre-woff2 UA so Google returns TTF, which satori (next/og) supports.
-          "User-Agent":
-            "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko",
-        },
-      }
-    ).then((r) => r.text());
-    const url = css.match(/src:\s*url\((.+?)\)\s*format/)?.[1];
-    if (!url) return null;
-    return await fetch(url).then((r) => r.arrayBuffer());
-  } catch {
-    return null;
-  }
-}
 
 interface SessionStats {
   count: number;
   spots: number;
 }
 
-function fallbackImage(message: string, fonts: { name: string; data: ArrayBuffer; weight: 400 | 600; style: "normal" }[]) {
+type BrandFonts = Awaited<ReturnType<typeof loadBrandFonts>>;
+
+function fallbackImage(message: string, fonts: BrandFonts) {
   return new ImageResponse(
     (
       <div
@@ -63,32 +46,7 @@ export async function GET(request: Request) {
   const session: "day" | "evening" | undefined =
     rawSession === "day" || rawSession === "evening" ? rawSession : undefined;
 
-  const [fraunces, libreFranklin, libreFranklinBold] = await Promise.all([
-    loadGoogleFont("Fraunces", 600),
-    loadGoogleFont("Libre Franklin", 400),
-    loadGoogleFont("Libre Franklin", 600),
-  ]);
-
-  const fonts = [
-    fraunces && { name: "Fraunces", data: fraunces, weight: 600 as const, style: "normal" as const },
-    libreFranklin && {
-      name: "Libre Franklin",
-      data: libreFranklin,
-      weight: 400 as const,
-      style: "normal" as const,
-    },
-    libreFranklinBold && {
-      name: "Libre Franklin",
-      data: libreFranklinBold,
-      weight: 600 as const,
-      style: "normal" as const,
-    },
-  ].filter(Boolean) as {
-    name: string;
-    data: ArrayBuffer;
-    weight: 400 | 600;
-    style: "normal";
-  }[];
+  const fonts = await loadBrandFonts();
 
   if (!dateParam) {
     return fallbackImage("Everybody Eats — Volunteer Portal", fonts);

--- a/web/src/app/shifts/details/page.tsx
+++ b/web/src/app/shifts/details/page.tsx
@@ -21,6 +21,97 @@ import {
   Location,
   getLocationMapsUrl,
 } from "@/lib/locations";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+import { getBaseUrl } from "@/lib/utils";
+import { ShareShiftButton } from "@/components/share-shift-button";
+
+type SessionFilter = "day" | "evening" | undefined;
+
+function parseSession(value: string | string[] | undefined): SessionFilter {
+  const v = Array.isArray(value) ? value[0] : value;
+  if (v === "day" || v === "evening") return v;
+  return undefined;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}): Promise<Metadata> {
+  const params = await searchParams;
+  const dateParam = Array.isArray(params.date) ? params.date[0] : params.date;
+  const locationParam = Array.isArray(params.location)
+    ? params.location[0]
+    : params.location;
+  const sessionFilter = parseSession(params.session);
+
+  if (!dateParam) {
+    return buildPageMetadata({
+      title: "Pick a day to volunteer",
+      description:
+        "Choose a date and location to see the volunteer shifts available at Everybody Eats.",
+      path: "/shifts/details",
+      noIndex: true,
+    });
+  }
+
+  let selectedDate: Date;
+  try {
+    selectedDate = parseISOInNZT(dateParam);
+  } catch {
+    return buildPageMetadata({
+      title: "Volunteer shifts",
+      description: "Browse upcoming volunteer shifts at Everybody Eats.",
+      path: "/shifts/details",
+      noIndex: true,
+    });
+  }
+
+  const decodedLocation = locationParam
+    ? decodeURIComponent(locationParam)
+    : undefined;
+  const dayLabel = formatInNZT(selectedDate, "EEEE d MMMM yyyy");
+  const sessionLabel =
+    sessionFilter === "day"
+      ? "Day shifts"
+      : sessionFilter === "evening"
+        ? "Evening shifts"
+        : "Volunteer shifts";
+
+  const title = `${sessionLabel}${
+    decodedLocation ? ` · ${decodedLocation}` : ""
+  } · ${dayLabel}`;
+
+  const isPast = selectedDate < new Date(new Date().setHours(0, 0, 0, 0));
+  const sessionDescription =
+    sessionFilter === "day"
+      ? "Day shifts run before 4pm."
+      : sessionFilter === "evening"
+        ? "Evening shifts run from 4pm onwards."
+        : "See every shift on the day at a glance.";
+
+  const description = `Volunteer with Everybody Eats on ${dayLabel}${
+    decodedLocation ? ` at ${decodedLocation}` : ""
+  }. ${sessionDescription} Sign up to help transform rescued food into community meals.`;
+
+  const ogParams = new URLSearchParams({ date: dateParam });
+  if (decodedLocation) ogParams.set("location", decodedLocation);
+  if (sessionFilter) ogParams.set("session", sessionFilter);
+  const ogImage = `${getBaseUrl()}/shifts/details/og?${ogParams.toString()}`;
+
+  const canonicalParams = new URLSearchParams({ date: dateParam });
+  if (decodedLocation) canonicalParams.set("location", decodedLocation);
+  if (sessionFilter) canonicalParams.set("session", sessionFilter);
+
+  return buildPageMetadata({
+    title,
+    description,
+    path: `/shifts/details?${canonicalParams.toString()}`,
+    ogImage,
+    noIndex: isPast,
+  });
+}
 
 export default async function ShiftDetailsPage({
   searchParams,
@@ -33,6 +124,7 @@ export default async function ShiftDetailsPage({
   const locationParam = Array.isArray(params.location)
     ? params.location[0]
     : params.location;
+  const sessionFilter = parseSession(params.session);
 
   if (!dateParam) {
     return (
@@ -67,8 +159,22 @@ export default async function ShiftDetailsPage({
     if (selectedLocation) {
       navParams.set("location", selectedLocation);
     }
+    if (sessionFilter) {
+      navParams.set("session", sessionFilter);
+    }
     return `/shifts/details?${navParams.toString()}`;
   };
+
+  const shareParams = new URLSearchParams({ date: dateParam });
+  if (selectedLocation) shareParams.set("location", selectedLocation);
+  if (sessionFilter) shareParams.set("session", sessionFilter);
+  const shareUrl = `${getBaseUrl()}/shifts/details?${shareParams.toString()}`;
+  const shareLabel =
+    sessionFilter === "day"
+      ? `Day shifts on ${formatInNZT(selectedDate, "EEEE d MMMM")}`
+      : sessionFilter === "evening"
+        ? `Evening shifts on ${formatInNZT(selectedDate, "EEEE d MMMM")}`
+        : `Volunteer shifts on ${formatInNZT(selectedDate, "EEEE d MMMM")}`;
 
   return (
     <PageContainer testid="shifts-details-page">
@@ -89,6 +195,14 @@ export default async function ShiftDetailsPage({
         </Button>
 
         <div className="flex items-center gap-1 sm:gap-2">
+          <ShareShiftButton
+            url={shareUrl}
+            title={`${shareLabel}${selectedLocation ? ` at ${selectedLocation}` : ""} — Everybody Eats`}
+            text={`Kia ora! Come volunteer on ${formatInNZT(
+              selectedDate,
+              "EEEE d MMMM"
+            )}${selectedLocation ? ` at ${selectedLocation}` : ""}.`}
+          />
           <Button variant="outline" size="sm" asChild data-testid="prev-day-button">
             <Link href={buildNavUrl(previousDateParam)}>
               <ChevronLeft className="h-4 w-4 sm:mr-1" />
@@ -150,7 +264,7 @@ export default async function ShiftDetailsPage({
           subtree (Radix Dialog/Drawer inside ShiftSignupButton) into one of
           its own descendants, throwing HierarchyRequestError during commit. */}
       <Suspense
-        key={`${dateParam}-${selectedLocation ?? "all"}`}
+        key={`${dateParam}-${selectedLocation ?? "all"}-${sessionFilter ?? "both"}`}
         fallback={
           <div className="space-y-8">
             <div className="space-y-4">
@@ -190,6 +304,7 @@ export default async function ShiftDetailsPage({
         <ShiftDetailsContent
           dateParam={dateParam}
           selectedLocation={selectedLocation}
+          session={sessionFilter}
         />
       </Suspense>
     </PageContainer>

--- a/web/src/app/shifts/details/shift-details-content.tsx
+++ b/web/src/app/shifts/details/shift-details-content.tsx
@@ -16,6 +16,7 @@ import {
   MapPin,
   Users,
   UserCheck,
+  ArrowUpRight,
 } from "lucide-react";
 import { getShiftTheme } from "@/lib/shift-themes";
 import { checkProfileCompletion } from "@/lib/profile-completion";
@@ -172,7 +173,14 @@ function ShiftCard({
                 </div>
                 <div className="min-w-0 flex-1">
                   <h3 className="font-bold text-xl text-gray-900 dark:text-white truncate mb-1">
-                    {shift.shiftType.name}
+                    <Link
+                      href={`/shifts/${shift.id}`}
+                      className="inline-flex items-baseline gap-1 hover:underline underline-offset-4 decoration-2 focus-visible:outline-none focus-visible:underline rounded-sm"
+                      data-testid={`shift-card-title-link-${shift.id}`}
+                    >
+                      <span className="truncate">{shift.shiftType.name}</span>
+                      <ArrowUpRight className="h-4 w-4 shrink-0 self-center opacity-60 group-hover:opacity-100 transition-opacity" />
+                    </Link>
                   </h3>
                   <div className="flex items-center gap-2">
                     <Badge

--- a/web/src/app/shifts/details/shift-details-content.tsx
+++ b/web/src/app/shifts/details/shift-details-content.tsx
@@ -19,6 +19,8 @@ import {
 } from "lucide-react";
 import { getShiftTheme } from "@/lib/shift-themes";
 import { checkProfileCompletion } from "@/lib/profile-completion";
+import { ShareShiftButton } from "@/components/share-shift-button";
+import { getBaseUrl } from "@/lib/utils";
 
 function getDurationInHours(start: Date, end: Date): string {
   const durationMs = end.getTime() - start.getTime();
@@ -327,11 +329,13 @@ function ShiftCard({
 interface ShiftDetailsContentProps {
   dateParam: string;
   selectedLocation?: string;
+  session?: "day" | "evening";
 }
 
 export async function ShiftDetailsContent({
   dateParam,
   selectedLocation,
+  session: sessionFilter,
 }: ShiftDetailsContentProps) {
   const session = await getServerSession(authOptions);
 
@@ -468,7 +472,10 @@ export async function ShiftDetailsContent({
         const hasAMShifts = locationTimeShifts.AM.length > 0;
         const hasPMShifts = locationTimeShifts.PM.length > 0;
 
-        if (!hasAMShifts && !hasPMShifts) return null;
+        const showAM = hasAMShifts && sessionFilter !== "evening";
+        const showPM = hasPMShifts && sessionFilter !== "day";
+
+        if (!showAM && !showPM) return null;
 
         return (
           <section
@@ -490,19 +497,34 @@ export async function ShiftDetailsContent({
               </div>
             )}
 
-            {hasAMShifts && (
+            {showAM && (
               <div className="space-y-4" data-testid={`shifts-am-section-${locationKey.toLowerCase().replace(/\s+/g, "-")}`}>
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-gradient-to-br from-amber-500 to-orange-600 rounded-lg flex items-center justify-center text-lg">
-                    ☀️
+                <div className="flex items-center justify-between gap-3 flex-wrap">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-gradient-to-br from-amber-500 to-orange-600 rounded-lg flex items-center justify-center text-lg">
+                      ☀️
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-semibold">Day Shifts</h3>
+                      <p className="text-sm text-muted-foreground">
+                        {locationTimeShifts.AM.length} shift
+                        {locationTimeShifts.AM.length !== 1 ? "s" : ""} available (before 4pm)
+                      </p>
+                    </div>
                   </div>
-                  <div>
-                    <h3 className="text-lg font-semibold">Day Shifts</h3>
-                    <p className="text-sm text-muted-foreground">
-                      {locationTimeShifts.AM.length} shift
-                      {locationTimeShifts.AM.length !== 1 ? "s" : ""} available (before 4pm)
-                    </p>
-                  </div>
+                  {!sessionFilter && (
+                    <ShareShiftButton
+                      url={`${getBaseUrl()}/shifts/details?date=${dateParam}${
+                        locationKey !== "TBD"
+                          ? `&location=${encodeURIComponent(locationKey)}`
+                          : ""
+                      }&session=day`}
+                      title={`Day shifts at Everybody Eats ${locationKey === "TBD" ? "" : locationKey}`}
+                      text={`Day shifts on ${formatInNZT(selectedDate, "EEEE d MMMM")}${
+                        locationKey !== "TBD" ? ` at ${locationKey}` : ""
+                      } — come along!`}
+                    />
+                  )}
                 </div>
                 <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                   {locationTimeShifts.AM.map((shift) => (
@@ -521,19 +543,34 @@ export async function ShiftDetailsContent({
               </div>
             )}
 
-            {hasPMShifts && (
+            {showPM && (
               <div className="space-y-4" data-testid={`shifts-pm-section-${locationKey.toLowerCase().replace(/\s+/g, "-")}`}>
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg flex items-center justify-center text-lg">
-                    🌙
+                <div className="flex items-center justify-between gap-3 flex-wrap">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg flex items-center justify-center text-lg">
+                      🌙
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-semibold">Evening Shifts</h3>
+                      <p className="text-sm text-muted-foreground">
+                        {locationTimeShifts.PM.length} shift
+                        {locationTimeShifts.PM.length !== 1 ? "s" : ""} available (4pm onwards)
+                      </p>
+                    </div>
                   </div>
-                  <div>
-                    <h3 className="text-lg font-semibold">Evening Shifts</h3>
-                    <p className="text-sm text-muted-foreground">
-                      {locationTimeShifts.PM.length} shift
-                      {locationTimeShifts.PM.length !== 1 ? "s" : ""} available (4pm onwards)
-                    </p>
-                  </div>
+                  {!sessionFilter && (
+                    <ShareShiftButton
+                      url={`${getBaseUrl()}/shifts/details?date=${dateParam}${
+                        locationKey !== "TBD"
+                          ? `&location=${encodeURIComponent(locationKey)}`
+                          : ""
+                      }&session=evening`}
+                      title={`Evening shifts at Everybody Eats ${locationKey === "TBD" ? "" : locationKey}`}
+                      text={`Evening shifts on ${formatInNZT(selectedDate, "EEEE d MMMM")}${
+                        locationKey !== "TBD" ? ` at ${locationKey}` : ""
+                      } — join us!`}
+                    />
+                  )}
                 </div>
                 <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                   {locationTimeShifts.PM.map((shift) => (

--- a/web/src/app/shifts/details/shift-details-content.tsx
+++ b/web/src/app/shifts/details/shift-details-content.tsx
@@ -508,12 +508,29 @@ export async function ShiftDetailsContent({
             {showAM && (
               <div className="space-y-4" data-testid={`shifts-am-section-${locationKey.toLowerCase().replace(/\s+/g, "-")}`}>
                 <div className="flex items-center justify-between gap-3 flex-wrap">
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 group/heading">
                     <div className="w-8 h-8 bg-gradient-to-br from-amber-500 to-orange-600 rounded-lg flex items-center justify-center text-lg">
                       ☀️
                     </div>
                     <div>
-                      <h3 className="text-lg font-semibold">Day Shifts</h3>
+                      <h3 className="text-lg font-semibold">
+                        {sessionFilter ? (
+                          "Day Shifts"
+                        ) : (
+                          <Link
+                            href={`/shifts/details?date=${dateParam}${
+                              locationKey !== "TBD"
+                                ? `&location=${encodeURIComponent(locationKey)}`
+                                : ""
+                            }&session=day`}
+                            className="inline-flex items-baseline gap-1 hover:underline underline-offset-4 decoration-2 focus-visible:outline-none focus-visible:underline rounded-sm"
+                            data-testid={`shifts-am-section-link-${locationKey.toLowerCase().replace(/\s+/g, "-")}`}
+                          >
+                            <span>Day Shifts</span>
+                            <ArrowUpRight className="h-4 w-4 self-center opacity-60 group-hover/heading:opacity-100 transition-opacity" />
+                          </Link>
+                        )}
+                      </h3>
                       <p className="text-sm text-muted-foreground">
                         {locationTimeShifts.AM.length} shift
                         {locationTimeShifts.AM.length !== 1 ? "s" : ""} available (before 4pm)
@@ -554,12 +571,29 @@ export async function ShiftDetailsContent({
             {showPM && (
               <div className="space-y-4" data-testid={`shifts-pm-section-${locationKey.toLowerCase().replace(/\s+/g, "-")}`}>
                 <div className="flex items-center justify-between gap-3 flex-wrap">
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 group/heading">
                     <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-indigo-600 rounded-lg flex items-center justify-center text-lg">
                       🌙
                     </div>
                     <div>
-                      <h3 className="text-lg font-semibold">Evening Shifts</h3>
+                      <h3 className="text-lg font-semibold">
+                        {sessionFilter ? (
+                          "Evening Shifts"
+                        ) : (
+                          <Link
+                            href={`/shifts/details?date=${dateParam}${
+                              locationKey !== "TBD"
+                                ? `&location=${encodeURIComponent(locationKey)}`
+                                : ""
+                            }&session=evening`}
+                            className="inline-flex items-baseline gap-1 hover:underline underline-offset-4 decoration-2 focus-visible:outline-none focus-visible:underline rounded-sm"
+                            data-testid={`shifts-pm-section-link-${locationKey.toLowerCase().replace(/\s+/g, "-")}`}
+                          >
+                            <span>Evening Shifts</span>
+                            <ArrowUpRight className="h-4 w-4 self-center opacity-60 group-hover/heading:opacity-100 transition-opacity" />
+                          </Link>
+                        )}
+                      </h3>
                       <p className="text-sm text-muted-foreground">
                         {locationTimeShifts.PM.length} shift
                         {locationTimeShifts.PM.length !== 1 ? "s" : ""} available (4pm onwards)

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -2,6 +2,10 @@ import { MetadataRoute } from "next";
 import { getBaseUrl } from "@/lib/utils";
 import { prisma } from "@/lib/prisma";
 
+// Regenerate at most once per hour. Shifts can be created/edited frequently
+// but search engines don't fetch sitemaps often enough to need fresher data.
+export const revalidate = 3600;
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = getBaseUrl();
 
@@ -62,9 +66,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7, // Lower priority than main shifts page
     }));
 
-  // Individual upcoming shift detail pages
+  // Individual shift detail pages — filter on `end` rather than `start` so
+  // Postgres can use the existing @@index([end]) on Shift. Shifts currently
+  // in progress remain shareable until they wrap up.
   const upcomingShifts = await prisma.shift.findMany({
-    where: { start: { gte: new Date() } },
+    where: { end: { gte: new Date() } },
     select: { id: true, start: true },
     orderBy: { start: "asc" },
     take: 5000,

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -62,5 +62,20 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.7, // Lower priority than main shifts page
     }));
 
-  return [...staticPages, ...locationPages];
+  // Individual upcoming shift detail pages
+  const upcomingShifts = await prisma.shift.findMany({
+    where: { start: { gte: new Date() } },
+    select: { id: true, start: true },
+    orderBy: { start: "asc" },
+    take: 5000,
+  });
+
+  const shiftPages: MetadataRoute.Sitemap = upcomingShifts.map((shift) => ({
+    url: `${baseUrl}/shifts/${shift.id}`,
+    lastModified: shift.start,
+    changeFrequency: "daily" as const,
+    priority: 0.5,
+  }));
+
+  return [...staticPages, ...locationPages, ...shiftPages];
 }

--- a/web/src/components/share-shift-button.tsx
+++ b/web/src/components/share-shift-button.tsx
@@ -15,17 +15,7 @@ export function ShareShiftButton({ url, title, text }: ShareShiftButtonProps) {
   const [justCopied, setJustCopied] = useState(false);
 
   const handleShare = async () => {
-    // Web Share API exists on modern desktop browsers too (macOS Safari/Chrome
-    // route it to the OS share sheet), but on a desktop with a mouse the user
-    // really just wants the link in their clipboard. Restrict the native sheet
-    // to coarse-pointer devices (phones, tablets), copy-to-clipboard elsewhere.
-    const prefersNativeShare =
-      typeof window !== "undefined" &&
-      typeof navigator !== "undefined" &&
-      typeof navigator.share === "function" &&
-      window.matchMedia("(pointer: coarse)").matches;
-
-    if (prefersNativeShare) {
+    if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
       try {
         await navigator.share({ url, title, text });
         return;

--- a/web/src/components/share-shift-button.tsx
+++ b/web/src/components/share-shift-button.tsx
@@ -15,12 +15,24 @@ export function ShareShiftButton({ url, title, text }: ShareShiftButtonProps) {
   const [justCopied, setJustCopied] = useState(false);
 
   const handleShare = async () => {
-    if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+    // Web Share API exists on modern desktop browsers too (macOS Safari/Chrome
+    // route it to the OS share sheet), but on a desktop with a mouse the user
+    // really just wants the link in their clipboard. Restrict the native sheet
+    // to coarse-pointer devices (phones, tablets), copy-to-clipboard elsewhere.
+    const prefersNativeShare =
+      typeof window !== "undefined" &&
+      typeof navigator !== "undefined" &&
+      typeof navigator.share === "function" &&
+      window.matchMedia("(pointer: coarse)").matches;
+
+    if (prefersNativeShare) {
       try {
         await navigator.share({ url, title, text });
         return;
       } catch (err) {
         if ((err as DOMException)?.name === "AbortError") return;
+        // Fall through to clipboard if the native sheet rejected for any
+        // other reason (permission, transient OS error, etc.).
       }
     }
 

--- a/web/src/components/share-shift-button.tsx
+++ b/web/src/components/share-shift-button.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Share2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+interface ShareShiftButtonProps {
+  url: string;
+  title: string;
+  text: string;
+}
+
+export function ShareShiftButton({ url, title, text }: ShareShiftButtonProps) {
+  const [justCopied, setJustCopied] = useState(false);
+
+  const handleShare = async () => {
+    if (typeof navigator !== "undefined" && typeof navigator.share === "function") {
+      try {
+        await navigator.share({ url, title, text });
+        return;
+      } catch (err) {
+        if ((err as DOMException)?.name === "AbortError") return;
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setJustCopied(true);
+      toast.success("Link copied", {
+        description: "Share it with your whānau to invite them along.",
+      });
+      setTimeout(() => setJustCopied(false), 2000);
+    } catch {
+      toast.error("Couldn't copy link", {
+        description: "Please copy the URL from your address bar.",
+      });
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="gap-1.5"
+      onClick={handleShare}
+      aria-label="Share this shift"
+    >
+      {justCopied ? (
+        <>
+          <Check className="h-3.5 w-3.5" />
+          Copied
+        </>
+      ) : (
+        <>
+          <Share2 className="h-3.5 w-3.5" />
+          Share
+        </>
+      )}
+    </Button>
+  );
+}

--- a/web/src/lib/og-fonts.ts
+++ b/web/src/lib/og-fonts.ts
@@ -1,0 +1,75 @@
+const FONT_TIMEOUT_MS = 4000;
+const ALLOWED_FAMILIES = ["Fraunces", "Libre Franklin"] as const;
+type AllowedFamily = (typeof ALLOWED_FAMILIES)[number];
+
+async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FONT_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function loadGoogleFont(
+  family: AllowedFamily,
+  weight: number
+): Promise<ArrayBuffer | null> {
+  if (!ALLOWED_FAMILIES.includes(family)) return null;
+
+  try {
+    const css = await fetchWithTimeout(
+      `https://fonts.googleapis.com/css2?family=${encodeURIComponent(family)}:wght@${weight}&display=swap`,
+      {
+        headers: {
+          // Pre-woff2 UA so Google returns TTF, which satori (next/og) supports.
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko",
+        },
+      }
+    ).then((r) => r.text());
+
+    // Restrict to https URLs from a known font CDN to defuse any chance of
+    // the regex pulling in something other than a font file.
+    const match = css.match(/src:\s*url\((https:\/\/fonts\.gstatic\.com\/[^)]+)\)\s*format/);
+    if (!match) return null;
+
+    const response = await fetchWithTimeout(match[1]);
+    if (!response.ok) return null;
+    return await response.arrayBuffer();
+  } catch {
+    return null;
+  }
+}
+
+type SatoriFont = {
+  name: AllowedFamily;
+  data: ArrayBuffer;
+  weight: 400 | 600;
+  style: "normal";
+};
+
+export async function loadBrandFonts(): Promise<SatoriFont[]> {
+  const [fraunces, libreFranklin, libreFranklinBold] = await Promise.all([
+    loadGoogleFont("Fraunces", 600),
+    loadGoogleFont("Libre Franklin", 400),
+    loadGoogleFont("Libre Franklin", 600),
+  ]);
+
+  return [
+    fraunces && { name: "Fraunces" as const, data: fraunces, weight: 600 as const, style: "normal" as const },
+    libreFranklin && {
+      name: "Libre Franklin" as const,
+      data: libreFranklin,
+      weight: 400 as const,
+      style: "normal" as const,
+    },
+    libreFranklinBold && {
+      name: "Libre Franklin" as const,
+      data: libreFranklinBold,
+      weight: 600 as const,
+      style: "normal" as const,
+    },
+  ].filter(Boolean) as SatoriFont[];
+}


### PR DESCRIPTION
## Description

Improves shareability of individual shift pages so volunteers can post a link and have it render with a rich, branded preview on social platforms and messaging apps.

## What changed

- **Share button** ([web/src/components/share-shift-button.tsx](web/src/components/share-shift-button.tsx)) — Web Share API on mobile, copy-to-clipboard with a sonner toast on desktop. Shows a "Copied" check icon for ~2s after copy. Placed in a new "Spread the word" section beneath the calendar export buttons on the shift detail page.
- **Dynamic OG image** ([web/src/app/shifts/[id]/opengraph-image.tsx](web/src/app/shifts/[id]/opengraph-image.tsx)) — 1200×630 branded card rendered by `next/og` `ImageResponse`. Shows shift type heading (Fraunces), NZ-formatted day/date/time (Libre Franklin), location, and a status pill (`X spots left` / `Waitlist open` / `Shift complete`). Theme gradient blobs are colour-matched per shift type via `shift-themes.ts`. Fonts are fetched from Google Fonts at render time with a satori-compatible UA, with a graceful fallback if the fetch fails.
- **`generateMetadata`** on [web/src/app/shifts/[id]/page.tsx](web/src/app/shifts/[id]/page.tsx) — Per-shift title (e.g. `Dishwasher · Wellington · Friday 23 May`), description that includes the spots-remaining state, canonical URL via the existing `buildPageMetadata` helper. Past shifts are marked `noindex` so dead pages don't accumulate in search results.
- **Schema.org `Event` JSON-LD** emitted from the page using the existing `buildShiftEventSchema` helper — gives Google rich snippets for shift events.
- **Sitemap** ([web/src/app/sitemap.ts](web/src/app/sitemap.ts)) — Upcoming shift URLs (start ≥ now, capped at 5000) added with `lastModified = shift.start` and priority 0.5, so individual shifts become discoverable to crawlers.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Testing

- [x] `npm run typecheck` passes
- [x] `npm run lint` — 0 errors on changed files (only pre-existing repo warnings remain)
- [x] `next build` compiles all routes successfully (subsequent build-time data-collection failure is unrelated — pre-existing top-level Prisma call in `web/src/lib/locations.ts` that needs a real DB at build time)
- [ ] Manual preview testing — verify share button, OG preview, and sitemap entries in deployed preview

## How to test locally

1. `cd web && npm run dev`
2. Visit any shift page at `/shifts/<id>` and try the Share button (works both on mobile via native share sheet and on desktop via clipboard copy)
3. Visit `/shifts/<id>/opengraph-image` directly to preview the OG card
4. Paste a deployed preview URL into [opengraph.xyz](https://www.opengraph.xyz/) (or post in Slack / WhatsApp) to verify the OG image renders correctly

## Notes

- Share button and the "Spread the word" section are only rendered for upcoming shifts (matches existing calendar-export visibility), so we don't promote sharing of dead links.
- Description messaging uses warm te reo-flavoured tone consistent with the brand voice ("Kia ora — join the whānau", "Spread the word", etc.).
- No new dependencies — uses `next/og` (already part of Next.js) and existing `sonner`, `lucide-react`, and shadcn `Button`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)