### PR TITLE
feat(mobile-admin): restaurant filter + admin push for messages & approvals

### DIFF
--- a/mobile/app/(tabs)/admin.tsx
+++ b/mobile/app/(tabs)/admin.tsx
@@ -5,6 +5,7 @@ import React, { useCallback } from "react";
 import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { AdminLocationFilter } from "@/components/admin/location-filter";
 import { Eyebrow } from "@/components/ui/eyebrow";
 import { Brand, Colors, FontFamily, Palette } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
@@ -13,6 +14,7 @@ import {
   useAdminToday,
   useAdminUnreadCount,
 } from "@/hooks/use-admin";
+import { useAdminLocationFilter } from "@/lib/admin-location-filter";
 import { useAuth } from "@/lib/auth";
 
 /* ─── Editorial palette (mirrors the Help landing) ──────────────── */
@@ -52,9 +54,10 @@ export default function AdminScreen() {
   const router = useRouter();
   const { user } = useAuth();
 
+  const selectedLocation = useAdminLocationFilter((s) => s.selected);
   const unread = useAdminUnreadCount(true);
-  const pending = useAdminPending();
-  const today = useAdminToday("");
+  const pending = useAdminPending(selectedLocation);
+  const today = useAdminToday("", selectedLocation);
 
   const refetchAll = useCallback(() => {
     void pending.refetch();
@@ -118,6 +121,7 @@ export default function AdminScreen() {
 
         <View style={styles.channelEyebrow}>
           <Eyebrow color={paperTint.eyebrow}>What needs you</Eyebrow>
+          <AdminLocationFilter />
         </View>
 
         <View style={styles.optionList}>
@@ -263,7 +267,14 @@ const styles = StyleSheet.create({
   },
   scrollContent: { paddingHorizontal: 24 },
   eyebrowSpacing: { marginBottom: 20 },
-  channelEyebrow: { marginTop: 28, marginBottom: 16 },
+  channelEyebrow: {
+    marginTop: 28,
+    marginBottom: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+  },
   footerEyebrow: { alignSelf: "center" },
   heroBlock: { marginBottom: 28 },
   heroLine: { marginBottom: 18 },

--- a/mobile/app/admin/approvals.tsx
+++ b/mobile/app/admin/approvals.tsx
@@ -14,9 +14,11 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { AdminLocationFilter } from "@/components/admin/location-filter";
 import { Brand, Colors, FontFamily } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useAdminPending } from "@/hooks/use-admin";
+import { useAdminLocationFilter } from "@/lib/admin-location-filter";
 import { formatLongDate, formatTimeRange, GRADE_COLORS, initialOf } from "@/lib/admin-format";
 import { actOnSignup, type PendingSignup } from "@/lib/admin";
 import { queryClient } from "@/lib/query-client";
@@ -29,7 +31,9 @@ export default function ApprovalsScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
 
-  const { data, isPending, isError, refetch, isRefetching } = useAdminPending();
+  const selectedLocation = useAdminLocationFilter((s) => s.selected);
+  const { data, isPending, isError, refetch, isRefetching } =
+    useAdminPending(selectedLocation);
   const [busyId, setBusyId] = useState<string | null>(null);
 
   const rule = isDark ? "rgba(253,248,239,0.12)" : "rgba(29,83,55,0.14)";
@@ -47,8 +51,9 @@ export default function ApprovalsScreen() {
         const res = await actOnSignup(signup.id, action);
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         // Drop the handled signup from the cached list immediately.
-        queryClient.setQueryData<PendingSignup[]>(queryKeys.admin.pending(), (prev) =>
-          (prev ?? []).filter((s) => s.id !== signup.id)
+        queryClient.setQueryData<PendingSignup[]>(
+          queryKeys.admin.pending(selectedLocation),
+          (prev) => (prev ?? []).filter((s) => s.id !== signup.id)
         );
         // Counts elsewhere (hub, tonight's shifts) may have shifted.
         queryClient.invalidateQueries({ queryKey: queryKeys.admin.all });
@@ -65,7 +70,7 @@ export default function ApprovalsScreen() {
         setBusyId(null);
       }
     },
-    []
+    [selectedLocation]
   );
 
   const confirmDecline = useCallback(
@@ -92,6 +97,10 @@ export default function ApprovalsScreen() {
         <View style={styles.headerSide} />
       </View>
 
+      <View style={styles.filterRow}>
+        <AdminLocationFilter />
+      </View>
+
       {isPending ? (
         <View style={styles.center}>
           <ActivityIndicator color={eyebrow} />
@@ -108,7 +117,9 @@ export default function ApprovalsScreen() {
           <Text style={styles.emptyEmoji}>✅</Text>
           <Text style={[styles.emptyTitle, { color: colors.text }]}>Queue&apos;s clear</Text>
           <Text style={[styles.emptyBody, { color: colors.textSecondary }]}>
-            No signups waiting on approval. Ka pai!
+            {selectedLocation
+              ? `No signups waiting at ${selectedLocation}. Ka pai!`
+              : "No signups waiting on approval. Ka pai!"}
           </Text>
         </View>
       ) : (
@@ -257,6 +268,13 @@ const styles = StyleSheet.create({
   },
   headerSide: { width: 40, alignItems: "flex-start", justifyContent: "center" },
   headerTitle: { fontFamily: FontFamily.heading, fontSize: 20 },
+  filterRow: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 4,
+  },
   center: { flex: 1, alignItems: "center", justifyContent: "center", paddingHorizontal: 40 },
   emptyEmoji: { fontSize: 42, marginBottom: 12 },
   emptyTitle: { fontFamily: FontFamily.headingBold, fontSize: 21, marginBottom: 8, textAlign: "center" },

--- a/mobile/app/admin/messages/index.tsx
+++ b/mobile/app/admin/messages/index.tsx
@@ -4,6 +4,7 @@ import { useFocusEffect, useRouter, type Href } from "expo-router";
 import React, { useCallback, useEffect, useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   FlatList,
   Image,
   Pressable,
@@ -16,8 +17,13 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { Brand, Colors, FontFamily } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
-import { useAdminThreads, clearAdminUnreadCount } from "@/hooks/use-admin";
+import {
+  useAdminThreads,
+  clearAdminUnreadCount,
+  useAdminMessageNotifyPref,
+} from "@/hooks/use-admin";
 import { formatRelativeTime, initialOf } from "@/lib/admin-format";
+import { syncPushTokenWithServer } from "@/lib/push-notifications";
 import { queryClient } from "@/lib/query-client";
 import type { AdminThreadListItem, ThreadStatus } from "@/lib/admin";
 
@@ -61,6 +67,25 @@ export default function AdminInboxScreen() {
   const rule = isDark ? "rgba(253,248,239,0.12)" : "rgba(29,83,55,0.14)";
   const eyebrow = isDark ? Brand.greenLight : Brand.green;
 
+  const notifyPref = useAdminMessageNotifyPref();
+  const toggleNotify = useCallback(async () => {
+    const next = !notifyPref.enabled;
+    Haptics.selectionAsync();
+    // Turning on: make sure the OS has granted permission and the device's
+    // push token is registered, otherwise the toggle would silently do nothing.
+    if (next) {
+      const token = await syncPushTokenWithServer({ requestIfNeeded: true });
+      if (!token) {
+        Alert.alert(
+          "Notifications are off",
+          "Turn on notifications for Everybody Eats in your device settings to get message alerts."
+        );
+        return;
+      }
+    }
+    notifyPref.setEnabled(next);
+  }, [notifyPref]);
+
   const renderItem = useCallback(
     ({ item }: { item: AdminThreadListItem }) => (
       <ThreadRow
@@ -90,7 +115,25 @@ export default function AdminInboxScreen() {
           <Ionicons name="chevron-back" size={24} color={eyebrow} />
         </Pressable>
         <Text style={[styles.headerTitle, { color: colors.text }]}>Messages</Text>
-        <View style={styles.backBtn} />
+        <Pressable
+          onPress={toggleNotify}
+          hitSlop={12}
+          disabled={notifyPref.isLoading || notifyPref.isSaving}
+          style={styles.notifyBtn}
+          accessibilityRole="switch"
+          accessibilityState={{ checked: notifyPref.enabled }}
+          accessibilityLabel={
+            notifyPref.enabled
+              ? "Turn off new-message notifications"
+              : "Turn on new-message notifications"
+          }
+        >
+          <Ionicons
+            name={notifyPref.enabled ? "notifications" : "notifications-off-outline"}
+            size={22}
+            color={notifyPref.enabled ? eyebrow : colors.textSecondary}
+          />
+        </Pressable>
       </View>
 
       {/* Search */}
@@ -296,6 +339,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   backBtn: { width: 40, alignItems: "flex-start", justifyContent: "center" },
+  notifyBtn: { width: 40, alignItems: "flex-end", justifyContent: "center" },
   headerTitle: { fontFamily: FontFamily.heading, fontSize: 20 },
   controls: { paddingHorizontal: 16, paddingTop: 14, gap: 12 },
   searchField: {

--- a/mobile/app/admin/shifts/today.tsx
+++ b/mobile/app/admin/shifts/today.tsx
@@ -13,9 +13,11 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import { AdminLocationFilter } from "@/components/admin/location-filter";
 import { Brand, Colors, FontFamily } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useAdminToday } from "@/hooks/use-admin";
+import { useAdminLocationFilter } from "@/lib/admin-location-filter";
 import { formatTimeRange, initialOf } from "@/lib/admin-format";
 import type { TodayShift } from "@/lib/admin";
 
@@ -50,7 +52,11 @@ export default function TonightShiftsScreen() {
 
   const [offset, setOffset] = useState(0);
   const dateParam = useMemo(() => dateParamForOffset(offset), [offset]);
-  const { data, isPending, isError, refetch, isRefetching } = useAdminToday(dateParam);
+  const selectedLocation = useAdminLocationFilter((s) => s.selected);
+  const { data, isPending, isError, refetch, isRefetching } = useAdminToday(
+    dateParam,
+    selectedLocation
+  );
 
   const rule = isDark ? "rgba(253,248,239,0.12)" : "rgba(29,83,55,0.14)";
   const eyebrow = isDark ? Brand.greenLight : Brand.green;
@@ -82,6 +88,10 @@ export default function TonightShiftsScreen() {
         </Pressable>
       </View>
 
+      <View style={styles.filterRow}>
+        <AdminLocationFilter />
+      </View>
+
       {isPending ? (
         <View style={styles.center}>
           <ActivityIndicator color={eyebrow} />
@@ -98,7 +108,9 @@ export default function TonightShiftsScreen() {
           <Text style={styles.emptyEmoji}>🌙</Text>
           <Text style={[styles.emptyTitle, { color: colors.text }]}>No shifts scheduled</Text>
           <Text style={[styles.emptyBody, { color: colors.textSecondary }]}>
-            Nothing on the roster for this day.
+            {selectedLocation
+              ? `Nothing on the roster at ${selectedLocation} for this day.`
+              : "Nothing on the roster for this day."}
           </Text>
         </View>
       ) : (
@@ -238,6 +250,12 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   stepLabel: { fontFamily: FontFamily.heading, fontSize: 17 },
+  filterRow: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+  },
   center: { flex: 1, alignItems: "center", justifyContent: "center", paddingHorizontal: 40 },
   emptyEmoji: { fontSize: 42, marginBottom: 12 },
   emptyTitle: { fontFamily: FontFamily.headingBold, fontSize: 21, marginBottom: 8, textAlign: "center" },

--- a/mobile/components/admin/location-filter.tsx
+++ b/mobile/components/admin/location-filter.tsx
@@ -1,0 +1,313 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as Haptics from "expo-haptics";
+import React, { useState } from "react";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { Brand, Colors, FontFamily } from "@/constants/theme";
+import { useColorScheme } from "@/hooks/use-color-scheme";
+import { useAdminLocations } from "@/hooks/use-admin";
+import { useAdminLocationFilter } from "@/lib/admin-location-filter";
+
+/**
+ * Shared restaurant filter for the admin section. Reads/writes the
+ * `useAdminLocationFilter` store, so the choice is the same on the hub,
+ * approvals, and shifts screens. Renders a compact pill that opens a
+ * bottom-sheet picker — mirrors the volunteer shifts location picker.
+ */
+export function AdminLocationFilter() {
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme];
+  const isDark = colorScheme === "dark";
+
+  const { selected, setSelected } = useAdminLocationFilter();
+  const { data: locations } = useAdminLocations();
+  const [open, setOpen] = useState(false);
+
+  const label = selected ?? "All restaurants";
+
+  const onPick = (value: string | null) => {
+    Haptics.selectionAsync();
+    setSelected(value);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Pressable
+        onPress={() => {
+          Haptics.selectionAsync();
+          setOpen(true);
+        }}
+        hitSlop={8}
+        style={({ pressed }) => [
+          styles.pill,
+          {
+            backgroundColor: selected
+              ? isDark
+                ? "rgba(29,83,55,0.28)"
+                : Brand.greenLight
+              : isDark
+                ? "rgba(253,248,239,0.06)"
+                : colors.card,
+            borderColor: selected
+              ? isDark
+                ? "rgba(126,200,154,0.4)"
+                : "rgba(29,83,55,0.3)"
+              : colors.border,
+            opacity: pressed ? 0.7 : 1,
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={`Restaurant filter: ${label}. Tap to change.`}
+      >
+        <Ionicons
+          name="location"
+          size={13}
+          color={selected ? (isDark ? Brand.greenLight : Brand.green) : colors.textSecondary}
+        />
+        <Text
+          style={[
+            styles.pillText,
+            { color: selected ? (isDark ? Brand.greenLight : Brand.green) : colors.text },
+          ]}
+          numberOfLines={1}
+        >
+          {label}
+        </Text>
+        <Ionicons
+          name="chevron-down"
+          size={13}
+          color={selected ? (isDark ? Brand.greenLight : Brand.green) : colors.textSecondary}
+        />
+      </Pressable>
+
+      <LocationSheet
+        visible={open}
+        locations={locations ?? []}
+        selected={selected}
+        onSelect={onPick}
+        onClose={() => setOpen(false)}
+        isDark={isDark}
+        colors={colors}
+      />
+    </>
+  );
+}
+
+/* ─── Picker sheet ──────────────────────────────────────────── */
+
+function LocationSheet({
+  visible,
+  locations,
+  selected,
+  onSelect,
+  onClose,
+  isDark,
+  colors,
+}: {
+  visible: boolean;
+  locations: string[];
+  selected: string | null;
+  onSelect: (value: string | null) => void;
+  onClose: () => void;
+  isDark: boolean;
+  colors: (typeof Colors)["light"];
+}) {
+  const insets = useSafeAreaInsets();
+  const items: {
+    key: string;
+    label: string;
+    value: string | null;
+    icon: keyof typeof Ionicons.glyphMap;
+  }[] = [
+    { key: "all", label: "All restaurants", value: null, icon: "globe-outline" },
+    ...locations.map((loc) => ({
+      key: loc,
+      label: loc,
+      value: loc,
+      icon: "location" as const,
+    })),
+  ];
+
+  return (
+    <Modal
+      visible={visible}
+      presentationStyle="pageSheet"
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <View
+        style={[
+          styles.sheetPage,
+          {
+            backgroundColor: colors.background,
+            paddingBottom: Math.max(insets.bottom, 20),
+          },
+        ]}
+      >
+        <View style={styles.sheetHandleWrap}>
+          <View
+            style={[
+              styles.sheetHandle,
+              {
+                backgroundColor: isDark
+                  ? "rgba(253,248,239,0.22)"
+                  : "rgba(29,83,55,0.18)",
+              },
+            ]}
+          />
+        </View>
+
+        <View style={styles.sheetHeader}>
+          <View style={{ flex: 1 }}>
+            <Text style={[styles.sheetTitle, { color: colors.text }]}>
+              Filter by restaurant
+            </Text>
+            <Text style={[styles.sheetSubtitle, { color: colors.textSecondary }]}>
+              Applies across the admin section
+            </Text>
+          </View>
+          <Pressable
+            onPress={onClose}
+            hitSlop={10}
+            accessibilityLabel="Close"
+            accessibilityRole="button"
+            style={({ pressed }) => [
+              styles.sheetClose,
+              {
+                backgroundColor: isDark
+                  ? "rgba(253,248,239,0.08)"
+                  : colors.surfaceSunk,
+                opacity: pressed ? 0.6 : 1,
+              },
+            ]}
+          >
+            <Ionicons name="close" size={18} color={colors.textSecondary} />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          contentContainerStyle={styles.sheetList}
+          showsVerticalScrollIndicator={false}
+        >
+          {items.map((item) => {
+            const active = item.value === selected;
+            return (
+              <Pressable
+                key={item.key}
+                onPress={() => onSelect(item.value)}
+                style={({ pressed }) => [
+                  styles.sheetItem,
+                  {
+                    backgroundColor: active
+                      ? isDark
+                        ? "rgba(29, 83, 55, 0.22)"
+                        : Brand.greenLight
+                      : pressed
+                        ? isDark
+                          ? "rgba(253,248,239,0.04)"
+                          : colors.surfaceSoft
+                        : "transparent",
+                  },
+                ]}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+              >
+                <Ionicons
+                  name={item.icon}
+                  size={18}
+                  color={active ? (isDark ? colors.tint : Brand.green) : colors.textSecondary}
+                />
+                <Text
+                  style={[
+                    styles.sheetItemText,
+                    {
+                      color: active ? (isDark ? colors.tint : Brand.green) : colors.text,
+                      fontFamily: active ? FontFamily.semiBold : FontFamily.regular,
+                    },
+                  ]}
+                >
+                  {item.label}
+                </Text>
+                {active && (
+                  <Ionicons
+                    name="checkmark"
+                    size={18}
+                    color={isDark ? colors.tint : Brand.green}
+                  />
+                )}
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+    maxWidth: 200,
+  },
+  pillText: {
+    fontSize: 13,
+    fontFamily: FontFamily.semiBold,
+    maxWidth: 140,
+  },
+  sheetPage: { flex: 1 },
+  sheetHandleWrap: { alignItems: "center", paddingTop: 10, paddingBottom: 4 },
+  sheetHandle: { width: 36, height: 4, borderRadius: 2 },
+  sheetHeader: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 16,
+    gap: 12,
+  },
+  sheetTitle: {
+    fontSize: 20,
+    fontFamily: FontFamily.heading,
+    letterSpacing: 0.2,
+    lineHeight: 26,
+  },
+  sheetSubtitle: {
+    fontSize: 13,
+    fontFamily: FontFamily.regular,
+    lineHeight: 18,
+    marginTop: 2,
+  },
+  sheetClose: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sheetList: { paddingHorizontal: 12, gap: 2, paddingBottom: 12 },
+  sheetItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 14,
+    borderRadius: 12,
+    minHeight: 48,
+  },
+  sheetItemText: { flex: 1, fontSize: 15, lineHeight: 20 },
+});

--- a/mobile/hooks/use-admin.ts
+++ b/mobile/hooks/use-admin.ts
@@ -1,13 +1,21 @@
-import { useQuery, type QueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  type QueryClient,
+} from "@tanstack/react-query";
 
 import {
+  fetchAdminLocations,
+  fetchAdminMessageNotifyPref,
   fetchAdminPending,
   fetchAdminThread,
   fetchAdminThreads,
   fetchAdminToday,
   fetchAdminUnreadCount,
+  setAdminMessageNotifyPref,
   type ThreadStatus,
 } from "@/lib/admin";
+import { queryClient } from "@/lib/query-client";
 import { queryKeys } from "@/lib/query-keys";
 
 const UNREAD_POLL_MS = 30_000;
@@ -57,18 +65,74 @@ export function useAdminThread(id: string) {
   });
 }
 
-/** Shifts for a given service day (default today, resolved server-side). */
-export function useAdminToday(date: string) {
+/**
+ * Shifts for a given service day (default today, resolved server-side),
+ * optionally scoped to a single restaurant.
+ */
+export function useAdminToday(date: string, location: string | null = null) {
   return useQuery({
-    queryKey: queryKeys.admin.today(date),
-    queryFn: () => fetchAdminToday(date || undefined).then((r) => r.shifts),
+    queryKey: queryKeys.admin.today(date, location),
+    queryFn: () =>
+      fetchAdminToday(date || undefined, location ?? undefined).then(
+        (r) => r.shifts
+      ),
   });
 }
 
-/** Pending signups awaiting approval. */
-export function useAdminPending() {
+/** Pending signups awaiting approval, optionally scoped to one restaurant. */
+export function useAdminPending(location: string | null = null) {
   return useQuery({
-    queryKey: queryKeys.admin.pending(),
-    queryFn: () => fetchAdminPending().then((r) => r.signups),
+    queryKey: queryKeys.admin.pending(location),
+    queryFn: () =>
+      fetchAdminPending(location ?? undefined).then((r) => r.signups),
   });
+}
+
+/** Active restaurants for the admin location filter. */
+export function useAdminLocations() {
+  return useQuery({
+    queryKey: queryKeys.admin.locations(),
+    queryFn: () => fetchAdminLocations().then((r) => r.locations),
+    staleTime: 5 * 60_000,
+  });
+}
+
+/**
+ * Per-admin "push me when a volunteer messages the team" preference, plus a
+ * mutation to flip it. Optimistically updates the cache so the toggle feels
+ * instant, rolling back on error.
+ */
+export function useAdminMessageNotifyPref() {
+  const query = useQuery({
+    queryKey: queryKeys.admin.messageNotifyPref(),
+    queryFn: () => fetchAdminMessageNotifyPref().then((r) => r.enabled),
+    staleTime: 60_000,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (enabled: boolean) =>
+      setAdminMessageNotifyPref(enabled).then((r) => r.enabled),
+    onMutate: (enabled) => {
+      const key = queryKeys.admin.messageNotifyPref();
+      const previous = queryClient.getQueryData<boolean>(key);
+      queryClient.setQueryData<boolean>(key, enabled);
+      return { previous };
+    },
+    onError: (_err, _enabled, context) => {
+      queryClient.setQueryData(
+        queryKeys.admin.messageNotifyPref(),
+        context?.previous ?? false
+      );
+    },
+    onSuccess: (enabled) => {
+      queryClient.setQueryData(queryKeys.admin.messageNotifyPref(), enabled);
+    },
+  });
+
+  return {
+    enabled: query.data ?? false,
+    isLoading: query.isPending,
+    setEnabled: mutation.mutate,
+    isSaving: mutation.isPending,
+  };
 }

--- a/mobile/lib/admin-location-filter.ts
+++ b/mobile/lib/admin-location-filter.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+/**
+ * The restaurant the admin section is currently scoped to. Shared across the
+ * hub, approvals, and shifts screens so a manager picks their site once and it
+ * sticks while they move between screens. `null` means "all restaurants".
+ *
+ * In-memory only — the filter resets to all on a fresh launch, which is the
+ * safe default (you always see everything until you narrow it down).
+ */
+interface AdminLocationFilterState {
+  selected: string | null;
+  setSelected: (location: string | null) => void;
+}
+
+export const useAdminLocationFilter = create<AdminLocationFilterState>(
+  (set) => ({
+    selected: null,
+    setSelected: (selected) => set({ selected }),
+  })
+);

--- a/mobile/lib/admin.ts
+++ b/mobile/lib/admin.ts
@@ -170,6 +170,22 @@ export function fetchAdminUnreadCount(): Promise<{ count: number }> {
   return api<{ count: number }>("/api/mobile/admin/messages/unread-count");
 }
 
+/** Whether this admin gets a push when a volunteer messages the team. */
+export function fetchAdminMessageNotifyPref(): Promise<{ enabled: boolean }> {
+  return api<{ enabled: boolean }>(
+    "/api/mobile/admin/messages/notify-preference"
+  );
+}
+
+export function setAdminMessageNotifyPref(
+  enabled: boolean
+): Promise<{ enabled: boolean }> {
+  return api<{ enabled: boolean }>(
+    "/api/mobile/admin/messages/notify-preference",
+    { method: "PUT", body: { enabled } }
+  );
+}
+
 /* ─── Shifts ─────────────────────────────────────────────────── */
 
 export function fetchAdminToday(
@@ -194,6 +210,13 @@ export function fetchAdminPending(
   return api<{ signups: PendingSignup[] }>(
     `/api/mobile/admin/signups/pending${qs}`
   );
+}
+
+/* ─── Locations ──────────────────────────────────────────────── */
+
+/** Active restaurants, by name, for the admin location filter. */
+export function fetchAdminLocations(): Promise<{ locations: string[] }> {
+  return api<{ locations: string[] }>("/api/mobile/admin/locations");
 }
 
 export function actOnSignup(

--- a/mobile/lib/notification-routing.ts
+++ b/mobile/lib/notification-routing.ts
@@ -60,6 +60,23 @@ export function navigateToNotificationTarget(actionUrl: unknown) {
     return;
   }
 
+  // Admin: a pending-signup notification links to /admin/shifts/:id on web.
+  // Mobile has no per-shift admin page, so route to the approvals queue where
+  // the signup can actually be actioned.
+  if (
+    pathname === "/admin/approvals" ||
+    pathname.startsWith("/admin/shifts/")
+  ) {
+    router.push("/admin/approvals");
+    return;
+  }
+
+  // Admin: a new-message push links to the admin inbox.
+  if (pathname === "/admin/messages" || pathname.startsWith("/admin/messages")) {
+    router.push("/admin/messages");
+    return;
+  }
+
   // /shifts or /shifts/mine -> shifts tab
   if (pathname === "/shifts" || pathname.startsWith("/shifts/")) {
     router.push("/(tabs)/shifts");

--- a/mobile/lib/query-keys.ts
+++ b/mobile/lib/query-keys.ts
@@ -38,8 +38,13 @@ export const queryKeys = {
       [...queryKeys.admin.all, 'threads', status, q] as const,
     thread: (id: string) => [...queryKeys.admin.all, 'thread', id] as const,
     unreadCount: () => [...queryKeys.admin.all, 'unread-count'] as const,
-    today: (date: string) => [...queryKeys.admin.all, 'today', date] as const,
-    pending: () => [...queryKeys.admin.all, 'pending'] as const,
+    locations: () => [...queryKeys.admin.all, 'locations'] as const,
+    messageNotifyPref: () =>
+      [...queryKeys.admin.all, 'message-notify-pref'] as const,
+    today: (date: string, location: string | null) =>
+      [...queryKeys.admin.all, 'today', date, location ?? 'all'] as const,
+    pending: (location: string | null) =>
+      [...queryKeys.admin.all, 'pending', location ?? 'all'] as const,
   },
   feedComments: {
     all: ['feed', 'comments'] as const,

--- a/web/prisma/migrations/20260618000001_add_signup_request_notification_type/migration.sql
+++ b/web/prisma/migrations/20260618000001_add_signup_request_notification_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'SHIFT_SIGNUP_REQUEST';

--- a/web/prisma/migrations/20260618000002_add_admin_message_notifications/migration.sql
+++ b/web/prisma/migrations/20260618000002_add_admin_message_notifications/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "adminMessageNotifications" BOOLEAN NOT NULL DEFAULT false;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -36,6 +36,10 @@ model User {
   emailNewsletterSubscription  Boolean                @default(true)
   newsletterLists              String[]               @default([])
   notificationPreference       NotificationPreference @default(EMAIL)
+  // Admins only: opt-in to a mobile push when a volunteer messages the team.
+  // Off by default so existing admins aren't surprised; toggled on the mobile
+  // admin messages screen.
+  adminMessageNotifications    Boolean                @default(false)
   volunteerAgreementAccepted   Boolean                @default(false)
   healthSafetyPolicyAccepted   Boolean                @default(false)
   profileCompleted             Boolean                @default(false)
@@ -482,6 +486,7 @@ enum NotificationType {
   FEED_ITEM_LIKED // Someone liked your feed item (achievement, friend signup, announcement)
   FEED_ITEM_COMMENTED // Someone commented on your feed item
   FEED_ITEM_COMMENT_REPLY // Someone commented on a feed item you also commented on (thread participant)
+  SHIFT_SIGNUP_REQUEST // Volunteer signed up and needs approval - notify managers for that location
 }
 
 model RestaurantManager {

--- a/web/src/app/api/mobile/admin/locations/route.ts
+++ b/web/src/app/api/mobile/admin/locations/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { requireMobileAdmin } from "@/lib/mobile-auth";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/mobile/admin/locations
+ *
+ * The active restaurants, by name, for the admin location filter. Mirrors the
+ * web `/api/admin/locations` route but is authed with the mobile JWT. Returns a
+ * plain string list — the filter only ever sends the name back as `?location=`.
+ */
+export async function GET(req: Request) {
+  const auth = await requireMobileAdmin(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const locations = await prisma.location.findMany({
+    where: { isActive: true },
+    select: { name: true },
+    orderBy: { name: "asc" },
+  });
+
+  return NextResponse.json({ locations: locations.map((l) => l.name) });
+}

--- a/web/src/app/api/mobile/admin/messages/notify-preference/route.ts
+++ b/web/src/app/api/mobile/admin/messages/notify-preference/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { requireMobileAdmin } from "@/lib/mobile-auth";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET/PUT /api/mobile/admin/messages/notify-preference
+ *
+ * Per-admin opt-in for "push me when a volunteer messages the team". Stored on
+ * the user (`adminMessageNotifications`) so it follows the account across
+ * devices. Off by default. Toggled from the mobile admin messages screen.
+ */
+export async function GET(req: Request) {
+  const auth = await requireMobileAdmin(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: auth.userId },
+    select: { adminMessageNotifications: true },
+  });
+
+  return NextResponse.json({ enabled: user?.adminMessageNotifications ?? false });
+}
+
+export async function PUT(req: Request) {
+  const auth = await requireMobileAdmin(req);
+  if (!auth) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  let enabled: boolean;
+  try {
+    const json = (await req.json()) as { enabled?: unknown };
+    if (typeof json.enabled !== "boolean") {
+      return NextResponse.json(
+        { error: "enabled (boolean) is required" },
+        { status: 400 }
+      );
+    }
+    enabled = json.enabled;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  await prisma.user.update({
+    where: { id: auth.userId },
+    data: { adminMessageNotifications: enabled },
+  });
+
+  return NextResponse.json({ enabled });
+}

--- a/web/src/app/api/mobile/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/signup/route.ts
@@ -4,6 +4,7 @@ import { requireMobileUser } from "@/lib/mobile-auth";
 import { processAutoApproval } from "@/lib/auto-accept-rules";
 import { isAMShift, getShiftDate } from "@/lib/concurrent-shifts";
 import { getNotificationService } from "@/lib/notification-service";
+import { notifyManagersOfPendingSignup } from "@/lib/notifications";
 import { getShiftConfirmedCount } from "@/lib/placeholder-utils";
 
 /**
@@ -225,6 +226,19 @@ export async function POST(
       user.id,
       shift.id
     );
+
+    // Still needs a human? Ping the restaurant's managers (fire-and-forget).
+    if (
+      autoApprovalResult.status === "PENDING" ||
+      autoApprovalResult.status === "REGULAR_PENDING"
+    ) {
+      void notifyManagersOfPendingSignup(signup.id).catch((err) =>
+        console.error(
+          "[mobile/signup] Failed to notify managers of pending signup:",
+          err
+        )
+      );
+    }
 
     return NextResponse.json({
       id: signup.id,

--- a/web/src/app/api/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/shifts/[id]/signup/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { getNotificationService } from "@/lib/notification-service";
+import { notifyManagersOfPendingSignup } from "@/lib/notifications";
 import { processAutoApproval } from "@/lib/auto-accept-rules";
 import { MAX_NOTE_LENGTH, GUARDIAN_REQUIRED_AGE, calculateAge } from "@/lib/utils";
 import { isAMShift, getShiftDate } from "@/lib/concurrent-shifts";
@@ -280,6 +281,19 @@ export async function POST(
       user.id,
       shift.id
     );
+
+    // Still needs a human? Ping the restaurant's managers (fire-and-forget).
+    if (
+      autoApprovalResult.status === "PENDING" ||
+      autoApprovalResult.status === "REGULAR_PENDING"
+    ) {
+      void notifyManagersOfPendingSignup(signup.id).catch((err) =>
+        console.error(
+          "[signup] Failed to notify managers of pending signup:",
+          err
+        )
+      );
+    }
 
     // Achievements will be calculated when user visits dashboard/achievements page
 

--- a/web/src/lib/messaging-notify.ts
+++ b/web/src/lib/messaging-notify.ts
@@ -1,6 +1,8 @@
 import type { Message, Role, User } from "@/generated/client";
+import { prisma } from "@/lib/prisma";
 import { createNotification } from "./notifications";
 import { notificationSSEManager } from "./notification-sse-manager";
+import { sendPushToUsers } from "./services/expo-push";
 
 /**
  * Realtime + push notification helpers for the volunteer ↔ team direct
@@ -15,6 +17,11 @@ import { notificationSSEManager } from "./notification-sse-manager";
  * message created one — they get a live SSE event only with the full
  * message body, and their inbox UI keeps unread state from the thread's
  * `teamLastReadAt` column.
+ *
+ * On top of the SSE event, admins who have opted in (`adminMessageNotifications`,
+ * toggled on the mobile admin messages screen, off by default) get a mobile
+ * push so they can reply on the go. Push-only — still no DB notification row,
+ * to keep the "don't drown admins" property.
  */
 
 const MESSAGE_PREVIEW_LIMIT = 140;
@@ -94,4 +101,32 @@ export async function broadcastNewMessageToAdmins(
     .catch((err) =>
       console.error("[messaging-notify] broadcastNewMessageToAdmins:", err)
     );
+
+  // Opt-in mobile push to admins (push-only, no DB notification row).
+  try {
+    const optedInAdmins = await prisma.user.findMany({
+      where: {
+        role: "ADMIN",
+        adminMessageNotifications: true,
+        id: { not: args.message.senderId },
+      },
+      select: { id: true },
+    });
+    if (optedInAdmins.length > 0) {
+      await sendPushToUsers(
+        optedInAdmins.map((a) => a.id),
+        {
+          title: `${volunteerName} messaged the team`,
+          body: preview(args.message.body),
+          data: {
+            type: "DIRECT_MESSAGE_ADMIN",
+            threadId: args.threadId,
+            actionUrl: "/admin/messages",
+          },
+        }
+      );
+    }
+  } catch (err) {
+    console.error("[messaging-notify] admin message push:", err);
+  }
 }

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -548,6 +548,80 @@ export async function notifyFeedItemCommentReply(args: {
 }
 
 /**
+ * Notify the restaurant managers for a shift's location that a volunteer has
+ * signed up and is waiting on approval. Mirrors the shift-cancellation manager
+ * notification, but for inbound pending signups.
+ *
+ * Recipients are restaurant managers whose assigned `locations` include the
+ * shift's location and who have `receiveNotifications` enabled (the toggle on
+ * the admin restaurant-managers page). Bell + push via
+ * `createNotificationsForUsers`. No-ops when the shift has no location or no
+ * manager is assigned to it.
+ *
+ * Safe to call fire-and-forget after a signup is created — re-reads the signup
+ * so it only fires when the status is still PENDING / REGULAR_PENDING (i.e. it
+ * wasn't auto-approved).
+ */
+export async function notifyManagersOfPendingSignup(
+  signupId: string
+): Promise<void> {
+  const signup = await prisma.signup.findUnique({
+    where: { id: signupId },
+    select: {
+      status: true,
+      user: {
+        select: { firstName: true, lastName: true, name: true, email: true },
+      },
+      shift: {
+        select: {
+          id: true,
+          location: true,
+          start: true,
+          shiftType: { select: { name: true } },
+        },
+      },
+    },
+  });
+
+  if (!signup) return;
+  if (signup.status !== "PENDING" && signup.status !== "REGULAR_PENDING") return;
+
+  const location = signup.shift.location;
+  if (!location) return;
+
+  const managers = await prisma.restaurantManager.findMany({
+    where: {
+      locations: { has: location },
+      receiveNotifications: true,
+      user: { role: "ADMIN" },
+    },
+    select: { userId: true },
+  });
+  if (managers.length === 0) return;
+
+  const volunteerName =
+    [signup.user.firstName, signup.user.lastName].filter(Boolean).join(" ") ||
+    signup.user.name ||
+    signup.user.email;
+
+  const dateLabel = new Intl.DateTimeFormat("en-NZ", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    timeZone: "Pacific/Auckland",
+  }).format(signup.shift.start);
+
+  await createNotificationsForUsers({
+    userIds: managers.map((m) => m.userId),
+    type: "SHIFT_SIGNUP_REQUEST",
+    title: "New signup to review",
+    message: `${volunteerName} signed up for ${signup.shift.shiftType.name} on ${dateLabel} at ${location}`,
+    actionUrl: `/admin/shifts/${signup.shift.id}`,
+    relatedId: signup.shift.id,
+  });
+}
+
+/**
  * Create a shift canceled notification
  */
 export async function createShiftCanceledNotification(


### PR DESCRIPTION
# Pull Request

## Description

Two related additions to the mobile **admin** section:

1. **Restaurant filter** on the admin screens (Shifts + Approvals), with a **shared** selection that applies across the section.
2. **Admin push notifications** for the two events that previously notified no one: new volunteer→team messages, and new pending shift signups (approval requests).

### Restaurant filter (Shifts + Approvals)
- Shared, in-memory selection (Zustand) applied across the admin hub, approvals, and tonight's shifts — pick a restaurant once and it sticks while moving between screens. `null` = all restaurants, resets on launch (safe default).
- Drives the **existing** server-side `?location=` params on the shifts/approvals endpoints; query keys are location-scoped.
- Reuses the volunteer shifts location-picker UI (pill + bottom sheet) for consistency.
- New mobile-authed `GET /api/mobile/admin/locations` supplies the picker list.

### Approval-request push — location-scoped, reuses the restaurant-manager page
- `notifyManagersOfPendingSignup` notifies the `RestaurantManager`s whose assigned `locations` include the shift's location **and** who have `receiveNotifications` enabled — the existing toggle on the restaurant-managers admin page (no new UI). Bell + push.
- Hooked into **both** the web (`/api/shifts/[id]/signup`) and mobile (`/api/mobile/shifts/[id]/signup`) signup routes, after auto-approval runs (only fires if the signup is still `PENDING`/`REGULAR_PENDING`).

### New-message push — opt-in, toggle on the screen
- Volunteer→team messages now also push to admins who opt in. **Push-only, no DB notification row**, preserving the existing "don't drown admins" design (admins still get the live web SSE event as before).
- Bell toggle in the mobile messages header, **off by default**, persisted to the account (`User.adminMessageNotifications`) via `GET/PUT /api/mobile/admin/messages/notify-preference`. Enabling it also requests OS permission + registers the push token so the toggle can't silently no-op.

### Plumbing
- New `SHIFT_SIGNUP_REQUEST` `NotificationType` value + `User.adminMessageNotifications` field — each with a migration (mirrors the existing enum-add migration pattern).
- Mobile push tap-routing: `/admin/shifts/:id` → approvals queue, `/admin/messages` → inbox.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Typechecked both `web/` and `mobile/` against a freshly regenerated Prisma client — **zero** errors from these changes (only two pre-existing, unrelated errors on `main`).
- [ ] Unit tests — none added yet (see notes).
- [ ] Manual / device testing — a real push round-trip needs a physical device + Expo and wasn't possible in this environment.

## Reviewer notes
- **Sanity check (confirmed):** the admin tab is gated for non-admins both client-side (`isAdmin` tab render + route guard) and **server-side** (every `/api/mobile/admin/*` route, including the new ones, uses `requireMobileAdmin` → 403).
- **Why the manager page, not the in-app filter:** the restaurant filter is per-device/ephemeral and can't drive server-side push. Approval pushes use the persisted `RestaurantManager` → location mapping instead, which already has a `receiveNotifications` toggle.
- **Recipients differ by design:** approvals → location-matched managers; messages → all opted-in admins (messages aren't tied to a restaurant).
- **Scope:** only the two interactive signup routes (volunteer self-signup) trigger approval pushes. Regular-volunteer auto-generated `REGULAR_PENDING` signups created elsewhere are not covered yet.
- **Migrations** couldn't be applied locally (no DB in the worktree); CI's Postgres will run them. The enum-add migration mirrors `20260421000001_add_shift_shortage_notification_type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)