### PR TITLE
fix(flaky): admin-notes beforeAll race condition + strict-mode login button

### DIFF
--- a/web/tests/e2e/admin-notes.spec.ts
+++ b/web/tests/e2e/admin-notes.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect } from "./base";
 import type { Page } from "@playwright/test";
 import { loginAsAdmin } from "./helpers/auth";
-import { createTestUser, getUserByEmail } from "./helpers/test-helpers";
+import {
+  createTestUser,
+  deleteTestUsers,
+  getUserByEmail,
+} from "./helpers/test-helpers";
 
 // Helper function to wait for page to load completely
 async function waitForPageLoad(page: Page) {
@@ -19,17 +23,30 @@ test.describe("Admin Notes Management", () => {
   const testEmail = "admin-notes-test@example.com";
 
   test.beforeAll(async ({ browser }) => {
-    // Create a test volunteer for all tests in this suite
     const context = await browser.newContext();
     const page = await context.newPage();
 
-    // Create test user
-    await createTestUser(page, testEmail, "VOLUNTEER");
+    // Guard against parallel workers both executing beforeAll and racing to
+    // create the same email — check existence first, create only if absent.
+    let user = await getUserByEmail(page, testEmail);
+    if (!user) {
+      try {
+        await createTestUser(page, testEmail, "VOLUNTEER");
+        user = await getUserByEmail(page, testEmail);
+      } catch {
+        // Another worker won the race; fetch the user they created.
+        user = await getUserByEmail(page, testEmail);
+      }
+    }
+    testVolunteerId = user?.id ?? null;
 
-    // Get the user ID
-    const user = await getUserByEmail(page, testEmail);
-    testVolunteerId = user?.id || null;
+    await context.close();
+  });
 
+  test.afterAll(async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await deleteTestUsers(page, [testEmail]);
     await context.close();
   });
 

--- a/web/tests/e2e/helpers/auth.ts
+++ b/web/tests/e2e/helpers/auth.ts
@@ -15,7 +15,11 @@ export async function loginAsAdmin(page: Page) {
     await page.goto("/login");
     await page.waitForLoadState("load");
 
-    const adminLoginButton = page.getByTestId("quick-login-admin-button");
+    // Use .first() because Next.js streaming can briefly render both
+    // loading.tsx and page.tsx simultaneously, producing two buttons.
+    const adminLoginButton = page
+      .getByTestId("quick-login-admin-button")
+      .first();
     await adminLoginButton.waitFor({ state: "visible", timeout: 10000 });
     await adminLoginButton.click();
 


### PR DESCRIPTION
$(cat <<'EOF'
## Root-cause analysis

This PR fixes the #1 flakiest test identified in this week's flaky-test audit (4 of the 7 Test workflow failures in the last 7 days involved `admin-notes.spec.ts`).

### Cause 1 — `beforeAll` race condition in `admin-notes.spec.ts`

`playwright.config.ts` sets `fullyParallel: true` and `workers: 2`. With `fullyParallel` enabled, Playwright splits individual tests — including tests within the same `describe` block — across parallel workers. Each worker independently executes the `beforeAll` hook for any describe block it touches.

The `Admin Notes Management` describe block held ~8 tests and used a **hardcoded email** (`admin-notes-test@example.com`) to create a shared test user in `beforeAll`. When both workers reached that hook at roughly the same time, the second `INSERT INTO "User"` hit the `User_email_key` unique constraint. That made every test in the losing worker's queue fail with:

```
Failed to create test user: 500 – {"error":"Failed to create user"}
```

…and the cascade further broke retries via a different path: after the losing worker's `beforeAll` threw, Playwright spun up a *new* worker for the retry, whose own `beforeAll` faced the same already-existing user.

**Fix:** check for the user's existence before creating, wrap the create in a `try/catch` to survive the narrow race window, and add `afterAll` to delete the user so subsequent retries start with a clean slate.

### Cause 2 — Strict-mode violation on `quick-login-admin-button` in `helpers/auth.ts`

Next.js App Router streaming temporarily places both `loading.tsx` and `page.tsx` in the DOM simultaneously. A comment already in `auth.ts` documents this for `admin-dashboard-page` and uses `.first()` to cope. The same streaming double-render affects `quick-login-admin-button` on the `/login` route, causing Playwright's strict-mode locator to throw:

```
strict mode violation: getByTestId('quick-login-admin-button') resolved to 2 elements
```

**Fix:** append `.first()` — identical pattern to the existing fix for `admin-dashboard-page`.

## Changes

| File | Change |
|------|--------|
| `web/tests/e2e/admin-notes.spec.ts` | `beforeAll`: existence-check + try/catch guard; new `afterAll` cleanup |
| `web/tests/e2e/helpers/auth.ts` | `loginAsAdmin`: `.first()` on `quick-login-admin-button` |

## Test plan

- [ ] Confirm `npx playwright test tests/e2e/admin-notes.spec.ts --project=chromium` passes across multiple local runs
- [ ] Confirm `npx playwright test tests/e2e/ --project=chromium` does not regress other tests
- [ ] CI Test workflow on this PR should show all 20 shards green

https://claude.ai/code/session_01TYPmor9by3VVJaStTFSuwp
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYPmor9by3VVJaStTFSuwp)_