### PR TITLE
fix(flaky): should delete notification — replace snapshot count with toHaveCount

### DIFF
--- a/web/tests/e2e/notifications.spec.ts
+++ b/web/tests/e2e/notifications.spec.ts
@@ -188,19 +188,16 @@ test.describe("Notification System", () => {
       // Click delete button
       await firstNotification.getByTestId("delete-notification-button").click();
 
-      // Count should decrease by 1 or show empty state
-      const newCount = await page
-        .locator('[data-testid*="notification-item-"]')
-        .count();
-
       if (initialCount === 1) {
         // Should show empty state
         await expect(
           page.getByTestId("notifications-empty-state")
         ).toBeVisible();
       } else {
-        // Should have one less notification
-        expect(newCount).toBe(initialCount - 1);
+        // toHaveCount retries automatically until the DOM reflects the deletion
+        await expect(
+          page.locator('[data-testid*="notification-item-"]')
+        ).toHaveCount(initialCount - 1);
       }
     }
   });


### PR DESCRIPTION
## Root-cause analysis

**Flaky test:** `[chromium] › Notification System › should delete notification`
**File:** `web/tests/e2e/notifications.spec.ts:168`
**Confirmed on:** run [27109358143](https://github.com/everybody-eats-nz/volunteer-portal/actions/runs/27109358143) (commit `c83e19a9`), shard 14 — failed with `Expected: 4, Received: 5`, then passed on retry.

### What was happening

```ts
// ❌ Before — synchronous snapshot, no waiting
await firstNotification.getByTestId("delete-notification-button").click();
const newCount = await page.locator('[data-testid*="notification-item-"]').count();
expect(newCount).toBe(initialCount - 1);   // can be evaluated before DOM updates
```

`.count()` returns the current DOM state instantly. Clicking the delete button fires a `DELETE /api/notifications/:id` fetch, but the component re-renders asynchronously after the response arrives. On a slower runner the assertion evaluated before the optimistic/response-driven update propagated, leaving `newCount === initialCount`.

### Fix

```ts
// ✅ After — auto-retrying assertion
await firstNotification.getByTestId("delete-notification-button").click();
await expect(
  page.locator('[data-testid*="notification-item-"]')
).toHaveCount(initialCount - 1);
```

`expect(locator).toHaveCount()` polls until the condition is met or the default 5 s timeout expires. This is the same pattern used for the mark-as-read badge assertion three tests earlier in the same file (see comment: *"no arbitrary wait needed since Playwright's expect retries automatically"*).

## Other flaky tests identified this week (not fixed here)

| # | Test | File | Flake evidence |
|---|------|------|----------------|
| 2 | `should redirect unauthenticated users to login` | `admin-users.spec.ts:48` | Passed on retry; redirected to `/admin` instead of `/login` — stale session race |
| 3 | `should show response details when clicking a response` | `admin-surveys.spec.ts:811` | Failed all retries in Test workflow but CI passed same commit `aaed7ad6` |
| 4 | `should allow filtering responses by status` | `admin-surveys.spec.ts:821` | Same pattern as #3 |
| 5 | `should delete shift successfully when confirming` | `admin-shift-edit-delete.spec.ts:333` | Strict-mode violation: `getByTestId('shift-deleted-message')` resolved to 2 elements |

## Test plan

- [x] `web/tests/e2e/notifications.spec.ts` — patch applied, logic verified
- [ ] Run `npx playwright test notifications.spec.ts --project=chromium` locally across several runs to confirm consistent green

https://claude.ai/code/session_01EeVhB5gnxsjas9Yq8KGPm9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeVhB5gnxsjas9Yq8KGPm9)_