### PR TITLE
fix(mobile): remove media-library permissions for Play policy compliance

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Everybody Eats",
     "slug": "everybody-eats",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "everybody-eats",
@@ -36,7 +36,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "permissions": ["android.permission.READ_MEDIA_VISUAL_USER_SELECTED"],
+      "permissions": [],
       "intentFilters": [
         {
           "action": "VIEW",
@@ -85,14 +85,6 @@
         {
           "color": "#0e3a23",
           "defaultChannel": "default"
-        }
-      ],
-      [
-        "expo-media-library",
-        {
-          "photosPermission": "Allow Everybody Eats to save shift photos to your library.",
-          "savePhotosPermission": "Allow Everybody Eats to save shift photos to your library.",
-          "isAccessMediaLocationEnabled": false
         }
       ],
       [

--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -206,15 +206,8 @@ export default function ProfileScreen() {
       }
       result = await ImagePicker.launchCameraAsync(common);
     } else {
-      const { status } =
-        await ImagePicker.requestMediaLibraryPermissionsAsync();
-      if (status !== "granted") {
-        Alert.alert(
-          "Photos access needed",
-          "Please enable photo library access in Settings to choose a profile photo."
-        );
-        return;
-      }
+      // Uses the system photo picker (Android Photo Picker / iOS PHPicker),
+      // which requires no media-library permission.
       result = await ImagePicker.launchImageLibraryAsync(common);
     }
 

--- a/mobile/app/profile/edit.tsx
+++ b/mobile/app/profile/edit.tsx
@@ -312,15 +312,8 @@ export default function EditProfileScreen() {
       }
       result = await ImagePicker.launchCameraAsync(common);
     } else {
-      const { status } =
-        await ImagePicker.requestMediaLibraryPermissionsAsync();
-      if (status !== "granted") {
-        Alert.alert(
-          "Photos access needed",
-          "Please enable photo library access in Settings to choose a profile photo."
-        );
-        return;
-      }
+      // Uses the system photo picker (Android Photo Picker / iOS PHPicker),
+      // which requires no media-library permission.
       result = await ImagePicker.launchImageLibraryAsync(common);
     }
 

--- a/mobile/components/image-viewer.tsx
+++ b/mobile/components/image-viewer.tsx
@@ -1,7 +1,6 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as FileSystem from "expo-file-system";
 import * as Haptics from "expo-haptics";
