### PR TITLE
feat(shifts): show per-shift notes as the volunteer-facing description

### DIFF
--- a/mobile/app/shift/[id].tsx
+++ b/mobile/app/shift/[id].tsx
@@ -44,6 +44,7 @@ import { ShiftSignupSheet } from "@/components/shift-signup-sheet";
 import { GlassButton } from "@/components/glass-button";
 import { Eyebrow } from "@/components/ui/eyebrow";
 import { getShiftThemeByName, getLocationMapsUrl } from "@/lib/dummy-data";
+import { getShiftDescription } from "@/lib/shift-description";
 import { posthog } from "@/lib/posthog";
 
 /* ── Duration Helper ── */
@@ -405,9 +406,9 @@ export default function ShiftDetailScreen() {
             </Text>
 
             {/* Description pulled tight under title */}
-            {shift.shiftType.description ? (
+            {getShiftDescription(shift.notes, shift.shiftType.description) ? (
               <Text style={s.heroDescription} numberOfLines={2}>
-                {shift.shiftType.description}
+                {getShiftDescription(shift.notes, shift.shiftType.description)}
               </Text>
             ) : null}
 

--- a/mobile/components/shift-signup-sheet.tsx
+++ b/mobile/components/shift-signup-sheet.tsx
@@ -20,6 +20,7 @@ import { router } from 'expo-router';
 import { Colors, Brand, FontFamily, Palette } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { api, ApiError } from '@/lib/api';
+import { getShiftDescription } from '@/lib/shift-description';
 
 type ConcurrentShift = {
   id: string;
@@ -67,6 +68,7 @@ type ShiftSignupSheetProps = {
     location: string;
     capacity: number;
     signedUp: number;
+    notes?: string | null;
   };
   isWaitlist: boolean;
   formatDate: (date: Date, fmt: string) => string;
@@ -255,9 +257,9 @@ export function ShiftSignupSheet({
           {/* Shift details card */}
           <View style={[ss.card, { backgroundColor: colors.surfaceSoft }]}>
             <Text style={[ss.cardTitle, { color: colors.text }]}>{shift.shiftType.name}</Text>
-            {shift.shiftType.description ? (
+            {getShiftDescription(shift.notes, shift.shiftType.description) ? (
               <Text style={[ss.cardDescription, { color: colors.textSecondary }]}>
-                {shift.shiftType.description}
+                {getShiftDescription(shift.notes, shift.shiftType.description)}
               </Text>
             ) : null}
             <View style={ss.cardDetails}>

--- a/mobile/lib/calendar-sync.ts
+++ b/mobile/lib/calendar-sync.ts
@@ -3,6 +3,7 @@ import * as Calendar from "expo-calendar";
 import { Platform } from "react-native";
 
 import { LOCATION_ADDRESSES, type Shift } from "./dummy-data";
+import { getShiftDescription } from "./shift-description";
 
 const SHIFT_EVENT_MAP_KEY = "@ee/calendar-shift-events";
 const CALENDAR_SYNC_ENABLED_KEY = "@ee/calendar-sync-enabled";
@@ -62,7 +63,7 @@ function buildShiftUrl(shiftId: string): string {
 
 function buildNotes(shift: Shift): string {
   const url = buildShiftUrl(shift.id);
-  const desc = shift.shiftType.description ?? "";
+  const desc = getShiftDescription(shift.notes, shift.shiftType.description) ?? "";
   return [desc, `View shift details: ${url}`]
     .filter((p) => p.length > 0)
     .join("\n\n");

--- a/mobile/lib/shift-description.ts
+++ b/mobile/lib/shift-description.ts
@@ -1,0 +1,15 @@
+/**
+ * Resolve the description shown to volunteers for a shift.
+ *
+ * Per-shift notes (set on the shift template and copied onto the shift at
+ * creation, or edited per shift) are the canonical description. The shift
+ * type's generic description is only the fallback when a shift has no notes.
+ */
+export function getShiftDescription(
+  notes?: string | null,
+  shiftTypeDescription?: string | null
+): string | null {
+  const trimmedNotes = notes?.trim();
+  if (trimmedNotes) return trimmedNotes;
+  return shiftTypeDescription ?? null;
+}

--- a/web/src/app/api/friends/[friendId]/profile/route.ts
+++ b/web/src/app/api/friends/[friendId]/profile/route.ts
@@ -178,6 +178,7 @@ export async function GET(
       start: signup.shift.start,
       end: signup.shift.end,
       location: signup.shift.location,
+      notes: signup.shift.notes,
       shiftType: signup.shift.shiftType,
       status: signup.status,
     }));

--- a/web/src/app/api/shifts/[id]/calendar/route.ts
+++ b/web/src/app/api/shifts/[id]/calendar/route.ts
@@ -31,6 +31,7 @@ export async function GET(
       start: shift.start,
       end: shift.end,
       location: shift.location,
+      notes: shift.notes,
       shiftType: {
         name: shift.shiftType.name,
         description: shift.shiftType.description,

--- a/web/src/app/shifts/[id]/page.tsx
+++ b/web/src/app/shifts/[id]/page.tsx
@@ -23,6 +23,7 @@ import Link from "next/link";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { ProfileCompletionBannerServer } from "@/components/profile-completion-banner-server";
 import { generateCalendarUrls } from "@/lib/calendar-utils";
+import { getShiftDescription } from "@/lib/shift-description";
 import { LOCATION_ADDRESSES, type Location } from "@/lib/locations";
 import { ShiftSignupButton } from "@/components/shift-signup-button";
 import { ShareShiftButton } from "@/components/share-shift-button";
@@ -301,9 +302,9 @@ export default async function ShiftDetailPage({
           <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">
             {shift.shiftType.name}
           </h1>
-          {shift.shiftType.description && (
+          {getShiftDescription(shift.notes, shift.shiftType.description) && (
             <p className="text-muted-foreground mt-1">
-              {shift.shiftType.description}
+              {getShiftDescription(shift.notes, shift.shiftType.description)}
             </p>
           )}
         </div>
@@ -613,7 +614,10 @@ export default async function ShiftDetailPage({
                 buildShiftEventSchema({
                   id: shift.id,
                   name: shift.shiftType.name,
-                  description: shift.shiftType.description,
+                  description: getShiftDescription(
+                    shift.notes,
+                    shift.shiftType.description
+                  ),
                   startDate: new Date(shift.start),
                   endDate: new Date(shift.end),
                   location: shift.location,

--- a/web/src/app/shifts/details/shift-details-content.tsx
+++ b/web/src/app/shifts/details/shift-details-content.tsx
@@ -19,6 +19,7 @@ import {
   ArrowUpRight,
 } from "lucide-react";
 import { getShiftTheme } from "@/lib/shift-themes";
+import { getShiftDescription } from "@/lib/shift-description";
 import { checkProfileCompletion } from "@/lib/profile-completion";
 import { ShareShiftButton } from "@/components/share-shift-button";
 import { getBaseUrl } from "@/lib/utils";
@@ -63,7 +64,10 @@ function getConcurrentShiftsFromList(
       return {
         id: shift.id,
         shiftTypeName: shift.shiftType.name,
-        shiftTypeDescription: shift.shiftType.description,
+        shiftTypeDescription: getShiftDescription(
+          shift.notes,
+          shift.shiftType.description
+        ),
         spotsRemaining: Math.max(0, shift.capacity - confirmedCount),
       };
     });
@@ -210,9 +214,9 @@ function ShiftCard({
               </div>
             </div>
 
-            {shift.shiftType.description && (
+            {getShiftDescription(shift.notes, shift.shiftType.description) && (
               <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed line-clamp-2">
-                {shift.shiftType.description}
+                {getShiftDescription(shift.notes, shift.shiftType.description)}
               </p>
             )}
 

--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -18,6 +18,7 @@ import { getAuthInfo } from "@/lib/auth-utils";
 import { LocationAddress } from "@/components/location-address";
 import type { Metadata } from "next";
 import { buildPageMetadata, buildShiftEventSchema } from "@/lib/seo";
+import { getShiftDescription } from "@/lib/shift-description";
 import {
   captureFunnelEvent,
   FunnelEvent,
@@ -438,16 +439,18 @@ export default async function ShiftsCalendarPage({
   }
 
   // Generate Event schema for up to 20 shifts
-  const shiftSchemas = shiftSummaries.slice(0, 20).map((shift) =>
+  const shiftSchemas = shifts.slice(0, 20).map((shift) =>
     buildShiftEventSchema({
       id: shift.id,
       name: shift.shiftType.name,
-      description: shift.shiftType.description,
+      description: getShiftDescription(shift.notes, shift.shiftType.description),
       startDate: shift.start,
       endDate: shift.end,
       location: shift.location,
       capacity: shift.capacity,
-      spotsAvailable: shift.capacity - shift.confirmedCount,
+      spotsAvailable:
+        shift.capacity -
+        (shift._count.signups + shift._count.placeholders),
     })
   );
 

--- a/web/src/components/friend-profile-dialog.tsx
+++ b/web/src/components/friend-profile-dialog.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { format } from "date-fns";
 import { formatInNZT } from "@/lib/timezone";
+import { getShiftDescription } from "@/lib/shift-description";
 import {
   Calendar,
   Clock,
@@ -31,6 +32,7 @@ interface FriendShift {
   start: string;
   end: string;
   location: string | null;
+  notes: string | null;
   shiftType: {
     name: string;
     description: string | null;
@@ -199,7 +201,10 @@ export function FriendProfileDialog({
                             <div>
                               <h4 className="font-medium">{shift.shiftType.name}</h4>
                               <p className="text-sm text-gray-600 mb-2">
-                                {shift.shiftType.description}
+                                {getShiftDescription(
+                                  shift.notes,
+                                  shift.shiftType.description
+                                )}
                               </p>
                               <div className="flex items-center space-x-4 text-sm text-gray-600">
                                 <div className="flex items-center">

--- a/web/src/components/shift-signup-button.tsx
+++ b/web/src/components/shift-signup-button.tsx
@@ -14,6 +14,7 @@ interface ShiftSignupButtonProps {
     end: Date;
     location: string | null;
     capacity: number;
+    notes?: string | null;
     shiftType: {
       name: string;
       description: string | null;

--- a/web/src/components/shift-signup-dialog.tsx
+++ b/web/src/components/shift-signup-dialog.tsx
@@ -23,6 +23,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { calculateAge } from "@/lib/utils";
+import { getShiftDescription } from "@/lib/shift-description";
 import { MessageSquareDot, User } from "lucide-react";
 import Link from "next/link";
 import { Turnstile, type TurnstileHandle } from "@/components/turnstile";
@@ -34,6 +35,7 @@ interface ShiftSignupDialogProps {
     end: Date;
     location: string | null;
     capacity: number;
+    notes?: string | null;
     shiftType: {
       name: string;
       description: string | null;
@@ -435,12 +437,12 @@ export function ShiftSignupDialog({
               {shift.shiftType.name}
             </h3>
 
-            {shift.shiftType.description && (
+            {getShiftDescription(shift.notes, shift.shiftType.description) && (
               <p
                 className="text-sm text-muted-foreground mb-3"
                 data-testid="shift-details-description"
               >
-                {shift.shiftType.description}
+                {getShiftDescription(shift.notes, shift.shiftType.description)}
               </p>
             )}
 

--- a/web/src/lib/calendar-utils.ts
+++ b/web/src/lib/calendar-utils.ts
@@ -1,6 +1,7 @@
 import { formatInNZT } from "./timezone";
 import { LOCATION_ADDRESSES } from "./locations";
 import { getBaseUrl } from "./utils";
+import { getShiftDescription } from "./shift-description";
 
 /**
  * Calendar utilities for generating calendar links for shifts
@@ -11,6 +12,7 @@ interface ShiftCalendarData {
   start: Date;
   end: Date;
   location: string | null;
+  notes?: string | null;
   shiftType: {
     name: string;
     description: string | null;
@@ -56,7 +58,8 @@ function buildCalendarDescription(
 ): string {
   const shiftDetailsLink = `${getBaseUrl()}/shifts/${shift.id}`;
   const fullAddress = getFullAddress(shift.location, false); // Don't escape yet
-  const shiftDescription = shift.shiftType.description || "";
+  const shiftDescription =
+    getShiftDescription(shift.notes, shift.shiftType.description) || "";
 
   if (format === "ics") {
     // For ICS: use separators that display consistently across all calendar apps

--- a/web/src/lib/concurrent-shifts.ts
+++ b/web/src/lib/concurrent-shifts.ts
@@ -5,6 +5,7 @@ import {
   getShiftEffectiveCount,
   shiftCapacityCountSelect,
 } from "@/lib/placeholder-utils";
+import { getShiftDescription } from "@/lib/shift-description";
 
 /** Hour cutoff (NZ time) — shifts starting before this are "Day", at or after are "Evening" */
 export const DAY_EVENING_CUTOFF_HOUR = 16;
@@ -74,6 +75,7 @@ export async function getConcurrentShifts(shiftId: string) {
       id: true,
       start: true,
       capacity: true,
+      notes: true,
       shiftType: {
         select: {
           name: true,
@@ -97,7 +99,7 @@ export async function getConcurrentShifts(shiftId: string) {
   return concurrentShifts.map((s) => ({
     id: s.id,
     shiftTypeName: s.shiftType.name,
-    shiftTypeDescription: s.shiftType.description,
+    shiftTypeDescription: getShiftDescription(s.notes, s.shiftType.description),
     spotsRemaining: Math.max(0, s.capacity - getShiftEffectiveCount(s)),
   }));
 }

--- a/web/src/lib/shift-description.ts
+++ b/web/src/lib/shift-description.ts
@@ -1,0 +1,15 @@
+/**
+ * Resolve the description shown to volunteers for a shift.
+ *
+ * Per-shift notes (set on the shift template and copied onto the shift at
+ * creation, or edited per shift) are the canonical description. The shift
+ * type's generic description is only the fallback when a shift has no notes.
+ */
+export function getShiftDescription(
+  notes?: string | null,
+  shiftTypeDescription?: string | null
+): string | null {
+  const trimmedNotes = notes?.trim();
+  if (trimmedNotes) return trimmedNotes;
+  return shiftTypeDescription ?? null;
+}


### PR DESCRIPTION
## Description
The shift description shown to volunteers was always the **shift type's** generic description (e.g. "Guest service and dining room support"). The per-shift **notes** — set on the shift template and copied onto each shift at creation, and editable per shift — were never surfaced in the browsing/signup flow.

This PR makes a shift show its **notes** as the description, falling back to the shift type description only when the shift has no notes. The rule is applied consistently to every volunteer-facing single-description surface on web and mobile via a shared `getShiftDescription(notes, shiftTypeDescription)` helper.

**Web**
- Public shift detail card (`/shifts/details`) + its backup-shift list
- Individual shift page (`/shifts/[id]`) + its SEO event schema
- `/shifts` SEO event schema
- Signup dialog + backup-shift options (`concurrent-shifts`)
- Friend profile dialog (+ friend profile API now returns `notes`)
- Calendar `.ics` / Google / Outlook invites (`calendar-utils` + ICS route)

**Mobile**
- Shift detail screen
- Signup sheet
- Native calendar event (`calendar-sync`)

**Intentionally unchanged**
- The **"My Shifts" dialog** already renders "Description" and "Notes" as two deliberately separate sections, so it was left as-is.
- Transactional **emails** build inline calendar data from params that don't carry shift notes, so that inline path is unchanged (the email's "download .ics" link points to the calendar route, which now includes notes).

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Testing
- [x] `tsc --noEmit` clean on both web and mobile (web's only error is a pre-existing, unrelated ApexCharts typing issue in `restaurant-reports.tsx`)
- [x] Manual testing completed — ran the web dev server against the dev DB with a temporary future shift:
  - With notes → both `/shifts/[id]` and `/shifts/details` showed the **notes** text, not the type description
  - With notes cleared → both correctly fell back to the **shift type description**
  - Temporary test shift removed afterward
- Mobile changes use the identical helper against data the mobile APIs already return (`notes` + `shiftType.description`); not runnable in this harness but typecheck clean.

## Additional Notes
New shared helpers: `web/src/lib/shift-description.ts` and `mobile/lib/shift-description.ts`.