### PR TITLE
fix(deploy): unbreak Vercel build by gating standalone output behind a flag

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -97,6 +97,10 @@ jobs:
 
       - name: Build application
         run: npm run build
+        env:
+          # Emit the standalone bundle the Docker runtime image needs.
+          # (Vercel builds without this flag so it manages its own output.)
+          BUILD_STANDALONE: "1"
 
       # next build copies the build-time .env into .next/standalone/. Runtime
       # env is injected by Coolify, so strip it before packaging the image.

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,20 +1,31 @@
 import { withPostHogConfig } from "@posthog/nextjs-config";
 import type { NextConfig } from "next";
 
+// Only emit the standalone bundle for the self-hosted Docker/Coolify image.
+// On Vercel this MUST stay off — Vercel manages its own build output and the
+// relocated standalone output breaks its post-build step
+// (ENOENT .next/package.json). The Docker workflow sets BUILD_STANDALONE=1.
+const standalone = process.env.BUILD_STANDALONE === "1";
+
 const nextConfig: NextConfig = {
-  // Self-contained build output for Docker deployment
-  output: "standalone",
+  // Self-contained build output for Docker deployment (opt-in via env)
+  ...(standalone
+    ? {
+        output: "standalone" as const,
 
-  // Serve uncompressed from the origin and let Cloudflare compress at the edge
-  // (brotli). Cloudflare passes through origin gzip rather than upgrading it,
-  // so disabling Next's gzip is required to get brotli to the browser.
-  // The app domain is always behind the Cloudflare proxy in production.
-  compress: false,
+        // Serve uncompressed from the origin and let Cloudflare compress at the
+        // edge (brotli). Cloudflare passes through origin gzip rather than
+        // upgrading it, so disabling Next's gzip is required to get brotli to
+        // the browser. The app domain is always behind the Cloudflare proxy in
+        // production.
+        compress: false,
 
-  // Pin the tracing root to web/ so standalone output always has server.js
-  // at its top level regardless of where the repo is checked out
-  // (next build always runs from web/)
-  outputFileTracingRoot: process.cwd(),
+        // Pin the tracing root to web/ so standalone output always has
+        // server.js at its top level regardless of where the repo is checked
+        // out (next build always runs from web/)
+        outputFileTracingRoot: process.cwd(),
+      }
+    : {}),
 
   // Keep native/heavy packages out of the server bundle
   serverExternalPackages: ["@prisma/client", "bcrypt"],


### PR DESCRIPTION
## What

Gates the Docker/Coolify-only Next.js build options (`output: \"standalone\"`, `compress: false`, `outputFileTracingRoot`) behind a `BUILD_STANDALONE=1` env flag that **only** the `docker-image` workflow sets.

## Why

Vercel deploys were failing with:

```
ENOENT: no such file or directory, lstat '/vercel/path0/.next/package.json'
```

Commit `ac7b1908` (Coolify self-hosting migration) added `output: \"standalone\"` to `web/next.config.ts`. That output mode is required for the self-hosted Docker runtime image, but **Vercel manages its own build output and breaks on standalone's relocated `.next` structure** — hence the missing `.next/package.json`.

Both Vercel and the Docker CI run the same `npm run build`, so the Docker-only config leaked into the Vercel build.

## How

- `web/next.config.ts` — `output`/`compress`/`outputFileTracingRoot` now only apply when `BUILD_STANDALONE === \"1\"`. Vercel builds without the flag → standard output → no ENOENT.
- `.github/workflows/docker-image.yml` — the "Build application" step sets `BUILD_STANDALONE: \"1\"`, so the GHCR/Coolify image still gets `.next/standalone`.

| Build | `BUILD_STANDALONE` | `output` | Result |
|-------|-------------------|----------|--------|
| Vercel | unset | default | Vercel handles output |
| Docker CI | `"1"` | `standalone` | `server.js` bundle for the image |

## Reviewer notes

- Verify locally in `web/`: `BUILD_STANDALONE=1 npm run build` produces `.next/standalone/server.js`; plain `npm run build` does **not** emit standalone.
- Open question: if Vercel is being decommissioned in favor of Coolify, an alternative is to stop deploying to Vercel entirely. This PR keeps **both** paths green during the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)