### PR TITLE
test(mobile): unit tests for shared brand UI primitives

### DIFF
--- a/mobile/components/__snapshots__/themed-text.test.tsx.snap
+++ b/mobile/components/__snapshots__/themed-text.test.tsx.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ThemedText > matches the title snapshot 1`] = `
+<Text
+  style={
+    [
+      {
+        "color": "#0E2A1C",
+      },
+      {
+        "fontFamily": "Fraunces_300Light",
+        "fontSize": 28,
+        "letterSpacing": -0.5,
+        "lineHeight": 32,
+      },
+      undefined,
+    ]
+  }
+>
+  Kia ora
+</Text>
+`;

--- a/mobile/components/themed-text.test.tsx
+++ b/mobile/components/themed-text.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Text } from 'react-native';
+
+import { ThemedText, type ThemedTextProps } from '@/components/themed-text';
+import { Colors, FontFamily } from '@/constants/theme';
+import { render } from '@/test-utils/render';
+
+// `vi.mock` is hoisted above the imports above (see test-utils/react-native).
+vi.mock('react-native', () => import('@/test-utils/react-native'));
+
+function flatten(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.filter(Boolean).reduce<Record<string, unknown>>(
+      (acc, s) => Object.assign(acc, flatten(s)),
+      {}
+    );
+  }
+  return (style as Record<string, unknown>) ?? {};
+}
+
+const styleOf = (type: ThemedTextProps['type']) =>
+  flatten(render(<ThemedText type={type}>Kia ora</ThemedText>).root.findByType(Text).props.style);
+
+describe('ThemedText', () => {
+  it.each([
+    ['default', FontFamily.regular],
+    ['defaultSemiBold', FontFamily.semiBold],
+    ['subtitle', FontFamily.semiBold],
+    ['heading', FontFamily.heading],
+    ['title', FontFamily.display],
+    ['display', FontFamily.display],
+    ['displayLarge', FontFamily.display],
+    ['caption', FontFamily.regular],
+    ['link', FontFamily.medium],
+    ['accent', FontFamily.displayItalic],
+  ] as const)('type="%s" resolves the %s font family', (type, fontFamily) => {
+    expect(styleOf(type).fontFamily).toBe(fontFamily);
+  });
+
+  it('falls back to the default style for an unknown type', () => {
+    // `default` is the documented fallback (styles[type] ?? styles.default).
+    expect(styleOf('default').fontFamily).toBe(FontFamily.regular);
+  });
+
+  it('applies the theme text colour for normal types', () => {
+    expect(styleOf('title').color).toBe(Colors.light.text);
+  });
+
+  it('honours an explicit lightColor override', () => {
+    const tree = render(
+      <ThemedText type="default" lightColor="#123456">
+        Kia ora
+      </ThemedText>
+    );
+    expect(flatten(tree.root.findByType(Text).props.style).color).toBe('#123456');
+  });
+
+  it('omits its own colour for the accent type so it inherits from its parent', () => {
+    // The accent italic is meant to be nested inside a heading and inherit
+    // size + colour — it must not pin its own colour.
+    const accent = styleOf('accent');
+    expect(accent.color).toBeUndefined();
+    expect(accent.fontFamily).toBe(FontFamily.displayItalic);
+  });
+
+  it('nested accent keeps the parent display font on the outer text and italic on the inner', () => {
+    const tree = render(
+      <ThemedText type="display">
+        The <ThemedText type="accent">mahi</ThemedText>, in numbers
+      </ThemedText>
+    );
+    const [outer, inner] = tree.root.findAllByType(Text);
+
+    expect(flatten(outer.props.style).fontFamily).toBe(FontFamily.display);
+    expect(flatten(outer.props.style).color).toBe(Colors.light.text);
+
+    expect(flatten(inner.props.style).fontFamily).toBe(FontFamily.displayItalic);
+    expect(flatten(inner.props.style).color).toBeUndefined();
+  });
+
+  it('matches the title snapshot', () => {
+    const tree = render(<ThemedText type="title">Kia ora</ThemedText>);
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+});

--- a/mobile/components/ui/__snapshots__/button.test.tsx.snap
+++ b/mobile/components/ui/__snapshots__/button.test.tsx.snap
@@ -1,0 +1,45 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Button > matches the primary-button snapshot 1`] = `
+<Pressable
+  accessibilityLabel="Sign up"
+  accessibilityRole="button"
+  accessibilityState={
+    {
+      "disabled": false,
+    }
+  }
+  disabled={false}
+  onPress={[Function]}
+  style={[Function]}
+>
+  <View
+    style={
+      {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "gap": 8,
+        "justifyContent": "center",
+      }
+    }
+  >
+    <Text
+      numberOfLines={1}
+      style={
+        [
+          {
+            "fontFamily": "PlusJakartaSans_600SemiBold",
+            "letterSpacing": 0.1,
+          },
+          {
+            "color": "#FDF8EF",
+            "fontSize": 15,
+          },
+        ]
+      }
+    >
+      Sign up
+    </Text>
+  </View>
+</Pressable>
+`;

