### PR TITLE
feat(admin): export service-night analytics as CSV

### DIFF
--- a/web/src/app/admin/analytics/restaurant-analytics-client.tsx
+++ b/web/src/app/admin/analytics/restaurant-analytics-client.tsx
@@ -40,7 +40,9 @@ import {
   Salad,
   Beef,
   CloudSun,
+  Download,
 } from "lucide-react";
+import { toast } from "sonner";
 import dynamic from "next/dynamic";
 import {
   Tooltip,
@@ -245,6 +247,7 @@ export function RestaurantAnalyticsClient({
   const [to, setTo] = useState(initialTo);
   const [trendView, setTrendView] = useState<"monthly" | "weekly">("monthly");
   const [kohaStack, setKohaStack] = useState<StackMode>("stacked");
+  const [exporting, setExporting] = useState(false);
   const chartThemeMode = (resolvedTheme === "dark" ? "dark" : "light") as
     | "dark"
     | "light";
@@ -276,6 +279,47 @@ export function RestaurantAnalyticsClient({
       // Preserve scroll position — only the query string changes
       router.push(`/admin/analytics?${params}`, { scroll: false });
     });
+  };
+
+  // Export every service night for the *applied* filters (what's on screen) as CSV.
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const params = new URLSearchParams({
+        months: initialMonths,
+        location: initialLocation,
+        format: "csv",
+      });
+      if (initialDays) params.set("days", initialDays);
+      if (initialFrom && initialTo) {
+        params.set("from", initialFrom);
+        params.set("to", initialTo);
+      }
+      const res = await fetch(`/api/admin/analytics/service-nights?${params}`);
+      if (!res.ok) throw new Error(`Export failed (${res.status})`);
+      const text = await res.text();
+      const rows = Math.max(0, text.trim().split("\n").length - 1); // minus header
+      const filename =
+        res.headers
+          .get("Content-Disposition")
+          ?.match(/filename="?([^"]+)"?/)?.[1] ?? "service-nights.csv";
+      const url = URL.createObjectURL(new Blob([text], { type: "text/csv" }));
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      toast.success(
+        `Exported ${rows.toLocaleString()} service night${rows === 1 ? "" : "s"}`
+      );
+    } catch (error) {
+      console.error("Error exporting service nights:", error);
+      toast.error("Couldn't export CSV");
+    } finally {
+      setExporting(false);
+    }
   };
 
   const labelColor = chartThemeMode === "dark" ? "#94a3b8" : "#475569";
