### PR TITLE
test(mobile): de-duplicate flatten() style helper

### DIFF
--- a/mobile/components/themed-text.test.tsx
+++ b/mobile/components/themed-text.test.tsx
@@ -4,19 +4,10 @@ import { Text } from 'react-native';
 import { ThemedText, type ThemedTextProps } from '@/components/themed-text';
 import { Colors, FontFamily } from '@/constants/theme';
 import { render } from '@/test-utils/render';
+import { flatten } from '@/test-utils/style';
 
 // `vi.mock` is hoisted above the imports above (see test-utils/react-native).
 vi.mock('react-native', () => import('@/test-utils/react-native'));
-
-function flatten(style: unknown): Record<string, unknown> {
-  if (Array.isArray(style)) {
-    return style.filter(Boolean).reduce<Record<string, unknown>>(
-      (acc, s) => Object.assign(acc, flatten(s)),
-      {}
-    );
-  }
-  return (style as Record<string, unknown>) ?? {};
-}
 
 const styleOf = (type: ThemedTextProps['type']) =>
   flatten(render(<ThemedText type={type}>Kia ora</ThemedText>).root.findByType(Text).props.style);

--- a/mobile/components/ui/button.test.tsx
+++ b/mobile/components/ui/button.test.tsx
@@ -5,6 +5,7 @@ import { ActivityIndicator, Pressable, Text } from 'react-native';
 import { Button } from '@/components/ui/button';
 import { Colors, Palette } from '@/constants/theme';
 import { render } from '@/test-utils/render';
+import { flatten } from '@/test-utils/style';
 
 // `vi.mock` is hoisted above the imports above, so the component resolves these
 // stubs. Native primitives → lightweight stubs (see test-utils/react-native).
@@ -14,17 +15,6 @@ vi.mock('expo-haptics', () => ({
   impactAsync: vi.fn(),
   ImpactFeedbackStyle: { Light: 'light' },
 }));
-
-/** Flatten a style value (possibly a nested array) into one object. */
-function flatten(style: unknown): Record<string, unknown> {
-  if (Array.isArray(style)) {
-    return style.filter(Boolean).reduce<Record<string, unknown>>(
-      (acc, s) => Object.assign(acc, flatten(s)),
-      {}
-    );
-  }
-  return (style as Record<string, unknown>) ?? {};
-}
 
 /** Resolve Pressable's `style` render-prop (unpressed) into one object. */
 function pressableStyle(tree: ReturnType<typeof render>) {

--- a/mobile/components/ui/eyebrow.test.tsx
+++ b/mobile/components/ui/eyebrow.test.tsx
@@ -4,19 +4,10 @@ import { Text, View } from 'react-native';
 import { Eyebrow } from '@/components/ui/eyebrow';
 import { Colors } from '@/constants/theme';
 import { render } from '@/test-utils/render';
+import { flatten } from '@/test-utils/style';
 
 // `vi.mock` is hoisted above the imports above (see test-utils/react-native).
 vi.mock('react-native', () => import('@/test-utils/react-native'));
-
-function flatten(style: unknown): Record<string, unknown> {
-  if (Array.isArray(style)) {
-    return style.filter(Boolean).reduce<Record<string, unknown>>(
-      (acc, s) => Object.assign(acc, flatten(s)),
-      {}
-    );
-  }
-  return (style as Record<string, unknown>) ?? {};
-}
 
 describe('Eyebrow', () => {
   it('uppercases its text and marks it as a header', () => {

--- a/mobile/test-utils/style.ts
+++ b/mobile/test-utils/style.ts
@@ -1,0 +1,14 @@
+/**
+ * Flatten an RN `style` value — which may be a (possibly nested) array of
+ * style objects, a single object, or undefined — into one merged object, so
+ * tests can assert on a single resolved property (e.g. `flatten(style).color`).
+ */
+export function flatten(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.filter(Boolean).reduce<Record<string, unknown>>(
+      (acc, s) => Object.assign(acc, flatten(s)),
+      {}
+    );
+  }
+  return (style as Record<string, unknown>) ?? {};
+}


### PR DESCRIPTION
Follow-up to [#998](https://github.com/everybody-eats-nz/volunteer-portal/pull/998), addressing the one actionable suggestion from that PR's code review.

## What changed

The `flatten()` style helper was copy-pasted into all three primitive test files (`button.test.tsx`, `eyebrow.test.tsx`, `themed-text.test.tsx`). Extracted it to `mobile/test-utils/style.ts` and imported it in each — no behaviour change.

## Verification

- `cd mobile && npm run test:run` → **39/39 pass**.
- `eslint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)