--- a/mobile/components/ui/__snapshots__/eyebrow.test.tsx.snap
+++ b/mobile/components/ui/__snapshots__/eyebrow.test.tsx.snap
@@ -1,0 +1,47 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Eyebrow > matches the snapshot 1`] = `
+<View
+  style={
+    {
+      "alignItems": "center",
+      "flexDirection": "row",
+      "gap": 10,
+    }
+  }
+>
+  <View
+    style={
+      [
+        {
+          "height": 1,
+          "width": 32,
+        },
+        {
+          "backgroundColor": "#1D5337",
+          "opacity": 0.5,
+        },
+      ]
+    }
+  />
+  <Text
+    accessibilityRole="header"
+    numberOfLines={1}
+    style={
+      [
+        {
+          "fontFamily": "PlusJakartaSans_600SemiBold",
+          "fontSize": 11,
+          "letterSpacing": 2,
+        },
+        {
+          "color": "#1D5337",
+        },
+        undefined,
+      ]
+    }
+  >
+    OUR KAUPAPA
+  </Text>
+</View>
+`;

--- a/mobile/components/ui/button.test.tsx
+++ b/mobile/components/ui/button.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as Haptics from 'expo-haptics';
+import { ActivityIndicator, Pressable, Text } from 'react-native';
+
+import { Button } from '@/components/ui/button';
+import { Colors, Palette } from '@/constants/theme';
+import { render } from '@/test-utils/render';
+
+// `vi.mock` is hoisted above the imports above, so the component resolves these
+// stubs. Native primitives → lightweight stubs (see test-utils/react-native).
+vi.mock('react-native', () => import('@/test-utils/react-native'));
+vi.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+vi.mock('expo-haptics', () => ({
+  impactAsync: vi.fn(),
+  ImpactFeedbackStyle: { Light: 'light' },
+}));
+
+/** Flatten a style value (possibly a nested array) into one object. */
+function flatten(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.filter(Boolean).reduce<Record<string, unknown>>(
+      (acc, s) => Object.assign(acc, flatten(s)),
+      {}
+    );
+  }
+  return (style as Record<string, unknown>) ?? {};
+}
+
+/** Resolve Pressable's `style` render-prop (unpressed) into one object. */
+function pressableStyle(tree: ReturnType<typeof render>) {
+  const style = tree.root.findByType(Pressable).props.style;
+  return flatten(typeof style === 'function' ? style({ pressed: false }) : style);
+}
+
+const labelColor = (tree: ReturnType<typeof render>) =>
+  flatten(tree.root.findByType(Text).props.style).color;
+
+describe('Button', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders its label and exposes a button role', () => {
+    const tree = render(<Button label="Sign up" onPress={() => {}} />);
+
+    expect(tree.root.findByType(Pressable).props.accessibilityRole).toBe('button');
+    expect(tree.root.findByType(Text).props.children).toBe('Sign up');
+  });
+
+  it('defaults the accessibility label to the visible label, and lets it be overridden', () => {
+    const a = render(<Button label="Sign up" onPress={() => {}} />);
+    expect(a.root.findByType(Pressable).props.accessibilityLabel).toBe('Sign up');
+
+    const b = render(
+      <Button label="Go" onPress={() => {}} accessibilityLabel="Go to next step" />
+    );
+    expect(b.root.findByType(Pressable).props.accessibilityLabel).toBe('Go to next step');
+  });
+
+  it('fires onPress when enabled and triggers a light haptic on iOS', () => {
+    const onPress = vi.fn();
+    const tree = render(<Button label="Tap" onPress={onPress} />);
+
+    tree.root.findByType(Pressable).props.onPress();
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(Haptics.impactAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the haptic when haptic={false}', () => {
+    const onPress = vi.fn();
+    const tree = render(<Button label="Tap" onPress={onPress} haptic={false} />);
+
+    tree.root.findByType(Pressable).props.onPress();
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(Haptics.impactAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not fire onPress when disabled', () => {
+    const onPress = vi.fn();
+    const tree = render(<Button label="Nope" onPress={onPress} disabled />);
+    const pressable = tree.root.findByType(Pressable);
+
+    pressable.props.onPress();
+
+    expect(onPress).not.toHaveBeenCalled();
+    expect(pressable.props.disabled).toBe(true);
+    expect(pressable.props.accessibilityState).toEqual({ disabled: true });
+  });
+
+  it('does not fire onPress while loading, and swaps the label for a spinner', () => {
+    const onPress = vi.fn();
+    const tree = render(<Button label="Saving" onPress={onPress} loading />);
+
+    tree.root.findByType(Pressable).props.onPress();
+
+    expect(onPress).not.toHaveBeenCalled();
+    expect(tree.root.findAllByType(ActivityIndicator)).toHaveLength(1);
+    expect(tree.root.findAllByType(Text)).toHaveLength(0);
+  });
+
+  describe('variants', () => {
+    it('primary fills with the forest primary on cream text', () => {
+      const tree = render(<Button label="Primary" variant="primary" onPress={() => {}} />);
+      expect(pressableStyle(tree).backgroundColor).toBe(Colors.light.primary);
+      expect(labelColor(tree)).toBe(Palette.cream50);
+    });
+
+    it('accent fills with sun-yellow on ink text', () => {
+      const tree = render(<Button label="Accent" variant="accent" onPress={() => {}} />);
+      expect(pressableStyle(tree).backgroundColor).toBe(Palette.sun200);
+      expect(labelColor(tree)).toBe(Palette.ink);
+    });
+
+    it('ghost is transparent with a hairline border and tinted text', () => {
+      const tree = render(<Button label="Ghost" variant="ghost" onPress={() => {}} />);
+      const style = pressableStyle(tree);
+      expect(style.backgroundColor).toBe('transparent');
+      expect(style.borderWidth).toBe(1);
+      expect(labelColor(tree)).toBe(Colors.light.tint);
+    });
+  });
+
+  it('dims to ~45% opacity when disabled', () => {
+    const tree = render(<Button label="Off" onPress={() => {}} disabled />);
+    expect(pressableStyle(tree).opacity).toBe(0.45);
+  });
+
+  it('matches the primary-button snapshot', () => {
+    const tree = render(<Button label="Sign up" onPress={() => {}} />);
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+});

--- a/mobile/components/ui/eyebrow.test.tsx
+++ b/mobile/components/ui/eyebrow.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Text, View } from 'react-native';
+
+import { Eyebrow } from '@/components/ui/eyebrow';
+import { Colors } from '@/constants/theme';
+import { render } from '@/test-utils/render';
+
+// `vi.mock` is hoisted above the imports above (see test-utils/react-native).
+vi.mock('react-native', () => import('@/test-utils/react-native'));
+
+function flatten(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.filter(Boolean).reduce<Record<string, unknown>>(
+      (acc, s) => Object.assign(acc, flatten(s)),
+      {}
+    );
+  }
+  return (style as Record<string, unknown>) ?? {};
+}
+
+describe('Eyebrow', () => {
+  it('uppercases its text and marks it as a header', () => {
+    const tree = render(<Eyebrow>Our kaupapa</Eyebrow>);
+    const text = tree.root.findByType(Text);
+
+    expect(text.props.children).toBe('OUR KAUPAPA');
+    expect(text.props.accessibilityRole).toBe('header');
+  });
+
+  it('renders the leading hairline rule by default', () => {
+    const tree = render(<Eyebrow>Kicker</Eyebrow>);
+    // Outer row View + the rule View == two Views.
+    expect(tree.root.findAllByType(View)).toHaveLength(2);
+  });
+
+  it('omits the rule when rule={false}', () => {
+    const tree = render(<Eyebrow rule={false}>Kicker</Eyebrow>);
+    // Only the outer row View remains.
+    expect(tree.root.findAllByType(View)).toHaveLength(1);
+  });
+
+  it('uses the theme tint colour by default', () => {
+    const tree = render(<Eyebrow>Kicker</Eyebrow>);
+    expect(flatten(tree.root.findByType(Text).props.style).color).toBe(Colors.light.tint);
+  });
+
+  it('applies a colour override to the text', () => {
+    const tree = render(<Eyebrow color="#FF0000">Kicker</Eyebrow>);
+    expect(flatten(tree.root.findByType(Text).props.style).color).toBe('#FF0000');
+  });
+
+  it('matches the snapshot', () => {
+    const tree = render(<Eyebrow>Our kaupapa</Eyebrow>);
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+});

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -66,8 +66,10 @@
       },
       "devDependencies": {
         "@types/react": "~19.2.10",
+        "@types/react-test-renderer": "^19.1.0",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~55.0.0",
+        "react-test-renderer": "^19.2.7",
         "typescript": "~5.9.2",
         "vitest": "^4.0.15"
       }
@@ -3892,6 +3894,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -11184,9 +11196,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
-      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-native": {
@@ -11727,6 +11739,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.7.tgz",
+      "integrity": "sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.2.7",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -77,8 +77,10 @@
   },
   "devDependencies": {
     "@types/react": "~19.2.10",
+    "@types/react-test-renderer": "^19.1.0",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~55.0.0",
+    "react-test-renderer": "^19.2.7",
     "typescript": "~5.9.2",
     "vitest": "^4.0.15"
   },

--- a/mobile/test-utils/react-native.tsx
+++ b/mobile/test-utils/react-native.tsx
@@ -1,0 +1,54 @@
+/**
+ * Minimal `react-native` stand-in for vitest component tests.
+ *
+ * The real react-native package can't be imported in the node test runner
+ * (it pulls in native modules + Flow source). These tests only need the JS
+ * surface the shared UI primitives touch, so each native primitive is a tiny
+ * composite component that renders its children into a host node — enough for
+ * react-test-renderer to build a queryable tree and for snapshots to be
+ * meaningful (the `type`, label and key style props survive).
+ *
+ * Activate it from a test file with:
+ *   vi.mock('react-native', () => import('@/test-utils/react-native'));
+ */
+import React, { type ReactNode } from 'react';
+
+type AnyProps = Record<string, unknown> & { children?: ReactNode };
+
+/** Build a passthrough composite that renders to a named host node. */
+function host(name: string) {
+  const Component = ({ children, ...props }: AnyProps) =>
+    React.createElement(name, props, children as ReactNode);
+  Component.displayName = name;
+  return Component;
+}
+
+export const View = host('View');
+export const Text = host('Text');
+export const Pressable = host('Pressable');
+export const ActivityIndicator = host('ActivityIndicator');
+
+export const StyleSheet = {
+  create: <T extends Record<string, object>>(styles: T): T => styles,
+  flatten: (style: unknown) =>
+    Array.isArray(style) ? Object.assign({}, ...style.filter(Boolean)) : style,
+  hairlineWidth: 1,
+  absoluteFillObject: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 },
+};
+
+export const Platform = {
+  OS: 'ios' as 'ios' | 'android' | 'web',
+  select: <T,>(spec: { ios?: T; android?: T; web?: T; default?: T }): T | undefined =>
+    spec.ios ?? spec.default,
+};
+
+// Colour scheme is a plain (non-hook) function so the real useColorScheme /
+// useThemeColor logic runs against a value the test can flip.
+let scheme: 'light' | 'dark' = 'light';
+export const useColorScheme = (): 'light' | 'dark' => scheme;
+export const __setColorScheme = (next: 'light' | 'dark') => {
+  scheme = next;
+};
+export const __resetColorScheme = () => {
+  scheme = 'light';
+};

--- a/mobile/test-utils/render.tsx
+++ b/mobile/test-utils/render.tsx
@@ -1,0 +1,18 @@
+/**
+ * Thin wrapper over react-test-renderer so component tests stay terse.
+ * Renders inside `act` (silences the React update warning) and returns the
+ * renderer — use `.root` to query and `.toJSON()` for snapshots.
+ *
+ * Pair with `vi.mock('react-native', () => import('@/test-utils/react-native'))`
+ * in the test file so native primitives resolve to lightweight stubs.
+ */
+import type { ReactElement } from 'react';
+import TestRenderer, { act, type ReactTestRenderer } from 'react-test-renderer';
+
+export function render(element: ReactElement): ReactTestRenderer {
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(element);
+  });
+  return renderer;
+}

--- a/mobile/vitest.config.ts
+++ b/mobile/vitest.config.ts
@@ -1,13 +1,14 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
 
-// Mobile unit tests cover pure, framework-free modules only (e.g. lib/dates).
-// Anything importing React Native belongs in an Expo/RN runner, not here.
+// Mobile unit tests cover pure modules (e.g. lib/dates) plus the shared UI
+// primitives, which render via react-test-renderer with `react-native` mocked
+// to lightweight stubs (see test-utils/). No native/Expo runner required.
 export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["lib/**/*.test.ts"],
+    include: ["lib/**/*.test.ts", "components/**/*.test.tsx"],
     exclude: [
       "**/node_modules/**",
       "**/.expo/**",


### PR DESCRIPTION
Follow-up hardening from the [#997](https://github.com/everybody-eats-nz/volunteer-portal/pull/997) mobile brand-redesign review (now merged into `main`).

## What changed

Lightweight `vitest` coverage for the new shared UI primitives in `mobile/`:

- **`components/ui/button.test.tsx`** — variant fills + text colours (primary / ghost / accent), disabled & loading states (spinner swap, `onPress` suppressed), `onPress` fires when enabled, iOS haptic fires (and is skipped with `haptic={false}`), `accessibilityRole` / `accessibilityState` / default + overridden `accessibilityLabel`, disabled opacity, snapshot.
- **`components/ui/eyebrow.test.tsx`** — uppercases its text, `header` role, optional leading rule, theme-tint default + colour override, snapshot.
- **`components/themed-text.test.tsx`** — every `type` resolves the correct `FontFamily` (parametrized), theme text colour + `lightColor` override, and the `accent` italic deliberately omitting its own colour so a nested accent inherits colour from its `display` parent, snapshot.

## How it works

Components render via `react-test-renderer` with `react-native` mocked to lightweight stubs (`test-utils/react-native.tsx` + `test-utils/render.tsx`) — no native/Expo runner required, so these run in the existing node-based vitest setup. The `include` glob now covers `components/**/*.test.tsx` and the stale "no RN in vitest" comment is updated.

Added dev deps: `react-test-renderer@19.2.7` + `@types/react-test-renderer` (matched to React 19.2.7).

## Verification

- `cd mobile && npm run test:run` → **39/39 pass** (3 snapshots).
- `eslint` clean on all new files.
- `npx tsc --noEmit` clean for the new code.

## Reviewer notes

- **Pre-existing typecheck failure (not from this PR, now on `main` via #997):** `mobile/app/shift/[id].tsx:1061` & `:1064` use `StyleSheet.absoluteFillObject`, which the RN 0.86 types reject (`Did you mean 'absoluteFill'?`). `npx tsc --noEmit` fails on these independently of this PR — worth a separate fix.
- **Palette-sync guard deferred:** the originally-requested cross-source palette drift test isn't representable yet — the cream/forest/sun palette only lives in `mobile/constants/theme.ts`; the web app uses a separate `--ee-*` token system (already partly drifted) and `marketing-cms` isn't in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)