### PR TITLE
fix(notifications): mark notification as read when clicking its link

### DIFF
--- a/web/src/components/notification-item.tsx
+++ b/web/src/components/notification-item.tsx
@@ -32,6 +32,16 @@ export function NotificationItem({
 
     setMarking(true);
     try {
+      await markRead();
+    } finally {
+      setMarking(false);
+    }
+  };
+
+  const markRead = async () => {
+    if (notification.isRead) return;
+
+    try {
       const response = await fetch(`/api/notifications/${notification.id}`, {
         method: "PUT",
         headers: {
@@ -45,9 +55,14 @@ export function NotificationItem({
       }
     } catch (error) {
       console.error("Error marking notification as read:", error);
-    } finally {
-      setMarking(false);
     }
+  };
+
+  // When clicking the notification link, mark it as read (fire-and-forget so
+  // navigation isn't blocked) before closing the dropdown.
+  const handleLinkClick = () => {
+    void markRead();
+    onClick?.();
   };
 
   const handleDelete = async (e: React.MouseEvent) => {
@@ -196,7 +211,7 @@ export function NotificationItem({
       <Link
         href={notification.actionUrl}
         className="block hover:no-underline"
-        onClick={onClick}
+        onClick={handleLinkClick}
         data-testid="notification-link"
       >
         {content}


### PR DESCRIPTION
## What changed

When a notification has an `actionUrl`, clicking it now marks the notification as read in addition to navigating to the linked page and closing the dropdown.

## Why

Clicking the admin **"underage volunteer"** notification (which links to `/admin/parental-consent`) navigated correctly but never marked the notification as read — so it stayed in the unread list and kept the bell badge count up.

This wasn't specific to underage notifications. In `notification-item.tsx`, any notification with an `actionUrl` is wrapped in a `<Link>` whose `onClick` was wired only to the dropdown-close callback. The mark-as-read fetch was attached **only** to the small hover checkmark button, so clicking the notification body skipped it entirely.

## The fix

In `web/src/components/notification-item.tsx`:

- Extracted the mark-as-read `fetch` into a reusable `markRead()` helper.
- Added `handleLinkClick()` that fires `markRead()` **without** `preventDefault` (so navigation still proceeds) and then closes the dropdown.
- Pointed `<Link onClick>` at `handleLinkClick`.
- Refactored the existing checkmark button's `handleMarkRead` to reuse `markRead()`.

Marking as read also triggers the SSE unread-count broadcast in `markNotificationAsRead` (`src/lib/notifications.ts`), so the bell badge updates live.

## Reviewer notes

- `markRead` is fire-and-forget on link click: navigation typically unmounts the dropdown immediately, so the request is dispatched before navigation and completes server-side regardless.
- I could not run `typecheck` or a browser preview locally — this worktree has no `node_modules` installed, and exercising the path in-browser needs an admin session plus a seeded underage notification. The change is small, self-contained, and type-consistent with the existing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)