### PR TITLE
feat(seo): per-city volunteer landing pages (/volunteer, /volunteer/[city])

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ Uses **motion.dev** — not CSS animations. All variants in `src/lib/motion.ts`.
 ### SEO
 
 - Sitemap: `src/app/sitemap.ts`, Robots: `src/app/robots.ts`, Metadata: `src/lib/seo.ts`
-- Public pages (indexable): `/`, `/login`, `/register`, `/shifts`, `/resources`
+- Public pages (indexable): `/`, `/login`, `/register`, `/shifts`, `/resources`, `/volunteer`, `/volunteer/[city]`
 - Private pages (noindex): `/dashboard`, `/profile`, `/admin/*`, `/api/*`
 - Use `buildPageMetadata()` from `@/lib/seo` for new public pages
 

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -8,7 +8,14 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: ["/", "/login", "/register", "/shifts", "/resources"],
+        allow: [
+          "/",
+          "/login",
+          "/register",
+          "/shifts",
+          "/resources",
+          "/volunteer",
+        ],
         disallow: [
           "/api/",
           "/dashboard",

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from "next";
 import { getBaseUrl } from "@/lib/utils";
 import { prisma } from "@/lib/prisma";
+import { VOLUNTEER_LOCATIONS } from "@/lib/volunteer-locations";
 
 // Regenerate at most once per hour. Shifts can be created/edited frequently
 // but search engines don't fetch sitemaps often enough to need fresher data.
@@ -41,30 +42,25 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/volunteer`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
   ];
 
-  // Get unique locations from shift types for location-specific pages
-  // These help with local SEO (e.g., "volunteer Wellington")
-  const locations = await prisma.shift.findMany({
-    distinct: ["location"],
-    where: {
-      location: { not: null },
-      start: { gte: new Date() }, // Only include locations with upcoming shifts
-    },
-    select: {
-      location: true,
-    },
-  });
-
-  // Dynamic location pages
-  const locationPages: MetadataRoute.Sitemap = locations
-    .filter((item) => item.location)
-    .map((item) => ({
-      url: `${baseUrl}/shifts?location=${encodeURIComponent(item.location!)}`,
+  // Per-city volunteer landing pages — real indexable pages that target
+  // "volunteering <city>" searches (replacing the old `?location=` query-param
+  // URLs, which search engines largely ignore as distinct pages).
+  const locationPages: MetadataRoute.Sitemap = VOLUNTEER_LOCATIONS.map(
+    (loc) => ({
+      url: `${baseUrl}/volunteer/${loc.slug}`,
       lastModified: new Date(),
-      changeFrequency: "daily" as const,
-      priority: 0.7, // Lower priority than main shifts page
-    }));
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+    })
+  );
 
   // Individual shift detail pages — filter on `end` rather than `start` so
   // Postgres can use the existing @@index([end]) on Shift. Shifts currently

--- a/web/src/app/volunteer/[location]/page.tsx
+++ b/web/src/app/volunteer/[location]/page.tsx
@@ -13,6 +13,7 @@ import { buildPageMetadata, buildVolunteerLocationSchema } from "@/lib/seo";
 import {
   VOLUNTEER_LOCATIONS,
   VOLUNTEER_ROLES,
+  PREVIEW_SHIFT_COUNT,
   getVolunteerLocation,
   getUpcomingShiftCount,
   getUpcomingShifts,
@@ -100,7 +101,11 @@ function ShiftCard({
           </p>
           <span
             aria-label={
-              isFull ? "This shift is full — join the waitlist" : undefined
+              isFull
+                ? "This shift is full — join the waitlist"
+                : `${shift.spotsAvailable} ${
+                    shift.spotsAvailable === 1 ? "spot" : "spots"
+                  } available for this shift`
             }
             className={`rounded-full px-3 py-1 text-xs font-medium ${
               isFull
@@ -166,10 +171,18 @@ export default async function VolunteerLocationPage({
   const loc = getVolunteerLocation(location);
   if (!loc) notFound();
 
-  const [shiftCount, upcomingShifts] = await Promise.all([
-    getUpcomingShiftCount(loc.shiftLocations),
-    getUpcomingShifts(loc.shiftLocations, 6),
-  ]);
+  const upcomingShifts = await getUpcomingShifts(
+    loc.shiftLocations,
+    PREVIEW_SHIFT_COUNT
+  );
+  // When the city has fewer than a full preview's worth of shifts, the list IS
+  // the total — skip the extra count query (and avoid the two cached values
+  // drifting). Only when the preview is full do we fetch the real total for the
+  // "See N upcoming shifts" CTA.
+  const shiftCount =
+    upcomingShifts.length < PREVIEW_SHIFT_COUNT
+      ? upcomingShifts.length
+      : await getUpcomingShiftCount(loc.shiftLocations);
   const faqs = buildFaqs(loc);
   const schema = buildVolunteerLocationSchema({
     city: loc.city,

--- a/web/src/app/volunteer/[location]/page.tsx
+++ b/web/src/app/volunteer/[location]/page.tsx
@@ -99,6 +99,9 @@ function ShiftCard({
             {shift.dateLabel}
           </p>
           <span
+            aria-label={
+              isFull ? "This shift is full — join the waitlist" : undefined
+            }
             className={`rounded-full px-3 py-1 text-xs font-medium ${
               isFull
                 ? "bg-forest-500/10 text-forest-700/70 dark:bg-cream-50/10 dark:text-cream-50/60"
@@ -262,6 +265,7 @@ export default async function VolunteerLocationPage({
                         href={venueMapsUrl(venue)}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`${venue.name} — ${venue.address} (opens map in new tab)`}
                         className="group flex items-start gap-3"
                       >
                         <MapPinIcon className="mt-0.5 h-5 w-5 shrink-0 text-forest-500 dark:text-forest-200" />

--- a/web/src/app/volunteer/[location]/page.tsx
+++ b/web/src/app/volunteer/[location]/page.tsx
@@ -1,0 +1,404 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  HomePageWrapper,
+  HeroContent,
+  FeatureCard,
+  FeatureGrid,
+} from "@/components/home-animated";
+import { HeroImageCycler } from "@/components/hero-image-cycler";
+import { HERO_IMAGES } from "@/components/hero-images";
+import { buildPageMetadata, buildVolunteerLocationSchema } from "@/lib/seo";
+import {
+  VOLUNTEER_LOCATIONS,
+  VOLUNTEER_ROLES,
+  getVolunteerLocation,
+  getUpcomingShiftCount,
+  getUpcomingShifts,
+  venueMapsUrl,
+  type VolunteerLocation,
+  type UpcomingShift,
+} from "@/lib/volunteer-locations";
+
+// Pre-render every city page at build time (and refresh ISR-style via the
+// cached shift count). Unknown slugs fall through to notFound() in the page.
+export function generateStaticParams() {
+  return VOLUNTEER_LOCATIONS.map((l) => ({ location: l.slug }));
+}
+
+type Params = { location: string };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { location } = await params;
+  const loc = getVolunteerLocation(location);
+  if (!loc) return buildPageMetadata({ title: "Volunteer", description: "", path: "/volunteer", noIndex: true });
+
+  return buildPageMetadata({
+    title: `Volunteer in ${loc.city}`,
+    description: `Volunteer with Everybody Eats in ${loc.city}. Help turn rescued food into quality three-course meals on a pay-what-you-can basis — flexible shifts, no experience needed. Sign up today.`,
+    path: `/volunteer/${loc.slug}`,
+  });
+}
+
+const pill =
+  "inline-flex items-center justify-center rounded-full px-7 py-3.5 text-sm font-medium transition-all duration-200";
+const pillPrimary = `${pill} bg-forest-500 text-cream-50 hover:bg-forest-600 hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0`;
+const pillGhost = `${pill} border border-forest-500/30 text-forest-700 hover:bg-forest-700 hover:text-cream-50 hover:border-forest-700 dark:border-cream-50/30 dark:text-cream-50 dark:hover:bg-cream-50 dark:hover:text-forest-700`;
+const eyebrowLight = "eyebrow text-forest-500/80 dark:text-cream-50/60";
+
+function Highlight({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="relative inline-block">
+      {children}
+      <span
+        className="absolute -bottom-1 sm:-bottom-2 left-0 right-0 h-2 sm:h-3 bg-sun-200 -z-10 rounded-full dark:bg-sun-200/70"
+        aria-hidden
+      />
+    </span>
+  );
+}
+
+function MapPinIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden className={className}>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a2 2 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+      <circle cx="12" cy="11" r="3" strokeWidth={2} />
+    </svg>
+  );
+}
+
+/** A single real, bookable shift — role, when, where and spots left. */
+function ShiftCard({
+  shift,
+  delay,
+  showVenue,
+}: {
+  shift: UpcomingShift;
+  delay: number;
+  showVenue: boolean;
+}) {
+  const isFull = shift.spotsAvailable <= 0;
+
+  return (
+    <FeatureCard
+      delay={delay}
+      className="grain rounded-[2rem] border border-forest-500/10 bg-cream-100 dark:border-cream-50/10 dark:bg-forest-800/60"
+    >
+      <Link
+        href={`/shifts/${shift.id}`}
+        className="block p-8"
+        data-testid="volunteer-shift-card"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <p className="font-mono text-xs tracking-[0.2em] text-forest-500/70 dark:text-cream-50/50">
+            {shift.dateLabel}
+          </p>
+          <span
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              isFull
+                ? "bg-forest-500/10 text-forest-700/70 dark:bg-cream-50/10 dark:text-cream-50/60"
+                : "bg-sun-200 text-forest-700"
+            }`}
+          >
+            {isFull
+              ? "Waitlist"
+              : `${shift.spotsAvailable} ${
+                  shift.spotsAvailable === 1 ? "spot" : "spots"
+                } left`}
+          </span>
+        </div>
+        <h3 className="display display-medium mt-5 text-2xl tracking-tight text-forest-700 dark:text-cream-50">
+          {shift.role}
+        </h3>
+        <p className="mt-2 text-forest-700/75 dark:text-cream-50/70">
+          {shift.timeLabel}
+          {showVenue ? ` · ${shift.venue}` : ""}
+        </p>
+      </Link>
+    </FeatureCard>
+  );
+}
+
+function buildFaqs(loc: VolunteerLocation) {
+  const venueList =
+    loc.venues.length > 1
+      ? loc.venues.map((v) => v.name).join(" and ")
+      : loc.venues[0].name;
+  return [
+    {
+      question: `Do I need experience to volunteer in ${loc.city}?`,
+      answer:
+        "No experience or qualifications are needed. Our team shows you everything on the night, and there's a role to suit everyone — from the kitchen to the dining room.",
+    },
+    {
+      question: `Where is Everybody Eats in ${loc.city}?`,
+      answer: `You'll find us at ${loc.venues
+        .map((v) => `${v.name} (${v.address})`)
+        .join(", ")}.`,
+    },
+    {
+      question: "How much time do I need to commit?",
+      answer:
+        "Volunteering is flexible — pick a single shift that suits you or come back regularly. There's no long-term commitment required.",
+    },
+    {
+      question: `How do I sign up to volunteer in ${venueList}?`,
+      answer:
+        "Create a free account on the Everybody Eats volunteer portal, browse upcoming shifts and book the ones that fit your schedule.",
+    },
+  ];
+}
+
+export default async function VolunteerLocationPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { location } = await params;
+  const loc = getVolunteerLocation(location);
+  if (!loc) notFound();
+
+  const [shiftCount, upcomingShifts] = await Promise.all([
+    getUpcomingShiftCount(loc.shiftLocations),
+    getUpcomingShifts(loc.shiftLocations, 6),
+  ]);
+  const faqs = buildFaqs(loc);
+  const schema = buildVolunteerLocationSchema({
+    city: loc.city,
+    slug: loc.slug,
+    intro: loc.intro,
+    venues: loc.venues,
+    faqs,
+  });
+
+  const shiftsHref =
+    loc.venues.length === 1
+      ? `/shifts?location=${encodeURIComponent(loc.venues[0].name)}`
+      : "/shifts";
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      />
+      <HomePageWrapper data-testid="volunteer-location-page">
+        {/* ============ Hero ============ */}
+        <section
+          className="grain relative overflow-hidden pb-16 pt-10 sm:pb-24 sm:pt-16"
+          data-testid="volunteer-hero"
+        >
+          <div className="mx-auto grid max-w-[88rem] items-end gap-10 px-5 sm:px-8 lg:grid-cols-12 lg:gap-12 lg:px-12">
+            <HeroContent className="relative z-10 lg:col-span-7">
+              <p className={`${eyebrowLight} mb-6 flex items-center gap-3`}>
+                <span className="inline-block h-px w-8 bg-forest-500/50 dark:bg-cream-50/40" />
+                <Link href="/volunteer" className="hover:underline">
+                  Volunteer
+                </Link>
+                <span aria-hidden>·</span>
+                {loc.reoName}
+              </p>
+              <h1
+                className="display text-5xl leading-[0.98] tracking-tight text-forest-700 sm:text-6xl lg:text-7xl dark:text-cream-50"
+                data-testid="volunteer-hero-title"
+              >
+                Volunteer in{" "}
+                <Highlight>{loc.city}</Highlight>
+              </h1>
+              <p className="mt-8 max-w-2xl text-lg leading-relaxed text-forest-700/85 sm:text-xl dark:text-cream-50/85">
+                {loc.intro}
+              </p>
+              <div className="mt-10 flex flex-col gap-3 sm:flex-row sm:items-center">
+                <Link href="/register" className={`${pillPrimary} text-base`} data-testid="volunteer-cta-register">
+                  Sign up to volunteer
+                </Link>
+                <Link href={shiftsHref} className={pillGhost} data-testid="volunteer-cta-shifts">
+                  {shiftCount > 0
+                    ? `See ${shiftCount} upcoming shift${shiftCount === 1 ? "" : "s"}`
+                    : "Browse shifts"}
+                </Link>
+              </div>
+            </HeroContent>
+
+            <HeroContent className="relative hidden md:block lg:col-span-5">
+              <div className="group relative aspect-[4/5] overflow-hidden rounded-[3rem] shadow-2xl">
+                <HeroImageCycler images={HERO_IMAGES} />
+              </div>
+            </HeroContent>
+          </div>
+        </section>
+
+        {/* ============ About + venues ============ */}
+        <section
+          className="mx-auto max-w-[88rem] px-5 pb-20 sm:px-8 sm:pb-24 lg:px-12"
+          data-testid="volunteer-about"
+        >
+          <div className="grid gap-12 lg:grid-cols-12">
+            <div className="lg:col-span-7">
+              <h2 className="display text-3xl tracking-tight text-forest-700 sm:text-5xl dark:text-cream-50">
+                Good kai, good <em>company</em>
+              </h2>
+              <p className="mt-6 text-lg leading-relaxed text-forest-700/80 dark:text-cream-50/75">
+                {loc.about}
+              </p>
+              <p className="mt-4 text-lg leading-relaxed text-forest-700/80 dark:text-cream-50/75">
+                {loc.gettingThere}
+              </p>
+            </div>
+            <div className="lg:col-span-5">
+              <div className="grain rounded-[2rem] border border-forest-500/10 bg-cream-100 p-8 dark:border-cream-50/10 dark:bg-forest-800/60">
+                <p className={`${eyebrowLight} mb-5`}>
+                  Our {loc.city} {loc.venues.length === 1 ? "restaurant" : "restaurants"}
+                </p>
+                <ul className="space-y-5">
+                  {loc.venues.map((venue) => (
+                    <li key={venue.name}>
+                      <a
+                        href={venueMapsUrl(venue)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group flex items-start gap-3"
+                      >
+                        <MapPinIcon className="mt-0.5 h-5 w-5 shrink-0 text-forest-500 dark:text-forest-200" />
+                        <span>
+                          <span className="block font-accent text-lg font-medium text-forest-700 group-hover:underline dark:text-cream-50">
+                            {venue.name}
+                          </span>
+                          <span className="block text-sm text-forest-700/70 dark:text-cream-50/65">
+                            {venue.address}
+                          </span>
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ============ Roles ============ */}
+        <section
+          className="mx-auto max-w-[88rem] px-5 pb-20 sm:px-8 sm:pb-24 lg:px-12"
+          data-testid="volunteer-roles"
+        >
+          <div className="mb-12">
+            <p className={`${eyebrowLight} mb-4 flex items-center gap-3`}>
+              <span className="inline-block h-px w-8 bg-forest-500/50 dark:bg-cream-50/40" />
+              {upcomingShifts.length > 0 ? "What's coming up" : "Ways to help"}
+            </p>
+            <h2 className="display max-w-3xl text-4xl tracking-tight text-forest-700 sm:text-6xl dark:text-cream-50">
+              Find your <em>role</em> in {loc.city}
+            </h2>
+            {upcomingShifts.length > 0 && (
+              <p className="mt-5 max-w-2xl text-lg leading-relaxed text-forest-700/80 dark:text-cream-50/75">
+                From the kitchen to the dining room — here are the next shifts
+                you can book in {loc.city}. Tap one to see the details and sign
+                up.
+              </p>
+            )}
+          </div>
+
+          {upcomingShifts.length > 0 ? (
+            <>
+              <FeatureGrid className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {upcomingShifts.map((shift, i) => (
+                  <ShiftCard
+                    key={shift.id}
+                    shift={shift}
+                    delay={0.1 + i * 0.06}
+                    showVenue={loc.venues.length > 1}
+                  />
+                ))}
+              </FeatureGrid>
+              <div className="mt-10">
+                <Link href={shiftsHref} className={pillGhost} data-testid="volunteer-see-all-shifts">
+                  See all {loc.city} shifts
+                </Link>
+              </div>
+            </>
+          ) : (
+            <FeatureGrid className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+              {VOLUNTEER_ROLES.map((role, i) => (
+                <FeatureCard
+                  key={role.title}
+                  delay={0.1 + i * 0.08}
+                  className="grain rounded-[2rem] border border-forest-500/10 bg-cream-100 p-8 dark:border-cream-50/10 dark:bg-forest-800/60"
+                >
+                  <p className="font-mono text-xs tracking-[0.2em] text-forest-500/70 dark:text-cream-50/50">
+                    0{i + 1}
+                  </p>
+                  <h3 className="display display-medium mt-5 text-2xl tracking-tight text-forest-700 dark:text-cream-50">
+                    {role.title}
+                  </h3>
+                  <p className="mt-3 leading-relaxed text-forest-700/80 dark:text-cream-50/75">
+                    {role.copy}
+                  </p>
+                </FeatureCard>
+              ))}
+            </FeatureGrid>
+          )}
+        </section>
+
+        {/* ============ FAQ ============ */}
+        <section
+          className="mx-auto max-w-[88rem] px-5 pb-20 sm:px-8 sm:pb-24 lg:px-12"
+          data-testid="volunteer-faq"
+        >
+          <div className="mb-12">
+            <p className={`${eyebrowLight} mb-4 flex items-center gap-3`}>
+              <span className="inline-block h-px w-8 bg-forest-500/50 dark:bg-cream-50/40" />
+              Good to know
+            </p>
+            <h2 className="display text-4xl tracking-tight text-forest-700 sm:text-6xl dark:text-cream-50">
+              Questions, <em>answered</em>
+            </h2>
+          </div>
+          <dl className="mx-auto grid max-w-4xl gap-px overflow-hidden rounded-3xl bg-forest-500/15 ring-1 ring-forest-500/15 dark:bg-cream-50/15 dark:ring-cream-50/15">
+            {faqs.map((faq) => (
+              <div key={faq.question} className="bg-background p-8">
+                <dt className="display display-medium text-xl tracking-tight text-forest-700 dark:text-cream-50">
+                  {faq.question}
+                </dt>
+                <dd className="mt-3 leading-relaxed text-forest-700/80 dark:text-cream-50/75">
+                  {faq.answer}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        {/* ============ Final CTA ============ */}
+        <section
+          className="mx-auto max-w-[88rem] px-5 pb-24 sm:px-8 sm:pb-32 lg:px-12"
+          data-testid="volunteer-cta-section"
+        >
+          <div className="grain relative overflow-hidden rounded-[3rem] bg-sun-200 px-8 py-16 text-center text-forest-700 sm:px-16 sm:py-20 dark:bg-sun-200/90">
+            <div className="relative mx-auto max-w-2xl">
+              <h2 className="display text-4xl tracking-tight sm:text-6xl">
+                Ready to join the <em>{loc.city}</em> whānau?
+              </h2>
+              <p className="mt-6 text-lg leading-relaxed text-forest-700/85">
+                Ka pai! Create your free account and book your first shift — we&rsquo;d
+                love to have you.
+              </p>
+              <div className="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
+                <Link href="/register" className={`${pillPrimary} text-base`}>
+                  Get started
+                </Link>
+                <Link href={shiftsHref} className={`${pill} border border-forest-700/30 text-forest-700 hover:bg-forest-700 hover:text-cream-50`}>
+                  Browse shifts
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      </HomePageWrapper>
+    </>
+  );
+}

--- a/web/src/app/volunteer/page.tsx
+++ b/web/src/app/volunteer/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  HomePageWrapper,
+  HeroContent,
+  FeatureCard,
+  FeatureGrid,
+} from "@/components/home-animated";
+import { buildPageMetadata } from "@/lib/seo";
+import { VOLUNTEER_LOCATIONS } from "@/lib/volunteer-locations";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Volunteer in Wellington & Auckland",
+  description:
+    "Volunteer with Everybody Eats across Aotearoa. Help turn rescued food into quality three-course meals on a pay-what-you-can basis in Wellington and Auckland — flexible shifts, no experience needed.",
+  path: "/volunteer",
+});
+
+const pill =
+  "inline-flex items-center justify-center rounded-full px-7 py-3.5 text-sm font-medium transition-all duration-200";
+const pillPrimary = `${pill} bg-forest-500 text-cream-50 hover:bg-forest-600 hover:-translate-y-0.5 hover:shadow-lg active:translate-y-0`;
+const eyebrowLight = "eyebrow text-forest-500/80 dark:text-cream-50/60";
+
+function Arrow({ className }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+    </svg>
+  );
+}
+
+export default function VolunteerIndexPage() {
+  return (
+    <HomePageWrapper data-testid="volunteer-index-page">
+      {/* ============ Hero ============ */}
+      <section className="grain relative overflow-hidden pb-12 pt-10 sm:pb-16 sm:pt-16">
+        <div className="mx-auto max-w-[88rem] px-5 sm:px-8 lg:px-12">
+          <HeroContent className="max-w-3xl">
+            <p className={`${eyebrowLight} mb-6 flex items-center gap-3`}>
+              <span className="inline-block h-px w-8 bg-forest-500/50 dark:bg-cream-50/40" />
+              Everybody Eats · Volunteering
+            </p>
+            <h1 className="display text-5xl leading-[0.98] tracking-tight text-forest-700 sm:text-6xl lg:text-7xl dark:text-cream-50">
+              Volunteer across <em>Aotearoa</em>
+            </h1>
+            <p className="mt-8 max-w-2xl text-lg leading-relaxed text-forest-700/85 sm:text-xl dark:text-cream-50/85">
+              Everybody Eats transforms rescued food into quality three-course
+              meals on a pay-what-you-can basis. Volunteers are the heart of
+              every service. Choose your city to find shifts near you.
+            </p>
+          </HeroContent>
+        </div>
+      </section>
+
+      {/* ============ City cards ============ */}
+      <section className="mx-auto max-w-[88rem] px-5 pb-20 sm:px-8 sm:pb-24 lg:px-12" data-testid="volunteer-cities">
+        <FeatureGrid className="grid gap-6 md:grid-cols-2">
+          {VOLUNTEER_LOCATIONS.map((loc, i) => (
+            <FeatureCard
+              key={loc.slug}
+              delay={0.1 + i * 0.1}
+              className="grain group relative overflow-hidden rounded-[2rem] border border-forest-500/10 bg-cream-100 dark:border-cream-50/10 dark:bg-forest-800/60"
+            >
+              <Link href={`/volunteer/${loc.slug}`} className="block p-8 sm:p-10" data-testid={`volunteer-city-${loc.slug}`}>
+                <p className="font-mono text-xs tracking-[0.2em] text-forest-500/70 dark:text-cream-50/50">
+                  {loc.reoName}
+                </p>
+                <h2 className="display mt-5 flex items-center gap-3 text-3xl tracking-tight text-forest-700 sm:text-4xl dark:text-cream-50">
+                  {loc.city}
+                  <Arrow className="h-6 w-6 transition-transform group-hover:translate-x-1" />
+                </h2>
+                <p className="mt-4 leading-relaxed text-forest-700/80 dark:text-cream-50/75">
+                  {loc.intro}
+                </p>
+                <p className="mt-5 text-sm uppercase tracking-[0.15em] text-forest-500/70 dark:text-cream-50/55">
+                  {loc.venues.map((v) => v.name).join(" · ")}
+                </p>
+              </Link>
+            </FeatureCard>
+          ))}
+        </FeatureGrid>
+      </section>
+
+      {/* ============ CTA ============ */}
+      <section className="mx-auto max-w-[88rem] px-5 pb-24 sm:px-8 sm:pb-32 lg:px-12">
+        <div className="grain relative overflow-hidden rounded-[3rem] bg-forest-700 px-8 py-16 text-center text-cream-50 sm:px-16 sm:py-20">
+          <div className="relative mx-auto max-w-2xl">
+            <h2 className="display text-4xl tracking-tight sm:text-6xl">
+              Make a <em>difference</em>, one shift at a time
+            </h2>
+            <p className="mt-6 text-lg leading-relaxed text-cream-50/85">
+              No experience needed, no long-term commitment — just a few hours
+              and a willingness to help. Nau mai, haere mai.
+            </p>
+            <div className="mt-10 flex justify-center">
+              <Link href="/register" className={`${pillPrimary} text-base`}>
+                Sign up to volunteer
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </HomePageWrapper>
+  );
+}

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -108,6 +108,67 @@ export function buildOrganizationSchema() {
   };
 }
 
+// LocalBusiness + Breadcrumb + FAQ schema for a per-city volunteer page.
+// Helps Google understand we're a real org with physical restaurants in this
+// city, and powers FAQ rich results for "volunteering <city>" queries.
+interface VolunteerLocationSchemaData {
+  city: string;
+  slug: string;
+  intro: string;
+  venues: { name: string; address: string }[];
+  faqs: { question: string; answer: string }[];
+}
+
+export function buildVolunteerLocationSchema(data: VolunteerLocationSchemaData) {
+  const baseUrl = getBaseUrl();
+  const url = `${baseUrl}/volunteer/${data.slug}`;
+
+  const organizations = data.venues.map((venue) => ({
+    "@context": "https://schema.org",
+    "@type": ["NGO", "FoodEstablishment"],
+    name: `Everybody Eats ${venue.name}`,
+    description: data.intro,
+    url,
+    parentOrganization: {
+      "@type": "NGO",
+      name: "Everybody Eats",
+      url: "https://everybodyeats.nz",
+    },
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: venue.address,
+      addressRegion: data.city,
+      addressCountry: "NZ",
+    },
+    potentialAction: {
+      "@type": "JoinAction",
+      name: `Volunteer in ${data.city}`,
+      target: `${baseUrl}/register`,
+    },
+  }));
+
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Volunteer", item: `${baseUrl}/volunteer` },
+      { "@type": "ListItem", position: 2, name: data.city, item: url },
+    ],
+  };
+
+  const faqPage = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: data.faqs.map((faq) => ({
+      "@type": "Question",
+      name: faq.question,
+      acceptedAnswer: { "@type": "Answer", text: faq.answer },
+    })),
+  };
+
+  return [...organizations, breadcrumb, faqPage];
+}
+
 // Shift Event Schema Data
 interface ShiftEventData {
   id: string;

--- a/web/src/lib/volunteer-locations.ts
+++ b/web/src/lib/volunteer-locations.ts
@@ -17,7 +17,8 @@ import {
 } from "@/lib/placeholder-utils";
 import { formatInNZT } from "@/lib/timezone";
 
-/** How many upcoming shifts to preview in the "Find your role" section. */
+/** How many upcoming shifts to preview in the "Find your role" section
+ *  before linking out to the full list. */
 export const PREVIEW_SHIFT_COUNT = 6;
 
 export interface Venue {

--- a/web/src/lib/volunteer-locations.ts
+++ b/web/src/lib/volunteer-locations.ts
@@ -7,6 +7,7 @@
 // the keyword "volunteer" with a specific city name + suburb addresses — the
 // thing the portal previously never said out loud.
 
+import type { SignupStatus } from "@/generated/client";
 import { prisma } from "@/lib/prisma";
 import { cacheLife } from "next/cache";
 import { getGoogleMapsUrl } from "@/lib/locations";
@@ -15,6 +16,9 @@ import {
   getShiftEffectiveCount,
 } from "@/lib/placeholder-utils";
 import { formatInNZT } from "@/lib/timezone";
+
+/** How many upcoming shifts to preview in the "Find your role" section. */
+export const PREVIEW_SHIFT_COUNT = 6;
 
 export interface Venue {
   /** Suburb / restaurant name, e.g. "Onehunga". Matches Shift.location. */
@@ -135,8 +139,14 @@ export interface UpcomingShift {
 }
 
 // Statuses that occupy a spot — mirrors the public shifts listing so the
-// "spots left" figure here matches what volunteers see on /shifts.
-const SPOT_TAKING_STATUSES = ["CONFIRMED", "PENDING", "REGULAR_PENDING"] as const;
+// "spots left" figure here matches what volunteers see on /shifts. `satisfies`
+// validates the literals against the Prisma enum, so a renamed/removed status
+// fails the build here rather than silently miscounting.
+const SPOT_TAKING_STATUSES = [
+  "CONFIRMED",
+  "PENDING",
+  "REGULAR_PENDING",
+] as const satisfies readonly SignupStatus[];
 
 /**
  * Real upcoming shifts for a city's restaurants, soonest first. Powers the
@@ -146,7 +156,7 @@ const SPOT_TAKING_STATUSES = ["CONFIRMED", "PENDING", "REGULAR_PENDING"] as cons
  */
 export async function getUpcomingShifts(
   shiftLocations: string[],
-  limit = 6
+  limit = PREVIEW_SHIFT_COUNT
 ): Promise<UpcomingShift[]> {
   "use cache";
   cacheLife("hours");

--- a/web/src/lib/volunteer-locations.ts
+++ b/web/src/lib/volunteer-locations.ts
@@ -1,0 +1,187 @@
+// City-level content for the public "Volunteer in <city>" SEO landing pages
+// (`/volunteer` and `/volunteer/[city]`).
+//
+// These pages exist to rank for generic, non-branded local searches such as
+// "volunteering Wellington" or "volunteer opportunities Auckland". Unlike the
+// logged-in portal, every word here is crawlable, server-rendered, and pairs
+// the keyword "volunteer" with a specific city name + suburb addresses — the
+// thing the portal previously never said out loud.
+
+import { prisma } from "@/lib/prisma";
+import { cacheLife } from "next/cache";
+import { getGoogleMapsUrl } from "@/lib/locations";
+import {
+  shiftCapacityCountSelect,
+  getShiftEffectiveCount,
+} from "@/lib/placeholder-utils";
+import { formatInNZT } from "@/lib/timezone";
+
+export interface Venue {
+  /** Suburb / restaurant name, e.g. "Onehunga". Matches Shift.location. */
+  name: string;
+  address: string;
+}
+
+export interface VolunteerLocation {
+  /** URL slug — `/volunteer/<slug>`. */
+  slug: string;
+  /** City as people search for it, e.g. "Wellington", "Auckland". */
+  city: string;
+  /** Te Reo Māori name for the rohe, woven into the copy. */
+  reoName: string;
+  /** Shift.location values in the DB that belong to this city. */
+  shiftLocations: string[];
+  /** Restaurants in this city. */
+  venues: Venue[];
+  /** 1–2 sentence hero intro — written distinctly per city (no thin dupes). */
+  intro: string;
+  /** "What you'd do" — short, city-flavoured paragraph. */
+  about: string;
+  /** Getting-there / when-we're-open note, unique per city. */
+  gettingThere: string;
+}
+
+/** Volunteer roles offered across every restaurant. Shared, kept generic. */
+export const VOLUNTEER_ROLES = [
+  {
+    title: "Kitchen prep",
+    copy: "Turn rescued ingredients into the building blocks of a three-course meal — chopping, portioning and prepping alongside our chefs.",
+  },
+  {
+    title: "Front of house",
+    copy: "Welcome diners, set the tables and host the room. The friendly face that makes everyone feel part of the whānau.",
+  },
+  {
+    title: "Service & pack-down",
+    copy: "Plate up, run dishes and reset the restaurant after service. The buzz of a full dining room in full swing.",
+  },
+  {
+    title: "Dishwashing",
+    copy: "Keep the kitchen moving and the plates flowing. Unsung, essential, and weirdly satisfying.",
+  },
+] as const;
+
+export const VOLUNTEER_LOCATIONS: VolunteerLocation[] = [
+  {
+    slug: "wellington",
+    city: "Wellington",
+    reoName: "Te Whanganui-a-Tara",
+    shiftLocations: ["Wellington"],
+    venues: [
+      { name: "Wellington", address: "60 Dixon Street, Te Aro, Wellington" },
+    ],
+    intro:
+      "Lend a hand at our Te Aro restaurant and help turn rescued kai into restaurant-quality meals for the Wellington community — no experience or long-term commitment needed.",
+    about:
+      "Our Wellington restaurant on Dixon Street serves a three-course meal at shared tables several evenings a week, on a pay-what-you-can basis. Volunteers keep the whole place running, from the kitchen to the dining room.",
+    gettingThere:
+      "We're right in the heart of Te Aro at 60 Dixon Street — a few minutes' walk from Courtenay Place and Cuba Street, and easy to reach by bus from across the city.",
+  },
+  {
+    slug: "auckland",
+    city: "Auckland",
+    reoName: "Tāmaki Makaurau",
+    shiftLocations: ["Glen Innes", "Onehunga"],
+    venues: [
+      { name: "Glen Innes", address: "133 Line Road, Glen Innes, Auckland" },
+      { name: "Onehunga", address: "306 Onehunga Mall, Onehunga, Auckland" },
+    ],
+    intro:
+      "Volunteer at our Glen Innes or Onehunga restaurants and help share good food, not waste, with your local Auckland community — come as you are, no experience required.",
+    about:
+      "Everybody Eats runs two restaurants across Tāmaki Makaurau — in Glen Innes and Onehunga. Both serve a three-course meal at shared tables on a pay-what-you-can basis, and both rely on volunteers for every part of the night.",
+    gettingThere:
+      "Find us in Glen Innes (133 Line Road) and Onehunga (306 Onehunga Mall) — both close to train and bus links, with parking nearby. Pick whichever restaurant is closest to you.",
+  },
+];
+
+export function getVolunteerLocation(slug: string): VolunteerLocation | undefined {
+  return VOLUNTEER_LOCATIONS.find((l) => l.slug === slug);
+}
+
+export function venueMapsUrl(venue: Venue): string {
+  return getGoogleMapsUrl(venue.address);
+}
+
+/**
+ * Count upcoming, published shifts across a city's restaurants. Cached hourly
+ * so the number renders into the static HTML (crawlable) without hammering the
+ * DB — freshness within the hour is plenty for an SEO landing page.
+ */
+export async function getUpcomingShiftCount(
+  shiftLocations: string[]
+): Promise<number> {
+  "use cache";
+  cacheLife("hours");
+
+  return prisma.shift.count({
+    where: {
+      location: { in: shiftLocations },
+      start: { gte: new Date() },
+    },
+  });
+}
+
+export interface UpcomingShift {
+  id: string;
+  /** Shift-type name, e.g. "Front of House" — the volunteer's "role". */
+  role: string;
+  /** Which restaurant (suburb) the shift is at. */
+  venue: string;
+  /** Pre-formatted NZ-time labels, e.g. "Sun 22 Jun" and "5:30pm–9:00pm". */
+  dateLabel: string;
+  timeLabel: string;
+  spotsAvailable: number;
+}
+
+// Statuses that occupy a spot — mirrors the public shifts listing so the
+// "spots left" figure here matches what volunteers see on /shifts.
+const SPOT_TAKING_STATUSES = ["CONFIRMED", "PENDING", "REGULAR_PENDING"] as const;
+
+/**
+ * Real upcoming shifts for a city's restaurants, soonest first. Powers the
+ * "Find your role" section with concrete, bookable shifts (role + venue + date
+ * + spots) instead of static copy. Cached hourly so it stays in the static
+ * HTML — fresh enough for an SEO landing page, and never per-request heavy.
+ */
+export async function getUpcomingShifts(
+  shiftLocations: string[],
+  limit = 6
+): Promise<UpcomingShift[]> {
+  "use cache";
+  cacheLife("hours");
+
+  const shifts = await prisma.shift.findMany({
+    where: {
+      location: { in: shiftLocations },
+      start: { gte: new Date() },
+    },
+    orderBy: { start: "asc" },
+    take: limit,
+    select: {
+      id: true,
+      start: true,
+      end: true,
+      location: true,
+      capacity: true,
+      shiftType: { select: { name: true } },
+      _count: shiftCapacityCountSelect(SPOT_TAKING_STATUSES),
+    },
+  });
+
+  // Format the NZ-time labels here, inside the cache scope. Reading the clock
+  // (which date formatting does) is only allowed in a cached/dynamic context
+  // under Next's cacheComponents — doing it in the page's render would break
+  // the static prerender.
+  return shifts.map((shift) => ({
+    id: shift.id,
+    role: shift.shiftType.name,
+    venue: shift.location ?? "",
+    dateLabel: formatInNZT(shift.start, "EEE d MMM"),
+    timeLabel: `${formatInNZT(shift.start, "h:mmaaa")}–${formatInNZT(
+      shift.end,
+      "h:mmaaa"
+    )}`,
+    spotsAvailable: Math.max(0, shift.capacity - getShiftEffectiveCount(shift)),
+  }));
+}

--- a/web/tests/e2e/volunteer-pages.spec.ts
+++ b/web/tests/e2e/volunteer-pages.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "./base";
+
+// Public, unauthenticated SEO landing pages: /volunteer and /volunteer/[city].
+test.describe("Volunteer landing pages", () => {
+  test("index lists each city with working links", async ({ page }) => {
+    await page.goto("/volunteer");
+    await page.waitForLoadState("load");
+
+    await expect(page).toHaveURL("/volunteer");
+    await expect(page.getByTestId("volunteer-index-page")).toBeVisible();
+
+    const wellington = page.getByTestId("volunteer-city-wellington");
+    const auckland = page.getByTestId("volunteer-city-auckland");
+    await expect(wellington).toBeVisible();
+    await expect(auckland).toBeVisible();
+    await expect(wellington).toHaveAttribute("href", "/volunteer/wellington");
+    await expect(auckland).toHaveAttribute("href", "/volunteer/auckland");
+  });
+
+  test("city page renders hero, metadata and shifts-or-roles", async ({
+    page,
+  }) => {
+    await page.goto("/volunteer/wellington");
+    await page.waitForLoadState("load");
+
+    await expect(page.getByTestId("volunteer-location-page")).toBeVisible();
+    await expect(page.getByTestId("volunteer-hero-title")).toContainText(
+      "Wellington"
+    );
+    await expect(page).toHaveTitle(/Volunteer in Wellington/);
+    await expect(page.getByTestId("volunteer-cta-register")).toBeVisible();
+
+    // The "Find your role" section renders either real shift cards or the
+    // static role fallback — both are acceptable depending on DB state.
+    await expect(page.getByTestId("volunteer-roles")).toBeVisible();
+    const shiftCards = page.getByTestId("volunteer-shift-card");
+    if ((await shiftCards.count()) > 0) {
+      await expect(shiftCards.first()).toBeVisible();
+    }
+  });
+
+  test("auckland page targets the city in its title", async ({ page }) => {
+    await page.goto("/volunteer/auckland");
+    await page.waitForLoadState("load");
+
+    await expect(page.getByTestId("volunteer-hero-title")).toContainText(
+      "Auckland"
+    );
+    await expect(page).toHaveTitle(/Volunteer in Auckland/);
+  });
+
+  test("unknown city slug does not render a city page", async ({ page }) => {
+    await page.goto("/volunteer/christchurch");
+    await page.waitForLoadState("load");
+
+    // notFound() short-circuits before the city page renders, and the route's
+    // metadata marks unknown slugs noindex so they can't be indexed.
+    await expect(page.getByTestId("volunteer-location-page")).toHaveCount(0);
+    await expect(page.getByTestId("volunteer-hero-title")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Description

Adds public, server-rendered **per-city volunteer landing pages** so the portal can rank for generic local searches like *"volunteering Wellington"* and *"volunteer opportunities Auckland"*.

**Why:** Those queries currently surface aggregators (SEEK Volunteer, Volunteering Auckland, Volunteer Wellington) and never Everybody Eats. The root cause: no indexable page on the portal ever paired the word *"volunteer"* with a city name — the homepage says "volunteer" ~15× and "Wellington"/"Auckland" zero times, and the only "location pages" were `?location=` query-string URLs that search engines ignore.

### What's new
- **`/volunteer`** — index page ("Volunteer across Aotearoa") linking to each city.
- **`/volunteer/[city]`** — Wellington & Auckland pages, each with:
  - city + venue addresses in the `<title>`, H1, body and metadata (canonical, OG)
  - **real upcoming shifts** from the DB (role, NZ-formatted time, venue, spots-left/waitlist), cached hourly so they render into the static HTML; static role copy kept as a fallback when no shifts are scheduled
  - the homepage hero **image carousel** for visual parity
  - `LocalBusiness` + `BreadcrumbList` + `FAQPage` JSON-LD
- **Sitemap**: replaced the weak `?location=` entries with the real pages; **Robots**: allow `/volunteer`.
- Auckland page aggregates both Glen Innes + Onehunga restaurants (targets "volunteering auckland" directly).

### Notes for reviewers
- Date/time labels are formatted **inside** the cached data helper (`getUpcomingShifts`) so the static prerender never reads the clock — required under Next 16 `cacheComponents` (formatting in render throws `next-prerender-current-time`).
- Reuses the existing brand system (Fraunces/cream/forest/sun, motion wrappers, `HeroImageCycler`) — no new design language.
- A companion PR on **everybody-eats-nz/marketing-cms** links the new marketing site to these pages (footer + the get-involved/volunteer page) for crawl path + authority.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update (CLAUDE.md SEO page list)

## Testing
- [x] `tsc --noEmit` clean on all changed files
- [x] `eslint` clean on all changed files
- [x] Manual testing completed — verified in dev: both cities + index render (light/dark); SSR HTML contains titles, meta, canonical, JSON-LD, real shift cards and the carousel image; no console/prerender errors; sitemap lists the pages; unknown slugs 404 + noindex
- [ ] New e2e tests (happy to add in a follow-up if desired)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Suggested version label: `version:minor` (new feature).
🤖 Generated with [Claude Code](https://claude.com/claude-code)