### PR TITLE
fix(shifts): hydration crash, translation-extension crashes & error-tracking noise

### DIFF
--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -1,60 +1,15 @@
 import posthog from "posthog-js";
 import { installDomTranslationGuard } from "@/lib/dom-translation-guard";
+import { isNoiseException } from "@/lib/posthog-noise-filter";
 
 // Protect React from in-browser translation extensions that mutate the DOM
 // (Google Translate etc.) and otherwise crash the page. Runs before hydration.
 installDomTranslationGuard();
 
-/**
- * Exception messages that originate from browser extensions or opaque
- * cross-origin scripts — not from our code. They add noise to error tracking
- * (and inflate week-over-week trends) without being actionable, so we drop them
- * before they're sent to PostHog.
- */
-const NOISE_EXCEPTION_PATTERNS: RegExp[] = [
-  // Outlook "Safe Links" / other extension content-script injectors.
-  /Object Not Found Matching Id:\d+, MethodName:update/i,
-  // Opaque cross-origin script errors — no actionable stack trace.
-  // (Some browsers append "(line 0)" etc., so this isn't anchored at the end.)
-  /^Script error\.?/i,
-  // Benign browser layout notifications, not real errors.
-  /ResizeObserver loop (limit exceeded|completed with undelivered notifications)/i,
-];
-
-function isNoiseException(event: {
-  event: string;
-  properties?: Record<string, unknown>;
-}): boolean {
-  if (event.event !== "$exception") return false;
-
-  const props = event.properties ?? {};
-  const values: string[] = [];
-
-  const list = props.$exception_list;
-  if (Array.isArray(list)) {
-    for (const item of list) {
-      if (item && typeof item === "object" && "value" in item) {
-        const value = (item as { value?: unknown }).value;
-        if (typeof value === "string") values.push(value);
-      }
-    }
-  }
-
-  const exceptionValues = props.$exception_values;
-  if (Array.isArray(exceptionValues)) {
-    for (const value of exceptionValues) {
-      if (typeof value === "string") values.push(value);
-    }
-  }
-
-  return values.some((value) =>
-    NOISE_EXCEPTION_PATTERNS.some((pattern) => pattern.test(value))
-  );
-}
-
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   defaults: "2025-05-24",
+  // Drop extension / cross-origin exception noise before it reaches PostHog.
   before_send: (event) => {
     if (event && isNoiseException(event)) return null;
     return event;

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -1,6 +1,62 @@
 import posthog from "posthog-js";
+import { installDomTranslationGuard } from "@/lib/dom-translation-guard";
+
+// Protect React from in-browser translation extensions that mutate the DOM
+// (Google Translate etc.) and otherwise crash the page. Runs before hydration.
+installDomTranslationGuard();
+
+/**
+ * Exception messages that originate from browser extensions or opaque
+ * cross-origin scripts — not from our code. They add noise to error tracking
+ * (and inflate week-over-week trends) without being actionable, so we drop them
+ * before they're sent to PostHog.
+ */
+const NOISE_EXCEPTION_PATTERNS: RegExp[] = [
+  // Outlook "Safe Links" / other extension content-script injectors.
+  /Object Not Found Matching Id:\d+, MethodName:update/i,
+  // Opaque cross-origin script errors — no actionable stack trace.
+  // (Some browsers append "(line 0)" etc., so this isn't anchored at the end.)
+  /^Script error\.?/i,
+  // Benign browser layout notifications, not real errors.
+  /ResizeObserver loop (limit exceeded|completed with undelivered notifications)/i,
+];
+
+function isNoiseException(event: {
+  event: string;
+  properties?: Record<string, unknown>;
+}): boolean {
+  if (event.event !== "$exception") return false;
+
+  const props = event.properties ?? {};
+  const values: string[] = [];
+
+  const list = props.$exception_list;
+  if (Array.isArray(list)) {
+    for (const item of list) {
+      if (item && typeof item === "object" && "value" in item) {
+        const value = (item as { value?: unknown }).value;
+        if (typeof value === "string") values.push(value);
+      }
+    }
+  }
+
+  const exceptionValues = props.$exception_values;
+  if (Array.isArray(exceptionValues)) {
+    for (const value of exceptionValues) {
+      if (typeof value === "string") values.push(value);
+    }
+  }
+
+  return values.some((value) =>
+    NOISE_EXCEPTION_PATTERNS.some((pattern) => pattern.test(value))
+  );
+}
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   defaults: "2025-05-24",
+  before_send: (event) => {
+    if (event && isNoiseException(event)) return null;
+    return event;
+  },
 });

