### PR TITLE
feat(mobile): up-front shift signup eligibility gating (conflict, email, parental consent)

### DIFF
--- a/mobile/app/(tabs)/shifts.tsx
+++ b/mobile/app/(tabs)/shifts.tsx
@@ -39,6 +39,11 @@ import { Eyebrow } from "@/components/ui/eyebrow";
 import { Brand, Colors, FontFamily, Palette } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useShifts, type PeriodFriend } from "@/hooks/use-shifts";
+import {
+  getShiftDayKey,
+  getShiftPeriod,
+  getShiftPeriodLabel,
+} from "@/lib/shift-eligibility";
 import { getShiftThemeByName, type Shift } from "@/lib/dummy-data";
 
 /* ── Types ── */
@@ -233,6 +238,19 @@ export default function ShiftsScreen() {
         : past,
     [past, locationFilter]
   );
+
+  /* Day+period keys the user already holds (CONFIRMED/PENDING) — mirrors the
+     web's "one Day + one Evening shift per day" rule so available cards that
+     would clash are flagged before the user taps in. */
+  const bookedPeriodKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const s of myShifts) {
+      if (s.status === "CONFIRMED" || s.status === "PENDING") {
+        keys.add(`${getShiftDayKey(s.start)}|${getShiftPeriod(s.start)}`);
+      }
+    }
+    return keys;
+  }, [myShifts]);
 
   /* Available locations across all shifts — used by the picker */
   const locations = useMemo(() => {
@@ -567,6 +585,14 @@ export default function ShiftsScreen() {
                           colors={colors}
                           isDark={isDark}
                           showStatus={!!shift.status}
+                          conflicting={
+                            !shift.status &&
+                            bookedPeriodKeys.has(
+                              `${getShiftDayKey(shift.start)}|${getShiftPeriod(
+                                shift.start
+                              )}`
+                            )
+                          }
                         />
                       ))}
                     </View>
