### PR TITLE
fix(shifts): pluralize 'spot' correctly when only one remaining

### DIFF
--- a/web/src/app/shifts/[id]/page.tsx
+++ b/web/src/app/shifts/[id]/page.tsx
@@ -275,7 +275,7 @@ export default async function ShiftDetailPage({
                 </Badge>
               ) : (
                 <Badge className="bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800/50">
-                  {spotsRemaining} spots left
+                  {spotsRemaining} {spotsRemaining === 1 ? "spot" : "spots"} left
                 </Badge>
               )}
             </div>

--- a/web/src/app/shifts/details/shift-details-content.tsx
+++ b/web/src/app/shifts/details/shift-details-content.tsx
@@ -232,7 +232,7 @@ function ShiftCard({
                   <div className="text-xs text-gray-500 dark:text-gray-400">
                     {remaining > 0 ? (
                       <span className="text-green-600 dark:text-green-400 font-medium">
-                        {remaining} spots left
+                        {remaining} {remaining === 1 ? "spot" : "spots"} left
                       </span>
                     ) : confirmedCount + pendingCount > shift.capacity ? (
                       <span className="text-orange-600 dark:text-orange-400 font-medium">

--- a/web/src/components/assign-volunteer-dialog.tsx
+++ b/web/src/components/assign-volunteer-dialog.tsx
@@ -272,7 +272,7 @@ export function AssignVolunteerDialog({
                   {confirmedCount}/{shift.capacity} confirmed
                   {remaining > 0 ? (
                     <span className="text-green-600 ml-1">
-                      ({remaining} spots left)
+                      ({remaining} {remaining === 1 ? "spot" : "spots"} left)
                     </span>
                   ) : (
                     <span className="text-orange-600 ml-1">(Full)</span>

--- a/web/src/components/shift-signup-dialog.tsx
+++ b/web/src/components/shift-signup-dialog.tsx
@@ -480,7 +480,7 @@ export function ShiftSignupDialog({
                   {confirmedCount}/{shift.capacity} confirmed
                   {!isWaitlist && remaining > 0 && (
                     <span className="text-green-600 ml-1">
-                      ({remaining} spots left)
+                      ({remaining} {remaining === 1 ? "spot" : "spots"} left)
                     </span>
                   )}
                 </span>

--- a/web/src/components/volunteer-actions.tsx
+++ b/web/src/components/volunteer-actions.tsx
@@ -404,7 +404,7 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
                           value={shift.id}
                           data-testid={`move-target-option-${shift.id}`}
                         >
-                          {shift.shiftType.name} • {formatInNZT(new Date(shift.start), "h:mm a")} - {formatInNZT(new Date(shift.end), "h:mm a")} • {shift.capacity - shift.confirmedCount} spots available
+                          {shift.shiftType.name} • {formatInNZT(new Date(shift.start), "h:mm a")} - {formatInNZT(new Date(shift.end), "h:mm a")} • {shift.capacity - shift.confirmedCount} {shift.capacity - shift.confirmedCount === 1 ? "spot" : "spots"} available
                         </SelectItem>
                       ))}
                     </SelectContent>


### PR DESCRIPTION
## Summary
- Replaced the hard-coded "spots left/available" strings with `count === 1 ? "spot" : "spots"` so users see "1 spot left" instead of "1 spots left".
- Applied the same fix to four other capacity readouts found while sweeping the codebase:
  - [shift-details-content.tsx](web/src/app/shifts/details/shift-details-content.tsx) capacity caption
  - [volunteer-actions.tsx](web/src/components/volunteer-actions.tsx) move-target select item ("spots available")
  - [assign-volunteer-dialog.tsx](web/src/components/assign-volunteer-dialog.tsx) capacity badge
  - [shift-signup-dialog.tsx](web/src/components/shift-signup-dialog.tsx) capacity badge

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` (no new errors; 15 pre-existing warnings unrelated)
- [ ] Visually confirm singular/plural display on `/shifts/[id]`, admin assign dialog, and signup dialog when remaining capacity is 1 vs more

🤖 Generated with [Claude Code](https://claude.com/claude-code)