### PR TITLE
fix(notifications): deep-link shift shortage notifications to the day

### DIFF
--- a/mobile/lib/notification-routing.ts
+++ b/mobile/lib/notification-routing.ts
@@ -77,6 +77,17 @@ export function navigateToNotificationTarget(actionUrl: unknown) {
     return;
   }
 
+  // /shifts/details?date=YYYY-MM-DD -> shifts tab focused on that day.
+  // Shortage notifications deep-link here; the shifts tab honours ?date=.
+  // (location isn't forwarded — the tab applies the user's own filter.)
+  if (pathname === "/shifts/details") {
+    const date = query.get("date");
+    router.push(
+      date ? { pathname: "/(tabs)/shifts", params: { date } } : "/(tabs)/shifts"
+    );
+    return;
+  }
+
   // /shifts or /shifts/mine -> shifts tab
   if (pathname === "/shifts" || pathname.startsWith("/shifts/")) {
     router.push("/(tabs)/shifts");

--- a/web/src/app/api/admin/notifications/send-shortage/route.ts
+++ b/web/src/app/api/admin/notifications/send-shortage/route.ts
@@ -164,14 +164,30 @@ export async function POST(request: Request) {
 
     if (notifiedUserIds.length > 0) {
       const firstShift = shiftsForEmail[0];
+      // Shortage notifications always cover a single day, so multi-shift
+      // notifications can deep-link to that date's shift list. Include the
+      // location too when every shift shares one.
+      const allSameLocation = shiftsForEmail.every(
+        (s) => s.location === firstShift.location
+      );
+      const dateLink = `/shifts/details?date=${firstShift.shiftDateISO}${
+        allSameLocation
+          ? `&location=${encodeURIComponent(firstShift.location)}`
+          : ""
+      }`;
+
       const pushTitle =
         shifts.length === 1
           ? `Shift needs volunteers: ${firstShift.shiftName}`
-          : `${shifts.length} shifts need volunteers`;
+          : `${shifts.length} shifts need volunteers on ${firstShift.shiftDate}`;
       const pushMessage =
         shifts.length === 1
           ? `${firstShift.shiftName} on ${firstShift.shiftDate} at ${firstShift.location} — ${firstShift.neededVolunteers} more needed.`
-          : `Tap to see ${shifts.length} shifts across our locations that still need cover.`;
+          : `${firstShift.shiftDate}: ${shifts.length} shifts ${
+              allSameLocation
+                ? `at ${firstShift.location} `
+                : "across our locations "
+            }still need cover. Tap to help out.`;
 
       await createNotificationsForUsers({
         userIds: notifiedUserIds,
@@ -179,7 +195,7 @@ export async function POST(request: Request) {
         title: pushTitle,
         message: pushMessage,
         actionUrl:
-          shifts.length === 1 ? `/shifts/${firstShift.shiftId}` : "/shifts",
+          shifts.length === 1 ? `/shifts/${firstShift.shiftId}` : dateLink,
       });
     }
 

--- a/web/src/lib/email-service.ts
+++ b/web/src/lib/email-service.ts
@@ -800,8 +800,17 @@ class EmailService {
       spotsNeeded: String(shift.neededVolunteers),
     }));
 
-    // Build shifts page link with date and location from first shift
-    const shiftsPageLink = `${getBaseUrl()}/shifts/details?date=${firstShift.shiftDateISO}&location=${encodeURIComponent(firstShift.location)}`;
+    // Build shifts page link for the shortage day. Only pin the location when
+    // every shift shares one — otherwise the link would wrongly filter a
+    // multi-location send down to the first shift's location.
+    const allSameLocation = params.shifts.every(
+      (s) => s.location === firstShift.location
+    );
+    const shiftsPageLink = `${getBaseUrl()}/shifts/details?date=${firstShift.shiftDateISO}${
+      allSameLocation
+        ? `&location=${encodeURIComponent(firstShift.location)}`
+        : ""
+    }`;
 
     const emailData: ShiftShortageEmailData = {
       firstName,


### PR DESCRIPTION
## What changed

Shift shortage notifications now point volunteers to the **specific day** the shortage is for, instead of dumping them on the generic shifts page with a vague message.

A shortage send can cover multiple shifts, but it's **always for a single day**. Previously, multi-shift notifications:
- linked to `/shifts` (the location picker — no date context)
- said only *"Tap to see N shifts across our locations that still need cover."*

Now multi-shift notifications:
- **link to that date's shift list** — `/shifts/details?date=2026-02-08&location=Auckland` (the same deep-link pattern the shortage email already uses). Location is appended only when every shift shares one; otherwise just the date.
- **include the date** in the title and message, e.g.
  - Title: `3 shifts need volunteers on Saturday, February 8, 2026`
  - Message: `Saturday, February 8, 2026: 3 shifts at Auckland still need cover. Tap to help out.` (falls back to *"across our locations"* when shifts span multiple sites)

Single-shift notifications are **unchanged** — they already linked to `/shifts/{id}` and named the date.

## Why

Clicking a shortage notification took volunteers to the generic shifts page rather than the relevant date, and the message gave no indication of which day needed cover.

## Reviewer notes

- The multi-shift link drops the location query param when shifts span multiple locations, since `/shifts/details` filters to one location — the date alone still scopes it correctly.
- The deep-link target matches the `/shifts/details?date=...` link already used in the shortage **email**, so in-app/push and email now agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)