### PR TITLE
fix(messages): hide empty threads from admin inbox

### DIFF
--- a/web/src/lib/services/messaging.test.ts
+++ b/web/src/lib/services/messaging.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { listThreadsForAdmin } from "./messaging";
+import { prisma } from "@/lib/prisma";
+
+// Mock the prisma client
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    messageThread: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+// messaging.ts imports notification helpers at module load; stub them out so
+// the import graph doesn't pull in real services.
+vi.mock("@/lib/messaging-notify", () => ({
+  broadcastNewMessageToAdmins: vi.fn(),
+  notifyVolunteerOfTeamMessage: vi.fn(),
+}));
+
+const findMany = prisma.messageThread.findMany as ReturnType<typeof vi.fn>;
+
+function buildThread(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "thread-1",
+    status: "OPEN",
+    lastMessageAt: new Date("2025-01-01T00:00:00Z"),
+    teamLastReadAt: null,
+    volunteer: {
+      id: "vol-1",
+      firstName: "Aroha",
+      lastName: "Ngata",
+      name: null,
+      email: "aroha@example.com",
+      profilePhotoUrl: null,
+      defaultLocation: "Wellington",
+    },
+    messages: [
+      {
+        body: "Kia ora, can I help on Friday?",
+        senderRole: "VOLUNTEER",
+        createdAt: new Date("2025-01-01T00:00:00Z"),
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("listThreadsForAdmin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("only queries threads that have at least one message", async () => {
+    findMany.mockResolvedValue([]);
+
+    await listThreadsForAdmin();
+
+    expect(findMany).toHaveBeenCalledTimes(1);
+    const where = findMany.mock.calls[0][0].where;
+    // Guards the regression: empty threads created when a volunteer merely
+    // opens the mobile chat screen must not appear in the admin inbox.
+    expect(where.messages).toEqual({ some: {} });
+  });
+
+  it("keeps the message filter alongside status and search filters", async () => {
+    findMany.mockResolvedValue([]);
+
+    await listThreadsForAdmin({ status: "RESOLVED", search: "aroha" });
+
+    const where = findMany.mock.calls[0][0].where;
+    expect(where.messages).toEqual({ some: {} });
+    expect(where.status).toBe("RESOLVED");
+    expect(where.volunteer).toBeDefined();
+  });
+
+  it("maps a thread with messages into a list item", async () => {
+    findMany.mockResolvedValue([buildThread()]);
+
+    const items = await listThreadsForAdmin();
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: "thread-1",
+      status: "OPEN",
+      unreadForTeam: true,
+      lastMessage: { body: "Kia ora, can I help on Friday?" },
+      volunteer: { id: "vol-1", name: "Aroha Ngata" },
+    });
+  });
+});

--- a/web/src/lib/services/messaging.ts
+++ b/web/src/lib/services/messaging.ts
@@ -282,7 +282,13 @@ export async function listThreadsForAdmin(
     cursor,
   } = opts;
 
-  const where: Prisma.MessageThreadWhereInput = {};
+  const where: Prisma.MessageThreadWhereInput = {
+    // Threads are created lazily when a volunteer first opens the mobile chat
+    // screen, before they've actually sent anything. Only surface threads that
+    // contain at least one message so the inbox isn't filled with people who
+    // merely opened the screen.
+    messages: { some: {} },
+  };
   if (status !== "ALL") where.status = status;
   const volunteerFilters: Prisma.UserWhereInput[] = [];
   if (location) volunteerFilters.push({ defaultLocation: location });


### PR DESCRIPTION
## Problem

The admin **Messages** page was getting noisy: a volunteer appeared in the inbox as soon as they *opened* the chat screen on mobile, even if they never sent a message.

## Root cause

When the mobile chat screen mounts, it calls `GET /api/mobile/messages/thread`, which runs `getOrCreateThreadForVolunteer()`. This **lazily creates an empty `MessageThread`** so the screen has something to attach the read marker to — before the volunteer types anything.

`listThreadsForAdmin()` then returned *every* thread regardless of whether it contained any messages, so these empty "just opened the screen" threads showed up in the admin inbox.

## Fix

Add a `messages: { some: {} }` filter to the admin thread query so only threads with at least one actual message are surfaced.

```ts
const where: Prisma.MessageThreadWhereInput = {
  messages: { some: {} },
};
```

### Why this approach
- **Keeps lazy thread creation** — the mobile screen still gets a thread object for its read marker; that flow is untouched.
- **Unread badge already safe** — `isUnreadForTeam()` already returns `false` for message-less threads, so this only affects the visible list.
- **Retroactive** — also hides empty threads already in the DB from past opens, with no data migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)