@@ -493,7 +537,7 @@ export function RestaurantAnalyticsClient({
               <div className="flex-1">
                 <DayOfWeekFilter value={days} onChange={setDays} />
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
                 {hasCustomRange && (
                   <Button
                     variant="ghost"
@@ -506,6 +550,20 @@ export function RestaurantAnalyticsClient({
                     Clear range
                   </Button>
                 )}
+                <Button
+                  variant="outline"
+                  onClick={handleExport}
+                  disabled={exporting}
+                  className="sm:w-auto w-full"
+                  title="Download the applied service-night data as a CSV"
+                >
+                  {exporting ? (
+                    <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  ) : (
+                    <Download className="h-4 w-4 mr-2" />
+                  )}
+                  Export CSV
+                </Button>
                 <Button
                   onClick={handleApplyFilters}
                   className="sm:w-auto w-full"

--- a/web/src/app/api/admin/analytics/service-nights/route.ts
+++ b/web/src/app/api/admin/analytics/service-nights/route.ts
@@ -24,6 +24,53 @@ export interface ServiceNightRow {
   bookings: number | null;
 }
 
+// Richer row used for CSV export (superset of the table's ServiceNightRow).
+interface FullServiceNightRow extends ServiceNightRow {
+  cash: number | null;
+  eftpos: number | null;
+  stripe: number | null;
+  vege: number | null;
+  takeaways: number | null;
+  eftposTransactions: number | null;
+  notes: string | null;
+}
+
+const CSV_COLUMNS: { header: string; value: (r: FullServiceNightRow) => unknown }[] = [
+  { header: "Date", value: (r) => r.date },
+  { header: "Location", value: (r) => r.location },
+  { header: "Customers", value: (r) => r.customers },
+  { header: "Non-paying", value: (r) => r.nonPaying },
+  { header: "Cash", value: (r) => r.cash },
+  { header: "Eftpos", value: (r) => r.eftpos },
+  { header: "Quest/Stripe", value: (r) => r.stripe },
+  { header: "Total koha", value: (r) => r.totalKoha },
+  { header: "$ per head", value: (r) => r.perHead },
+  { header: "Bookings", value: (r) => r.bookings },
+  { header: "New volunteers", value: (r) => r.newVolunteers },
+  { header: "Vege", value: (r) => r.vege },
+  { header: "Takeaways", value: (r) => r.takeaways },
+  { header: "Eftpos transactions", value: (r) => r.eftposTransactions },
+  { header: "Protein", value: (r) => r.protein },
+  { header: "Weather", value: (r) => r.weather },
+  { header: "Notes", value: (r) => r.notes },
+];
+
+// RFC-4180 cell: quote when the value contains a comma, quote or newline.
+const csvCell = (v: unknown): string => {
+  if (v === null || v === undefined) return "";
+  const s = String(v);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+};
+
+function buildCsv(rows: FullServiceNightRow[]): string {
+  const lines = [CSV_COLUMNS.map((c) => c.header).join(",")];
+  for (const r of rows) {
+    lines.push(CSV_COLUMNS.map((c) => csvCell(c.value(r))).join(","));
+  }
+  // Lead with a BOM so Excel reads UTF-8 correctly.
+  return "﻿" + lines.join("\r\n");
+}
+
 const SORTABLE = new Set([
   "date",
   "location",
@@ -61,6 +108,7 @@ export async function GET(request: NextRequest) {
   const sortByRaw = sp.get("sortBy") || "date";
   const sortBy = SORTABLE.has(sortByRaw) ? sortByRaw : "date";
   const sortDir = sp.get("sortDir") === "asc" ? "asc" : "desc";
+  const isCsv = sp.get("format") === "csv";
 
   // Date window — custom range overrides the month preset (mirrors the lib)
   const dateRe = /^\d{4}-\d{2}-\d{2}$/;
@@ -99,15 +147,24 @@ export async function GET(request: NextRequest) {
         weather: true,
         newVolunteers: true,
         bookingsPax: true,
+        vege: true,
+        takeaways: true,
+        eftposTransactions: true,
+        notes: true,
       },
     });
 
-    let rows: ServiceNightRow[] = records
+    const dec = (v: unknown): number | null =>
+      v === null || v === undefined ? null : Number(v);
+
+    let rows: FullServiceNightRow[] = records
       .filter((r) => !daysFilter || daysFilter.includes(toNZT(r.date).getDay()))
       .map((r) => {
+        const cash = dec(r.cash);
+        const eftpos = dec(r.eftpos);
+        const stripe = dec(r.stripe);
         const totalKoha =
-          Math.round((toNum(r.cash) + toNum(r.eftpos) + toNum(r.stripe)) * 100) /
-          100;
+          Math.round((toNum(cash) + toNum(eftpos) + toNum(stripe)) * 100) / 100;
         const customers = r.mealsServed;
         return {
           date: r.date.toISOString().substring(0, 10),
@@ -123,6 +180,13 @@ export async function GET(request: NextRequest) {
           weather: r.weather,
           newVolunteers: r.newVolunteers,
           bookings: r.bookingsPax,
+          cash,
+          eftpos,
+          stripe,
+          vege: r.vege,
+          takeaways: r.takeaways,
+          eftposTransactions: r.eftposTransactions,
+          notes: r.notes,
         };
       });
 
@@ -137,6 +201,25 @@ export async function GET(request: NextRequest) {
       }
       return String(av).localeCompare(String(bv)) * dir;
     });
+
+    // CSV export: every row for the current filters, richer columns for analysis.
+    if (isCsv) {
+      const rangeLabel = customRange
+        ? `${from}_to_${to}`
+        : allTime
+          ? "all-time"
+          : `last-${months}mo`;
+      const locLabel = isLocationFiltered
+        ? `_${location!.replace(/\s+/g, "-")}`
+        : "";
+      return new NextResponse(buildCsv(rows), {
+        status: 200,
+        headers: {
+          "Content-Type": "text/csv; charset=utf-8",
+          "Content-Disposition": `attachment; filename="ee-service-nights_${rangeLabel}${locLabel}.csv"`,
+        },
+      });
+    }
 
     const total = rows.length;
     const start = (page - 1) * pageSize;


### PR DESCRIPTION
## What

Adds an **Export CSV** button to the `/admin/analytics` filter toolbar (next to *Apply Filters*) that downloads the service-night data for the **currently applied filters**.

## Why

Makes it easy to pull the restaurant data out for ad-hoc analysis (e.g. uploading to a spreadsheet or an LLM's analysis tool) without hand-querying the DB. The on-screen table is paginated; the export gives the full filtered dataset in one file.

## How

- New `?format=csv` mode on `GET /api/admin/analytics/service-nights` returns **all** matching rows (ignores pagination), respecting the same filters (time period, location, day-of-week, custom date range) and sort.
- Richer columns than the table — includes the full koha split (cash / eftpos / quest-stripe) plus vege, takeaways, eftpos transactions and notes — ideal for analysis.
- RFC-4180 cell quoting + UTF-8 BOM so Excel/Google Sheets open it cleanly. Sensible filename, e.g. `ee-service-nights_all-time_Wellington.csv`.
- Button exports the **applied** filters (what's on screen), shows a loading state, and toasts the row count. Click *Apply Filters* first if you've changed a filter.

## Verification

Typecheck: 0 errors. Lint: 0 errors / baseline warnings. Verified end-to-end locally — button renders in the filter toolbar, exporting all-time Wellington produced 852 rows with the correct header/koha-split and a success toast, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)