### PR TITLE
feat(admin): shift coverage report, reactivated volunteers & RM milestone heads-up

### DIFF
--- a/web/src/app/admin/analytics/coverage/coverage-analytics-client.tsx
+++ b/web/src/app/admin/analytics/coverage/coverage-analytics-client.tsx
@@ -1,0 +1,544 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useTheme } from "next-themes";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { motion } from "motion/react";
+import { staggerContainer, staggerItem } from "@/lib/motion";
+import {
+  CalendarRange,
+  Users,
+  UserMinus,
+  CircleSlash,
+  AlertTriangle,
+  ShieldAlert,
+  Loader2,
+  BarChart3,
+  Info,
+} from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import dynamic from "next/dynamic";
+import { DayOfWeekFilter } from "@/components/day-of-week-filter";
+import type { ShiftCoverageData, ShiftCoverageRow } from "@/lib/shift-coverage";
+
+const Chart = dynamic(() => import("react-apexcharts"), { ssr: false });
+
+interface Props {
+  data: ShiftCoverageData;
+  months: string;
+  location: string;
+  days: string;
+  locations: Array<{ value: string; label: string }>;
+}
+
+const MONTHS_LABELS: Record<string, string> = {
+  "1": "1 month",
+  "3": "3 months",
+  "6": "6 months",
+  "12": "12 months",
+};
+
+function CoverageRing({
+  value,
+  color,
+  size = 72,
+  strokeWidth = 6,
+}: {
+  value: number;
+  color: string;
+  size?: number;
+  strokeWidth?: number;
+}) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const pct = Math.min(Math.max(value, 0), 100) / 100;
+  const offset = circumference * (1 - pct);
+
+  return (
+    <svg width={size} height={size} className="shrink-0 -rotate-90">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        className="text-muted/20"
+      />
+      <motion.circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference}
+        animate={{ strokeDashoffset: offset }}
+        transition={{ duration: 0.8, ease: [0.4, 0, 0.2, 1], delay: 0.3 }}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export function CoverageAnalyticsClient({
+  data,
+  months: initialMonths,
+  location: initialLocation,
+  days: initialDays,
+  locations,
+}: Props) {
+  const router = useRouter();
+  const { resolvedTheme } = useTheme();
+  const [isPending, startTransition] = useTransition();
+  const [months, setMonths] = useState(initialMonths);
+  const [location, setLocation] = useState(initialLocation);
+  const [days, setDays] = useState(initialDays);
+  const chartThemeMode = (resolvedTheme === "dark" ? "dark" : "light") as
+    | "dark"
+    | "light";
+
+  const handleApplyFilters = () => {
+    const params = new URLSearchParams({ months, location });
+    if (days) params.set("days", days);
+    startTransition(() => {
+      router.push(`/admin/analytics/coverage?${params}`);
+    });
+  };
+
+  const { totals, byLocation } = data;
+
+  // Stacked bar: mutually exclusive staffing bands per restaurant.
+  const chartLocations = byLocation.map((r) => r.location);
+  const adequateSeries = byLocation.map(
+    (r) => r.totalShifts - r.understaffedShifts
+  );
+  const understaffedSeries = byLocation.map(
+    (r) => r.understaffedShifts - r.criticallyUnderstaffedShifts
+  );
+  const criticalSeries = byLocation.map((r) => r.criticallyUnderstaffedShifts);
+  const hasData = totals.totalShifts > 0;
+
+  const statCards: Array<{
+    label: string;
+    value: number;
+    desc: string;
+    tooltip: string;
+    icon: React.ComponentType<{ className?: string }>;
+    bg: string;
+    fg: string;
+  }> = [
+    {
+      label: "Unfilled Shifts",
+      value: totals.unfilledShifts,
+      desc: "Have empty positions",
+      tooltip:
+        "Shifts where at least one position went unfilled (filled < capacity).",
+      icon: UserMinus,
+      bg: "bg-amber-50 dark:bg-amber-950/20",
+      fg: "text-amber-600 dark:text-amber-400",
+    },
+    {
+      label: "Fully Empty",
+      value: totals.fullyEmptyShifts,
+      desc: "Nobody signed up",
+      tooltip: "Shifts that ran with zero volunteers signed up.",
+      icon: CircleSlash,
+      bg: "bg-orange-50 dark:bg-orange-950/20",
+      fg: "text-orange-600 dark:text-orange-400",
+    },
+    {
+      label: "Understaffed",
+      value: totals.understaffedShifts,
+      desc: "Under 75% filled",
+      tooltip:
+        "Shifts filled to less than 75% of capacity (includes critically understaffed).",
+      icon: AlertTriangle,
+      bg: "bg-amber-50 dark:bg-amber-950/20",
+      fg: "text-amber-600 dark:text-amber-400",
+    },
+    {
+      label: "Critically Understaffed",
+      value: totals.criticallyUnderstaffedShifts,
+      desc: "Under 50% filled",
+      tooltip: "Shifts filled to less than 50% of capacity — the most at risk.",
+      icon: ShieldAlert,
+      bg: "bg-red-50 dark:bg-red-950/20",
+      fg: "text-red-600 dark:text-red-400",
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      {/* Filters */}
+      <Card>
+        <CardContent className="py-4">
+          <div className="flex flex-col sm:flex-row items-end gap-4">
+            <div className="flex-1 grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="months">Time Period</Label>
+                <Select value={months} onValueChange={setMonths}>
+                  <SelectTrigger id="months">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="1">Last 1 month</SelectItem>
+                    <SelectItem value="3">Last 3 months</SelectItem>
+                    <SelectItem value="6">Last 6 months</SelectItem>
+                    <SelectItem value="12">Last 12 months</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="location">Location</Label>
+                <Select value={location} onValueChange={setLocation}>
+                  <SelectTrigger id="location">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All Locations</SelectItem>
+                    {locations.map((loc) => (
+                      <SelectItem key={loc.value} value={loc.value}>
+                        {loc.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <DayOfWeekFilter value={days} onChange={setDays} />
+            </div>
+            <Button
+              onClick={handleApplyFilters}
+              className="sm:w-auto w-full"
+              disabled={isPending}
+            >
+              {isPending && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+              Apply Filters
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <motion.div
+        variants={staggerContainer}
+        initial="hidden"
+        animate="visible"
+        className={`space-y-6 transition-opacity ${isPending ? "opacity-50 pointer-events-none" : ""}`}
+      >
+        {/* Hero — fill rate + headline counts */}
+        <motion.div variants={staggerItem}>
+          <Card className="overflow-hidden">
+            <div className="flex flex-col md:flex-row">
+              <div className="flex items-center gap-5 p-6">
+                <div className="relative">
+                  <CoverageRing value={totals.fillRate} color="#10b981" />
+                  <div className="absolute inset-0 flex items-center justify-center text-sm font-bold tabular-nums">
+                    {totals.fillRate}%
+                  </div>
+                </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="cursor-help pl-6">
+                      <p className="text-sm text-muted-foreground">Fill Rate</p>
+                      <p className="text-3xl font-bold tracking-tight tabular-nums">
+                        {totals.filledPositions}
+                        <span className="text-lg text-muted-foreground">
+                          {" "}
+                          / {totals.totalPositions}
+                        </span>
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Positions filled · last {MONTHS_LABELS[initialMonths]}
+                      </p>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="w-auto max-w-56">
+                    Filled positions ÷ positions offered. &ldquo;Filled&rdquo;
+                    counts confirmed volunteers, regulars and walk-ins.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+
+              <div className="flex-1 grid grid-cols-2 divide-x border-t md:border-t-0 md:border-l">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex flex-col items-center justify-center p-5 cursor-help">
+                      <CalendarRange className="h-4 w-4 text-muted-foreground mb-1" />
+                      <p className="text-2xl font-bold tracking-tight tabular-nums">
+                        {totals.totalShifts}
+                      </p>
+                      <p className="text-xs text-muted-foreground">Shifts Run</p>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="w-auto max-w-56">
+                    Shifts scheduled to start within the selected period.
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex flex-col items-center justify-center p-5 cursor-help">
+                      <Users className="h-4 w-4 text-muted-foreground mb-1" />
+                      <p className="text-2xl font-bold tracking-tight tabular-nums">
+                        {totals.totalPositions}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        Positions Offered
+                      </p>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="w-auto max-w-56">
+                    Total capacity across all shifts in the period.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            </div>
+          </Card>
+        </motion.div>
+
+        {/* Stat cards */}
+        <motion.div
+          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"
+          variants={staggerContainer}
+          initial="hidden"
+          animate="visible"
+        >
+          {statCards.map((stat) => {
+            const Icon = stat.icon;
+            return (
+              <motion.div key={stat.label} variants={staggerItem}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Card className={`${stat.bg} border-0 cursor-help`}>
+                      <CardContent className="flex items-center gap-4 py-5">
+                        <div
+                          className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-background/70 ${stat.fg}`}
+                        >
+                          <Icon className="h-5 w-5" />
+                        </div>
+                        <div className="min-w-0">
+                          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                            {stat.label}
+                          </p>
+                          <p className="text-2xl font-bold tracking-tight tabular-nums">
+                            {stat.value}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {stat.desc}
+                          </p>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="w-auto max-w-56">
+                    {stat.tooltip}
+                  </TooltipContent>
+                </Tooltip>
+              </motion.div>
+            );
+          })}
+        </motion.div>
+
+        {/* Staffing by restaurant — chart */}
+        <motion.div variants={staggerItem}>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base font-semibold flex items-center gap-2">
+                <BarChart3 className="h-4 w-4 text-emerald-500" />
+                Staffing by Restaurant
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {hasData ? (
+                <Chart
+                  key={`coverage-${initialMonths}-${initialLocation}-${initialDays}`}
+                  options={{
+                    chart: {
+                      type: "bar" as const,
+                      stacked: true,
+                      toolbar: { show: false },
+                      background: "transparent",
+                      fontFamily: "var(--font-libre-franklin), sans-serif",
+                    },
+                    plotOptions: {
+                      bar: {
+                        horizontal: true,
+                        borderRadius: 4,
+                        barHeight: "60%",
+                      },
+                    },
+                    xaxis: {
+                      categories: chartLocations,
+                      labels: { style: { fontSize: "11px" } },
+                      axisBorder: { show: false },
+                      axisTicks: { show: false },
+                    },
+                    yaxis: { labels: { style: { fontSize: "12px" } } },
+                    colors: ["#10b981", "#f59e0b", "#ef4444"],
+                    dataLabels: { enabled: false },
+                    grid: {
+                      borderColor: "#e5e7eb",
+                      strokeDashArray: 4,
+                      yaxis: { lines: { show: false } },
+                    },
+                    legend: {
+                      position: "top" as const,
+                      fontSize: "12px",
+                      markers: { size: 6, offsetX: -2 },
+                    },
+                    tooltip: {
+                      shared: true,
+                      intersect: false,
+                      y: {
+                        formatter: (val: number) =>
+                          `${Math.round(val)} shift${val === 1 ? "" : "s"}`,
+                      },
+                    },
+                    theme: { mode: chartThemeMode },
+                  }}
+                  series={[
+                    { name: "Adequate (75%+)", data: adequateSeries },
+                    { name: "Understaffed (50–74%)", data: understaffedSeries },
+                    { name: "Critical (<50%)", data: criticalSeries },
+                  ]}
+                  type="bar"
+                  height={Math.max(220, chartLocations.length * 56)}
+                />
+              ) : (
+                <div className="flex items-center justify-center h-[220px] text-muted-foreground text-sm">
+                  No shifts in the selected period
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </motion.div>
+
+        {/* Per-restaurant breakdown table */}
+        <motion.div variants={staggerItem}>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base font-semibold flex items-center gap-2">
+                <Info className="h-4 w-4 text-muted-foreground" />
+                Per-Restaurant Breakdown
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Restaurant</TableHead>
+                      <TableHead className="text-right">Shifts</TableHead>
+                      <TableHead className="text-right">Positions</TableHead>
+                      <TableHead className="text-right">Filled</TableHead>
+                      <TableHead className="text-right">Fill Rate</TableHead>
+                      <TableHead className="text-right">Unfilled</TableHead>
+                      <TableHead className="text-right">Empty</TableHead>
+                      <TableHead className="text-right">Understaffed</TableHead>
+                      <TableHead className="text-right">Critical</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {byLocation.length === 0 ? (
+                      <TableRow>
+                        <TableCell
+                          colSpan={9}
+                          className="text-center text-muted-foreground py-8"
+                        >
+                          No shifts in the selected period
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      <>
+                        {byLocation.map((row: ShiftCoverageRow) => (
+                          <TableRow key={row.location}>
+                            <TableCell className="font-medium">
+                              {row.location}
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {row.totalShifts}
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {row.totalPositions}
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {row.filledPositions}
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {row.fillRate}%
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {row.unfilledShifts}
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums">
+                              {row.fullyEmptyShifts}
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums text-amber-600 dark:text-amber-400">
+                              {row.understaffedShifts}
+                            </TableCell>
+                            <TableCell className="text-right tabular-nums text-red-600 dark:text-red-400">
+                              {row.criticallyUnderstaffedShifts}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                        <TableRow className="border-t-2 font-semibold">
+                          <TableCell>All Locations</TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {totals.totalShifts}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {totals.totalPositions}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {totals.filledPositions}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {totals.fillRate}%
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {totals.unfilledShifts}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {totals.fullyEmptyShifts}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums text-amber-600 dark:text-amber-400">
+                            {totals.understaffedShifts}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums text-red-600 dark:text-red-400">
+                            {totals.criticallyUnderstaffedShifts}
+                          </TableCell>
+                        </TableRow>
+                      </>
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+}

--- a/web/src/app/admin/analytics/coverage/page.tsx
+++ b/web/src/app/admin/analytics/coverage/page.tsx
@@ -1,0 +1,56 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { PageContainer } from "@/components/page-container";
+import { CoverageAnalyticsClient } from "./coverage-analytics-client";
+import { LOCATIONS } from "@/lib/locations";
+import { getShiftCoverage } from "@/lib/shift-coverage";
+import { parseDaysParam } from "@/lib/parse-days-param";
+
+export default async function CoverageAnalyticsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect("/login?callbackUrl=/admin/analytics/coverage");
+  }
+
+  if (session.user.role !== "ADMIN") {
+    redirect("/dashboard");
+  }
+
+  const params = await searchParams;
+
+  const months = (params.months as string) || "3";
+  const location = (params.location as string) || "all";
+  const days = (params.days as string) || "";
+  const daysFilter = parseDaysParam(days);
+
+  const data = await getShiftCoverage(parseInt(months, 10), location, daysFilter);
+
+  const locationOptions = LOCATIONS.map((loc) => ({
+    value: loc,
+    label: loc,
+  }));
+
+  return (
+    <AdminPageWrapper
+      title="Shift Coverage"
+      description="Shifts run, positions filled, and understaffing by restaurant"
+    >
+      <PageContainer testid="coverage-analytics-page">
+        <CoverageAnalyticsClient
+          data={data}
+          months={months}
+          location={location}
+          days={days}
+          locations={locationOptions}
+        />
+      </PageContainer>
+    </AdminPageWrapper>
+  );
+}

--- a/web/src/app/admin/analytics/engagement/engagement-analytics-client.tsx
+++ b/web/src/app/admin/analytics/engagement/engagement-analytics-client.tsx
@@ -312,7 +312,7 @@ export function EngagementAnalyticsClient({
               </div>
 
               {/* Right: secondary metrics */}
-              <div className="flex-1 grid grid-cols-3 divide-x">
+              <div className="flex-1 grid grid-cols-2 sm:grid-cols-4 divide-x">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <div className="flex flex-col items-center justify-center p-5 cursor-help">
@@ -355,6 +355,21 @@ export function EngagementAnalyticsClient({
                   <TooltipContent side="bottom" className="w-auto max-w-56">
                     Volunteers who completed their first ever shift during the
                     selected period
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex flex-col items-center justify-center p-5 cursor-help">
+                      <UserCheck className="h-4 w-4 text-muted-foreground mb-1" />
+                      <p className="text-2xl font-bold tracking-tight tabular-nums">
+                        {data.summary.reactivatedCount}
+                      </p>
+                      <p className="text-xs text-muted-foreground">Reactivated</p>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="w-auto max-w-56">
+                    Returning volunteers — completed a shift in the period after
+                    6+ months of inactivity (excludes first-timers)
                   </TooltipContent>
                 </Tooltip>
               </div>

--- a/web/src/app/api/admin/analytics/coverage/route.ts
+++ b/web/src/app/api/admin/analytics/coverage/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { getShiftCoverage } from "@/lib/shift-coverage";
+import { parseDaysParam } from "@/lib/parse-days-param";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const months = parseInt(searchParams.get("months") || "3", 10);
+  const location = searchParams.get("location");
+  const daysFilter = parseDaysParam(searchParams.get("days") || undefined);
+
+  try {
+    const data = await getShiftCoverage(months, location, daysFilter);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error fetching shift coverage analytics:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch shift coverage data" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/components/animated-shift-cards.tsx
+++ b/web/src/components/animated-shift-cards.tsx
@@ -74,7 +74,10 @@ import {
   ArrowRightLeft,
   UserRound,
   Pencil,
+  PartyPopper,
+  Sparkles,
 } from "lucide-react";
+import { getMilestoneStatus } from "@/lib/milestone-thresholds";
 import { VolunteerActions } from "@/components/volunteer-actions";
 import { getShiftTheme } from "@/lib/shift-themes";
 import { isShiftCompleted } from "@/lib/shift-utils";
@@ -344,6 +347,20 @@ function VolunteerStatusGroups({
                   completedShifts
                 );
                 const GradeIcon = gradeInfo.icon;
+                // Milestone heads-up for RMs: only relevant for volunteers who
+                // will actually work this shift. completedShifts counts past
+                // shifts, so completing this one makes it their (completed+1)th.
+                const isAttending =
+                  signup.status === "CONFIRMED" ||
+                  signup.status === "REGULAR_PENDING";
+                const milestone = isAttending
+                  ? getMilestoneStatus(completedShifts)
+                  : null;
+                const showMilestoneHit = milestone?.hitsOnNext ?? false;
+                const showMilestoneApproaching =
+                  !!milestone &&
+                  !milestone.hitsOnNext &&
+                  milestone.shiftsAway <= 2;
                 return (
                   <div
                     key={signup.id}
@@ -476,6 +493,27 @@ function VolunteerStatusGroups({
                             </Badge>
                           ) : null;
                         })()}
+                        {showMilestoneHit && milestone?.nextThreshold && (
+                          <Badge
+                            className="text-xs bg-emerald-100 dark:bg-emerald-950/40 text-emerald-800 dark:text-emerald-200 border border-emerald-300 dark:border-emerald-800 px-1.5 py-0.5 gap-1"
+                            data-testid={`milestone-badge-${signup.user.id}`}
+                            title={`This shift is their ${milestone.nextThreshold}th — acknowledge it during the shift!`}
+                          >
+                            <PartyPopper className="h-3 w-3" />
+                            {milestone.nextThreshold}th shift today!
+                          </Badge>
+                        )}
+                        {showMilestoneApproaching && milestone?.nextThreshold && (
+                          <Badge
+                            variant="outline"
+                            className="text-xs bg-sky-50 dark:bg-sky-950/20 text-sky-700 dark:text-sky-300 border-sky-200 dark:border-sky-800 px-1.5 py-0.5 gap-1"
+                            data-testid={`milestone-approaching-badge-${signup.user.id}`}
+                            title={`${milestone.shiftsAway} shifts away from their ${milestone.nextThreshold}-shift milestone`}
+                          >
+                            <Sparkles className="h-3 w-3" />
+                            {milestone.shiftsAway} from {milestone.nextThreshold}
+                          </Badge>
+                        )}
                       </div>
                       {signup.note && (
                         <div className="text-xs text-slate-700 dark:text-slate-300 mt-1 p-3 bg-blue-50/50 dark:bg-blue-900/20 border-l-2 border-blue-400 dark:border-blue-600 rounded">

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -26,6 +26,7 @@ import {
   Award,
   Archive,
   ScrollText,
+  ClipboardCheck,
 } from "lucide-react";
 
 export interface AdminNavItem {
@@ -95,6 +96,14 @@ export const adminNavCategories: AdminNavCategory[] = [
         description:
           "Shift milestones, volunteer recognition, and 12-month projections",
         commandKey: "milestones",
+      },
+      {
+        title: "Shift Coverage",
+        href: "/admin/analytics/coverage",
+        icon: ClipboardCheck,
+        description:
+          "Shifts run, positions filled, and understaffing by restaurant",
+        commandKey: "coverage",
       },
     ],
   },
@@ -339,6 +348,7 @@ export const getIconColor = (
     "Volunteer Engagement": "text-emerald-600",
     "Volunteer Recruitment": "text-violet-600",
     "Milestone Analytics": "text-amber-600",
+    "Shift Coverage": "text-teal-600",
 
     // Volunteers
     "All Users": "text-purple-600",

--- a/web/src/lib/engagement.ts
+++ b/web/src/lib/engagement.ts
@@ -5,6 +5,12 @@ import { shiftStartNZ } from "@/lib/concurrent-shifts";
 export type EngagementStatus = "highly_active" | "active" | "inactive" | "never";
 
 /**
+ * Months of inactivity before a returning volunteer counts as "reactivated".
+ * @see getEngagementSummary
+ */
+export const REACTIVATION_GAP_MONTHS = 6;
+
+/**
  * Classify a volunteer's engagement level based on their shift history.
  *
  * - "never": 0 completed shifts ever
@@ -32,6 +38,7 @@ export interface EngagementSummaryData {
     neverVolunteeredCount: number;
     retentionRate: number;
     newInPeriodCount: number;
+    reactivatedCount: number;
   };
   monthlyTrend: Array<{
     month: string;
@@ -79,7 +86,31 @@ export async function getEngagementSummary(
 
   const safeMonths = Math.max(months, 1);
 
-  const [summaryResult, trendResult] = await Promise.all([
+  // A volunteer counts as "reactivated" if they completed a shift in the
+  // period after a quiet gap of at least this many months immediately before
+  // their first shift back — and they had volunteered before that gap (so
+  // brand-new volunteers are excluded).
+  const reactivationGap = Prisma.sql`INTERVAL '${Prisma.raw(
+    String(REACTIVATION_GAP_MONTHS)
+  )} months'`;
+  // Per-shift-alias location/day filters for the reactivation subqueries.
+  const aliasConds = (alias: string) => {
+    const loc = isLocationFiltered
+      ? Prisma.sql`AND ${Prisma.raw(alias)}.location = ${location}`
+      : Prisma.empty;
+    const dys =
+      daysFilter && daysFilter.length > 0
+        ? Prisma.sql`AND EXTRACT(DOW FROM ${shiftStartNZ(
+            `${alias}.start`
+          )})::int IN (${Prisma.join(daysFilter)})`
+        : Prisma.empty;
+    return { loc, dys };
+  };
+  const fp = aliasConds("shf");
+  const gp = aliasConds("shg");
+  const pp = aliasConds("shp");
+
+  const [summaryResult, trendResult, reactivationResult] = await Promise.all([
     prisma.$queryRaw<
       Array<{
         totalVolunteers: bigint;
@@ -146,6 +177,46 @@ export async function getEngagementSummary(
       GROUP BY date_trunc('week', sh."end")
       ORDER BY month
     `,
+    prisma.$queryRaw<Array<{ reactivatedCount: bigint }>>`
+      WITH first_in_period AS (
+        SELECT
+          sg."userId" AS user_id,
+          MIN(shf."end") AS first_end
+        FROM "Signup" sg
+        JOIN "Shift" shf ON shf.id = sg."shiftId"
+        JOIN "User" u ON u.id = sg."userId"
+        WHERE sg.status = 'CONFIRMED'
+          AND u.role = 'VOLUNTEER'::"Role"
+          AND shf."end" >= ${periodStart}
+          AND shf."end" < ${now}
+          ${fp.loc}
+          ${fp.dys}
+        GROUP BY sg."userId"
+      )
+      SELECT COUNT(*)::bigint AS "reactivatedCount"
+      FROM first_in_period f
+      WHERE NOT EXISTS (
+              SELECT 1
+              FROM "Signup" sg2
+              JOIN "Shift" shg ON shg.id = sg2."shiftId"
+              WHERE sg2."userId" = f.user_id
+                AND sg2.status = 'CONFIRMED'
+                AND shg."end" >= (f.first_end - ${reactivationGap})
+                AND shg."end" < f.first_end
+                ${gp.loc}
+                ${gp.dys}
+            )
+        AND EXISTS (
+              SELECT 1
+              FROM "Signup" sg3
+              JOIN "Shift" shp ON shp.id = sg3."shiftId"
+              WHERE sg3."userId" = f.user_id
+                AND sg3.status = 'CONFIRMED'
+                AND shp."end" < (f.first_end - ${reactivationGap})
+                ${pp.loc}
+                ${pp.dys}
+            )
+    `,
   ]);
 
   const summary = summaryResult[0];
@@ -156,6 +227,7 @@ export async function getEngagementSummary(
   const priorActiveCount = Number(summary?.priorActiveCount || 0);
   const retainedCount = Number(summary?.retainedCount || 0);
   const newInPeriodCount = Number(summary?.newInPeriodCount || 0);
+  const reactivatedCount = Number(reactivationResult[0]?.reactivatedCount || 0);
   const totalVolunteers = Number(summary?.totalVolunteers || 0);
   const prevHighlyActiveCount = Number(summary?.prevHighlyActiveCount || 0);
   const prevActiveCount = Number(summary?.prevActiveCount || 0);
@@ -197,6 +269,7 @@ export async function getEngagementSummary(
       neverVolunteeredCount,
       retentionRate,
       newInPeriodCount,
+      reactivatedCount,
     },
     monthlyTrend,
     breakdown: [

--- a/web/src/lib/milestone-analytics.ts
+++ b/web/src/lib/milestone-analytics.ts
@@ -2,11 +2,11 @@ import { prisma } from "@/lib/prisma";
 import { Prisma } from "@/generated/client";
 import { nowInNZT } from "@/lib/timezone";
 import { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
+import { MILESTONE_THRESHOLDS } from "@/lib/milestone-thresholds";
 
 export { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
-
-export const MILESTONE_THRESHOLDS = [10, 25, 50, 100, 200, 500] as const;
-export type MilestoneThreshold = (typeof MILESTONE_THRESHOLDS)[number];
+export { MILESTONE_THRESHOLDS } from "@/lib/milestone-thresholds";
+export type { MilestoneThreshold } from "@/lib/milestone-thresholds";
 
 export interface MilestoneHit {
   threshold: number;

--- a/web/src/lib/milestone-thresholds.test.ts
+++ b/web/src/lib/milestone-thresholds.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  getMilestoneStatus,
+  MILESTONE_THRESHOLDS,
+} from "./milestone-thresholds";
+
+describe("getMilestoneStatus", () => {
+  it("flags the shift that lands exactly on a milestone (hitsOnNext)", () => {
+    expect(getMilestoneStatus(9)).toEqual({
+      nextThreshold: 10,
+      shiftsAway: 1,
+      hitsOnNext: true,
+    });
+    expect(getMilestoneStatus(24)).toEqual({
+      nextThreshold: 25,
+      shiftsAway: 1,
+      hitsOnNext: true,
+    });
+    expect(getMilestoneStatus(49)).toEqual({
+      nextThreshold: 50,
+      shiftsAway: 1,
+      hitsOnNext: true,
+    });
+  });
+
+  it("reports approaching volunteers (more than one shift away)", () => {
+    expect(getMilestoneStatus(23)).toEqual({
+      nextThreshold: 25,
+      shiftsAway: 2,
+      hitsOnNext: false,
+    });
+    expect(getMilestoneStatus(0)).toEqual({
+      nextThreshold: 10,
+      shiftsAway: 10,
+      hitsOnNext: false,
+    });
+  });
+
+  it("advances to the next threshold once one is reached", () => {
+    expect(getMilestoneStatus(10)).toEqual({
+      nextThreshold: 25,
+      shiftsAway: 15,
+      hitsOnNext: false,
+    });
+    expect(getMilestoneStatus(25)).toEqual({
+      nextThreshold: 50,
+      shiftsAway: 25,
+      hitsOnNext: false,
+    });
+  });
+
+  it("returns no next threshold past the top milestone", () => {
+    expect(getMilestoneStatus(500)).toEqual({
+      nextThreshold: null,
+      shiftsAway: 0,
+      hitsOnNext: false,
+    });
+    expect(getMilestoneStatus(999)).toEqual({
+      nextThreshold: null,
+      shiftsAway: 0,
+      hitsOnNext: false,
+    });
+    // One away from the top milestone still flags.
+    expect(getMilestoneStatus(499)).toEqual({
+      nextThreshold: 500,
+      shiftsAway: 1,
+      hitsOnNext: true,
+    });
+  });
+
+  it("handles invalid/negative/fractional input defensively", () => {
+    expect(getMilestoneStatus(-5)).toEqual({
+      nextThreshold: 10,
+      shiftsAway: 10,
+      hitsOnNext: false,
+    });
+    expect(getMilestoneStatus(9.7)).toEqual({
+      nextThreshold: 10,
+      shiftsAway: 1,
+      hitsOnNext: true,
+    });
+    expect(getMilestoneStatus(NaN)).toEqual({
+      nextThreshold: 10,
+      shiftsAway: 10,
+      hitsOnNext: false,
+    });
+  });
+
+  it("exposes the canonical thresholds", () => {
+    expect(MILESTONE_THRESHOLDS).toEqual([10, 25, 50, 100, 200, 500]);
+  });
+});

--- a/web/src/lib/milestone-thresholds.ts
+++ b/web/src/lib/milestone-thresholds.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared milestone thresholds (number of completed shifts).
+ *
+ * This is a *pure* module — no Prisma/server imports — so it can be safely
+ * imported from client components (e.g. the admin roster) as well as the
+ * server-side analytics code. `milestone-analytics.ts` re-exports these.
+ */
+
+export const MILESTONE_THRESHOLDS = [10, 25, 50, 100, 200, 500] as const;
+export type MilestoneThreshold = (typeof MILESTONE_THRESHOLDS)[number];
+
+export interface MilestoneStatus {
+  /** The next milestone the volunteer is working toward, or null if past the top one. */
+  nextThreshold: MilestoneThreshold | null;
+  /** Completed shifts still needed to reach `nextThreshold` (0 once reached). */
+  shiftsAway: number;
+  /**
+   * True when completing one more shift lands the volunteer exactly on a
+   * milestone — i.e. the shift they're rostered on is their Nth.
+   */
+  hitsOnNext: boolean;
+}
+
+/**
+ * Given a volunteer's number of already-completed shifts, describe their
+ * progress toward the next milestone.
+ *
+ * Examples (thresholds 10/25/50/…):
+ *  - completed 9  → nextThreshold 10, shiftsAway 1, hitsOnNext true
+ *  - completed 24 → nextThreshold 25, shiftsAway 1, hitsOnNext true
+ *  - completed 23 → nextThreshold 25, shiftsAway 2, hitsOnNext false
+ *  - completed 25 → nextThreshold 50, shiftsAway 25, hitsOnNext false
+ *  - completed 500+ → nextThreshold null, shiftsAway 0, hitsOnNext false
+ */
+export function getMilestoneStatus(completedShifts: number): MilestoneStatus {
+  const safeCompleted = Number.isFinite(completedShifts)
+    ? Math.max(0, Math.floor(completedShifts))
+    : 0;
+
+  const nextThreshold =
+    MILESTONE_THRESHOLDS.find((t) => t > safeCompleted) ?? null;
+
+  if (nextThreshold === null) {
+    return { nextThreshold: null, shiftsAway: 0, hitsOnNext: false };
+  }
+
+  const shiftsAway = nextThreshold - safeCompleted;
+  return {
+    nextThreshold,
+    shiftsAway,
+    hitsOnNext: shiftsAway === 1,
+  };
+}

--- a/web/src/lib/shift-coverage.test.ts
+++ b/web/src/lib/shift-coverage.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeCoverageTotals,
+  fillRate,
+  type ShiftCoverageRow,
+} from "./shift-coverage";
+
+function row(overrides: Partial<ShiftCoverageRow>): ShiftCoverageRow {
+  return {
+    location: "Wellington",
+    totalShifts: 0,
+    totalPositions: 0,
+    filledPositions: 0,
+    unfilledShifts: 0,
+    fullyEmptyShifts: 0,
+    understaffedShifts: 0,
+    criticallyUnderstaffedShifts: 0,
+    fillRate: 0,
+    ...overrides,
+  };
+}
+
+describe("fillRate", () => {
+  it("computes a rounded percentage", () => {
+    expect(fillRate(75, 100)).toBe(75);
+    expect(fillRate(1, 3)).toBe(33);
+    expect(fillRate(2, 3)).toBe(67);
+  });
+
+  it("returns 0 when no positions are offered (no divide-by-zero)", () => {
+    expect(fillRate(0, 0)).toBe(0);
+    expect(fillRate(5, 0)).toBe(0);
+  });
+});
+
+describe("computeCoverageTotals", () => {
+  it("returns an empty total for no rows", () => {
+    expect(computeCoverageTotals([])).toEqual({
+      location: "All Locations",
+      totalShifts: 0,
+      totalPositions: 0,
+      filledPositions: 0,
+      unfilledShifts: 0,
+      fullyEmptyShifts: 0,
+      understaffedShifts: 0,
+      criticallyUnderstaffedShifts: 0,
+      fillRate: 0,
+    });
+  });
+
+  it("sums every metric across restaurants and recomputes the fill rate", () => {
+    const totals = computeCoverageTotals([
+      row({
+        location: "Wellington",
+        totalShifts: 10,
+        totalPositions: 40,
+        filledPositions: 30,
+        unfilledShifts: 4,
+        fullyEmptyShifts: 1,
+        understaffedShifts: 3,
+        criticallyUnderstaffedShifts: 1,
+      }),
+      row({
+        location: "Auckland",
+        totalShifts: 6,
+        totalPositions: 20,
+        filledPositions: 10,
+        unfilledShifts: 5,
+        fullyEmptyShifts: 2,
+        understaffedShifts: 4,
+        criticallyUnderstaffedShifts: 2,
+      }),
+    ]);
+
+    expect(totals.totalShifts).toBe(16);
+    expect(totals.totalPositions).toBe(60);
+    expect(totals.filledPositions).toBe(40);
+    expect(totals.unfilledShifts).toBe(9);
+    expect(totals.fullyEmptyShifts).toBe(3);
+    expect(totals.understaffedShifts).toBe(7);
+    expect(totals.criticallyUnderstaffedShifts).toBe(3);
+    // 40 / 60 = 66.7% → 67
+    expect(totals.fillRate).toBe(67);
+  });
+
+  it("keeps critically understaffed as a subset of understaffed in the totals", () => {
+    const totals = computeCoverageTotals([
+      row({ understaffedShifts: 3, criticallyUnderstaffedShifts: 1 }),
+      row({ understaffedShifts: 2, criticallyUnderstaffedShifts: 2 }),
+    ]);
+    expect(totals.criticallyUnderstaffedShifts).toBeLessThanOrEqual(
+      totals.understaffedShifts
+    );
+  });
+});

--- a/web/src/lib/shift-coverage.ts
+++ b/web/src/lib/shift-coverage.ts
@@ -1,0 +1,179 @@
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/client";
+import { shiftStartNZ } from "@/lib/concurrent-shifts";
+import { UNSPECIFIED_LOCATION } from "@/lib/recruitment-types";
+
+/**
+ * Thresholds (fraction of capacity filled) used to classify staffing levels.
+ * `understaffed` is the superset (< 75% filled) and `criticallyUnderstaffed`
+ * is the worst subset of that (< 50% filled).
+ */
+export const UNDERSTAFFED_THRESHOLD = 0.75;
+export const CRITICALLY_UNDERSTAFFED_THRESHOLD = 0.5;
+
+/** Coverage figures for a single restaurant (or "Unspecified"). */
+export interface ShiftCoverageRow {
+  location: string;
+  /** Number of shift slots scheduled in the period. */
+  totalShifts: number;
+  /** Sum of `capacity` across those shifts (positions offered). */
+  totalPositions: number;
+  /** Positions filled (capped at capacity), i.e. confirmed + regulars + walk-ins. */
+  filledPositions: number;
+  /** Shifts with at least one empty position (`filled < capacity`). */
+  unfilledShifts: number;
+  /** Shifts with nobody signed up (`filled = 0`). */
+  fullyEmptyShifts: number;
+  /** Shifts under 75% filled (includes critically understaffed). */
+  understaffedShifts: number;
+  /** Shifts under 50% filled. */
+  criticallyUnderstaffedShifts: number;
+  /** filledPositions / totalPositions as a 0–100 percentage. */
+  fillRate: number;
+}
+
+export interface ShiftCoverageData {
+  totals: ShiftCoverageRow;
+  byLocation: ShiftCoverageRow[];
+  periodMonths: number;
+}
+
+interface CoverageQueryRow {
+  location: string;
+  total_shifts: bigint;
+  total_positions: bigint;
+  filled_positions: bigint;
+  unfilled_shifts: bigint;
+  fully_empty_shifts: bigint;
+  understaffed_shifts: bigint;
+  critically_understaffed_shifts: bigint;
+}
+
+export function fillRate(filled: number, positions: number): number {
+  return positions > 0 ? Math.round((filled / positions) * 100) : 0;
+}
+
+/**
+ * Roll per-restaurant coverage rows up into an "All Locations" total.
+ * Pure helper (no DB) so it can be unit tested independently.
+ */
+export function computeCoverageTotals(
+  byLocation: ShiftCoverageRow[]
+): ShiftCoverageRow {
+  const totals = byLocation.reduce<ShiftCoverageRow>(
+    (acc, row) => {
+      acc.totalShifts += row.totalShifts;
+      acc.totalPositions += row.totalPositions;
+      acc.filledPositions += row.filledPositions;
+      acc.unfilledShifts += row.unfilledShifts;
+      acc.fullyEmptyShifts += row.fullyEmptyShifts;
+      acc.understaffedShifts += row.understaffedShifts;
+      acc.criticallyUnderstaffedShifts += row.criticallyUnderstaffedShifts;
+      return acc;
+    },
+    {
+      location: "All Locations",
+      totalShifts: 0,
+      totalPositions: 0,
+      filledPositions: 0,
+      unfilledShifts: 0,
+      fullyEmptyShifts: 0,
+      understaffedShifts: 0,
+      criticallyUnderstaffedShifts: 0,
+      fillRate: 0,
+    }
+  );
+  totals.fillRate = fillRate(totals.filledPositions, totals.totalPositions);
+  return totals;
+}
+
+/**
+ * Restaurant-level shift coverage for the engagement report:
+ *  - how many shifts each restaurant ran in the period,
+ *  - how many positions were offered vs filled,
+ *  - how many shifts went unfilled / understaffed / critically understaffed.
+ *
+ * "Filled" matches the staffing definition used elsewhere (the shortage
+ * endpoint): CONFIRMED + REGULAR_PENDING signups plus walk-in placeholders.
+ * The window covers shifts that have already started within the period
+ * (`start >= periodStart AND start < now`) so fill rates reflect shifts that
+ * actually ran rather than future ones that are still filling up.
+ */
+export async function getShiftCoverage(
+  months: number,
+  location: string | null,
+  daysFilter: number[] | null = null
+): Promise<ShiftCoverageData> {
+  const now = new Date();
+  const periodStart = new Date(now);
+  periodStart.setMonth(periodStart.getMonth() - months);
+
+  const isLocationFiltered = !!location && location !== "all";
+  const locationCond = isLocationFiltered
+    ? Prisma.sql`AND sh.location = ${location}`
+    : Prisma.empty;
+  const daysCond =
+    daysFilter && daysFilter.length > 0
+      ? Prisma.sql`AND EXTRACT(DOW FROM ${shiftStartNZ()})::int IN (${Prisma.join(
+          daysFilter
+        )})`
+      : Prisma.empty;
+
+  const rows = await prisma.$queryRaw<CoverageQueryRow[]>`
+    WITH shift_fill AS (
+      SELECT
+        COALESCE(NULLIF(sh.location, ''), ${UNSPECIFIED_LOCATION}) AS location,
+        sh.capacity AS capacity,
+        (
+          SELECT COUNT(*) FROM "Signup" sg
+          WHERE sg."shiftId" = sh.id
+            AND sg.status IN ('CONFIRMED'::"SignupStatus", 'REGULAR_PENDING'::"SignupStatus")
+        )
+        + (
+          SELECT COUNT(*) FROM "ShiftPlaceholder" p
+          WHERE p."shiftId" = sh.id
+        ) AS filled
+      FROM "Shift" sh
+      WHERE sh."start" >= ${periodStart}
+        AND sh."start" < ${now}
+        ${locationCond}
+        ${daysCond}
+    )
+    SELECT
+      location,
+      COUNT(*)::bigint AS total_shifts,
+      COALESCE(SUM(capacity), 0)::bigint AS total_positions,
+      COALESCE(SUM(LEAST(filled, capacity)), 0)::bigint AS filled_positions,
+      COUNT(*) FILTER (WHERE filled < capacity)::bigint AS unfilled_shifts,
+      COUNT(*) FILTER (WHERE filled = 0)::bigint AS fully_empty_shifts,
+      COUNT(*) FILTER (
+        WHERE capacity > 0 AND filled::float / capacity < ${UNDERSTAFFED_THRESHOLD}
+      )::bigint AS understaffed_shifts,
+      COUNT(*) FILTER (
+        WHERE capacity > 0 AND filled::float / capacity < ${CRITICALLY_UNDERSTAFFED_THRESHOLD}
+      )::bigint AS critically_understaffed_shifts
+    FROM shift_fill
+    GROUP BY location
+    ORDER BY location
+  `;
+
+  const byLocation: ShiftCoverageRow[] = rows.map((r) => {
+    const totalPositions = Number(r.total_positions);
+    const filledPositions = Number(r.filled_positions);
+    return {
+      location: r.location,
+      totalShifts: Number(r.total_shifts),
+      totalPositions,
+      filledPositions,
+      unfilledShifts: Number(r.unfilled_shifts),
+      fullyEmptyShifts: Number(r.fully_empty_shifts),
+      understaffedShifts: Number(r.understaffed_shifts),
+      criticallyUnderstaffedShifts: Number(r.critically_understaffed_shifts),
+      fillRate: fillRate(filledPositions, totalPositions),
+    };
+  });
+
+  const totals = computeCoverageTotals(byLocation);
+
+  return { totals, byLocation, periodMonths: months };
+}


### PR DESCRIPTION
## Description

Implements the volunteer-engagement reporting functions requested by EE (Nic) for the first engagement report, plus a roster heads-up so Restaurant Managers can acknowledge volunteer milestones during a shift.

**1–3. Shift Coverage report** — new page at `/admin/analytics/coverage` (added under the Analytics nav group, mirrors the existing analytics pages' filter/KPI/chart patterns):
- **Shifts available per restaurant** — shifts run + positions offered, per location and overall
- **Unfilled shifts** — shifts with empty positions, plus a "fully empty" (zero signups) sub-count
- **Understaffed / critically understaffed** — `< 75%` and `< 50%` filled, with a per-restaurant stacked bar chart and breakdown table

"Filled" reuses the existing staffing definition (CONFIRMED + REGULAR_PENDING signups + walk-in placeholders), matching the shortage endpoint.

**4. Reactivated volunteers** — new KPI on the existing Volunteer Engagement report: volunteers who returned after a 6-month gap of inactivity (excludes first-timers).

**5. RM milestone heads-up** — on the `/admin/shifts` roster, each attending volunteer's card flags when this shift is their Nth (10/25/50/100/200/500) — e.g. "🎉 10th shift today!" — and a softer "1 from 25" hint when within 2. Reuses the completed-shift count already loaded on the page, so no extra queries. No access changes needed (RMs are ADMIN users who already access the roster).

A new pure `milestone-thresholds` module is the single source of truth for the thresholds (shared by the analytics code and the client roster component).

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Unit tests pass (208 pass, incl. new `milestone-thresholds` boundary tests and `shift-coverage` aggregation tests)
- [x] Manual testing completed
- [x] New tests added
- `npm run typecheck` and `npm run lint` clean (0 errors)
- Verified live against the dev DB as admin: Shift Coverage figures **cross-checked against a direct SQL query — exact match** (213 shifts, 119 unfilled, 92 empty, 116 understaffed, 108 critical); Reactivated KPI renders (0 for the demo dataset, which has no 6-month gaps — confirmed correct); milestone badge confirmed via a reversible data scenario ("10th shift today!" appeared on the roster, then test rows removed)

## Reviewer notes
- Default business definitions are easy to tune later if EE prefers different numbers: count of slots; unfilled = has empty positions; understaffed `<75%` / critical `<50%`; reactivation = 6-month gap; milestone flag on exact-hit + within-2.
- The milestone flag is **roster-display only**, as requested — no emails/notifications.
- Coverage window = shifts that have started within the selected period (`start >= periodStart AND start < now`), so fill rates reflect shifts that actually ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)