### PR TITLE
Add public impact-stats API endpoint

### DIFF
--- a/web/src/app/api/public/impact-stats/route.ts
+++ b/web/src/app/api/public/impact-stats/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { getPublicImpactStats } from "@/lib/impact-stats";
+
+// CORS headers so external consumers (e.g. the marketing site) can read this.
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders });
+}
+
+/**
+ * Public impact-stats endpoint consumed by the marketing site.
+ *
+ * Returns aggregate, non-sensitive headline figures:
+ *   - peopleServed   total customers served across all service nights
+ *   - volunteerHours total hours logged across completed confirmed shifts
+ *   - foodSavedKg    estimated kg of food saved (derived from people served)
+ *
+ * Cached at the edge for 1 hour; these totals move slowly.
+ */
+export async function GET() {
+  try {
+    const stats = await getPublicImpactStats();
+    return NextResponse.json(stats, {
+      headers: {
+        ...corsHeaders,
+        "Cache-Control":
+          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    });
+  } catch (error) {
+    console.error("Error computing impact stats:", error);
+    return NextResponse.json(
+      { error: "Failed to compute impact stats" },
+      { status: 500, headers: corsHeaders }
+    );
+  }
+}

--- a/web/src/lib/impact-stats.test.ts
+++ b/web/src/lib/impact-stats.test.ts
@@ -1,0 +1,101 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    mealsServed: { aggregate: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+}));
+
+import {
+  getPublicImpactStats,
+  FOOD_SAVED_KG_PER_MEAL,
+} from "./impact-stats";
+import { prisma } from "./prisma";
+
+const mockedAggregate = prisma.mealsServed.aggregate as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockedQueryRaw = prisma.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+
+/** Mock the two parallel queries: meals aggregate + raw hours sum. */
+function mockStats(opts: { mealsSum: number | null; seconds: number | null }) {
+  mockedAggregate.mockResolvedValue({ _sum: { mealsServed: opts.mealsSum } });
+  mockedQueryRaw.mockResolvedValue([{ seconds: opts.seconds }]);
+}
+
+describe("getPublicImpactStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns zero values when no data exists", async () => {
+    mockStats({ mealsSum: null, seconds: 0 });
+
+    const stats = await getPublicImpactStats();
+
+    expect(stats.peopleServed).toBe(0);
+    expect(stats.volunteerHours).toBe(0);
+    expect(stats.foodSavedKg).toBe(0);
+  });
+
+  it("sums recorded meals into peopleServed", async () => {
+    mockStats({ mealsSum: 279550, seconds: 0 });
+
+    const stats = await getPublicImpactStats();
+
+    expect(stats.peopleServed).toBe(279550);
+  });
+
+  it("derives foodSavedKg from peopleServed using the conversion factor", async () => {
+    mockStats({ mealsSum: 279550, seconds: 0 });
+
+    const stats = await getPublicImpactStats();
+
+    expect(FOOD_SAVED_KG_PER_MEAL).toBe(0.5);
+    expect(stats.foodSavedKg).toBe(
+      Math.round(stats.peopleServed * FOOD_SAVED_KG_PER_MEAL)
+    );
+    expect(stats.foodSavedKg).toBe(139775);
+    // Exposes the factor so consumers can show their own working.
+    expect(stats.foodSavedKgPerMeal).toBe(FOOD_SAVED_KG_PER_MEAL);
+  });
+
+  it("converts seconds to whole hours, rounded to nearest hour", async () => {
+    // 1417.5 hours -> 5_103_000 seconds, rounds up to 1418.
+    mockStats({ mealsSum: 0, seconds: 1417.5 * 3600 });
+
+    const stats = await getPublicImpactStats();
+
+    expect(stats.volunteerHours).toBe(1418);
+  });
+
+  it("treats a null hours sum as zero", async () => {
+    mockStats({ mealsSum: 0, seconds: null });
+
+    const stats = await getPublicImpactStats();
+
+    expect(stats.volunteerHours).toBe(0);
+  });
+
+  it("defends against an empty raw-query result set", async () => {
+    mockedAggregate.mockResolvedValue({ _sum: { mealsServed: 10 } });
+    mockedQueryRaw.mockResolvedValue([]);
+
+    const stats = await getPublicImpactStats();
+
+    expect(stats.volunteerHours).toBe(0);
+    expect(stats.peopleServed).toBe(10);
+  });
+
+  it("stamps the payload with an ISO generatedAt timestamp", async () => {
+    mockStats({ mealsSum: 1, seconds: 3600 });
+
+    const stats = await getPublicImpactStats();
+
+    expect(stats.generatedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+    );
+    expect(new Date(stats.generatedAt).toISOString()).toBe(stats.generatedAt);
+  });
+});

