### PR TITLE
fix(auth): verify passkey assertion in-process to fix prod login timeout

### DIFF
--- a/web/src/app/api/passkey/authenticate/verify-authentication/route.ts
+++ b/web/src/app/api/passkey/authenticate/verify-authentication/route.ts
@@ -3,181 +3,34 @@
  *
  * Verify the WebAuthn authentication response and return user info.
  * This is the second (final) step in the passkey authentication ceremony.
- * Called by the NextAuth passkey provider to verify the user.
+ *
+ * Note: the NextAuth passkey provider does NOT call this over HTTP — it calls
+ * `verifyPasskeyAuthentication()` directly in-process. This route remains for
+ * any direct/external callers and shares the same verification core.
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import {
-  verifyAuthenticationResponse,
-  AuthenticationResponseJSON,
-  VerifiedAuthenticationResponse,
-  AuthenticatorTransport,
-} from "@simplewebauthn/server";
-import { prisma } from "@/lib/prisma";
-import {
-  verifyAndConsumeChallenge,
-  base64URLToBuffer,
-  bufferToBase64URL,
-} from "@/lib/webauthn-utils";
-import { rpID, expectedOrigin } from "@/lib/webauthn-config";
-import { unarchiveUser } from "@/lib/archive-service";
-import { ArchiveTriggerSource } from "@/generated/client";
+import { AuthenticationResponseJSON } from "@simplewebauthn/server";
+import { verifyPasskeyAuthentication } from "@/lib/passkey-auth";
 
 export async function POST(req: NextRequest) {
   try {
-    // Parse request body
     const body = await req.json();
     const { authenticationResponse } = body as {
       authenticationResponse: AuthenticationResponseJSON;
     };
 
-    if (!authenticationResponse) {
+    const result = await verifyPasskeyAuthentication(authenticationResponse);
+
+    if (!result.verified) {
       return NextResponse.json(
-        { error: "Missing authentication response" },
-        { status: 400 }
+        { error: result.error, ...(result.details ? { details: result.details } : {}) },
+        { status: result.status }
       );
     }
 
-    // Decode credential ID to find the passkey
-    const credentialIdBuffer = base64URLToBuffer(authenticationResponse.id);
-
-    // Find the passkey in database
-    const passkey = await prisma.passkey.findUnique({
-      where: {
-        credentialId: Buffer.from(credentialIdBuffer),
-      },
-      include: {
-        user: {
-          select: {
-            id: true,
-            email: true,
-            name: true,
-            firstName: true,
-            lastName: true,
-            role: true,
-            phone: true,
-            emailVerified: true,
-            archivedAt: true,
-          },
-        },
-      },
-    });
-
-    if (!passkey) {
-      return NextResponse.json({ error: "Passkey not found" }, { status: 404 });
-    }
-
-    // Extract and verify the challenge
-    let extractedChallenge: string;
-
-    try {
-      const clientDataJSON = JSON.parse(
-        Buffer.from(
-          authenticationResponse.response.clientDataJSON,
-          "base64url"
-        ).toString()
-      );
-
-      extractedChallenge = clientDataJSON.challenge;
-
-      await verifyAndConsumeChallenge(extractedChallenge, "authentication");
-    } catch (error) {
-      console.error("Challenge verification failed:", error);
-      return NextResponse.json(
-        {
-          error: "Invalid or expired challenge",
-          details: error instanceof Error ? error.message : "Unknown error",
-        },
-        { status: 400 }
-      );
-    }
-
-    // Verify the authentication response
-    let verification: VerifiedAuthenticationResponse;
-
-    try {
-      verification = await verifyAuthenticationResponse({
-        response: authenticationResponse,
-        expectedChallenge: extractedChallenge, // Use the extracted challenge string
-        expectedOrigin,
-        expectedRPID: rpID,
-        // SimpleWebAuthn v11+ uses 'credential' instead of 'authenticator'
-        credential: {
-          id: bufferToBase64URL(passkey.credentialId),
-          publicKey: Uint8Array.from(passkey.credentialPublicKey),
-          counter: Number(passkey.counter),
-          transports: passkey.transports as AuthenticatorTransport[],
-        },
-      });
-    } catch (error) {
-      console.error("Authentication verification failed:", error);
-      return NextResponse.json(
-        {
-          error: "Failed to verify authentication",
-          details: error instanceof Error ? error.message : "Unknown error",
-        },
-        { status: 400 }
-      );
-    }
-
-    if (!verification.verified) {
-      return NextResponse.json(
-        { error: "Authentication verification failed" },
-        { status: 400 }
-      );
-    }
-
-    const { authenticationInfo } = verification;
-    const { newCounter } = authenticationInfo;
-
-    // Verify counter has incremented (anti-cloning protection)
-    // Note: Counter value of 0 means the authenticator doesn't support counters
-    // Only check counter if both old and new are non-zero
-    const oldCounter = Number(passkey.counter);
-    if (newCounter > 0 && oldCounter > 0 && newCounter <= oldCounter) {
-      console.error(
-        `Passkey counter did not increment. Old: ${oldCounter}, New: ${newCounter}. Possible cloned credential.`
-      );
-      return NextResponse.json(
-        { error: "Invalid passkey counter. Possible security issue." },
-        { status: 403 }
-      );
-    }
-
-    // Update passkey counter and last used timestamp
-    await prisma.passkey.update({
-      where: { id: passkey.id },
-      data: {
-        counter: BigInt(newCounter),
-        lastUsedAt: new Date(),
-      },
-    });
-
-    // Auto-reactivate archived users — successful passkey assertion is
-    // cryptographic proof of identity, same standard as OAuth re-auth.
-    if (passkey.user.archivedAt) {
-      await unarchiveUser({
-        userId: passkey.user.id,
-        triggerSource: ArchiveTriggerSource.SELF_REACTIVATION,
-        actorId: passkey.user.id,
-      });
-    }
-
-    // Return user info for NextAuth session
     return NextResponse.json(
-      {
-        verified: true,
-        user: {
-          id: passkey.user.id,
-          email: passkey.user.email,
-          name: passkey.user.name,
-          firstName: passkey.user.firstName,
-          lastName: passkey.user.lastName,
-          role: passkey.user.role,
-          phone: passkey.user.phone,
-          emailVerified: passkey.user.emailVerified,
-        },
-      },
+      { verified: true, user: result.user },
       { status: 200 }
     );
   } catch (error) {

--- a/web/src/lib/auth-options.ts
+++ b/web/src/lib/auth-options.ts
@@ -12,6 +12,7 @@ import { prisma } from "@/lib/prisma";
 import bcrypt from "bcrypt";
 import { unarchiveUser } from "@/lib/archive-service";
 import { ArchiveTriggerSource } from "@/generated/client";
+import { verifyPasskeyAuthentication } from "@/lib/passkey-auth";
 
 type AppRole = "ADMIN" | "VOLUNTEER";
 
@@ -168,25 +169,17 @@ export const authOptions: NextAuthOptions = {
         try {
           const response = JSON.parse(credentials.authenticationResponse);
 
-          // Call our verification endpoint
-          const verifyResult = await fetch(
-            `${process.env.NEXTAUTH_URL}/api/passkey/authenticate/verify-authentication`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ authenticationResponse: response }),
-            }
-          );
+          // Verify in-process. Do NOT fetch our own public URL here — in
+          // production the server can't reliably route back to its own
+          // hostname, which times out the whole passkey login.
+          const result = await verifyPasskeyAuthentication(response);
 
-          if (!verifyResult.ok) {
-            console.error("Passkey verification failed:", await verifyResult.text());
+          if (!result.verified) {
+            console.error("Passkey verification failed:", result.error);
             return null;
           }
 
-          const { verified, user } = await verifyResult.json();
-
-          if (!verified || !user) return null;
-
+          const { user } = result;
           return {
             id: user.id,
             email: user.email,

--- a/web/src/lib/passkey-auth.ts
+++ b/web/src/lib/passkey-auth.ts
@@ -1,0 +1,193 @@
+/**
+ * Passkey authentication verification (in-process)
+ *
+ * Shared core for verifying a WebAuthn authentication assertion. Used by both
+ * the HTTP route (`/api/passkey/authenticate/verify-authentication`) and the
+ * NextAuth passkey provider in `auth-options.ts`.
+ *
+ * IMPORTANT: NextAuth's `authorize()` must call this directly — never via an
+ * HTTP fetch to our own public URL. In production the server cannot reliably
+ * route back to its own public hostname (hairpin NAT / proxy in front), which
+ * caused passkey logins to fail with a connect timeout.
+ */
+
+import {
+  verifyAuthenticationResponse,
+  AuthenticationResponseJSON,
+  VerifiedAuthenticationResponse,
+  AuthenticatorTransport,
+} from "@simplewebauthn/server";
+import { prisma } from "@/lib/prisma";
+import {
+  verifyAndConsumeChallenge,
+  base64URLToBuffer,
+  bufferToBase64URL,
+} from "@/lib/webauthn-utils";
+import { rpID, expectedOrigin } from "@/lib/webauthn-config";
+import { unarchiveUser } from "@/lib/archive-service";
+import { ArchiveTriggerSource, Role } from "@/generated/client";
+
+export interface PasskeyAuthUser {
+  id: string;
+  email: string;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  role: Role;
+  phone: string | null;
+  emailVerified: boolean;
+}
+
+export type PasskeyAuthResult =
+  | { verified: true; user: PasskeyAuthUser }
+  | { verified: false; status: number; error: string; details?: string };
+
+/**
+ * Verify a WebAuthn authentication assertion and return the authenticated user.
+ *
+ * Performs the full ceremony: locate the passkey, verify + consume the
+ * challenge, verify the assertion signature, enforce the anti-cloning counter,
+ * update the counter / lastUsedAt, and auto-reactivate an archived user
+ * (successful assertion is cryptographic proof of identity).
+ */
+export async function verifyPasskeyAuthentication(
+  authenticationResponse: AuthenticationResponseJSON
+): Promise<PasskeyAuthResult> {
+  if (!authenticationResponse) {
+    return { verified: false, status: 400, error: "Missing authentication response" };
+  }
+
+  // Decode credential ID to find the passkey
+  const credentialIdBuffer = base64URLToBuffer(authenticationResponse.id);
+
+  const passkey = await prisma.passkey.findUnique({
+    where: {
+      credentialId: Buffer.from(credentialIdBuffer),
+    },
+    include: {
+      user: {
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          firstName: true,
+          lastName: true,
+          role: true,
+          phone: true,
+          emailVerified: true,
+          archivedAt: true,
+        },
+      },
+    },
+  });
+
+  if (!passkey) {
+    return { verified: false, status: 404, error: "Passkey not found" };
+  }
+
+  // Extract and verify the challenge embedded in clientDataJSON
+  let extractedChallenge: string;
+  try {
+    const clientDataJSON = JSON.parse(
+      Buffer.from(
+        authenticationResponse.response.clientDataJSON,
+        "base64url"
+      ).toString()
+    );
+
+    extractedChallenge = clientDataJSON.challenge;
+
+    await verifyAndConsumeChallenge(extractedChallenge, "authentication");
+  } catch (error) {
+    console.error("Challenge verification failed:", error);
+    return {
+      verified: false,
+      status: 400,
+      error: "Invalid or expired challenge",
+      details: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+
+  // Verify the authentication response
+  let verification: VerifiedAuthenticationResponse;
+  try {
+    verification = await verifyAuthenticationResponse({
+      response: authenticationResponse,
+      expectedChallenge: extractedChallenge,
+      expectedOrigin,
+      expectedRPID: rpID,
+      credential: {
+        id: bufferToBase64URL(passkey.credentialId),
+        publicKey: Uint8Array.from(passkey.credentialPublicKey),
+        counter: Number(passkey.counter),
+        transports: passkey.transports as AuthenticatorTransport[],
+      },
+    });
+  } catch (error) {
+    console.error("Authentication verification failed:", error);
+    return {
+      verified: false,
+      status: 400,
+      error: "Failed to verify authentication",
+      details: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+
+  if (!verification.verified) {
+    return {
+      verified: false,
+      status: 400,
+      error: "Authentication verification failed",
+    };
+  }
+
+  const { newCounter } = verification.authenticationInfo;
+
+  // Verify counter has incremented (anti-cloning protection).
+  // Counter value of 0 means the authenticator doesn't support counters —
+  // only check when both old and new are non-zero.
+  const oldCounter = Number(passkey.counter);
+  if (newCounter > 0 && oldCounter > 0 && newCounter <= oldCounter) {
+    console.error(
+      `Passkey counter did not increment. Old: ${oldCounter}, New: ${newCounter}. Possible cloned credential.`
+    );
+    return {
+      verified: false,
+      status: 403,
+      error: "Invalid passkey counter. Possible security issue.",
+    };
+  }
+
+  // Update passkey counter and last used timestamp
+  await prisma.passkey.update({
+    where: { id: passkey.id },
+    data: {
+      counter: BigInt(newCounter),
+      lastUsedAt: new Date(),
+    },
+  });
+
+  // Auto-reactivate archived users — successful passkey assertion is
+  // cryptographic proof of identity, same standard as OAuth re-auth.
+  if (passkey.user.archivedAt) {
+    await unarchiveUser({
+      userId: passkey.user.id,
+      triggerSource: ArchiveTriggerSource.SELF_REACTIVATION,
+      actorId: passkey.user.id,
+    });
+  }
+
+  return {
+    verified: true,
+    user: {
+      id: passkey.user.id,
+      email: passkey.user.email,
+      name: passkey.user.name,
+      firstName: passkey.user.firstName,
+      lastName: passkey.user.lastName,
+      role: passkey.user.role,
+      phone: passkey.user.phone,
+      emailVerified: passkey.user.emailVerified,
+    },
+  };
+}


### PR DESCRIPTION
## Description

Passkey login was failing in production with a connect timeout:

```
Passkey authentication error: [TypeError: fetch failed] {
  [cause]: Error [ConnectTimeoutError]: Connect Timeout Error
      (attempted address: volunteers.everybodyeats.nz:443, timeout: 10000ms)
}
```

**Root cause:** the NextAuth passkey provider verified assertions by making an HTTP `fetch()` to `${NEXTAUTH_URL}/api/passkey/authenticate/verify-authentication` — i.e. the server calling its own public hostname. On the new Coolify/Vultr (Sydney) infra there is no hairpin-NAT loopback (the proxy sits in front), so the server cannot route back to its own public URL and the request hangs until undici's 10s timeout. This worked on Vercel due to how it handled the loopback, but broke after the migration.

**Fix:** extract the full verification ceremony into a shared in-process function, `verifyPasskeyAuthentication()` in `web/src/lib/passkey-auth.ts`, and call it directly from:
- the NextAuth passkey `authorize()` callback in `auth-options.ts` (no more network hop), and
- the HTTP route `verify-authentication/route.ts`, now a thin wrapper that delegates to the same function.

No behavioural change to the verification logic itself — same challenge consumption, assertion verification, anti-cloning counter check, counter/`lastUsedAt` update, and archived-user reactivation.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactoring (no functional changes)

## Version Bump Required
`version:patch`

## Testing
- [x] `tsc --noEmit` passes on all changed files (one pre-existing, unrelated error remains in `restaurant-reports.tsx`)
- [ ] Live passkey login not exercisable locally — WebAuthn needs real authenticator hardware and the prod RP origin. Verified by type-checking + code review; confirm on the deploy.

## Additional Notes
- Scanned the rest of `src/` — this was the **only** server-side self-fetch to the app's own public URL, so no other feature carries the same latent bug.
- The mobile passkey verify route (`/api/auth/mobile/passkey/verify`) already verified in-process and was unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)