### PR TITLE
feat(admin): sync service-night Stripe koha from the Stripe API

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -55,6 +55,11 @@ CAMPAIGN_MONITOR_ANNOUNCEMENT_EMAIL_ID=""
 OPENROUTER_API_KEY=""
 OPENROUTER_MODEL="anthropic/claude-sonnet-4" # optional, this is the default
 
+# Stripe (service-night koha sync — optional; Sync button is disabled when unset)
+# Use a RESTRICTED, READ-ONLY key with read access to: Checkout Sessions,
+# PaymentIntents, and Products/Prices. Use a test key (sk_test_…) for local dev.
+STRIPE_SECRET_KEY=""
+
 # Supabase (for file storage)
 NEXT_PUBLIC_SUPABASE_URL=""
 NEXT_PUBLIC_SUPABASE_ANON_KEY=""

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -73,6 +73,7 @@
         "sanitize-html": "^2.17.5",
         "sharp": "^0.34.5",
         "sonner": "^2.0.7",
+        "stripe": "^22.2.2",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "unpdf": "^1.6.2",
@@ -2864,6 +2865,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@posthog/cli/node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@posthog/cli/node_modules/proxy-from-env": {
@@ -15992,6 +16009,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.2.2",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.2.tgz",
+      "integrity": "sha512-lRXLiarjW/I2QVa6QuFfz1Ma7Dc2yBQ7vlYH6NEmp5htMJNQGfiWExmOv0McfqY5wMCGV8DLuCvsyVRIPJlUUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/style-to-js": {

--- a/web/package.json
+++ b/web/package.json
@@ -93,6 +93,7 @@
     "sanitize-html": "^2.17.5",
     "sharp": "^0.34.5",
     "sonner": "^2.0.7",
+    "stripe": "^22.2.2",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "unpdf": "^1.6.2",

--- a/web/src/app/api/admin/meals-served/route.ts
+++ b/web/src/app/api/admin/meals-served/route.ts
@@ -62,26 +62,29 @@ export async function GET(request: NextRequest) {
       end: endOfDayUTC,
     });
 