--- a/web/src/lib/impact-stats.ts
+++ b/web/src/lib/impact-stats.ts
@@ -1,0 +1,61 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Estimated kilograms of food saved per meal served.
+ *
+ * Everybody Eats rescues surplus food and turns it into restaurant-quality
+ * meals, so each meal served represents food diverted from landfill. We don't
+ * weigh rescued food per service, so we estimate weight from meals served using
+ * the industry-standard food-rescue conversion (~0.5 kg per meal, as used by
+ * OzHarvest / FoodCloud). This is the single source of truth for the factor —
+ * the marketing site only displays the computed value.
+ */
+export const FOOD_SAVED_KG_PER_MEAL = 0.5;
+
+export type PublicImpactStats = {
+  /** Total customers served across all service nights (a.k.a. meals served). */
+  peopleServed: number;
+  /** Total volunteer hours logged across all completed, confirmed shifts. */
+  volunteerHours: number;
+  /** Estimated kilograms of food saved, derived from people served. */
+  foodSavedKg: number;
+  /** The conversion factor used to derive `foodSavedKg`, for transparency. */
+  foodSavedKgPerMeal: number;
+  /** ISO timestamp the figures were computed. */
+  generatedAt: string;
+};
+
+/**
+ * Computes the headline impact figures shared publicly (e.g. on the marketing
+ * site). Kept deliberately lean — only the three numbers we expose — so it can
+ * back a cacheable public endpoint without the heavier home-dashboard queries.
+ *
+ * - `peopleServed`: sum of recorded customers served (`MealsServed.mealsServed`).
+ * - `volunteerHours`: sum of `(shift.end - shift.start)` for every CONFIRMED
+ *   signup whose shift has finished. Computed in SQL so there's no row cap.
+ */
+export async function getPublicImpactStats(): Promise<PublicImpactStats> {
+  const now = new Date();
+
+  const [mealsAggregate, hoursRows] = await Promise.all([
+    prisma.mealsServed.aggregate({ _sum: { mealsServed: true } }),
+    prisma.$queryRaw<{ seconds: number | null }[]>`
+      SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (s."end" - s."start"))), 0)::float8 AS seconds
+      FROM "Signup" sg
+      JOIN "Shift" s ON s.id = sg."shiftId"
+      WHERE sg.status = 'CONFIRMED' AND s."end" < ${now}
+    `,
+  ]);
+
+  const peopleServed = mealsAggregate._sum.mealsServed ?? 0;
+  const volunteerHours = Math.round((hoursRows[0]?.seconds ?? 0) / 3600);
+  const foodSavedKg = Math.round(peopleServed * FOOD_SAVED_KG_PER_MEAL);
+
+  return {
+    peopleServed,
+    volunteerHours,
+    foodSavedKg,
+    foodSavedKgPerMeal: FOOD_SAVED_KG_PER_MEAL,
+    generatedAt: now.toISOString(),
+  };
+}


### PR DESCRIPTION
## What

Adds a public, cacheable endpoint exposing three aggregate impact figures for the marketing site (consumed by everybody-eats-nz/marketing-cms#49):

- **peopleServed** — sum of `MealsServed.mealsServed` (customers served across all service nights)
- **volunteerHours** — sum of `(shift.end − shift.start)` over completed `CONFIRMED` signups
- **foodSavedKg** — estimated kg of food saved, derived as `peopleServed × 0.5` (industry-standard food-rescue conversion)

```
GET /api/public/impact-stats
→ { peopleServed, volunteerHours, foodSavedKg, foodSavedKgPerMeal, generatedAt }
```

## How

- `web/src/lib/impact-stats.ts` — `getPublicImpactStats()`. Meals via a Prisma aggregate; hours via a single raw-SQL `SUM(EXTRACT(EPOCH ...))` so there's no row cap. The 0.5 kg/meal factor lives here as the single source of truth.
- `web/src/app/api/public/impact-stats/route.ts` — public GET with CORS (mirrors `/api/menus`) and `Cache-Control: s-maxage=3600`. No auth — non-sensitive aggregate totals already shown on the portal home page.

## Reviewer notes

- **No schema or data changes** — read-only aggregation over existing tables.
- Returns real production numbers today: `{ peopleServed: 279550, volunteerHours: 1417, foodSavedKg: 139775 }`.
- **Coverage caveat:** `volunteerHours` only reflects shifts recorded in the portal (post-launch), whereas `peopleServed` is the full migrated history. Intentional; a historical baseline could be added later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)