### PR TITLE
fix(ci): unwedge automatic version bump — serialize runs, atomic push, tag-collision guard

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -6,6 +6,12 @@ on:
     branches: [main]
     paths: ["web/**"]
 
+# Serialize runs: concurrent merges previously raced, stranding tags on
+# commits that never landed on main (v0.112.9, v0.113.0)
+concurrency:
+  group: version-bump
+  cancel-in-progress: false
+
 jobs:
   version-bump:
     if: github.event.pull_request.merged == true
@@ -92,6 +98,15 @@ jobs:
           esac
 
           NEW_VERSION="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+
+          # Skip past any tag that already exists (e.g. stranded by a past
+          # failed run) so one bad tag can't wedge every future release
+          while git rev-parse -q --verify "refs/tags/v${NEW_VERSION}" > /dev/null; do
+            echo "Tag v${NEW_VERSION} already exists, trying next patch version"
+            NEW_PATCH=$((NEW_PATCH + 1))
+            NEW_VERSION="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+          done
+
           echo "New version: $NEW_VERSION"
 
           # Update package.json
@@ -171,7 +186,10 @@ jobs:
         if: steps.version-type.outputs.bump_type != 'skip'
         run: |
           git remote set-url origin git@github.com:everybody-eats-nz/volunteer-portal.git
-          git push origin main "v${{ steps.bump-version.outputs.new_version }}"
+          # --atomic: if the main push is rejected (e.g. a race with another
+          # merge), don't push the tag either — a stranded tag blocks all
+          # future runs at the same version
+          git push --atomic origin main "v${{ steps.bump-version.outputs.new_version }}"
 
       - name: Create GitHub Release
         if: steps.version-type.outputs.bump_type != 'skip'


### PR DESCRIPTION
## Why

Every `version-bump.yml` run since early March has failed with `fatal: tag 'v0.112.9' already exists` (or `v0.113.0`). Root cause: on 7–8 March, concurrent version-bump runs raced. The losing run's push to `main` was rejected as non-fast-forward, **but its tag still pushed** (the push wasn't atomic). That stranded `v0.112.9` and `v0.113.0` on commits unreachable from any branch. Since `main`'s `package.json` is still `0.112.8`, every run since recomputes one of those two versions and dies at the tag-creation step.

## Changes

- **`concurrency` group** — serializes version-bump runs so two merges can't race each other
- **`git push --atomic`** — if the `main` push is rejected, the tag isn't pushed either, so a failed run can never strand a tag again
- **Tag-collision guard** — the bump step skips forward past any already-existing tag, so even a stranded tag (like the two current ones) can't permanently wedge the workflow

## Cleanup

The orphan tags `v0.112.9` and `v0.113.0` should also be deleted (no releases reference them, commits not on any branch):

```bash
git push origin :refs/tags/v0.112.9 :refs/tags/v0.113.0
```

With the guard above the workflow recovers either way, but deleting them keeps the version sequence clean (next patch release becomes 0.112.9 instead of skipping to 0.112.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)