### PR TITLE
test: shift-theme unit tests + cross-platform colour alignment (follow-up to #1008)

### DIFF
--- a/mobile/lib/dummy-data.ts
+++ b/mobile/lib/dummy-data.ts
@@ -204,7 +204,12 @@ const DEFAULT_SHIFT_TYPE_THEME: ShiftTypeTheme = {
  * Stand") and hyphenation ("Front-of-House") that an exact lookup misses, which
  * left ~20 of the live shift types on the generic dining-room cover. First rule
  * whose keyword appears in the (normalised) name wins, so order matters: the
- * most specific role keywords come first. */
+ * most specific role keywords come first.
+ *
+ * MAINTENANCE: keywords are matched against live shift-type names from the DB.
+ * Keep them in sync with web/src/lib/shift-themes.ts (same keywords, order and
+ * emoji) so both apps resolve identically; if shift-type names change, update
+ * both. */
 const KEYWORD_THEME_RULES: { keywords: string[]; theme: ShiftTypeTheme }[] = [
   {
     keywords: ['dishwash'],

--- a/web/src/lib/shift-themes.test.ts
+++ b/web/src/lib/shift-themes.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { getShiftTheme, DEFAULT_THEME, SHIFT_THEMES } from "./shift-themes";
+
+describe("getShiftTheme", () => {
+  // The full set of live shift-type names (from production) mapped to the emoji
+  // each should resolve to. This is the real-world coverage guarantee: every
+  // production shift type gets a role-appropriate theme, none fall to default.
+  // The same names + emoji are expected to resolve identically in the mobile
+  // app (mobile/lib/dummy-data.ts) — keep both in sync.
+  const PRODUCTION_SHIFT_TYPES: [name: string, emoji: string][] = [
+    ["Dishwasher", "🧽"], // exact
+    ["Event Front-of-House", "✨"], // foh keyword (hyphen normalised)
+    ["Event Helpers", "🎉"], // event
+    ["Event Prep", "🔪"], // prep
+    ["Event Prep - Dishwashing", "🧽"], // dishwash wins over prep (order)
+    ["Event Set-up", "🛠️"], // set up wins over event (order)
+    ["Extra Cleaning Helper", "🧹"], // clean
+    ["FOH Set-Up & Service", "✨"], // exact
+    ["Food Rescue Helper", "🥕"], // rescue
+    ["Food Rescue Helper & Prep", "🥕"], // rescue wins over prep (order)
+    ["Front of House", "🌟"], // exact
+    ["Front of House Service & Clean Up", "✨"], // foh wins over clean (order)
+    ["Information Session", "📋"], // information/session
+    ["Kitchen Prep", "🔪"], // exact
+    ["Kitchen Prep & Service", "🍳"], // exact
+    ["Kitchen Service & Pack Down", "📦"], // exact
+    ["Media Role", "📷"], // exact
+    ["Moving, Packing, Sorting", "📦"], // moving
+    ["Offsite help", "🚚"], // offsite
+    ["Photography & Socials", "📷"], // photograph
+    ["Save a Bite", "🥪"], // save a bite
+    ["Save a Bite Dinner -  Social & Planning Session  ONE", "🥪"],
+    ["Save a Bite Dinner -  Social & Planning Session GI", "🥪"],
+    ["Save a Bite Pop-Up GI", "🥪"],
+    ["Save a Bite Pop-Up Stand GI", "🥪"],
+    ["Save a Bite Pop-Up Stand ONE", "🥪"],
+    ["Set-up Only", "🛠️"], // set up
+    ["Special Event", "🎉"], // event
+    ["Sunday Kitchen Prep (Onehunga)", "🔪"], // kitchen prep (location suffix)
+  ];
+
+  it.each(PRODUCTION_SHIFT_TYPES)(
+    "resolves %s to %s",
+    (name, expectedEmoji) => {
+      expect(getShiftTheme(name).emoji).toBe(expectedEmoji);
+    },
+  );
+
+  it("never falls back to the generic default for any live shift type", () => {
+    for (const [name] of PRODUCTION_SHIFT_TYPES) {
+      expect(getShiftTheme(name)).not.toBe(DEFAULT_THEME);
+    }
+  });
+
+  it("prefers an exact match over a keyword match", () => {
+    // "Kitchen" exactly maps to 🧽; the 'kitchen' keyword would give 🍳.
+    expect(getShiftTheme("Kitchen")).toBe(SHIFT_THEMES["Kitchen"]);
+    expect(getShiftTheme("Kitchen").emoji).toBe("🧽");
+  });
+
+  it("normalises hyphens so 'Front-of-House' matches the foh keyword", () => {
+    expect(getShiftTheme("Front-of-House").emoji).toBe("✨");
+  });
+
+  it("respects keyword order: 'set up' beats 'event'", () => {
+    expect(getShiftTheme("Event Set-up").emoji).toBe("🛠️");
+  });
+
+  it("respects keyword order: 'front of house' beats 'clean'", () => {
+    expect(getShiftTheme("Front of House Service & Clean Up").emoji).toBe("✨");
+  });
+
+  it("respects keyword order: 'dishwash' beats 'prep'", () => {
+    expect(getShiftTheme("Event Prep - Dishwashing").emoji).toBe("🧽");
+  });
+
+  it("returns the default theme for unrecognised names", () => {
+    expect(getShiftTheme("Mystery Role")).toBe(DEFAULT_THEME);
+    expect(getShiftTheme("")).toBe(DEFAULT_THEME);
+  });
+
+  it("always returns a complete theme object (no missing class fields)", () => {
+    const fields = [
+      "emoji",
+      "borderColor",
+      "textColor",
+      "gradient",
+      "bgColor",
+      "fullGradient",
+    ] as const;
+    const names = [
+      ...PRODUCTION_SHIFT_TYPES.map(([n]) => n),
+      "Totally Unknown Shift",
+    ];
+    for (const name of names) {
+      const theme = getShiftTheme(name);
+      for (const field of fields) {
+        expect(theme[field], `${name}.${field}`).toBeTruthy();
+      }
+    }
+  });
+});

--- a/web/src/lib/shift-themes.test.ts
+++ b/web/src/lib/shift-themes.test.ts
@@ -7,6 +7,12 @@ describe("getShiftTheme", () => {
   // production shift type gets a role-appropriate theme, none fall to default.
   // The same names + emoji are expected to resolve identically in the mobile
   // app (mobile/lib/dummy-data.ts) — keep both in sync.
+  //
+  // NOTE: if these tests fail after a production change, it most likely means a
+  // shift-type name was renamed (or a new type was added) in the database.
+  // Update this array to match the new reality and confirm the keyword rules in
+  // shift-themes.ts still resolve it correctly — that's expected maintenance,
+  // not a regression.
   const PRODUCTION_SHIFT_TYPES: [name: string, emoji: string][] = [
     ["Dishwasher", "🧽"], // exact
     ["Event Front-of-House", "✨"], // foh keyword (hyphen normalised)

--- a/web/src/lib/shift-themes.ts
+++ b/web/src/lib/shift-themes.ts
@@ -271,6 +271,11 @@ const KEYWORD_THEMES: { keywords: string[]; theme: ShiftTheme }[] = [
   },
 ];
 
+/**
+ * Resolve the theme for a shift type. Resolution order: exact name match →
+ * keyword match (names normalised so hyphen/slash variants still match) →
+ * generic default. Always returns a complete theme; never null.
+ */
 export function getShiftTheme(shiftTypeName: string): ShiftTheme {
   // 1. Exact, hand-curated match wins.
   const exact = SHIFT_THEMES[shiftTypeName as keyof typeof SHIFT_THEMES];

--- a/web/src/lib/shift-themes.ts
+++ b/web/src/lib/shift-themes.ts
@@ -106,6 +106,11 @@ type ShiftTheme = typeof DEFAULT_THEME;
  *
  * NOTE: Tailwind only generates classes it sees as full literal strings — keep
  * these spelled out, never build class names by interpolation.
+ *
+ * MAINTENANCE: keywords are matched against live shift-type names from the DB.
+ * If those names change (or new types appear), update the keywords here AND in
+ * mobile/lib/dummy-data.ts so both stay in sync; otherwise they fall back to
+ * the generic default. See shift-themes.test.ts for the expected resolutions.
  */
 const KEYWORD_THEMES: { keywords: string[]; theme: ShiftTheme }[] = [
   {
@@ -123,22 +128,22 @@ const KEYWORD_THEMES: { keywords: string[]; theme: ShiftTheme }[] = [
     keywords: ["food rescue", "rescue"],
     theme: {
       emoji: "🥕",
-      borderColor: "border-green-300",
-      textColor: "text-green-800",
-      gradient: "from-green-100 to-emerald-100",
-      bgColor: "bg-green-50 dark:bg-green-950/20",
-      fullGradient: "from-green-500 to-emerald-500",
+      borderColor: "border-lime-300",
+      textColor: "text-lime-800",
+      gradient: "from-lime-100 to-green-100",
+      bgColor: "bg-lime-50 dark:bg-lime-950/20",
+      fullGradient: "from-lime-500 to-green-500",
     },
   },
   {
     keywords: ["save a bite"],
     theme: {
       emoji: "🥪",
-      borderColor: "border-emerald-300",
-      textColor: "text-emerald-800",
-      gradient: "from-emerald-100 to-green-100",
-      bgColor: "bg-emerald-50 dark:bg-emerald-950/20",
-      fullGradient: "from-emerald-500 to-green-500",
+      borderColor: "border-teal-300",
+      textColor: "text-teal-800",
+      gradient: "from-teal-100 to-emerald-100",
+      bgColor: "bg-teal-50 dark:bg-teal-950/20",
+      fullGradient: "from-teal-500 to-emerald-500",
     },
   },
   {
@@ -156,11 +161,11 @@ const KEYWORD_THEMES: { keywords: string[]; theme: ShiftTheme }[] = [
     keywords: ["moving", "packing", "sorting"],
     theme: {
       emoji: "📦",
-      borderColor: "border-indigo-300",
-      textColor: "text-indigo-800",
-      gradient: "from-indigo-100 to-purple-100",
-      bgColor: "bg-indigo-50 dark:bg-indigo-950/20",
-      fullGradient: "from-indigo-500 to-purple-500",
+      borderColor: "border-violet-300",
+      textColor: "text-violet-800",
+      gradient: "from-violet-100 to-purple-100",
+      bgColor: "bg-violet-50 dark:bg-violet-950/20",
+      fullGradient: "from-violet-500 to-purple-500",
     },
   },
   {


### PR DESCRIPTION
## Description

Follow-up to **#1008** (which merged before review feedback could be applied). Addresses the review on that PR:

1. **Align keyword-theme colours across platforms** — the same emoji now reads the same colour family on web and mobile:
   - Food Rescue 🥕: web green → **lime** (matches mobile `#65a30d`)
   - Save a Bite 🥪: web emerald → **teal** (matches mobile `#0d9488`)
   - Moving/Packing/Sorting 📦: web indigo → **violet** (matches mobile `#7c3aed`)
2. **Add web unit tests** (`web/src/lib/shift-themes.test.ts`, 37 cases) driven by the real production shift-type names — proves every live type resolves to the expected emoji, and covers hyphen/slash normalisation, keyword ordering (`set up`>`event`, `front of house`>`clean`, `dishwash`>`prep`), exact-vs-keyword precedence, and the default fallback.
3. **Maintenance notes** in both theme files — keywords match live DB names and must stay in sync across web/mobile.

Mobile changes are limited to the maintenance comment (its colours were already lime/teal/violet); the web theme classes are brought into line.

## Type of Change
- [x] 🧪 Tests (adding missing tests)
- [x] 🐛 Bug fix (colour inconsistency between apps)

## Version Bump Required
- `version:patch`

## Testing
- [x] `web/src/lib/shift-themes.test.ts` — 37/37 pass
- [x] `tsc --noEmit` clean for the changed files (pre-existing unrelated errors elsewhere from a stale generated Prisma client in my local env only)

## Context
PR #1008 was squash-merged (`92a7fd7`) while I was preparing these review fixes, so they're shipped here as a small follow-up instead.