### PR TITLE
feat: cover photos & themes for all shift types via keyword fallback

### DIFF
--- a/mobile/lib/dummy-data.ts
+++ b/mobile/lib/dummy-data.ts
@@ -104,6 +104,14 @@ const SHIFT_COVERS = {
   chefPlating: require('@/assets/photos/ee-chef-plating.jpg'),
   /** Volunteer serving a plated meal to the floor */
   fohServing: require('@/assets/photos/ee-foh-serving.jpg'),
+  /** Beaming front-of-house volunteer carrying two plates through a full room */
+  fohPortrait: require('@/assets/photos/ee-foh-portrait.jpg'),
+  /** Two volunteers carrying plates through an event venue */
+  crewPlates: require('@/assets/photos/ee-crew-plates.jpg'),
+  /** Buffet / catering spread with a gathered crowd — events & info sessions */
+  cateringSpread: require('@/assets/photos/ee-volunteer-team.jpg'),
+  /** Volunteer holding three plated meals outdoors — pop-up service */
+  servingPlates: require('@/assets/photos/ee-serving-plates.jpg'),
 };
 
 export const SHIFT_TYPE_THEMES_BY_NAME: Record<string, ShiftTypeTheme> = {
@@ -190,8 +198,188 @@ const DEFAULT_SHIFT_TYPE_THEME: ShiftTypeTheme = {
   heroImage: SHIFT_COVERS.diningRoom,
 };
 
+/**
+ * Keyword fallback for shift types that aren't an exact match above. Shift type
+ * names carry location/variant suffixes ("GI", "ONE", "(Onehunga)", "Pop-Up
+ * Stand") and hyphenation ("Front-of-House") that an exact lookup misses, which
+ * left ~20 of the live shift types on the generic dining-room cover. First rule
+ * whose keyword appears in the (normalised) name wins, so order matters: the
+ * most specific role keywords come first. */
+const KEYWORD_THEME_RULES: { keywords: string[]; theme: ShiftTypeTheme }[] = [
+  {
+    keywords: ['dishwash'],
+    theme: {
+      emoji: '🧽',
+      color: '#2563eb',
+      colorDark: '#60a5fa',
+      bgLight: '#eff6ff',
+      bgDark: 'rgba(37, 99, 235, 0.12)',
+      heroImage: SHIFT_COVERS.dishwasher,
+    },
+  },
+  {
+    keywords: ['food rescue', 'rescue'],
+    theme: {
+      emoji: '🥕',
+      color: '#65a30d',
+      colorDark: '#bef264',
+      bgLight: '#f7fee7',
+      bgDark: 'rgba(101, 163, 13, 0.12)',
+      heroImage: SHIFT_COVERS.cateringSpread,
+    },
+  },
+  {
+    keywords: ['save a bite'],
+    theme: {
+      emoji: '🥪',
+      color: '#0d9488',
+      colorDark: '#5eead4',
+      bgLight: '#f0fdfa',
+      bgDark: 'rgba(13, 148, 136, 0.12)',
+      heroImage: SHIFT_COVERS.servingPlates,
+    },
+  },
+  {
+    keywords: ['photograph', 'socials', 'media'],
+    theme: {
+      emoji: '📷',
+      color: '#db2777',
+      colorDark: '#f472b6',
+      bgLight: '#fdf2f8',
+      bgDark: 'rgba(219, 39, 119, 0.12)',
+      heroImage: SHIFT_COVERS.servicePass,
+    },
+  },
+  {
+    keywords: ['moving', 'packing', 'sorting'],
+    theme: {
+      emoji: '📦',
+      color: '#7c3aed',
+      colorDark: '#a78bfa',
+      bgLight: '#f5f3ff',
+      bgDark: 'rgba(124, 58, 237, 0.12)',
+      heroImage: SHIFT_COVERS.crewPlates,
+    },
+  },
+  {
+    keywords: ['offsite'],
+    theme: {
+      emoji: '🚚',
+      color: '#0891b2',
+      colorDark: '#67e8f9',
+      bgLight: '#ecfeff',
+      bgDark: 'rgba(8, 145, 178, 0.12)',
+      heroImage: SHIFT_COVERS.frontOfHouse,
+    },
+  },
+  {
+    // Before 'clean' so "Front of House Service & Clean Up" reads as FOH.
+    keywords: ['front of house', 'foh'],
+    theme: {
+      emoji: '✨',
+      color: '#9333ea',
+      colorDark: '#c084fc',
+      bgLight: '#faf5ff',
+      bgDark: 'rgba(147, 51, 234, 0.12)',
+      heroImage: SHIFT_COVERS.fohPortrait,
+    },
+  },
+  {
+    keywords: ['clean'],
+    theme: {
+      emoji: '🧹',
+      color: '#2563eb',
+      colorDark: '#60a5fa',
+      bgLight: '#eff6ff',
+      bgDark: 'rgba(37, 99, 235, 0.12)',
+      heroImage: SHIFT_COVERS.dishwasher,
+    },
+  },
+  {
+    keywords: ['kitchen prep', 'prep'],
+    theme: {
+      emoji: '🔪',
+      color: '#ea580c',
+      colorDark: '#fb923c',
+      bgLight: '#fff7ed',
+      bgDark: 'rgba(234, 88, 12, 0.12)',
+      heroImage: SHIFT_COVERS.kitchenPrep,
+    },
+  },
+  {
+    keywords: ['kitchen'],
+    theme: {
+      emoji: '🍳',
+      color: '#dc2626',
+      colorDark: '#f87171',
+      bgLight: '#fef2f2',
+      bgDark: 'rgba(220, 38, 38, 0.12)',
+      heroImage: SHIFT_COVERS.kitchenTeam,
+    },
+  },
+  {
+    // Before 'event' so "Event Set-up" reads as a set-up shift.
+    keywords: ['set up', 'setup'],
+    theme: {
+      emoji: '🛠️',
+      color: '#d97706',
+      colorDark: '#fbbf24',
+      bgLight: '#fffbeb',
+      bgDark: 'rgba(217, 119, 6, 0.12)',
+      heroImage: SHIFT_COVERS.communityTable,
+    },
+  },
+  {
+    keywords: ['information', 'info session', 'session'],
+    theme: {
+      emoji: '📋',
+      color: '#0891b2',
+      colorDark: '#67e8f9',
+      bgLight: '#ecfeff',
+      bgDark: 'rgba(8, 145, 178, 0.12)',
+      heroImage: SHIFT_COVERS.diningRoom,
+    },
+  },
+  {
+    keywords: ['event'],
+    theme: {
+      emoji: '🎉',
+      color: '#9333ea',
+      colorDark: '#c084fc',
+      bgLight: '#faf5ff',
+      bgDark: 'rgba(147, 51, 234, 0.12)',
+      heroImage: SHIFT_COVERS.communityTable,
+    },
+  },
+  {
+    keywords: ['service', 'serving'],
+    theme: {
+      emoji: '✨',
+      color: '#9333ea',
+      colorDark: '#c084fc',
+      bgLight: '#faf5ff',
+      bgDark: 'rgba(147, 51, 234, 0.12)',
+      heroImage: SHIFT_COVERS.fohServing,
+    },
+  },
+];
+
 export function getShiftThemeByName(name: string): ShiftTypeTheme {
-  return SHIFT_TYPE_THEMES_BY_NAME[name] ?? DEFAULT_SHIFT_TYPE_THEME;
+  // 1. Exact, hand-curated match wins.
+  const exact = SHIFT_TYPE_THEMES_BY_NAME[name];
+  if (exact) return exact;
+
+  // 2. Keyword match — flatten hyphens/slashes so "Front-of-House" and
+  //    "Helper & Prep" still resolve to a role-appropriate cover.
+  const normalized = name.toLowerCase().replace(/[-/]/g, ' ');
+  for (const rule of KEYWORD_THEME_RULES) {
+    if (rule.keywords.some((keyword) => normalized.includes(keyword))) {
+      return rule.theme;
+    }
+  }
+
+  // 3. Generic fallback.
+  return DEFAULT_SHIFT_TYPE_THEME;
 }
 
 /** Volunteer signup info for display on shift detail */

--- a/web/src/lib/shift-themes.ts
+++ b/web/src/lib/shift-themes.ts
@@ -93,6 +93,193 @@ export const DEFAULT_THEME = {
   fullGradient: "from-gray-500 to-slate-500",
 };
 
-export function getShiftTheme(shiftTypeName: string) {
-  return SHIFT_THEMES[shiftTypeName as keyof typeof SHIFT_THEMES] || DEFAULT_THEME;
+type ShiftTheme = typeof DEFAULT_THEME;
+
+/**
+ * Keyword fallback, mirroring the mobile app's shift-type themes
+ * (mobile/lib/dummy-data.ts). Shift type names carry location/variant suffixes
+ * ("GI", "ONE", "(Onehunga)", "Pop-Up Stand") and hyphenation
+ * ("Front-of-House") that the exact lookup above misses, leaving most live
+ * shift types on the generic default. First rule whose keyword appears in the
+ * normalised name wins, so order matters: most specific role keywords first.
+ * Emoji match the mobile set so both apps read as one product.
+ *
+ * NOTE: Tailwind only generates classes it sees as full literal strings — keep
+ * these spelled out, never build class names by interpolation.
+ */
+const KEYWORD_THEMES: { keywords: string[]; theme: ShiftTheme }[] = [
+  {
+    keywords: ["dishwash"],
+    theme: {
+      emoji: "🧽",
+      borderColor: "border-blue-300",
+      textColor: "text-blue-800",
+      gradient: "from-blue-100 to-cyan-100",
+      bgColor: "bg-blue-50 dark:bg-blue-950/20",
+      fullGradient: "from-blue-500 to-cyan-500",
+    },
+  },
+  {
+    keywords: ["food rescue", "rescue"],
+    theme: {
+      emoji: "🥕",
+      borderColor: "border-green-300",
+      textColor: "text-green-800",
+      gradient: "from-green-100 to-emerald-100",
+      bgColor: "bg-green-50 dark:bg-green-950/20",
+      fullGradient: "from-green-500 to-emerald-500",
+    },
+  },
+  {
+    keywords: ["save a bite"],
+    theme: {
+      emoji: "🥪",
+      borderColor: "border-emerald-300",
+      textColor: "text-emerald-800",
+      gradient: "from-emerald-100 to-green-100",
+      bgColor: "bg-emerald-50 dark:bg-emerald-950/20",
+      fullGradient: "from-emerald-500 to-green-500",
+    },
+  },
+  {
+    keywords: ["photograph", "socials", "media"],
+    theme: {
+      emoji: "📷",
+      borderColor: "border-pink-300",
+      textColor: "text-pink-800",
+      gradient: "from-pink-100 to-rose-100",
+      bgColor: "bg-pink-50 dark:bg-pink-950/20",
+      fullGradient: "from-pink-500 to-rose-500",
+    },
+  },
+  {
+    keywords: ["moving", "packing", "sorting"],
+    theme: {
+      emoji: "📦",
+      borderColor: "border-indigo-300",
+      textColor: "text-indigo-800",
+      gradient: "from-indigo-100 to-purple-100",
+      bgColor: "bg-indigo-50 dark:bg-indigo-950/20",
+      fullGradient: "from-indigo-500 to-purple-500",
+    },
+  },
+  {
+    keywords: ["offsite"],
+    theme: {
+      emoji: "🚚",
+      borderColor: "border-cyan-300",
+      textColor: "text-cyan-800",
+      gradient: "from-cyan-100 to-blue-100",
+      bgColor: "bg-cyan-50 dark:bg-cyan-950/20",
+      fullGradient: "from-cyan-500 to-blue-500",
+    },
+  },
+  {
+    // Before "clean" so "Front of House Service & Clean Up" reads as FOH.
+    keywords: ["front of house", "foh"],
+    theme: {
+      emoji: "✨",
+      borderColor: "border-purple-300",
+      textColor: "text-purple-800",
+      gradient: "from-purple-100 to-pink-100",
+      bgColor: "bg-purple-50 dark:bg-purple-950/20",
+      fullGradient: "from-purple-500 to-pink-500",
+    },
+  },
+  {
+    keywords: ["clean"],
+    theme: {
+      emoji: "🧹",
+      borderColor: "border-blue-300",
+      textColor: "text-blue-800",
+      gradient: "from-blue-100 to-cyan-100",
+      bgColor: "bg-blue-50 dark:bg-blue-950/20",
+      fullGradient: "from-blue-500 to-cyan-500",
+    },
+  },
+  {
+    keywords: ["kitchen prep", "prep"],
+    theme: {
+      emoji: "🔪",
+      borderColor: "border-orange-300",
+      textColor: "text-orange-800",
+      gradient: "from-orange-100 to-amber-100",
+      bgColor: "bg-orange-50 dark:bg-orange-950/20",
+      fullGradient: "from-orange-500 to-amber-500",
+    },
+  },
+  {
+    keywords: ["kitchen"],
+    theme: {
+      emoji: "🍳",
+      borderColor: "border-red-300",
+      textColor: "text-red-800",
+      gradient: "from-red-100 to-pink-100",
+      bgColor: "bg-red-50 dark:bg-red-950/20",
+      fullGradient: "from-red-500 to-pink-500",
+    },
+  },
+  {
+    // Before "event" so "Event Set-up" reads as a set-up shift.
+    keywords: ["set up", "setup"],
+    theme: {
+      emoji: "🛠️",
+      borderColor: "border-amber-300",
+      textColor: "text-amber-800",
+      gradient: "from-amber-100 to-orange-100",
+      bgColor: "bg-amber-50 dark:bg-amber-950/20",
+      fullGradient: "from-amber-500 to-orange-500",
+    },
+  },
+  {
+    keywords: ["information", "info session", "session"],
+    theme: {
+      emoji: "📋",
+      borderColor: "border-cyan-300",
+      textColor: "text-cyan-800",
+      gradient: "from-cyan-100 to-blue-100",
+      bgColor: "bg-cyan-50 dark:bg-cyan-950/20",
+      fullGradient: "from-cyan-500 to-blue-500",
+    },
+  },
+  {
+    keywords: ["event"],
+    theme: {
+      emoji: "🎉",
+      borderColor: "border-purple-300",
+      textColor: "text-purple-800",
+      gradient: "from-purple-100 to-pink-100",
+      bgColor: "bg-purple-50 dark:bg-purple-950/20",
+      fullGradient: "from-purple-500 to-pink-500",
+    },
+  },
+  {
+    keywords: ["service", "serving"],
+    theme: {
+      emoji: "✨",
+      borderColor: "border-purple-300",
+      textColor: "text-purple-800",
+      gradient: "from-purple-100 to-pink-100",
+      bgColor: "bg-purple-50 dark:bg-purple-950/20",
+      fullGradient: "from-purple-500 to-pink-500",
+    },
+  },
+];
+
+export function getShiftTheme(shiftTypeName: string): ShiftTheme {
+  // 1. Exact, hand-curated match wins.
+  const exact = SHIFT_THEMES[shiftTypeName as keyof typeof SHIFT_THEMES];
+  if (exact) return exact;
+
+  // 2. Keyword match — flatten hyphens/slashes so "Front-of-House" and
+  //    "Helper & Prep" still resolve to a role-appropriate theme.
+  const normalized = shiftTypeName.toLowerCase().replace(/[-/]/g, " ");
+  for (const rule of KEYWORD_THEMES) {
+    if (rule.keywords.some((keyword) => normalized.includes(keyword))) {
+      return rule.theme;
+    }
+  }
+
+  // 3. Generic fallback.
+  return DEFAULT_THEME;
 }


### PR DESCRIPTION
## Description

Shift-type cover photos (mobile) and emoji/colour themes (web) were resolved by **exact name only** — just ~9 names mapped. Of the ~29 live shift types, the rest (Event*, Save a Bite*, Food Rescue*, Photography, Cleaning, Moving, Information Session, Set-up, Offsite, Special Event, Sunday Kitchen Prep…) matched nothing and fell back to a single generic cover/theme.

This adds a **keyword fallback** after the exact lookup on both platforms. Names are normalised (hyphens/slashes flattened) so variants with location suffixes (`GI`, `ONE`, `(Onehunga)`, `Pop-Up Stand`) and hyphenation (`Front-of-House`) resolve to a role-appropriate result. First matching keyword wins; ordering is deliberate (e.g. `front of house` before `clean`, `set up` before `event`). Curated exact matches still win.

**Mobile** (`mobile/lib/dummy-data.ts`): registered the two photos already in `assets/photos/` that were going unused (`ee-foh-portrait`, `ee-crew-plates`) and spread all 13 covers across roles instead of reusing two generics.

**Web** (`web/src/lib/shift-themes.ts`): mirrors the same keywords/order with the **same emoji set** so both apps read as one product. Web has no cover photos (it never did) — these are emoji + border/text/gradient Tailwind themes. Classes are kept as full literal strings so the JIT generates them.

A given shift type now shows a consistent emoji across web and mobile:

| Shift types | Emoji |
|---|---|
| Dishwasher, Event Prep - Dishwashing | 🧽 |
| Food Rescue Helper (+ & Prep) | 🥕 |
| Save a Bite (+ all variants) | 🥪 |
| Photography & Socials | 📷 |
| Moving, Packing, Sorting | 📦 |
| Offsite help | 🚚 |
| Event Front-of-House, FOH Service & Clean Up | ✨ |
| Extra Cleaning Helper | 🧹 |
| Event Prep, Sunday Kitchen Prep (Onehunga) | 🔪 |
| Event Set-up, Set-up Only | 🛠️ |
| Information Session | 📋 |
| Event Helpers, Special Event | 🎉 |

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
- `version:minor`

## Testing
- [x] `tsc --noEmit` passes for both apps (mobile clean; web — only a pre-existing unrelated `restaurant-reports.tsx` error)
- [x] Verified all mobile `require()` asset paths exist and every cover reference resolves
- [ ] Manual/visual check in browser preview not run (data/theme logic, exercised by existing shift pages)

## Reviewer notes
- No data migration — purely presentational mapping in `getShiftThemeByName` (mobile) / `getShiftTheme` (web).
- Web Tailwind classes are intentionally full literal strings (comment in source explains why) and reuse colour families already present in the file.
- Anything genuinely unrecognised still gets the existing generic default; none of the current live shift types hit it now.