### PR TITLE
fix(ci): stop GHCR "unknown blob" push failures

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,8 +17,6 @@ permissions:
 
 on:
   push:
-    # TODO(remove before merge): temporary trigger so we can build a staging
-    # image from this branch without merging to main.
     branches: [main]
     paths: ["web/**", ".github/workflows/docker-image.yml"]
   workflow_dispatch:
@@ -128,6 +126,10 @@ jobs:
           context: web
           file: web/Dockerfile
           push: true
+          # Provenance/SBOM attestation manifests trigger intermittent
+          # "unknown blob" push failures on GHCR — disable them.
+          provenance: false
+          sbom: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
## Problem

The `Docker Image` workflow (production deploy pipeline, added in #956) intermittently fails when pushing to GHCR:

```
#15 ERROR: unknown blob
ERROR: failed to build: unknown blob
```

This already broke a `main` deploy once and required a manual re-run.

## Cause & fix

`docker/build-push-action@v6` attaches **provenance + SBOM attestation manifests** by default. Pushing those extra manifests to GHCR is the well-known trigger for intermittent `unknown blob` errors. Disabling them resolves it with no downside for this use case:

```yaml
provenance: false
sbom: false
```

Also removed the stale `TODO(remove before merge)` comment above the `branches: [main]` trigger — the temporary branch trigger is already gone, the comment was left behind.

## Notes

- No change to the built image contents, tags, or runtime.
- Doesn't address the rarer GHCR *login* timeout (a separate transient); can add a push retry later if it recurs.
- `version:patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)