### PR TITLE
Add public impact-story API endpoint

### DIFF
--- a/web/src/app/api/public/impact-story/route.ts
+++ b/web/src/app/api/public/impact-story/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { getPublicImpactStory } from "@/lib/impact-story";
+
+// CORS headers so external consumers (e.g. the marketing site) can read this.
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: corsHeaders });
+}
+
+/**
+ * Public impact-story endpoint consumed by the marketing site's `/impact` page.
+ *
+ * Returns the all-time, aggregate, non-sensitive dataset behind the data-story:
+ * a year-by-year koha/need breakdown, payment mix, per-venue and per-weekday
+ * rhythms, and the volunteer milestone ladder. See {@link getPublicImpactStory}.
+ *
+ * Cached at the edge for 1 hour; these totals move slowly.
+ */
+export async function GET() {
+  try {
+    const story = await getPublicImpactStory();
+    return NextResponse.json(story, {
+      headers: {
+        ...corsHeaders,
+        "Cache-Control":
+          "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    });
+  } catch (error) {
+    console.error("Error computing impact story:", error);
+    return NextResponse.json(
+      { error: "Failed to compute impact story" },
+      { status: 500, headers: corsHeaders }
+    );
+  }
+}

--- a/web/src/lib/impact-story.test.ts
+++ b/web/src/lib/impact-story.test.ts
@@ -1,0 +1,228 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    mealsServed: { findMany: vi.fn(), aggregate: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+}));
+
+import { getPublicImpactStory } from "./impact-story";
+import { prisma } from "./prisma";
+
+const mockedFindMany = prisma.mealsServed.findMany as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockedAggregate = prisma.mealsServed.aggregate as unknown as ReturnType<
+  typeof vi.fn
+>;
+const mockedQueryRaw = prisma.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+
+type Row = {
+  date: Date;
+  location: string;
+  mealsServed: number | null;
+  nonPayingCount: number | null;
+  newVolunteers: number | null;
+  cash: number | null;
+  eftpos: number | null;
+  stripe: number | null;
+};
+
+function row(date: string, overrides: Partial<Row> = {}): Row {
+  return {
+    date: new Date(date),
+    location: "Wellington",
+    mealsServed: 100,
+    nonPayingCount: 0,
+    newVolunteers: 0,
+    cash: 0,
+    eftpos: 0,
+    stripe: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * `getPublicImpactStory` issues three distinct `$queryRaw` calls (headline
+ * hours sum, milestone ladder, distinct volunteer count). Route each by the
+ * SQL it contains so a single mock can serve all three.
+ */
+function mockStory(opts: {
+  rows: Row[];
+  mealsSum?: number | null;
+  hoursSeconds?: number | null;
+  shiftCounts?: number[];
+  volunteerCount?: number;
+}) {
+  mockedFindMany.mockResolvedValue(opts.rows);
+  mockedAggregate.mockResolvedValue({
+    _sum: { mealsServed: opts.mealsSum ?? null },
+  });
+  mockedQueryRaw.mockImplementation((strings: TemplateStringsArray) => {
+    const sql = strings.join("");
+    if (sql.includes("EXTRACT(EPOCH")) {
+      return Promise.resolve([{ seconds: opts.hoursSeconds ?? 0 }]);
+    }
+    if (sql.includes("COUNT(DISTINCT")) {
+      return Promise.resolve([
+        { count: BigInt(opts.volunteerCount ?? 0) },
+      ]);
+    }
+    // Milestone ladder: one { shifts } row per volunteer.
+    return Promise.resolve((opts.shiftCounts ?? []).map((shifts) => ({ shifts })));
+  });
+}
+
+describe("getPublicImpactStory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty aggregates when there is no data", async () => {
+    mockStory({ rows: [] });
+
+    const story = await getPublicImpactStory();
+
+    expect(story.totals.nights).toBe(0);
+    expect(story.totals.koha).toBe(0);
+    expect(story.totals.perHead).toBeNull();
+    expect(story.totals.firstNight).toBeNull();
+    expect(story.totals.lastNight).toBeNull();
+    expect(story.yearly).toEqual([]);
+    expect(story.locations).toEqual([]);
+    expect(story.weekday).toEqual([]);
+  });
+
+  it("aggregates a single service night", async () => {
+    mockStory({
+      rows: [
+        row("2025-06-01T00:00:00.000Z", {
+          mealsServed: 120,
+          cash: 100,
+          eftpos: 200,
+          stripe: 300,
+        }),
+      ],
+      mealsSum: 120,
+    });
+
+    const story = await getPublicImpactStory();
+
+    expect(story.totals.nights).toBe(1);
+    expect(story.totals.koha).toBe(600); // cash + eftpos + stripe
+    expect(story.totals.meals).toBe(120); // from headline aggregate
+    expect(story.totals.perHead).toBe(5); // 600 / 120
+    expect(story.yearly).toHaveLength(1);
+    expect(story.yearly[0].year).toBe(2025);
+  });
+
+  it("buckets a service night by its NZ calendar date, not UTC", async () => {
+    // 2024-12-31T11:00:00Z is midnight Jan 1 2025 in NZ (NZDT, UTC+13) — the
+    // way MealsServed.date is stored. A UTC slice would mis-bucket this into
+    // 2024 / Tuesday; NZ time correctly yields 2025 / Wednesday.
+    mockStory({
+      rows: [
+        row("2024-12-31T11:00:00.000Z", { mealsServed: 50, cash: 500 }),
+      ],
+      mealsSum: 50,
+    });
+
+    const story = await getPublicImpactStory();
+
+    expect(story.yearly).toHaveLength(1);
+    expect(story.yearly[0].year).toBe(2025);
+    expect(story.totals.firstNight).toBe("2025-01-01");
+    expect(story.totals.lastNight).toBe("2025-01-01");
+    // Jan 1 2025 falls on a Wednesday (day index 3) in NZ.
+    expect(story.weekday).toHaveLength(1);
+    expect(story.weekday[0].day).toBe(3);
+    expect(story.weekday[0].label).toBe("Wed");
+  });
+
+  it("computes perPaying and nonPaying% from non-paying customers", async () => {
+    mockStory({
+      rows: [
+        row("2025-03-05T00:00:00.000Z", {
+          mealsServed: 100,
+          nonPayingCount: 20,
+          cash: 800,
+        }),
+      ],
+      mealsSum: 100,
+    });
+
+    const story = await getPublicImpactStory();
+
+    expect(story.totals.perHead).toBe(8); // 800 / 100 customers
+    expect(story.totals.perPaying).toBe(10); // 800 / (100 - 20) paying
+    expect(story.totals.nonPayingPercent).toBe(20); // 20 / 100
+  });
+
+  it("reports the payment-tender mix as percentages of koha", async () => {
+    mockStory({
+      rows: [
+        row("2025-02-01T00:00:00.000Z", {
+          mealsServed: 100,
+          cash: 500,
+          eftpos: 300,
+          stripe: 200,
+        }),
+      ],
+      mealsSum: 100,
+    });
+
+    const story = await getPublicImpactStory();
+    const year = story.yearly[0];
+
+    expect(year.cashPercent).toBe(50);
+    expect(year.eftposPercent).toBe(30);
+    expect(year.digitalPercent).toBe(20);
+  });
+
+  it("counts volunteers at or above each milestone rung", async () => {
+    mockStory({
+      rows: [],
+      // Volunteers with 5, 12, 30, 100, 250 completed shifts.
+      shiftCounts: [5, 12, 30, 100, 250],
+    });
+
+    const story = await getPublicImpactStory();
+    const byThreshold = Object.fromEntries(
+      story.milestones.map((m) => [m.threshold, m.volunteers])
+    );
+
+    expect(byThreshold[10]).toBe(4); // 12, 30, 100, 250
+    expect(byThreshold[25]).toBe(3); // 30, 100, 250
+    expect(byThreshold[50]).toBe(2); // 100, 250
+    expect(byThreshold[100]).toBe(2); // 100, 250
+    expect(byThreshold[200]).toBe(1); // 250
+  });
+
+  it("ranks locations by customers served and tracks first year", async () => {
+    mockStory({
+      rows: [
+        row("2023-05-01T00:00:00.000Z", { location: "Wellington", mealsServed: 50 }),
+        row("2025-05-01T00:00:00.000Z", { location: "Auckland", mealsServed: 200 }),
+        row("2024-05-01T00:00:00.000Z", { location: "Wellington", mealsServed: 60 }),
+      ],
+      mealsSum: 310,
+    });
+
+    const story = await getPublicImpactStory();
+
+    expect(story.locations[0].name).toBe("Auckland"); // 200 > 110
+    expect(story.locations[1].name).toBe("Wellington");
+    const wellington = story.locations.find((l) => l.name === "Wellington")!;
+    expect(wellington.firstYear).toBe(2023);
+    expect(wellington.customers).toBe(110);
+  });
+
+  it("stamps the payload with an ISO generatedAt timestamp", async () => {
+    mockStory({ rows: [] });
+
+    const story = await getPublicImpactStory();
+
+    expect(new Date(story.generatedAt).toISOString()).toBe(story.generatedAt);
+  });
+});

--- a/web/src/lib/impact-story.ts
+++ b/web/src/lib/impact-story.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/prisma";
-import { toNZT } from "@/lib/timezone";
+import { formatInNZT, toNZT } from "@/lib/timezone";
 import {
   FOOD_SAVED_KG_PER_MEAL,
   getPublicImpactStats,
@@ -217,8 +217,12 @@ export async function getPublicImpactStory(): Promise<PublicImpactStory> {
     const nonPaying = r.nonPayingCount ?? 0;
     newVolunteers += r.newVolunteers ?? 0;
 
-    const year = Number(r.date.toISOString().slice(0, 4));
-    const nzDay = toNZT(r.date).getDay();
+    // MealsServed.date is NZ-midnight stored as UTC, so derive the calendar
+    // year (and weekday below) in NZ time — a UTC slice would shift a late-night
+    // service onto the previous day/year near boundaries.
+    const nzDate = toNZT(r.date);
+    const year = nzDate.getFullYear();
+    const nzDay = nzDate.getDay();
     const isWeekend = nzDay === 0 || nzDay === 6;
 
     add(bump(byYear, year), customers, cash, eftpos, stripe, nonPaying);
@@ -235,7 +239,8 @@ export async function getPublicImpactStory(): Promise<PublicImpactStory> {
     add(bump(isWeekend ? locWeekend : locWeeknight, r.location), customers, cash, eftpos, stripe, nonPaying);
   }
 
-  const firstYear = Math.min(...byYear.keys());
+  const firstYear =
+    byYear.size > 0 ? Math.min(...byYear.keys()) : currentYear;
   const yearly: ImpactStoryYear[] = [...byYear.entries()]
     .sort(([a], [b]) => a - b)
     .map(([year, b]) => ({
@@ -310,8 +315,12 @@ export async function getPublicImpactStory(): Promise<PublicImpactStory> {
       perHead: perHead(allTime),
       perPaying: perPaying(allTime),
       nonPayingPercent: nonPayingPercent(allTime),
-      firstNight: rows[0]?.date.toISOString().slice(0, 10) ?? null,
-      lastNight: rows[rows.length - 1]?.date.toISOString().slice(0, 10) ?? null,
+      // NZ calendar dates (rows are ordered by date asc), consistent with the
+      // NZ-based year/weekday aggregation above.
+      firstNight: rows[0] ? formatInNZT(rows[0].date, "yyyy-MM-dd") : null,
+      lastNight: rows[rows.length - 1]
+        ? formatInNZT(rows[rows.length - 1].date, "yyyy-MM-dd")
+        : null,
     },
     yearly,
     locations,

--- a/web/src/lib/impact-story.ts
+++ b/web/src/lib/impact-story.ts
@@ -1,0 +1,322 @@
+import { prisma } from "@/lib/prisma";
+import { toNZT } from "@/lib/timezone";
+import {
+  FOOD_SAVED_KG_PER_MEAL,
+  getPublicImpactStats,
+} from "@/lib/impact-stats";
+
+/**
+ * Public "impact story" dataset consumed by the marketing site's `/impact`
+ * page. Where {@link getPublicImpactStats} returns the three headline numbers,
+ * this returns the richer, all-time aggregates the data-story is built from:
+ * a year-by-year breakdown of koha and need, the payment mix, per-venue and
+ * per-weeknight rhythms, and the volunteer milestone ladder.
+ *
+ * Everything here is aggregate and non-sensitive — no per-person rows leave the
+ * portal. Definitions deliberately mirror the admin restaurant-analytics
+ * dashboard (`src/lib/restaurant-analytics.ts`) so the public figures agree with
+ * what staff see internally:
+ *   - perHead   = koha ÷ customers, over nights that recorded koha
+ *   - perPaying = koha ÷ (customers − non-paying), over nights that recorded koha
+ *   - nonPaying% = non-paying customers ÷ all customers
+ *
+ * Backs a cacheable public endpoint, so it runs a single all-time `findMany`
+ * over MealsServed plus two small grouped volunteer queries.
+ */
+
+export type ImpactStoryYear = {
+  year: number;
+  nights: number;
+  customers: number;
+  koha: number;
+  perHead: number | null;
+  perPaying: number | null;
+  nonPayingPercent: number | null;
+  /** Share of koha by tender, as percentages that sum to ~100 (0 when no koha). */
+  cashPercent: number;
+  eftposPercent: number;
+  digitalPercent: number;
+  /** True for the first and current calendar years, which don't span 12 months. */
+  partial: boolean;
+};
+
+export type ImpactStoryLocation = {
+  name: string;
+  firstYear: number;
+  nights: number;
+  customers: number;
+  koha: number;
+  perHead: number | null;
+  avgCustomersPerNight: number;
+  weeknightPerHead: number | null;
+  weekendPerHead: number | null;
+};
+
+export type ImpactStoryWeekday = {
+  /** 0 = Sunday … 6 = Saturday (NZ time). */
+  day: number;
+  label: string;
+  weekend: boolean;
+  perHead: number | null;
+  avgCustomersPerNight: number;
+};
+
+export type ImpactStoryMilestone = {
+  /** Minimum completed-shift count for this rung (10, 25, 50, …). */
+  threshold: number;
+  /** Volunteers who have served at least `threshold` shifts. */
+  volunteers: number;
+};
+
+export type PublicImpactStory = {
+  totals: {
+    nights: number;
+    meals: number;
+    koha: number;
+    newVolunteers: number;
+    volunteers: number;
+    volunteerHours: number;
+    foodSavedKg: number;
+    foodSavedKgPerMeal: number;
+    perHead: number | null;
+    perPaying: number | null;
+    nonPayingPercent: number | null;
+    firstNight: string | null;
+    lastNight: string | null;
+  };
+  yearly: ImpactStoryYear[];
+  locations: ImpactStoryLocation[];
+  weekday: ImpactStoryWeekday[];
+  milestones: ImpactStoryMilestone[];
+  generatedAt: string;
+};
+
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MILESTONE_RUNGS = [10, 25, 50, 100, 200] as const;
+
+function toNum(v: unknown): number {
+  if (v === null || v === undefined) return 0;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const pct = (part: number, whole: number) =>
+  whole > 0 ? Math.round((part / whole) * 1000) / 10 : 0;
+
+/** Running tallies for one bucket (a year, a venue, or a weekday). */
+type Bucket = {
+  nights: number;
+  customers: number;
+  koha: number;
+  cash: number;
+  eftpos: number;
+  stripe: number;
+  customersWithKoha: number;
+  nonPayingWithKoha: number;
+  nonPayingCount: number;
+};
+
+const emptyBucket = (): Bucket => ({
+  nights: 0,
+  customers: 0,
+  koha: 0,
+  cash: 0,
+  eftpos: 0,
+  stripe: 0,
+  customersWithKoha: 0,
+  nonPayingWithKoha: 0,
+  nonPayingCount: 0,
+});
+
+const perHead = (b: Bucket) =>
+  b.customersWithKoha > 0 ? round2(b.koha / b.customersWithKoha) : null;
+const perPaying = (b: Bucket) => {
+  const paying = b.customersWithKoha - b.nonPayingWithKoha;
+  return paying > 0 ? round2(b.koha / paying) : null;
+};
+const nonPayingPercent = (b: Bucket) =>
+  b.customers > 0 ? Math.round((b.nonPayingCount / b.customers) * 100) : null;
+
+export async function getPublicImpactStory(): Promise<PublicImpactStory> {
+  const now = new Date();
+  const currentYear = toNZT(now).getFullYear();
+
+  const [rows, headline, milestoneRows, volunteerCountRows] = await Promise.all([
+    prisma.mealsServed.findMany({
+      where: { mealsServed: { not: null } },
+      select: {
+        date: true,
+        location: true,
+        mealsServed: true,
+        nonPayingCount: true,
+        newVolunteers: true,
+        cash: true,
+        eftpos: true,
+        stripe: true,
+      },
+      orderBy: { date: "asc" },
+    }),
+    // Reuse the lean headline computation (people served, hours, food saved).
+    getPublicImpactStats(),
+    // Milestone ladder: how many volunteers have reached each completed-shift rung.
+    prisma.$queryRaw<{ shifts: number }[]>`
+      SELECT COUNT(*)::int AS shifts
+      FROM "Signup" sg
+      JOIN "Shift" s ON s.id = sg."shiftId"
+      WHERE sg.status = 'CONFIRMED' AND s."end" < ${now}
+      GROUP BY sg."userId"
+    `,
+    // Distinct volunteers with at least one completed, confirmed shift.
+    prisma.$queryRaw<{ count: bigint }[]>`
+      SELECT COUNT(DISTINCT sg."userId")::bigint AS count
+      FROM "Signup" sg
+      JOIN "Shift" s ON s.id = sg."shiftId"
+      WHERE sg.status = 'CONFIRMED' AND s."end" < ${now}
+    `,
+  ]);
+
+  const byYear = new Map<number, Bucket>();
+  const byLocation = new Map<string, Bucket & { firstYear: number }>();
+  const byWeekday = new Map<number, Bucket>();
+  // Per-location weeknight (Mon–Fri) vs weekend (Sat–Sun) koha intensity.
+  const locWeeknight = new Map<string, Bucket>();
+  const locWeekend = new Map<string, Bucket>();
+
+  let newVolunteers = 0;
+
+  const bump = (map: Map<number, Bucket> | Map<string, Bucket>, key: number | string) => {
+    let b = (map as Map<number | string, Bucket>).get(key);
+    if (!b) {
+      b = emptyBucket();
+      (map as Map<number | string, Bucket>).set(key, b);
+    }
+    return b;
+  };
+
+  const add = (b: Bucket, customers: number, cash: number, eftpos: number, stripe: number, nonPaying: number) => {
+    const koha = cash + eftpos + stripe;
+    b.nights += 1;
+    b.customers += customers;
+    b.cash += cash;
+    b.eftpos += eftpos;
+    b.stripe += stripe;
+    b.koha += koha;
+    if (koha > 0) {
+      b.customersWithKoha += customers;
+      b.nonPayingWithKoha += nonPaying;
+    }
+    b.nonPayingCount += nonPaying;
+  };
+
+  for (const r of rows) {
+    const customers = r.mealsServed ?? 0;
+    const cash = toNum(r.cash);
+    const eftpos = toNum(r.eftpos);
+    const stripe = toNum(r.stripe);
+    const nonPaying = r.nonPayingCount ?? 0;
+    newVolunteers += r.newVolunteers ?? 0;
+
+    const year = Number(r.date.toISOString().slice(0, 4));
+    const nzDay = toNZT(r.date).getDay();
+    const isWeekend = nzDay === 0 || nzDay === 6;
+
+    add(bump(byYear, year), customers, cash, eftpos, stripe, nonPaying);
+    add(bump(byWeekday, nzDay), customers, cash, eftpos, stripe, nonPaying);
+
+    let loc = byLocation.get(r.location);
+    if (!loc) {
+      loc = { ...emptyBucket(), firstYear: year };
+      byLocation.set(r.location, loc);
+    } else if (year < loc.firstYear) {
+      loc.firstYear = year;
+    }
+    add(loc, customers, cash, eftpos, stripe, nonPaying);
+    add(bump(isWeekend ? locWeekend : locWeeknight, r.location), customers, cash, eftpos, stripe, nonPaying);
+  }
+
+  const firstYear = Math.min(...byYear.keys());
+  const yearly: ImpactStoryYear[] = [...byYear.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([year, b]) => ({
+      year,
+      nights: b.nights,
+      customers: b.customers,
+      koha: Math.round(b.koha),
+      perHead: perHead(b),
+      perPaying: perPaying(b),
+      nonPayingPercent: nonPayingPercent(b),
+      cashPercent: pct(b.cash, b.koha),
+      eftposPercent: pct(b.eftpos, b.koha),
+      digitalPercent: pct(b.stripe, b.koha),
+      partial: year === currentYear || year === firstYear,
+    }));
+
+  const locations: ImpactStoryLocation[] = [...byLocation.entries()]
+    .sort(([, a], [, b]) => b.customers - a.customers)
+    .map(([name, b]) => ({
+      name,
+      firstYear: b.firstYear,
+      nights: b.nights,
+      customers: b.customers,
+      koha: Math.round(b.koha),
+      perHead: perHead(b),
+      avgCustomersPerNight: b.nights > 0 ? Math.round(b.customers / b.nights) : 0,
+      weeknightPerHead: perHead(locWeeknight.get(name) ?? emptyBucket()),
+      weekendPerHead: perHead(locWeekend.get(name) ?? emptyBucket()),
+    }));
+
+  const weekday: ImpactStoryWeekday[] = [...byWeekday.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([day, b]) => ({
+      day,
+      label: WEEKDAY_LABELS[day],
+      weekend: day === 0 || day === 6,
+      perHead: perHead(b),
+      avgCustomersPerNight: b.nights > 0 ? Math.round(b.customers / b.nights) : 0,
+    }));
+
+  // Milestone ladder — count volunteers at or above each rung.
+  const shiftCounts = milestoneRows.map((m) => m.shifts);
+  const milestones: ImpactStoryMilestone[] = MILESTONE_RUNGS.map((threshold) => ({
+    threshold,
+    volunteers: shiftCounts.filter((c) => c >= threshold).length,
+  }));
+
+  // Totals — fold every year's bucket into one for the all-time service figures.
+  const allTime = [...byYear.values()].reduce<Bucket>((acc, b) => {
+    acc.nights += b.nights;
+    acc.customers += b.customers;
+    acc.koha += b.koha;
+    acc.cash += b.cash;
+    acc.eftpos += b.eftpos;
+    acc.stripe += b.stripe;
+    acc.customersWithKoha += b.customersWithKoha;
+    acc.nonPayingWithKoha += b.nonPayingWithKoha;
+    acc.nonPayingCount += b.nonPayingCount;
+    return acc;
+  }, emptyBucket());
+
+  return {
+    totals: {
+      nights: allTime.nights,
+      meals: headline.peopleServed,
+      koha: Math.round(allTime.koha),
+      newVolunteers,
+      volunteers: Number(volunteerCountRows[0]?.count ?? 0),
+      volunteerHours: headline.volunteerHours,
+      foodSavedKg: headline.foodSavedKg,
+      foodSavedKgPerMeal: FOOD_SAVED_KG_PER_MEAL,
+      perHead: perHead(allTime),
+      perPaying: perPaying(allTime),
+      nonPayingPercent: nonPayingPercent(allTime),
+      firstNight: rows[0]?.date.toISOString().slice(0, 10) ?? null,
+      lastNight: rows[rows.length - 1]?.date.toISOString().slice(0, 10) ?? null,
+    },
+    yearly,
+    locations,
+    weekday,
+    milestones,
+    generatedAt: now.toISOString(),
+  };
+}


### PR DESCRIPTION
## What

Adds **`GET /api/public/impact-story`** — a cacheable, CORS-enabled public endpoint that returns the all-time aggregate dataset behind the marketing site's new `/impact` data-story page.

It's the richer sibling of the existing [`/api/public/impact-stats`](../blob/main/web/src/app/api/public/impact-stats/route.ts): where that returns the three headline numbers (people served, volunteer hours, food saved), this returns the full breakdown the story is built from.

## Payload shape

| Section | Fields |
| --- | --- |
| `totals` | nights, meals, koha, newVolunteers, volunteers, volunteerHours, foodSavedKg(+factor), perHead, perPaying, nonPaying%, first/last night |
| `yearly[]` | per-year nights, customers, koha, perHead, perPaying, nonPaying%, cash/eftpos/digital % mix, `partial` flag |
| `locations[]` | per-venue nights, customers, koha, perHead, avg customers/night, weeknight vs weekend perHead, first year |
| `weekday[]` | per-weekday (NZ time) perHead + avg customers/night |
| `milestones[]` | volunteers at ≥10 / 25 / 50 / 100 / 200 completed shifts |

## Notes

- **Aggregate & non-sensitive only** — no per-person rows leave the portal.
- **Definitions mirror the admin restaurant-analytics dashboard** (`src/lib/restaurant-analytics.ts`) so the public figures agree with what staff see internally: `perHead = koha ÷ customers` over koha nights, `perPaying = koha ÷ (customers − non-paying)`, `nonPaying% = non-paying ÷ all customers`.
- Reuses `getPublicImpactStats()` for the headline people-served / hours / food-saved figures.
- One all-time `findMany` over `MealsServed` plus two small grouped volunteer queries; cached at the edge for 1h (`s-maxage=3600, stale-while-revalidate=86400`), same as impact-stats. **No schema change / migration.**

## Consumer

The marketing site's `/impact` page (separate repo, in progress) fetches this via `VOLUNTEER_PORTAL_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)