### PR TITLE
fix(og): use dynamic OG image for shift pages

### DIFF
--- a/web/src/app/shifts/[id]/page.tsx
+++ b/web/src/app/shifts/[id]/page.tsx
@@ -86,6 +86,7 @@ export async function generateMetadata({
     description,
     path: `/shifts/${id}`,
     noIndex: isPast,
+    useFileBasedOgImage: true,
   });
 }
 

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -19,11 +19,23 @@ interface MetadataOptions {
   path: string;
   ogImage?: string;
   noIndex?: boolean;
+  /**
+   * When true, omit `openGraph.images` so Next.js's file-based
+   * `opengraph-image.tsx` convention takes over for this route.
+   */
+  useFileBasedOgImage?: boolean;
 }
 
 // Build complete page metadata
 export function buildPageMetadata(options: MetadataOptions): Metadata {
-  const { title, description, path, ogImage, noIndex = false } = options;
+  const {
+    title,
+    description,
+    path,
+    ogImage,
+    noIndex = false,
+    useFileBasedOgImage = false,
+  } = options;
   const baseUrl = getBaseUrl();
   const url = `${baseUrl}${path}`;
   const image = ogImage || SEO_CONFIG.ogImage;
@@ -41,14 +53,18 @@ export function buildPageMetadata(options: MetadataOptions): Metadata {
       siteName: SEO_CONFIG.siteName,
       locale: SEO_CONFIG.locale,
       type: "website",
-      images: [
-        {
-          url: image,
-          width: 1200,
-          height: 630,
-          alt: title,
-        },
-      ],
+      ...(useFileBasedOgImage
+        ? {}
+        : {
+            images: [
+              {
+                url: image,
+                width: 1200,
+                height: 630,
+                alt: title,
+              },
+            ],
+          }),
     },
     robots: noIndex
       ? {


### PR DESCRIPTION
## Summary

- `buildPageMetadata` always emitted `openGraph.images` pointing at the static `/og-image.png`, which silently shadowed the file-based [`opengraph-image.tsx`](web/src/app/shifts/[id]/opengraph-image.tsx) convention on `/shifts/[id]`.
- Added a `useFileBasedOgImage` opt-out to `buildPageMetadata` that omits `openGraph.images` so Next.js auto-wires the dynamic OG file.
- Opted the shift detail page into it — share previews now use the per-shift dynamic card instead of the generic fallback.

## Why

Next.js metadata rule: when `generateMetadata` returns `openGraph.images`, the explicit value wins and `opengraph-image.tsx` is ignored. The dynamic card was being generated but never referenced. Confirmed on `https://volunteers.everybodyeats.nz/shifts/cmofque6m001e04l8s05qddjd` — `<meta property="og:image">` pointed at the static `/og-image.png`.

## Test plan

- [ ] Deploy preview and check `<meta property="og:image">` on a shift page resolves to the dynamic OG URL (hashed `/shifts/<id>/opengraph-image/...`).
- [ ] Re-scrape with the Facebook / LinkedIn / Twitter card debuggers — confirm the per-shift card renders.
- [ ] Verify non-shift pages still get the static `/og-image.png` fallback (e.g. `/`, `/login`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)