-    const mealsRecord = await prisma.mealsServed.findUnique({
-      where: {
-        date_location: {
-          date: startOfDayUTC,
-          location,
+    const [mealsRecord, locationConfig] = await Promise.all([
+      prisma.mealsServed.findUnique({
+        where: {
+          date_location: {
+            date: startOfDayUTC,
+            location,
+          },
         },
-      },
-    });
+      }),
+      prisma.location.findUnique({ where: { name: location } }),
+    ]);
+
+    // Pop-up / special-event venues are koha-manual-only (no Stripe sync).
+    const isPopup = locationConfig?.isPopup ?? false;
 
     // If no record exists, get the default from Location model
     if (!mealsRecord) {
-      const locationConfig = await prisma.location.findUnique({
-        where: { name: location },
-      });
-
       return NextResponse.json({
         mealsServed: null,
         defaultMealsServed: locationConfig?.defaultMealsServed || 60,
         notes: null,
         newVolunteers,
+        isPopup,
       });
     }
 
@@ -89,6 +92,7 @@ export async function GET(request: NextRequest) {
       ...serializeStats(mealsRecord),
       newVolunteers, // live value overrides the stored snapshot
       defaultMealsServed: null,
+      isPopup,
     });
   } catch (error) {
     console.error("Error fetching meals served:", error);

--- a/web/src/app/api/admin/meals-served/stripe-sync/route.ts
+++ b/web/src/app/api/admin/meals-served/stripe-sync/route.ts
@@ -32,13 +32,17 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  // Pop-up / special-event venues are koha-manual-only — koha there isn't taken
-  // through the per-restaurant Stripe products, so never attribute charges to them.
   const locationConfig = await prisma.location.findUnique({
     where: { name: location },
     select: { isPopup: true },
   });
-  if (locationConfig?.isPopup) {
+  if (!locationConfig) {
+    return NextResponse.json({ error: "Location not found" }, { status: 404 });
+  }
+
+  // Pop-up / special-event venues are koha-manual-only — koha there isn't taken
+  // through the per-restaurant Stripe products, so never attribute charges to them.
+  if (locationConfig.isPopup) {
     return NextResponse.json(
       { error: "Stripe sync isn't available for special events — enter koha manually" },
       { status: 422 }

--- a/web/src/app/api/admin/meals-served/stripe-sync/route.ts
+++ b/web/src/app/api/admin/meals-served/stripe-sync/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+import { isStripeConfigured } from "@/lib/stripe";
+import { getStripeKohaForNight } from "@/lib/services/stripe-koha-sync";
+
+// GET - Compute tonight's Stripe koha total for a date + location.
+// Read-only: returns the figure for the admin to review and save manually.
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const date = searchParams.get("date");
+  const location = searchParams.get("location");
+
+  if (!date || !location) {
+    return NextResponse.json(
+      { error: "Date and location are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!isStripeConfigured()) {
+    return NextResponse.json(
+      { error: "Stripe isn't configured yet" },
+      { status: 503 }
+    );
+  }
+
+  // Pop-up / special-event venues are koha-manual-only — koha there isn't taken
+  // through the per-restaurant Stripe products, so never attribute charges to them.
+  const locationConfig = await prisma.location.findUnique({
+    where: { name: location },
+    select: { isPopup: true },
+  });
+  if (locationConfig?.isPopup) {
+    return NextResponse.json(
+      { error: "Stripe sync isn't available for special events — enter koha manually" },
+      { status: 422 }
+    );
+  }
+
+  try {
+    const { total, paymentCount } = await getStripeKohaForNight({
+      date,
+      location,
+    });
+    return NextResponse.json({ total, currency: "nzd", paymentCount });
+  } catch (error) {
+    console.error("Error syncing Stripe koha:", error);
+    return NextResponse.json(
+      { error: "Failed to sync with Stripe" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/components/meals-served-input.tsx
+++ b/web/src/components/meals-served-input.tsx
@@ -113,6 +113,10 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
   // New volunteers are derived from attendance (read-only), not entered.
   const [newVolunteers, setNewVolunteers] = useState<number | null>(null);
   const [weatherLoading, setWeatherLoading] = useState(false);
+  const [stripeSyncing, setStripeSyncing] = useState(false);
+  // Pop-up / special-event venues take koha outside the per-restaurant Stripe
+  // products, so the Stripe field stays manual-only (no Sync) for them.
+  const [isPopupLocation, setIsPopupLocation] = useState(false);
 
   const set = (key: StatKey, value: string) =>
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -175,6 +179,7 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
         setNewVolunteers(
           typeof data.newVolunteers === "number" ? data.newVolunteers : null
         );
+        setIsPopupLocation(data.isPopup === true);
         if (typeof data.defaultMealsServed === "number") {
           setDefaultValue(data.defaultMealsServed);
         }
@@ -227,12 +232,49 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
     }).format(d);
   }, [date]);
 
-  // Placeholder for the future Stripe API integration — the UI is in place but
-  // the figure is still entered manually until the backend sync is built.
-  const handleStripeSync = () => {
-    toast.info("Stripe sync is coming soon", {
-      description: "For now, enter tonight's Stripe total manually.",
-    });
+  // Pull tonight's Stripe koha for this location and fill the field. The figure
+  // is non-destructive — the admin reviews it and saves with the rest of the form.
+  const handleStripeSync = async () => {
+    setStripeSyncing(true);
+    try {
+      const res = await fetch(
+        `/api/admin/meals-served/stripe-sync?date=${date}&location=${encodeURIComponent(
+          location
+        )}`
+      );
+      if (res.status === 503) {
+        toast.info("Stripe isn't connected yet", {
+          description: "Add a Stripe API key to enable syncing.",
+        });
+        return;
+      }
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        toast.error(err?.error || "Couldn't sync with Stripe");
+        return;
+      }
+      const data = await res.json();
+      const total: number = typeof data.total === "number" ? data.total : 0;
+      const count: number =
+        typeof data.paymentCount === "number" ? data.paymentCount : 0;
+
+      if (count === 0) {
+        toast.info("No Stripe koha found for this night", {
+          description: "Nothing to sync — enter manually if needed.",
+        });
+        return;
+      }
+      set("stripe", total.toFixed(2));
+      toast.success(`Synced ${NZD.format(total)} from Stripe`, {
+        description: `Across ${count} payment${
+          count === 1 ? "" : "s"
+        } — review and save.`,
+      });
+    } catch {
+      toast.error("Couldn't sync with Stripe");
+    } finally {
+      setStripeSyncing(false);
+    }
   };
 
   const handleSave = async () => {
@@ -526,22 +568,22 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
             value={form.stripe}
             onChange={(v) => set("stripe", v)}
             action={
-              <div className="flex items-center gap-1.5">
-                <Badge
-                  variant="secondary"
-                  className="h-4 px-1.5 text-[10px] font-medium uppercase tracking-wide"
-                >
-                  Soon
-                </Badge>
+              isPopupLocation ? undefined : (
                 <button
                   type="button"
                   onClick={handleStripeSync}
-                  className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
+                  disabled={stripeSyncing}
+                  aria-label="Sync Stripe koha for this night"
+                  className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100/70 disabled:cursor-default disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
                 >
-                  <RefreshCw className="h-3 w-3" />
-                  Sync
+                  {stripeSyncing ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <RefreshCw className="h-3 w-3" />
+                  )}
+                  {stripeSyncing ? "Syncing…" : "Sync"}
                 </button>
-              </div>
+              )
             }
           />
           <CountField

--- a/web/src/lib/services/stripe-koha-sync.ts
+++ b/web/src/lib/services/stripe-koha-sync.ts
@@ -1,0 +1,99 @@
+import type Stripe from "stripe";
+import { startOfDay, endOfDay } from "date-fns";
+import { parseISOInNZT, toUTC } from "@/lib/timezone";
+import { getStripe } from "@/lib/stripe";
+import {
+  sumNightKoha,
+  type KohaSession,
+  type KohaPaymentIntent,
+  type NightKohaResult,
+} from "@/lib/stripe-koha";
+
+/** Convert a Date to a Stripe `created` filter bound (unix seconds). */
+const toUnix = (d: Date) => Math.floor(d.getTime() / 1000);
+
+/** A line item's product name, when the product is expanded and not deleted. */
+function productName(item: Stripe.LineItem): string | null {
+  const product = item.price?.product;
+  if (product && typeof product === "object" && "name" in product) {
+    return product.name ?? null;
+  }
+  return null;
+}
+
+/**
+ * Pull the Stripe koha for a single service night + location.
+ *
+ * Reads two flows over the NZ-day window (see lib/stripe-koha.ts for why both
+ * carry the location as text):
+ *  - paid Checkout Sessions → product names (via line items)
+ *  - succeeded PaymentIntents → description (pay-at-table)
+ *
+ * `sumNightKoha` dedupes a donation's session against its PaymentIntent and
+ * filters to the requested location. The caller should gate on
+ * {@link import("@/lib/stripe").isStripeConfigured} first.
+ */
+export async function getStripeKohaForNight({
+  date,
+  location,
+}: {
+  date: string; // YYYY-MM-DD (NZ service day)
+  location: string;
+}): Promise<NightKohaResult> {
+  const stripe = getStripe();
+
+  // NZ service-day bounds → UTC → unix seconds for Stripe's `created` filter.
+  const dateNZT = parseISOInNZT(date);
+  const created = {
+    gte: toUnix(toUTC(startOfDay(dateNZT))),
+    lte: toUnix(toUTC(endOfDay(dateNZT))),
+  };
+
+  // 1. Paid Checkout Sessions in the window (all locations; filtered later).
+  const paidSessions: Stripe.Checkout.Session[] = [];
+  for await (const session of stripe.checkout.sessions.list({
+    created,
+    limit: 100,
+  })) {
+    if (session.status === "complete" && session.payment_status === "paid") {
+      paidSessions.push(session);
+    }
+  }
+
+  // Resolve each paid session's product names from its line items. Line items
+  // aren't expandable on the list call, so they're fetched per session.
+  const sessions: KohaSession[] = await Promise.all(
+    paidSessions.map(async (session) => {
+      const lineItems = await stripe.checkout.sessions.listLineItems(
+        session.id,
+        { expand: ["data.price.product"], limit: 100 }
+      );
+      return {
+        id: session.id,
+        amountTotal: session.amount_total,
+        currency: session.currency,
+        paymentIntentId:
+          typeof session.payment_intent === "string"
+            ? session.payment_intent
+            : (session.payment_intent?.id ?? null),
+        productNames: lineItems.data
+          .map(productName)
+          .filter((name): name is string => name !== null),
+      };
+    })
+  );
+
+  // 2. Succeeded PaymentIntents in the window (pay-at-table flow).
+  const paymentIntents: KohaPaymentIntent[] = [];
+  for await (const pi of stripe.paymentIntents.list({ created, limit: 100 })) {
+    if (pi.status !== "succeeded") continue;
+    paymentIntents.push({
+      id: pi.id,
+      amountReceived: pi.amount_received,
+      currency: pi.currency,
+      description: pi.description,
+    });
+  }
+
+  return sumNightKoha({ sessions, paymentIntents }, location);
+}

--- a/web/src/lib/stripe-koha.test.ts
+++ b/web/src/lib/stripe-koha.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import {
+  matchesLocation,
+  centsToDollars,
+  sumNightKoha,
+  type KohaSession,
+  type KohaPaymentIntent,
+} from "./stripe-koha";
+
+describe("stripe-koha", () => {
+  describe("matchesLocation", () => {
+    it("matches an en-dash donation product name", () => {
+      expect(
+        matchesLocation(
+          "You're supporting Everybody Eats – Wellington",
+          "Wellington"
+        )
+      ).toBe(true);
+    });
+
+    it("matches an em-dash pay-at-table description", () => {
+      expect(matchesLocation("Everybody Eats — Glen Innes", "Glen Innes")).toBe(
+        true
+      );
+    });
+
+    it("is case- and whitespace-insensitive", () => {
+      expect(
+        matchesLocation("EVERYBODY   EATS —   onehunga", "Onehunga")
+      ).toBe(true);
+    });
+
+    it("excludes the Special events product from real locations", () => {
+      const name = "You're supporting Everybody Eats - Special events";
+      expect(matchesLocation(name, "Wellington")).toBe(false);
+      expect(matchesLocation(name, "Glen Innes")).toBe(false);
+      expect(matchesLocation(name, "Onehunga")).toBe(false);
+    });
+
+    it("does not match a different location", () => {
+      expect(
+        matchesLocation("Everybody Eats — Wellington", "Onehunga")
+      ).toBe(false);
+    });
+
+    it("returns false for empty text or location", () => {
+      expect(matchesLocation(null, "Wellington")).toBe(false);
+      expect(matchesLocation(undefined, "Wellington")).toBe(false);
+      expect(matchesLocation("Everybody Eats — Wellington", "")).toBe(false);
+    });
+  });
+
+  describe("centsToDollars", () => {
+    it("converts minor units to dollars", () => {
+      expect(centsToDollars(74819)).toBe(748.19);
+      expect(centsToDollars(0)).toBe(0);
+      expect(centsToDollars(500)).toBe(5);
+    });
+  });
+
+  describe("sumNightKoha", () => {
+    const session = (over: Partial<KohaSession>): KohaSession => ({
+      id: "cs_1",
+      amountTotal: 1000,
+      currency: "nzd",
+      paymentIntentId: null,
+      productNames: ["You're supporting Everybody Eats – Wellington"],
+      ...over,
+    });
+    const intent = (over: Partial<KohaPaymentIntent>): KohaPaymentIntent => ({
+      id: "pi_1",
+      amountReceived: 1000,
+      currency: "nzd",
+      description: "Everybody Eats — Wellington",
+      ...over,
+    });
+
+    it("sums donation sessions for the location", () => {
+      const result = sumNightKoha(
+        {
+          sessions: [
+            session({ id: "cs_1", amountTotal: 2500 }),
+            session({ id: "cs_2", amountTotal: 1500 }),
+          ],
+          paymentIntents: [],
+        },
+        "Wellington"
+      );
+      expect(result.totalCents).toBe(4000);
+      expect(result.total).toBe(40);
+      expect(result.paymentCount).toBe(2);
+    });
+
+    it("adds standalone pay-at-table PaymentIntents", () => {
+      const result = sumNightKoha(
+        {
+          sessions: [session({ amountTotal: 2000 })],
+          paymentIntents: [intent({ id: "pi_pat", amountReceived: 3000 })],
+        },
+        "Wellington"
+      );
+      expect(result.totalCents).toBe(5000);
+      expect(result.paymentCount).toBe(2);
+    });
+
+    it("dedupes a PaymentIntent already counted via its Checkout Session", () => {
+      const result = sumNightKoha(
+        {
+          sessions: [
+            session({ amountTotal: 2000, paymentIntentId: "pi_donation" }),
+          ],
+          // Same PI shows up in the PI list — must not be double counted.
+          paymentIntents: [intent({ id: "pi_donation", amountReceived: 2000 })],
+        },
+        "Wellington"
+      );
+      expect(result.totalCents).toBe(2000);
+      expect(result.paymentCount).toBe(1);
+    });
+
+    it("splits payments across locations", () => {
+      const input = {
+        sessions: [
+          session({
+            id: "cs_w",
+            amountTotal: 1000,
+            productNames: ["Everybody Eats – Wellington"],
+          }),
+          session({
+            id: "cs_o",
+            amountTotal: 5000,
+            productNames: ["Everybody Eats – Onehunga"],
+          }),
+        ],
+        paymentIntents: [
+          intent({
+            id: "pi_gi",
+            amountReceived: 700,
+            description: "Everybody Eats — Glen Innes",
+          }),
+        ],
+      };
+      expect(sumNightKoha(input, "Wellington").totalCents).toBe(1000);
+      expect(sumNightKoha(input, "Onehunga").totalCents).toBe(5000);
+      expect(sumNightKoha(input, "Glen Innes").totalCents).toBe(700);
+    });
+
+    it("ignores non-NZD payments", () => {
+      const result = sumNightKoha(
+        {
+          sessions: [session({ amountTotal: 9999, currency: "usd" })],
+          paymentIntents: [
+            intent({ id: "pi_usd", amountReceived: 9999, currency: "usd" }),
+          ],
+        },
+        "Wellington"
+      );
+      expect(result.totalCents).toBe(0);
+      expect(result.paymentCount).toBe(0);
+    });
+
+    it("skips sessions with no amount and unmatched products", () => {
+      const result = sumNightKoha(
+        {
+          sessions: [
+            session({ id: "cs_null", amountTotal: null }),
+            session({
+              id: "cs_other",
+              amountTotal: 1000,
+              productNames: ["Everybody Eats - Special events"],
+            }),
+          ],
+          paymentIntents: [],
+        },
+        "Wellington"
+      );
+      expect(result.totalCents).toBe(0);
+      expect(result.paymentCount).toBe(0);
+    });
+  });
+});

--- a/web/src/lib/stripe-koha.ts
+++ b/web/src/lib/stripe-koha.ts
@@ -1,0 +1,123 @@
+/**
+ * Pure helpers for attributing Stripe payments to an EE service night.
+ *
+ * EE runs a single Stripe account, so a location can't be filtered server-side.
+ * Instead the location name is embedded as text in two flows, both of which
+ * reduce to "a string that contains the location name":
+ *
+ *  1. Donations — a product per restaurant, e.g. the line item's product name
+ *     "You're supporting Everybody Eats – Wellington" (en-dash).
+ *  2. Pay-at-table — a PaymentIntent whose `description` is
+ *     "Everybody Eats — Wellington" (em-dash).
+ *
+ * These helpers contain no network calls so they can be unit-tested in isolation
+ * (mirrors restaurant-stats.ts). The sync service in services/stripe-koha-sync.ts
+ * fetches the raw Stripe objects and feeds plain shapes in here.
+ */
+
+const NZD = "nzd";
+
+/** Normalise a label for matching: lowercase, dashes → '-', collapse whitespace. */
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[–—]/g, "-") // en-dash, em-dash → hyphen
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * True when `text` (a product name or PaymentIntent description) names the given
+ * location. Dash style, casing, and spacing are normalised on both sides, so
+ * "…Everybody Eats – Wellington" and "Everybody Eats — Wellington" both match
+ * the location "Wellington", while "…- Special events" matches no real location.
+ */
+export function matchesLocation(
+  text: string | null | undefined,
+  location: string
+): boolean {
+  if (!text || !location) return false;
+  return normalize(text).includes(normalize(location));
+}
+
+/** Stripe minor units (cents) → dollars. NZD has 2 decimals. */
+export function centsToDollars(amount: number): number {
+  return amount / 100;
+}
+
+/** A paid Checkout Session, flattened to the fields koha attribution needs. */
+export interface KohaSession {
+  id: string;
+  /** Session total in cents (Stripe `amount_total`). */
+  amountTotal: number | null;
+  currency: string | null;
+  /** Underlying PaymentIntent id — used to dedupe against the PI pass. */
+  paymentIntentId: string | null;
+  /** Product names resolved from the session's line items. */
+  productNames: string[];
+}
+
+/** A succeeded PaymentIntent (the pay-at-table flow), flattened. */
+export interface KohaPaymentIntent {
+  id: string;
+  /** Captured amount in cents (Stripe `amount_received`). */
+  amountReceived: number;
+  currency: string | null;
+  description: string | null;
+}
+
+export interface NightKohaInput {
+  /** Every paid Checkout Session in the night's window (all locations). */
+  sessions: KohaSession[];
+  /** Every succeeded PaymentIntent in the night's window (all locations). */
+  paymentIntents: KohaPaymentIntent[];
+}
+
+export interface NightKohaResult {
+  totalCents: number;
+  /** Total koha in dollars. */
+  total: number;
+  /** Number of payments (sessions + intents) attributed to the location. */
+  paymentCount: number;
+}
+
+/**
+ * Sum the koha for one location from already-fetched Stripe objects.
+ *
+ * Dedupe: a donation creates both a Checkout Session and a PaymentIntent, so
+ * every session's `paymentIntentId` is collected first and any PaymentIntent in
+ * that set is skipped — only standalone pay-at-table intents survive the PI pass.
+ * Non-NZD payments are ignored.
+ */
+export function sumNightKoha(
+  input: NightKohaInput,
+  location: string
+): NightKohaResult {
+  let totalCents = 0;
+  let paymentCount = 0;
+
+  // Collect PI ids from ALL paid sessions (every location) before matching, so a
+  // donation's intent can never be double-counted by the PaymentIntent pass.
+  const sessionPaymentIntentIds = new Set<string>();
+  for (const s of input.sessions) {
+    if (s.paymentIntentId) sessionPaymentIntentIds.add(s.paymentIntentId);
+  }
+
+  for (const s of input.sessions) {
+    if (s.amountTotal == null) continue;
+    if (s.currency && s.currency.toLowerCase() !== NZD) continue;
+    if (!s.productNames.some((name) => matchesLocation(name, location))) continue;
+    totalCents += s.amountTotal;
+    paymentCount += 1;
+  }
+
+  for (const pi of input.paymentIntents) {
+    if (sessionPaymentIntentIds.has(pi.id)) continue; // counted via its session
+    if (pi.currency && pi.currency.toLowerCase() !== NZD) continue;
+    if (!matchesLocation(pi.description, location)) continue;
+    totalCents += pi.amountReceived;
+    paymentCount += 1;
+  }
+
+  return { totalCents, total: centsToDollars(totalCents), paymentCount };
+}

--- a/web/src/lib/stripe.ts
+++ b/web/src/lib/stripe.ts
@@ -1,0 +1,34 @@
+import Stripe from "stripe";
+
+/**
+ * Stripe API client — lazily initialised so importing this module never throws
+ * when no key is configured (the sync feature degrades gracefully instead).
+ *
+ * Use a **restricted, read-only** key. The service-night koha sync only needs
+ * read access to Checkout Sessions, PaymentIntents, and Products/Prices.
+ */
+let client: Stripe | null = null;
+
+/** True when a Stripe secret key is present in the environment. */
+export function isStripeConfigured(): boolean {
+  return Boolean(process.env.STRIPE_SECRET_KEY);
+}
+
+/**
+ * Returns the singleton Stripe client. Throws if the key is missing — callers
+ * should gate on {@link isStripeConfigured} first and surface a friendly error.
+ */
+export function getStripe(): Stripe {
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error("STRIPE_SECRET_KEY is not configured");
+  }
+  if (!client) {
+    // apiVersion intentionally omitted — pinned by the installed SDK version.
+    client = new Stripe(key, {
+      typescript: true,
+      appInfo: { name: "everybody-eats-volunteer-portal" },
+    });
+  }
+  return client;
+}


### PR DESCRIPTION
## Description

Makes the Service Night Report's **Sync** button real. It pulls the night's Stripe koha for the selected location from the Stripe API and fills the **Stripe** field — non-destructive, so the admin reviews it and saves with the rest of the report. Previously the button was a "Soon" placeholder and the figure was typed in by hand.

### How location is attributed (the tricky bit)

EE runs a **single Stripe account**, so location can't be filtered server-side. It lives as a *string* in two flows, both handled by one normalised matcher (dash/case/space-insensitive):

1. **Donations** — a product per restaurant (`"You're supporting Everybody Eats – Wellington"`), reachable only via Checkout Session → line item → price → product (charges/PaymentIntents carry no product info, and `line_items` isn't expandable on the sessions *list* — fetched per session).
2. **Pay-at-table** (being built) — PaymentIntents with a `description` like `"Everybody Eats — Wellington"`.

A donation's Checkout Session and its underlying PaymentIntent are **deduped** so nothing is double-counted; non-NZD payments are ignored.

### Special-event / pop-up venues

Venues with `Location.isPopup = true` are **koha-manual-only**: the Sync button is hidden for them, and the sync route refuses them with a `422` backstop. Only the three real restaurants (Glen Innes / Onehunga / Wellington) sync.

### Graceful degradation

No real `STRIPE_SECRET_KEY` is wired yet. Until one is set, the button shows a friendly **"Stripe isn't connected yet"** message (the endpoint returns `503`). No DB schema change — attribution is by string match, nothing new to persist.

**Follow-up for the maintainer:** add a restricted, read-only `STRIPE_SECRET_KEY` (Checkout Sessions / PaymentIntents / Products read). Use an `sk_test_…` key first to validate against the test dashboard, and confirm the pay-at-table flow's `description` format matches `"Everybody Eats — <Location>"`.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Unit tests pass (350/350; 13 new in `stripe-koha.test.ts` covering matching, Special-events exclusion, session/PI dedupe, location split, NZD guard)
- [ ] E2E tests pass
- [x] Manual testing completed
- [x] New tests added (if applicable)

Manual verification (preview, logged in as admin):
- No-key path: clicking **Sync** → `503` → "Stripe isn't connected yet" toast; field left untouched.
- Pop-up venue: temporarily set Wellington `isPopup=true` → Sync button hidden, Stripe field still editable; reverted → button returns.
- Auth guard: unauthenticated request → `403`.
- Typecheck + lint clean.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

New files: `web/src/lib/stripe.ts` (lazy client + `isStripeConfigured()`), `web/src/lib/stripe-koha.ts` (+ tests, pure helpers), `web/src/lib/services/stripe-koha-sync.ts` (Stripe fetch), `web/src/app/api/admin/meals-served/stripe-sync/route.ts` (ADMIN GET). `STRIPE_SECRET_KEY` added to `.env.example`. Sums gross of refunds for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)