-import * as MediaLibrary from "expo-media-library";
 import * as Sharing from "expo-sharing";
 import { useCallback, useState } from "react";
 import {
@@ -70,7 +69,7 @@ function ViewerOverlay({
 }) {
   const insets = useSafeAreaInsets();
   const { currentIndex, totalCount } = useGestureViewerState();
-  const [busy, setBusy] = useState<null | "share" | "save">(null);
+  const [busy, setBusy] = useState<null | "share">(null);
 
   const currentUri = images[currentIndex] ?? images[0];
 
@@ -101,30 +100,6 @@ function ViewerOverlay({
       });
     } catch {
       Alert.alert("Couldn't share", "Please try again.");
-    } finally {
-      setBusy(null);
-    }
-  }, [busy, currentUri, downloadToCache]);
-
-  const handleSave = useCallback(async () => {
-    if (busy || !currentUri) return;
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setBusy("save");
-    try {
-      const permission = await MediaLibrary.requestPermissionsAsync(true);
-      if (!permission.granted) {
-        Alert.alert(
-          "Permission needed",
-          "Please allow photo library access to save this image."
-        );
-        return;
-      }
-      const localUri = await downloadToCache(currentUri);
-      await MediaLibrary.saveToLibraryAsync(localUri);
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-      Alert.alert("Saved", "Photo saved to your library.");
-    } catch {
-      Alert.alert("Couldn't save", "Please try again.");
     } finally {
       setBusy(null);
     }
@@ -193,24 +168,6 @@ function ViewerOverlay({
             />
           )}
           <Text style={styles.actionLabel}>Share</Text>
-        </Pressable>
-
-        <Pressable
-          onPress={handleSave}
-          disabled={busy !== null}
-          style={({ pressed }) => [
-            styles.actionButton,
-            { opacity: pressed ? 0.7 : 1 },
-          ]}
-          accessibilityLabel="Save photo to library"
-          accessibilityRole="button"
-        >
-          {busy === "save" ? (
-            <ActivityIndicator color="#fff" />
-          ) : (
-            <Ionicons name="download-outline" size={24} color="#fff" />
-          )}
-          <Text style={styles.actionLabel}>Save</Text>
         </Pressable>
       </View>
     </>

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -37,7 +37,6 @@
         "expo-linear-gradient": "~55.0.13",
         "expo-linking": "~55.0.14",
         "expo-localization": "~55.0.13",
-        "expo-media-library": "~55.0.15",
         "expo-notifications": "~55.0.20",
         "expo-router": "~55.0.13",
         "expo-secure-store": "~55.0.13",
@@ -7225,16 +7224,6 @@
       },
       "peerDependencies": {
         "expo": "*"
-      }
-    },
-    "node_modules/expo-media-library": {
-      "version": "55.0.15",
-      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-55.0.15.tgz",
-      "integrity": "sha512-VD2Lppq0JR6TeI4ivVGsbz4UJ+hKD0DSB/P+I0eoOpoOcLc3/5WboDKgy2uW8YYZqee55V+JU7TMdRDi+lTnCg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react-native": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -48,7 +48,6 @@
     "expo-linear-gradient": "~55.0.13",
     "expo-linking": "~55.0.14",
     "expo-localization": "~55.0.13",
-    "expo-media-library": "~55.0.15",
     "expo-notifications": "~55.0.20",
     "expo-router": "~55.0.13",
     "expo-secure-store": "~55.0.13",


### PR DESCRIPTION
# Pull Request

## Description
Google Play rejected the Android submission under the **Photo and Video Permissions policy** for `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO`. These were never declared in `app.json` — they were injected into the merged Android manifest by the **`expo-media-library`** config plugin. The only consumer was the write-only **"Save to gallery"** button in the photo viewer, which is exactly the infrequent/one-time access the policy disallows.

This PR removes `expo-media-library` entirely and keeps the profile-photo picker (already compliant via the system photo picker).

### Changes
- **Remove `expo-media-library`** — dependency (`package.json` / lockfile), the `app.json` plugin entry, and the Save button + handler in `components/image-viewer.tsx`. Sharing still works via `expo-sharing`.
- **Empty `android.permissions`** — drops the now-unneeded `READ_MEDIA_VISUAL_USER_SELECTED`.
- **Stop gating `launchImageLibraryAsync` behind `requestMediaLibraryPermissionsAsync()`** in `app/(tabs)/profile.tsx` and `app/profile/edit.tsx`. This was necessary, not cosmetic: the system photo picker needs no permission, and once `READ_MEDIA_*` is gone from the manifest that runtime request returns "denied" and would break the picker. The camera path keeps its `CAMERA` permission check.
- **Bump mobile version** `1.0.5 → 1.0.6`.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
- [x] `version:skip` — mobile-only change; does not affect the `web/` app version.

## Testing
- [x] `tsc --noEmit` passes for the mobile app (0 errors)
- [x] Manual review of picker + photo-viewer flows
- [ ] E2E tests (web only; not applicable to mobile)

## Additional Notes
- Builds **1.0.6** (Android versionCode 9, iOS build 43) have already been queued on EAS with auto-submit (Android internal/draft, iOS App Store Connect) to verify the rejection is resolved.
- `expo-image-picker` (profile photos) was already compliant — `launchImageLibraryAsync` uses the Android Photo Picker / iOS PHPicker and adds no media permissions.
- Per Google's notice, the permission must be gone from **all tracks** in the rejected submission before resubmitting for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)