@@ -1159,12 +1185,15 @@ function ShiftCard({
   colors,
   isDark,
   showStatus,
+  conflicting,
 }: {
   shift: Shift;
   friends: PeriodFriend[];
   colors: (typeof Colors)["light"];
   isDark: boolean;
   showStatus?: boolean;
+  /** User already holds another shift in this day's same Day/Evening period. */
+  conflicting?: boolean;
 }) {
   const router = useRouter();
   const date = new Date(shift.start);
@@ -1254,6 +1283,8 @@ function ShiftCard({
             <StatusBadge status={displayStatus!} isDark={isDark} />
           ) : isPast ? (
             <StatusBadge status="COMPLETED" isDark={isDark} />
+          ) : conflicting ? (
+            <ConflictBadge isDark={isDark} />
           ) : (
             <SpotsBadge
               spotsLeft={spotsLeft}
@@ -1306,6 +1337,10 @@ function ShiftCard({
                   ? isDark
                     ? "rgba(253,248,239,0.25)"
                     : Palette.forest200
+                  : conflicting
+                  ? isDark
+                    ? "#fbbf24"
+                    : "#d97706"
                   : isFull
                   ? isDark
                     ? "#fca5a5"
@@ -1322,7 +1357,19 @@ function ShiftCard({
           />
           <Text style={[styles.capacityText, { color: colors.textSecondary }]}>
             {shift.signedUp}/{shift.capacity} volunteers
-            {!isPast && (
+            {!isPast && conflicting ? (
+              <>
+                {" · "}
+                <Text
+                  style={{
+                    color: isDark ? "#fbbf24" : "#d97706",
+                    fontFamily: FontFamily.semiBold,
+                  }}
+                >
+                  clashes with your {getShiftPeriodLabel(shift.start)}
+                </Text>
+              </>
+            ) : !isPast ? (
               <>
                 {" · "}
                 <Text
@@ -1342,7 +1389,7 @@ function ShiftCard({
                   {isFull ? "shift full" : `${spotsLeft} open`}
                 </Text>
               </>
-            )}
+            ) : null}
           </Text>
         </View>
 
@@ -1447,6 +1494,19 @@ function SpotsBadge({
     <View style={[styles.badge, { backgroundColor: bg }]}>
       <Ionicons name={icon} size={12} color={textColor} />
       <Text style={[styles.badgeText, { color: textColor }]}>{label}</Text>
+    </View>
+  );
+}
+
+/* Shown on an available shift the user can't take because they already hold
+   another shift in the same Day/Evening period that day. */
+function ConflictBadge({ isDark }: { isDark: boolean }) {
+  const bg = isDark ? "rgba(245, 158, 11, 0.15)" : "#fffbeb";
+  const textColor = isDark ? "#fbbf24" : "#d97706";
+  return (
+    <View style={[styles.badge, { backgroundColor: bg }]}>
+      <Ionicons name="calendar" size={12} color={textColor} />
+      <Text style={[styles.badgeText, { color: textColor }]}>Booked</Text>
     </View>
   );
 }

--- a/mobile/app/(tabs)/shifts.tsx
+++ b/mobile/app/(tabs)/shifts.tsx
@@ -40,8 +40,7 @@ import { Brand, Colors, FontFamily, Palette } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useShifts, type PeriodFriend } from "@/hooks/use-shifts";
 import {
-  getShiftDayKey,
-  getShiftPeriod,
+  getShiftPeriodKey,
   getShiftPeriodLabel,
 } from "@/lib/shift-eligibility";
 import { getShiftThemeByName, type Shift } from "@/lib/dummy-data";
@@ -246,7 +245,7 @@ export default function ShiftsScreen() {
     const keys = new Set<string>();
     for (const s of myShifts) {
       if (s.status === "CONFIRMED" || s.status === "PENDING") {
-        keys.add(`${getShiftDayKey(s.start)}|${getShiftPeriod(s.start)}`);
+        keys.add(getShiftPeriodKey(s.start));
       }
     }
     return keys;
@@ -587,11 +586,8 @@ export default function ShiftsScreen() {
                           showStatus={!!shift.status}
                           conflicting={
                             !shift.status &&
-                            bookedPeriodKeys.has(
-                              `${getShiftDayKey(shift.start)}|${getShiftPeriod(
-                                shift.start
-                              )}`
-                            )
+                            new Date(shift.end).getTime() >= Date.now() &&
+                            bookedPeriodKeys.has(getShiftPeriodKey(shift.start))
                           }
                         />
                       ))}

--- a/mobile/app/shift/[id].tsx
+++ b/mobile/app/shift/[id].tsx
@@ -650,6 +650,11 @@ export default function ShiftDetailScreen() {
           ]}
           pointerEvents="box-none"
         >
+          {/* `eligibility.profileComplete` is intentionally not gated here:
+              an incomplete profile is surfaced inside the signup sheet, where
+              the message links straight to /profile/edit so the user can fix
+              it in one tap. Email verification and parental consent aren't
+              self-resolvable in-app, so they block up front instead. */}
           {isPast ? (
             <BlockedPill
               icon="time-outline"

--- a/mobile/app/shift/[id].tsx
+++ b/mobile/app/shift/[id].tsx
@@ -69,6 +69,7 @@ export default function ShiftDetailScreen() {
     shift,
     signups: shiftSignups,
     periodFriends,
+    eligibility,
     isLoading,
     error,
     refresh,
@@ -650,44 +651,39 @@ export default function ShiftDetailScreen() {
           pointerEvents="box-none"
         >
           {isPast ? (
-            <View
-              style={[
-                s.pastPill,
-                {
-                  backgroundColor: colors.card,
-                  borderColor: colors.border,
-                },
-              ]}
-            >
-              <Ionicons
-                name="time-outline"
-                size={18}
-                color={colors.textSecondary}
-              />
-              <Text style={[s.pastPillText, { color: colors.textSecondary }]}>
-                This shift was in the past
-              </Text>
-            </View>
+            <BlockedPill
+              icon="time-outline"
+              label="This shift was in the past"
+              tone="neutral"
+              colors={colors}
+              isDark={isDark}
+            />
+          ) : eligibility && !eligibility.emailVerified ? (
+            <BlockedPill
+              icon="mail-unread-outline"
+              label="Verify your email to sign up"
+              tone="warn"
+              colors={colors}
+              isDark={isDark}
+            />
+          ) : eligibility && eligibility.needsParentalConsent ? (
+            <BlockedPill
+              icon="shield-outline"
+              label="Parental consent required to sign up"
+              tone="warn"
+              colors={colors}
+              isDark={isDark}
+            />
           ) : conflictingShift ? (
-            <View
-              style={[
-                s.pastPill,
-                {
-                  backgroundColor: colors.card,
-                  borderColor: colors.border,
-                },
-              ]}
-            >
-              <Ionicons
-                name="calendar-outline"
-                size={18}
-                color={colors.textSecondary}
-              />
-              <Text style={[s.pastPillText, { color: colors.textSecondary }]}>
-                You already have a {getShiftPeriodLabel(shift.start)} shift that
-                day
-              </Text>
-            </View>
+            <BlockedPill
+              icon="calendar-outline"
+              label={`You already have a ${getShiftPeriodLabel(
+                shift.start
+              )} shift that day`}
+              tone="neutral"
+              colors={colors}
+              isDark={isDark}
+            />
           ) : spotsLeft > 0 ? (
             <GlassButton
               onPress={() => openSignupSheet(false)}
@@ -1008,6 +1004,50 @@ function FriendRow({
         )
       )}
     </Pressable>
+  );
+}
+
+/* ═════════════════════════════════════════════════════════
+   BLOCKED CTA PILL — shown in place of the signup button when the
+   user can't sign up (past shift, unverified email, parental consent,
+   or a same-period clash). `warn` flags an account issue the user can act on.
+   ═════════════════════════════════════════════════════════ */
+
+function BlockedPill({
+  icon,
+  label,
+  tone,
+  colors,
+  isDark,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  tone: "neutral" | "warn";
+  colors: (typeof Colors)["light"];
+  isDark: boolean;
+}) {
+  const warn = tone === "warn";
+  const textColor = warn
+    ? isDark
+      ? "#fbbf24"
+      : "#d97706"
+    : colors.textSecondary;
+  const backgroundColor = warn
+    ? isDark
+      ? "rgba(245,158,11,0.12)"
+      : "#fffbeb"
+    : colors.card;
+  const borderColor = warn
+    ? isDark
+      ? "rgba(245,158,11,0.28)"
+      : "#fde68a"
+    : colors.border;
+
+  return (
+    <View style={[s.pastPill, { backgroundColor, borderColor }]}>
+      <Ionicons name={icon} size={18} color={textColor} />
+      <Text style={[s.pastPillText, { color: textColor }]}>{label}</Text>
+    </View>
   );
 }
 

--- a/mobile/app/shift/[id].tsx
+++ b/mobile/app/shift/[id].tsx
@@ -29,6 +29,11 @@ import { ThemedText } from "@/components/themed-text";
 import { Colors, Brand, FontFamily, Palette } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useShiftDetail, type PeriodFriend } from "@/hooks/use-shift-detail";
+import { useShifts } from "@/hooks/use-shifts";
+import {
+  findConflictingShift,
+  getShiftPeriodLabel,
+} from "@/lib/shift-eligibility";
 import { api, ApiError } from "@/lib/api";
 import {
   addShiftToCalendar,
@@ -68,7 +73,14 @@ export default function ShiftDetailScreen() {
     error,
     refresh,
   } = useShiftDetail(id);
+  // Cached from the shifts list (react-query) — used to mirror the web's
+  // pre-emptive "one Day + one Evening shift per day" conflict gate.
+  const { myShifts } = useShifts();
   const isMyShift = shift?.status != null;
+  const conflictingShift = useMemo(
+    () => (shift && !isMyShift ? findConflictingShift(shift, myShifts) : null),
+    [shift, isMyShift, myShifts]
+  );
   const [signupSheetVisible, setSignupSheetVisible] = useState(false);
   const [signupSheetWaitlist, setSignupSheetWaitlist] = useState(false);
   const [cancelLoading, setCancelLoading] = useState(false);
@@ -654,6 +666,26 @@ export default function ShiftDetailScreen() {
               />
               <Text style={[s.pastPillText, { color: colors.textSecondary }]}>
                 This shift was in the past
+              </Text>
+            </View>
+          ) : conflictingShift ? (
+            <View
+              style={[
+                s.pastPill,
+                {
+                  backgroundColor: colors.card,
+                  borderColor: colors.border,
+                },
+              ]}
+            >
+              <Ionicons
+                name="calendar-outline"
+                size={18}
+                color={colors.textSecondary}
+              />
+              <Text style={[s.pastPillText, { color: colors.textSecondary }]}>
+                You already have a {getShiftPeriodLabel(shift.start)} shift that
+                day
               </Text>
             </View>
           ) : spotsLeft > 0 ? (

--- a/mobile/hooks/use-shift-detail.ts
+++ b/mobile/hooks/use-shift-detail.ts
@@ -25,6 +25,14 @@ type ShiftDetailResponse = {
     profilePhotoUrl: string | null;
     isFriend: boolean;
   }[];
+  eligibility?: ShiftEligibility;
+};
+
+/** Account-level signup gates, mirrored from the web signup checks. */
+export type ShiftEligibility = {
+  emailVerified: boolean;
+  profileComplete: boolean;
+  needsParentalConsent: boolean;
 };
 
 /** Raw shape returned by GET /api/mobile/shifts/[id]/concurrent */
@@ -59,6 +67,8 @@ type UseShiftDetailReturn = {
   signups: ShiftSignup[];
   /** Friends signed up for any shift at the same location/date/AM-PM, with their role */
   periodFriends: PeriodFriend[];
+  /** Account-level signup gates (email/profile/parental consent); null until loaded */
+  eligibility: ShiftEligibility | null;
   isLoading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
@@ -124,6 +134,7 @@ export function useShiftDetail(shiftId: string | undefined): UseShiftDetailRetur
     shift,
     signups,
     periodFriends,
+    eligibility: data?.eligibility ?? null,
     isLoading: enabled ? detail.isPending : false,
     error: detail.error
       ? detail.error instanceof Error

--- a/mobile/lib/shift-eligibility.test.ts
+++ b/mobile/lib/shift-eligibility.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findConflictingShift,
+  getShiftDayKey,
+  getShiftPeriod,
+  getShiftPeriodKey,
+  getShiftPeriodLabel,
+} from "@/lib/shift-eligibility";
+import type { Shift } from "@/lib/dummy-data";
+
+// NZ is UTC+12 in June (NZST). Times below are the UTC instant with the
+// equivalent NZ local time noted, so the 4pm Day/Evening cutoff is explicit.
+const NZ_1300 = "2026-06-18T01:00:00.000Z"; // NZ 13:00 → Day
+const NZ_1500 = "2026-06-18T03:00:00.000Z"; // NZ 15:00 → Day
+const NZ_1600 = "2026-06-18T04:00:00.000Z"; // NZ 16:00 → Evening (cutoff)
+const NZ_1800 = "2026-06-18T06:00:00.000Z"; // NZ 18:00 → Evening
+
+function makeShift(over: Partial<Shift> & { id: string; start: string }): Shift {
+  return {
+    shiftType: { id: "st", name: "Kitchen", description: "" },
+    end: over.start,
+    location: "Wellington",
+    capacity: 5,
+    signedUp: 0,
+    status: "CONFIRMED",
+    ...over,
+  };
+}
+
+describe("getShiftDayKey", () => {
+  it("returns the NZ calendar day", () => {
+    expect(getShiftDayKey(NZ_1500)).toBe("2026-06-18");
+  });
+
+  it("uses the NZ day even when the UTC day differs", () => {
+    // NZ 10:00 on Jun 18 is still Jun 17 in UTC.
+    expect(getShiftDayKey("2026-06-17T22:00:00.000Z")).toBe("2026-06-18");
+  });
+});
+
+describe("getShiftPeriod", () => {
+  it("treats before 4pm NZ as Day", () => {
+    expect(getShiftPeriod(NZ_1300)).toBe("DAY");
+    expect(getShiftPeriod(NZ_1500)).toBe("DAY");
+  });
+
+  it("treats 4pm NZ and later as Evening (cutoff is exclusive)", () => {
+    expect(getShiftPeriod(NZ_1600)).toBe("EVENING");
+    expect(getShiftPeriod(NZ_1800)).toBe("EVENING");
+  });
+
+  it("is independent of the device timezone", () => {
+    const originalTZ = process.env.TZ;
+    try {
+      for (const tz of ["America/Los_Angeles", "UTC", "Pacific/Kiritimati"]) {
+        process.env.TZ = tz;
+        expect(getShiftPeriod(NZ_1500)).toBe("DAY");
+        expect(getShiftPeriod(NZ_1600)).toBe("EVENING");
+      }
+    } finally {
+      process.env.TZ = originalTZ;
+    }
+  });
+});
+
+describe("getShiftPeriodLabel / getShiftPeriodKey", () => {
+  it("labels the period in lowercase", () => {
+    expect(getShiftPeriodLabel(NZ_1500)).toBe("day");
+    expect(getShiftPeriodLabel(NZ_1600)).toBe("evening");
+  });
+
+  it("combines day + period into a stable key", () => {
+    expect(getShiftPeriodKey(NZ_1500)).toBe("2026-06-18|DAY");
+    expect(getShiftPeriodKey(NZ_1600)).toBe("2026-06-18|EVENING");
+  });
+});
+
+describe("findConflictingShift", () => {
+  const target = { id: "target", start: NZ_1500 }; // Day shift
+
+  it("returns null when the volunteer holds no shifts", () => {
+    expect(findConflictingShift(target, [])).toBeNull();
+  });
+
+  it("detects another booked shift in the same day + period", () => {
+    const mine = makeShift({ id: "a", start: NZ_1300, status: "CONFIRMED" });
+    expect(findConflictingShift(target, [mine])).toBe(mine);
+  });
+
+  it("counts PENDING signups as conflicts", () => {
+    const mine = makeShift({ id: "a", start: NZ_1300, status: "PENDING" });
+    expect(findConflictingShift(target, [mine])).toBe(mine);
+  });
+
+  it("does not clash across periods (one Day + one Evening allowed)", () => {
+    const evening = makeShift({ id: "a", start: NZ_1800, status: "CONFIRMED" });
+    expect(findConflictingShift(target, [evening])).toBeNull();
+  });
+
+  it("ignores WAITLISTED and REGULAR_PENDING signups", () => {
+    const waitlisted = makeShift({ id: "a", start: NZ_1300, status: "WAITLISTED" });
+    const regular = makeShift({ id: "b", start: NZ_1300, status: "REGULAR_PENDING" });
+    expect(findConflictingShift(target, [waitlisted, regular])).toBeNull();
+  });
+
+  it("does not flag the target shift against itself", () => {
+    const self = makeShift({ id: "target", start: NZ_1500, status: "CONFIRMED" });
+    expect(findConflictingShift(target, [self])).toBeNull();
+  });
+
+  it("does not clash on a different calendar day", () => {
+    const otherDay = makeShift({
+      id: "a",
+      start: "2026-06-19T03:00:00.000Z",
+      status: "CONFIRMED",
+    });
+    expect(findConflictingShift(target, [otherDay])).toBeNull();
+  });
+});

--- a/mobile/lib/shift-eligibility.ts
+++ b/mobile/lib/shift-eligibility.ts
@@ -1,0 +1,58 @@
+import { formatNZT } from "@/lib/dates";
+import type { Shift } from "@/lib/dummy-data";
+
+/**
+ * Client-side shift signup eligibility — mirrors the web app's pre-emptive
+ * checks (web/src/lib/concurrent-shifts.ts + the signup gating in
+ * shift-details-content.tsx) so the mobile UI can disable the signup CTA
+ * before a doomed request instead of only surfacing a server error.
+ *
+ * The server (POST /api/mobile/shifts/[id]/signup) remains the source of
+ * truth and re-runs every check — these helpers are a UX layer only.
+ */
+
+/** Hour cutoff (NZ time): shifts starting before 4pm are "Day", at/after are "Evening". */
+const DAY_EVENING_CUTOFF_HOUR = 16;
+
+export type ShiftPeriod = "DAY" | "EVENING";
+
+/** Calendar day key (YYYY-MM-DD) in NZ time — matches web's getShiftDate. */
+export function getShiftDayKey(start: string | Date): string {
+  return formatNZT(start, "yyyy-MM-dd");
+}
+
+/** Whether a shift falls in the day period (before 4pm NZ) — matches web's isAMShift. */
+export function getShiftPeriod(start: string | Date): ShiftPeriod {
+  const hour = Number(formatNZT(start, "H"));
+  return hour < DAY_EVENING_CUTOFF_HOUR ? "DAY" : "EVENING";
+}
+
+/** Lowercase label for the period, for inline copy ("day" / "evening"). */
+export function getShiftPeriodLabel(start: string | Date): string {
+  return getShiftPeriod(start) === "DAY" ? "day" : "evening";
+}
+
+/**
+ * A volunteer may hold at most one Day and one Evening shift per NZ calendar
+ * day. Returns the already-booked shift that clashes with `target`, or null.
+ *
+ * Only CONFIRMED/PENDING signups count as conflicts, matching the server's
+ * conflict query — WAITLISTED and REGULAR_PENDING do not block signup.
+ */
+export function findConflictingShift(
+  target: Pick<Shift, "id" | "start">,
+  myShifts: Shift[]
+): Shift | null {
+  const targetDay = getShiftDayKey(target.start);
+  const targetPeriod = getShiftPeriod(target.start);
+
+  return (
+    myShifts.find(
+      (s) =>
+        s.id !== target.id &&
+        (s.status === "CONFIRMED" || s.status === "PENDING") &&
+        getShiftDayKey(s.start) === targetDay &&
+        getShiftPeriod(s.start) === targetPeriod
+    ) ?? null
+  );
+}

--- a/mobile/lib/shift-eligibility.ts
+++ b/mobile/lib/shift-eligibility.ts
@@ -33,26 +33,37 @@ export function getShiftPeriodLabel(start: string | Date): string {
 }
 
 /**
+ * Stable key identifying a shift's day + period, e.g. "2026-06-18|DAY".
+ * Two shifts share a key iff a volunteer can't hold both (one Day + one
+ * Evening per day). Used to build/lookup the booked-period set on the list.
+ */
+export function getShiftPeriodKey(start: string | Date): string {
+  return `${getShiftDayKey(start)}|${getShiftPeriod(start)}`;
+}
+
+/**
  * A volunteer may hold at most one Day and one Evening shift per NZ calendar
  * day. Returns the already-booked shift that clashes with `target`, or null.
  *
- * Only CONFIRMED/PENDING signups count as conflicts, matching the server's
- * conflict query — WAITLISTED and REGULAR_PENDING do not block signup.
+ * This is a period-level rule, not a time-overlap check: two non-overlapping
+ * Day shifts (e.g. 10am–12pm and 2pm–4pm) still clash because they share the
+ * Day period. This matches the server's conflict query intentionally.
+ *
+ * Only CONFIRMED/PENDING signups count as conflicts, matching the server —
+ * WAITLISTED and REGULAR_PENDING do not block signup.
  */
 export function findConflictingShift(
   target: Pick<Shift, "id" | "start">,
   myShifts: Shift[]
 ): Shift | null {
-  const targetDay = getShiftDayKey(target.start);
-  const targetPeriod = getShiftPeriod(target.start);
+  const targetKey = getShiftPeriodKey(target.start);
 
   return (
     myShifts.find(
       (s) =>
         s.id !== target.id &&
         (s.status === "CONFIRMED" || s.status === "PENDING") &&
-        getShiftDayKey(s.start) === targetDay &&
-        getShiftPeriod(s.start) === targetPeriod
+        getShiftPeriodKey(s.start) === targetKey
     ) ?? null
   );
 }

--- a/web/src/app/api/mobile/shifts/[id]/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/route.ts
@@ -58,6 +58,19 @@ export async function GET(
     return NextResponse.json({ error: "Shift not found" }, { status: 404 });
   }
 
+  // Account-level signup eligibility (mirrors the gates in the signup POST
+  // route) so the app can disable the CTA up front instead of only surfacing
+  // a server error on submit.
+  const userRecord = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      emailVerified: true,
+      profileCompleted: true,
+      requiresParentalConsent: true,
+      parentalConsentReceived: true,
+    },
+  });
+
   // Get the current user's friendship data to determine who is a friend
   const friendships = await prisma.friendship.findMany({
     where: {
@@ -117,5 +130,13 @@ export async function GET(
     status: userStatus,
     notes: shift.notes,
     signups,
+    eligibility: {
+      emailVerified: Boolean(userRecord?.emailVerified),
+      profileComplete: Boolean(userRecord?.profileCompleted),
+      needsParentalConsent: Boolean(
+        userRecord?.requiresParentalConsent &&
+          !userRecord?.parentalConsentReceived
+      ),
+    },
   });
 }


### PR DESCRIPTION
## Description

Brings the mobile shift-signup eligibility UX up to parity with the web app. The mobile signup API (`POST /api/mobile/shifts/[id]/signup`) already enforces **every** web rule server-side (email verification, profile completion, parental consent, duplicate signup, capacity, and the same-day/same-period conflict). The gap was on the **client**: mobile only ran a subset of web's *pre-emptive* UI gating (past, full, already-signed-up), so the remaining blocks only surfaced as an error *after* the user opened the signup sheet and tapped submit.

This PR surfaces those blocks up front on the shift detail CTA (and the conflict on list cards), mirroring web's disabled-button gating.

### Gates added
1. **Same-day/same-period conflict** — a volunteer may hold at most one Day and one Evening shift per NZ calendar day.
2. **Email not verified.**
3. **Parental consent outstanding** (under-16 volunteers).

### What changed
- **New util — `mobile/lib/shift-eligibility.ts`**: mirrors web's `concurrent-shifts.ts` — NZ calendar-day key, 4pm Day/Evening cutoff, and `findConflictingShift` (counts only `CONFIRMED`/`PENDING` signups, matching the server's conflict query).
- **API — `/api/mobile/shifts/[id]`**: returns an `eligibility` object (`emailVerified` / `profileComplete` / `needsParentalConsent`) built from the same `User` fields the signup POST route already checks.
- **Hook — `mobile/hooks/use-shift-detail.ts`**: exposes `eligibility`.
- **Shift detail (`mobile/app/shift/[id].tsx`)**: computes the conflict from cached `myShifts` (`useShifts()`) and replaces the Join/Waitlist CTA with a disabled pill — a shared `BlockedPill` with a neutral tone for past/conflict and a warn tone for the email / parental-consent account issues.
- **Shift list (`mobile/app/(tabs)/shifts.tsx`)**: available cards that clash now show a "Booked" badge, an amber "clashes with your {day/evening}" note, and an amber status dot.

The server remains the source of truth and re-runs every check — these are a UX layer only. Profile-incompleteness continues to be handled by the existing actionable CTA inside the signup sheet.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Typecheck (`tsc --noEmit`) clean for all edited mobile files (the only remaining errors are pre-existing `StyleSheet.absoluteFillObject` noise from the worktree's mis-pinned RN install, in unmodified code)
- [ ] Manual testing on device/simulator recommended (unverified-email and under-16 accounts)

## Additional Notes
- On a deep-link straight to a shift detail (e.g. from a push notification), `myShifts`/eligibility load in the background; the gates activate once data arrives, and the server still guards on submit.