--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -514,6 +514,7 @@ export default async function ShiftsCalendarPage({
       <ShiftsCalendar
         shifts={shiftSummaries}
         selectedLocation={selectedLocation}
+        serverNow={Date.now()}
       />
     </PageContainer>
     </>

--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -177,10 +177,14 @@ export default async function ShiftsCalendarPage({
     hasExplicitLocationChoice = true;
   }
 
+  // Single server-side timestamp, reused for the shift query and seeded into
+  // the calendar so SSR and client hydration agree on "now" (see ShiftsCalendar).
+  const now = new Date();
+
   // Fetch shifts for calendar view - simplified data structure
   const shifts = await prisma.shift.findMany({
     where: {
-      start: { gte: new Date() },
+      start: { gte: now },
       ...(filterLocations.length > 0
         ? { location: { in: filterLocations } }
         : {}),
@@ -514,7 +518,7 @@ export default async function ShiftsCalendarPage({
       <ShiftsCalendar
         shifts={shiftSummaries}
         selectedLocation={selectedLocation}
-        serverNow={Date.now()}
+        serverNow={now.getTime()}
       />
     </PageContainer>
     </>

--- a/web/src/components/shifts-calendar.tsx
+++ b/web/src/components/shifts-calendar.tsx
@@ -51,6 +51,13 @@ interface ShiftSummary {
 interface ShiftsCalendarProps {
   shifts: ShiftSummary[];
   selectedLocation?: string;
+  /**
+   * Server-rendered "now" as an epoch-ms timestamp. Seeding all time-dependent
+   * state from a single server-provided value keeps the SSR output and the
+   * client hydration render identical, avoiding React #418 hydration mismatches
+   * when the server's clock and the client's clock straddle a day/month boundary.
+   */
+  serverNow: number;
 }
 
 interface DayShifts {
@@ -76,8 +83,16 @@ interface DayShifts {
 export function ShiftsCalendar({
   shifts,
   selectedLocation,
+  serverNow,
 }: ShiftsCalendarProps) {
-  const [currentMonth, setCurrentMonth] = useState(new Date());
+  // All "now"-derived values come from the server timestamp so the initial
+  // client render matches the SSR output exactly (prevents hydration errors).
+  const [currentMonth, setCurrentMonth] = useState(() => new Date(serverNow));
+
+  // Stable references to "now" for the initial render.
+  const nowDate = new Date(serverNow);
+  const todayMidnight = new Date(serverNow);
+  todayMidnight.setHours(0, 0, 0, 0);
 
   const monthStart = startOfMonth(currentMonth);
   const monthEnd = endOfMonth(currentMonth);
@@ -227,7 +242,7 @@ export function ShiftsCalendar({
             size="sm"
             onClick={previousMonth}
             disabled={
-              format(currentMonth, "yyyy-MM") <= format(new Date(), "yyyy-MM")
+              format(currentMonth, "yyyy-MM") <= format(nowDate, "yyyy-MM")
             }
             data-testid="calendar-prev-month"
           >
@@ -321,8 +336,7 @@ export function ShiftsCalendar({
                       dayShifts.date,
                       currentMonth
                     );
-                    const today = new Date();
-                    today.setHours(0, 0, 0, 0);
+                    const today = todayMidnight;
                     const dayStart = new Date(dayShifts.date);
                     dayStart.setHours(0, 0, 0, 0);
                     const isPastDate = dayStart < today;
@@ -497,10 +511,10 @@ export function ShiftsCalendar({
                   )}.`}
             </p>
             <p className="text-sm text-muted-foreground">
-              {format(currentMonth, "yyyy-MM") > format(new Date(), "yyyy-MM")
+              {format(currentMonth, "yyyy-MM") > format(nowDate, "yyyy-MM")
                 ? "Shifts are usually published closer to the date."
                 : format(currentMonth, "yyyy-MM") <
-                  format(new Date(), "yyyy-MM")
+                  format(nowDate, "yyyy-MM")
                 ? "This month has passed. Try viewing current or future months."
                 : "Check back soon for upcoming shifts, or try a different location."}
             </p>

--- a/web/src/lib/dom-translation-guard.test.ts
+++ b/web/src/lib/dom-translation-guard.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  installDomTranslationGuard,
+  shouldSkipRemoveChild,
+  shouldSkipInsertBefore,
+  type GuardableNode,
+} from "./dom-translation-guard";
+
+/** Build a minimal structural node for the guard predicates. */
+function makeNode(
+  parentNode: GuardableNode | null = null,
+  contained: ReadonlyArray<unknown> = []
+): GuardableNode {
+  const set = new Set(contained);
+  return {
+    parentNode,
+    contains: (other: unknown) => set.has(other),
+  };
+}
+
+describe("dom-translation-guard", () => {
+  describe("shouldSkipRemoveChild", () => {
+    it("skips when the child's parent is not this node (would throw NotFoundError)", () => {
+      const parent = makeNode();
+      const otherParent = makeNode();
+      const child = makeNode(otherParent);
+      expect(shouldSkipRemoveChild(parent, child)).toBe(true);
+    });
+
+    it("skips when the child has been detached (parentNode is null)", () => {
+      const parent = makeNode();
+      const child = makeNode(null);
+      expect(shouldSkipRemoveChild(parent, child)).toBe(true);
+    });
+
+    it("does not skip a genuine child (normal removeChild proceeds)", () => {
+      const parent = makeNode();
+      const child = makeNode(parent);
+      expect(shouldSkipRemoveChild(parent, child)).toBe(false);
+    });
+  });
+
+  describe("shouldSkipInsertBefore", () => {
+    it("skips when the reference node is not a child of this node (NotFoundError)", () => {
+      const parent = makeNode();
+      const stranger = makeNode(makeNode());
+      const newNode = makeNode();
+      expect(shouldSkipInsertBefore(parent, newNode, stranger)).toBe(true);
+    });
+
+    it("skips when the new node is an ancestor of this node (HierarchyRequestError)", () => {
+      const parent = makeNode();
+      // newNode "contains" parent -> inserting it under parent would create a cycle.
+      const newNode = makeNode(null, [parent]);
+      expect(shouldSkipInsertBefore(parent, newNode, null)).toBe(true);
+    });
+
+    it("does not skip a plain append (null reference node, no cycle)", () => {
+      const parent = makeNode();
+      const newNode = makeNode();
+      expect(shouldSkipInsertBefore(parent, newNode, null)).toBe(false);
+    });
+
+    it("does not skip a valid insert before a real child", () => {
+      const parent = makeNode();
+      const referenceNode = makeNode(parent);
+      const newNode = makeNode();
+      expect(shouldSkipInsertBefore(parent, newNode, referenceNode)).toBe(false);
+    });
+
+    it("does not flag a self-insert as a cycle", () => {
+      // newNode === parent: even if contains() reports true, the `newNode !==
+      // parent` guard must short-circuit so this is not mistaken for a cycle.
+      const parent = makeNode();
+      (parent as { contains: (other: unknown) => boolean }).contains = () =>
+        true;
+      expect(shouldSkipInsertBefore(parent, parent, null)).toBe(false);
+    });
+
+    it("tolerates nodes without a contains() method", () => {
+      const parent: GuardableNode = { parentNode: null };
+      const newNode: GuardableNode = { parentNode: null };
+      expect(shouldSkipInsertBefore(parent, newNode, null)).toBe(false);
+    });
+  });
+
+  describe("installDomTranslationGuard", () => {
+    it("is safe to call (and idempotent) when no DOM is present", () => {
+      // The vitest environment is `node`, so `Node` is undefined and the guard
+      // is a no-op. It must never throw and must be safe to call repeatedly.
+      expect(() => {
+        installDomTranslationGuard();
+        installDomTranslationGuard();
+      }).not.toThrow();
+    });
+  });
+});

--- a/web/src/lib/dom-translation-guard.ts
+++ b/web/src/lib/dom-translation-guard.ts
@@ -14,11 +14,48 @@
  * The exception is unhandled and takes the whole page down. We surfaced this on
  * `/shifts/details` and `/shifts/mine` in error tracking.
  *
- * These overrides make the two methods degrade gracefully in exactly the cases
- * that would otherwise throw, and otherwise defer to the native behaviour, so
- * normal rendering is untouched. This is the widely-used workaround for
- * https://github.com/facebook/react/issues/11538.
+ * The overrides below make the two methods degrade gracefully in exactly the
+ * cases that would otherwise throw, and otherwise defer to the native
+ * behaviour, so normal rendering is untouched. This is the widely-used
+ * workaround for https://github.com/facebook/react/issues/11538.
  */
+
+/**
+ * Minimal structural shape of a DOM node used by the guard predicates. Kept
+ * dependency-free so the decision logic is unit-testable without a DOM.
+ */
+export interface GuardableNode {
+  parentNode: GuardableNode | null;
+  contains?(other: unknown): boolean;
+}
+
+/**
+ * A native `removeChild(child)` throws `NotFoundError` when `child` is not
+ * actually a child of `parent`. Returns true when we should skip the call.
+ */
+export function shouldSkipRemoveChild(
+  parent: GuardableNode,
+  child: GuardableNode
+): boolean {
+  return child.parentNode !== parent;
+}
+
+/**
+ * A native `insertBefore(newNode, referenceNode)` throws when:
+ *   - `referenceNode` is not a child of `parent` (NotFoundError), or
+ *   - `newNode` is an ancestor of `parent` (HierarchyRequestError —
+ *     "the new child element contains the parent").
+ * Returns true when we should skip the call.
+ */
+export function shouldSkipInsertBefore(
+  parent: GuardableNode,
+  newNode: GuardableNode,
+  referenceNode: GuardableNode | null
+): boolean {
+  if (referenceNode && referenceNode.parentNode !== parent) return true;
+  if (newNode !== parent && newNode.contains?.(parent) === true) return true;
+  return false;
+}
 
 let installed = false;
 
@@ -39,7 +76,7 @@ export function installDomTranslationGuard(): void {
     this: Node,
     child: T
   ): T {
-    if (child.parentNode !== this) {
+    if (shouldSkipRemoveChild(this, child)) {
       warn("skipped removeChild for a node that is not a child", child);
       return child;
     }
@@ -52,14 +89,8 @@ export function installDomTranslationGuard(): void {
     newNode: T,
     referenceNode: Node | null
   ): T {
-    // NotFoundError: the reference node has been re-parented by translation.
-    if (referenceNode && referenceNode.parentNode !== this) {
-      warn("skipped insertBefore for a detached reference node", referenceNode);
-      return newNode;
-    }
-    // HierarchyRequestError: inserting an ancestor under itself.
-    if (newNode !== this && newNode.contains?.(this)) {
-      warn("skipped insertBefore that would create a cycle", newNode);
+    if (shouldSkipInsertBefore(this, newNode, referenceNode)) {
+      warn("skipped insertBefore that would throw", newNode, referenceNode);
       return newNode;
     }
     return originalInsertBefore.call(this, newNode, referenceNode) as T;

--- a/web/src/lib/dom-translation-guard.ts
+++ b/web/src/lib/dom-translation-guard.ts
@@ -66,7 +66,6 @@ export function installDomTranslationGuard(): void {
 
   const warn = (message: string, ...args: unknown[]) => {
     if (process.env.NODE_ENV !== "production") {
-      // eslint-disable-next-line no-console
       console.warn(`[dom-translation-guard] ${message}`, ...args);
     }
   };

--- a/web/src/lib/dom-translation-guard.ts
+++ b/web/src/lib/dom-translation-guard.ts
@@ -1,0 +1,67 @@
+/**
+ * Guards React against crashes caused by in-browser translation features
+ * (Google Translate, Microsoft Translator, and similar extensions).
+ *
+ * Those tools rewrite the page's text nodes — typically wrapping them in
+ * `<font>` elements — out from under React. When React's reconciler later
+ * calls `Node.removeChild` / `Node.insertBefore` to update the tree, the
+ * parent/child relationship it expects no longer matches the live DOM, so the
+ * browser throws:
+ *
+ *   - NotFoundError: ... node ... is not a child of this node
+ *   - HierarchyRequestError: The new child element contains the parent
+ *
+ * The exception is unhandled and takes the whole page down. We surfaced this on
+ * `/shifts/details` and `/shifts/mine` in error tracking.
+ *
+ * These overrides make the two methods degrade gracefully in exactly the cases
+ * that would otherwise throw, and otherwise defer to the native behaviour, so
+ * normal rendering is untouched. This is the widely-used workaround for
+ * https://github.com/facebook/react/issues/11538.
+ */
+
+let installed = false;
+
+export function installDomTranslationGuard(): void {
+  if (installed) return;
+  if (typeof Node !== "function" || !Node.prototype) return;
+  installed = true;
+
+  const warn = (message: string, ...args: unknown[]) => {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(`[dom-translation-guard] ${message}`, ...args);
+    }
+  };
+
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function removeChild<T extends Node>(
+    this: Node,
+    child: T
+  ): T {
+    if (child.parentNode !== this) {
+      warn("skipped removeChild for a node that is not a child", child);
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function insertBefore<T extends Node>(
+    this: Node,
+    newNode: T,
+    referenceNode: Node | null
+  ): T {
+    // NotFoundError: the reference node has been re-parented by translation.
+    if (referenceNode && referenceNode.parentNode !== this) {
+      warn("skipped insertBefore for a detached reference node", referenceNode);
+      return newNode;
+    }
+    // HierarchyRequestError: inserting an ancestor under itself.
+    if (newNode !== this && newNode.contains?.(this)) {
+      warn("skipped insertBefore that would create a cycle", newNode);
+      return newNode;
+    }
+    return originalInsertBefore.call(this, newNode, referenceNode) as T;
+  };
+}

--- a/web/src/lib/posthog-noise-filter.test.ts
+++ b/web/src/lib/posthog-noise-filter.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  getExceptionMessages,
+  isNoiseException,
+  NOISE_EXCEPTION_PATTERNS,
+  type InspectableEvent,
+} from "./posthog-noise-filter";
+
+function exceptionEvent(
+  messages: string[],
+  { useList = true }: { useList?: boolean } = {}
+): InspectableEvent {
+  return {
+    event: "$exception",
+    properties: useList
+      ? { $exception_list: messages.map((value) => ({ type: "Error", value })) }
+      : { $exception_values: messages },
+  };
+}
+
+describe("posthog-noise-filter", () => {
+  describe("isNoiseException", () => {
+    it("drops the Outlook Safe-Links extension UnhandledRejection", () => {
+      const event = exceptionEvent([
+        "Non-Error promise rejection captured with value: Object Not Found Matching Id:1, MethodName:update, ParamCount:4",
+      ]);
+      expect(isNoiseException(event)).toBe(true);
+    });
+
+    it("drops the extension error regardless of the numeric Id", () => {
+      for (const id of [1, 2, 3, 4, 17]) {
+        const event = exceptionEvent([
+          `Object Not Found Matching Id:${id}, MethodName:update, ParamCount:4`,
+        ]);
+        expect(isNoiseException(event)).toBe(true);
+      }
+    });
+
+    it("drops opaque cross-origin 'Script error.'", () => {
+      expect(isNoiseException(exceptionEvent(["Script error."]))).toBe(true);
+    });
+
+    it("drops 'Script error.' even with a trailing suffix", () => {
+      expect(
+        isNoiseException(exceptionEvent(["Script error. (line 0)"]))
+      ).toBe(true);
+    });
+
+    it("drops benign ResizeObserver loop notifications", () => {
+      expect(
+        isNoiseException(exceptionEvent(["ResizeObserver loop limit exceeded"]))
+      ).toBe(true);
+      expect(
+        isNoiseException(
+          exceptionEvent([
+            "ResizeObserver loop completed with undelivered notifications.",
+          ])
+        )
+      ).toBe(true);
+    });
+
+    it("reads messages from the flat $exception_values array too", () => {
+      const event = exceptionEvent(["Script error."], { useList: false });
+      expect(isNoiseException(event)).toBe(true);
+    });
+
+    it("matches if any exception in a multi-error list is noise", () => {
+      const event = exceptionEvent([
+        "TypeError: real app bug",
+        "Object Not Found Matching Id:2, MethodName:update, ParamCount:4",
+      ]);
+      expect(isNoiseException(event)).toBe(true);
+    });
+
+    it("keeps genuine application errors", () => {
+      const event = exceptionEvent([
+        "TypeError: Cannot read properties of undefined (reading 'id')",
+      ]);
+      expect(isNoiseException(event)).toBe(false);
+    });
+
+    it("keeps React hydration errors (those are real and actionable)", () => {
+      const event = exceptionEvent([
+        "Minified React error #418; visit https://react.dev/errors/418",
+      ]);
+      expect(isNoiseException(event)).toBe(false);
+    });
+
+    it("ignores non-exception events entirely", () => {
+      const event: InspectableEvent = {
+        event: "$pageview",
+        properties: { $exception_values: ["Script error."] },
+      };
+      expect(isNoiseException(event)).toBe(false);
+    });
+
+    it("handles exception events with no properties without throwing", () => {
+      expect(isNoiseException({ event: "$exception" })).toBe(false);
+    });
+
+    it("does not treat a message merely containing 'script error' mid-string as noise", () => {
+      // The pattern is anchored to the start, so this real error is kept.
+      const event = exceptionEvent([
+        "Failed to run script error handler for module X",
+      ]);
+      expect(isNoiseException(event)).toBe(false);
+    });
+  });
+
+  describe("getExceptionMessages", () => {
+    it("merges $exception_list values and $exception_values", () => {
+      const event: InspectableEvent = {
+        event: "$exception",
+        properties: {
+          $exception_list: [{ type: "Error", value: "from list" }],
+          $exception_values: ["from values"],
+        },
+      };
+      expect(getExceptionMessages(event)).toEqual(["from list", "from values"]);
+    });
+
+    it("skips non-string and malformed entries", () => {
+      const event: InspectableEvent = {
+        event: "$exception",
+        properties: {
+          $exception_list: [{ type: "Error" }, null, { value: 42 }],
+          $exception_values: ["ok", 99],
+        },
+      };
+      expect(getExceptionMessages(event)).toEqual(["ok"]);
+    });
+  });
+
+  describe("NOISE_EXCEPTION_PATTERNS", () => {
+    it("is a non-empty list of regexes", () => {
+      expect(NOISE_EXCEPTION_PATTERNS.length).toBeGreaterThan(0);
+      for (const pattern of NOISE_EXCEPTION_PATTERNS) {
+        expect(pattern).toBeInstanceOf(RegExp);
+      }
+    });
+  });
+});

--- a/web/src/lib/posthog-noise-filter.ts
+++ b/web/src/lib/posthog-noise-filter.ts
@@ -1,0 +1,64 @@
+/**
+ * Filters out exception events that originate from browser extensions or opaque
+ * cross-origin scripts rather than our own code. These add noise to PostHog
+ * error tracking (and inflate week-over-week trends) without being actionable,
+ * so they are dropped client-side before being sent.
+ *
+ * Used by `instrumentation-client.ts` as a PostHog `before_send` predicate.
+ */
+
+export const NOISE_EXCEPTION_PATTERNS: RegExp[] = [
+  // Outlook "Safe Links" / other extension content-script injectors.
+  /Object Not Found Matching Id:\d+, MethodName:update/i,
+  // Opaque cross-origin script errors — no actionable stack trace.
+  // (Some browsers append "(line 0)" etc., so this isn't anchored at the end.)
+  /^Script error\.?/i,
+  // Benign browser layout notifications, not real errors.
+  /ResizeObserver loop (limit exceeded|completed with undelivered notifications)/i,
+];
+
+/** Minimal structural shape of a PostHog capture event we need to inspect. */
+export interface InspectableEvent {
+  event: string;
+  properties?: Record<string, unknown>;
+}
+
+/**
+ * Pulls every exception message string out of a PostHog `$exception` event,
+ * looking at both the structured `$exception_list[].value` entries and the
+ * flat `$exception_values` array.
+ */
+export function getExceptionMessages(event: InspectableEvent): string[] {
+  const props = event.properties ?? {};
+  const messages: string[] = [];
+
+  const list = props.$exception_list;
+  if (Array.isArray(list)) {
+    for (const item of list) {
+      if (item && typeof item === "object" && "value" in item) {
+        const value = (item as { value?: unknown }).value;
+        if (typeof value === "string") messages.push(value);
+      }
+    }
+  }
+
+  const exceptionValues = props.$exception_values;
+  if (Array.isArray(exceptionValues)) {
+    for (const value of exceptionValues) {
+      if (typeof value === "string") messages.push(value);
+    }
+  }
+
+  return messages;
+}
+
+/**
+ * True when the event is an exception whose message matches a known-noise
+ * pattern and should be dropped before sending to PostHog.
+ */
+export function isNoiseException(event: InspectableEvent): boolean {
+  if (event.event !== "$exception") return false;
+  return getExceptionMessages(event).some((message) =>
+    NOISE_EXCEPTION_PATTERNS.some((pattern) => pattern.test(message))
+  );
+}


### PR DESCRIPTION
## Description
Fixes the top three issues surfaced in PostHog error tracking (the dashboard showed 410 exceptions, +70% WoW — most of it concentrated in these).

### 1. React #418 hydration mismatch on `/shifts` (the big one, ~150/wk, 60+ users)
`ShiftsCalendar` is a `"use client"` component, so Next.js renders it on the server for initial HTML and again on the client to hydrate. It called `new Date()` **during render** in four places (`currentMonth` seed, prev-month `disabled` check, per-cell `today`, empty-state copy). The server clock (UTC) and client clock (NZ, UTC+12/13) are different instants; when they straddle a **day/month boundary** the calendar grid, the `disabled` attribute, and the per-cell **`<Link>`-vs-`<div>` wrapper** rendered differently than the SSR output → React #418. Matches the intermittent, time-of-day-dependent, Safari/iOS-heavy signature.

**Fix:** seed every "now"-derived value from a single server-provided timestamp so SSR and the first client render are identical (`serverNow={Date.now()}` → lazy `useState`, hoisted `nowDate`/`todayMidnight`). Using the server clock (`TZ=Pacific/Auckland`) also makes "today" reflect NZ time.

### 2. `/shifts/details` + `/shifts/mine` DOMException crashes
In-browser translation extensions (Google Translate etc.) rewrite text nodes — wrapping them in `<font>` tags — out from under React. React's reconciler then calls `removeChild`/`insertBefore` on nodes whose parent relationship no longer matches its virtual DOM → `NotFoundError` / `HierarchyRequestError`, crashing the page.

**Fix:** `installDomTranslationGuard()` (`web/src/lib/dom-translation-guard.ts`), invoked early from `instrumentation-client.ts` (before hydration). It overrides the two `Node` methods to degrade gracefully in exactly the cases that would otherwise throw, deferring to native behaviour otherwise. Standard workaround for [facebook/react#11538](https://github.com/facebook/react/issues/11538).

### 3. Error-tracking noise (inflated the +70% trend)
Added a PostHog `before_send` filter that drops exceptions originating from browser extensions / opaque cross-origin scripts rather than our code:
- `Object Not Found Matching Id:N, MethodName:update` — extension injectors (the Jun-2 spike was ~110 of these in one day)
- `Script error.` — cross-origin, no actionable stack
- `ResizeObserver loop …` — benign browser layout notifications

Filtering in code keeps it version-controlled rather than a dashboard-only suppression rule.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
`version:patch`

## Testing
- [x] Typecheck passes for changed files (`tsc --noEmit` — verified against real `posthog-js`/DOM types via the main checkout's deps; the only `tsc` errors were pre-existing, from an out-of-sync Prisma client and unrelated to this PR)
- [ ] E2E tests
- [ ] Manual testing

> Run `npm install && npm run typecheck` in `web/` for a clean-room confirmation before merge.

## Files
- `web/src/app/shifts/page.tsx` — pass `serverNow`
- `web/src/components/shifts-calendar.tsx` — seed all "now" from `serverNow`
- `web/instrumentation-client.ts` — install DOM guard + PostHog `before_send` noise filter
- `web/src/lib/dom-translation-guard.ts` — new module

## Additional Notes
- **Residual TZ note (out of scope):** date-fns formats in the runtime's local timezone, so a visitor whose browser TZ differs wildly from NZ could still see off-by-a-day formatting of individual shift dates — a constant low rate, not the spike driver. Can be addressed separately with explicit `@date-fns/tz` bucketing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
