### PR TITLE
fix(locations): cascade location rename to free-text references

### DIFF
--- a/web/src/app/api/admin/locations/route.ts
+++ b/web/src/app/api/admin/locations/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@/generated/client";
 
 // Koha target per night — "" / null / undefined clear it; otherwise parse to 2dp.
 function parseTarget(value: unknown): number | null {
@@ -101,6 +102,16 @@ export async function PATCH(request: NextRequest) {
       );
     }
 
+    if (
+      name !== undefined &&
+      (typeof name !== "string" || name.trim() === "")
+    ) {
+      return NextResponse.json(
+        { error: "Location name must be a non-empty string" },
+        { status: 400 }
+      );
+    }
+
     const updateData: Record<string, string | number | boolean | null> = {};
     if (name !== undefined) updateData.name = name;
     if (address !== undefined) updateData.address = address;
@@ -136,6 +147,9 @@ export async function PATCH(request: NextRequest) {
       });
 
       if (isRename) {
+        // Only rows explicitly referencing the old name are touched; rows with
+        // a null location (templates/rules that apply to all locations) are
+        // intentionally left untouched.
         const where = { location: oldName };
         const data = { location: newName };
         await Promise.all([
@@ -165,6 +179,21 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json(location);
   } catch (error) {
     console.error("Error updating location:", error);
+    // A rename can collide with a unique constraint on one of the cascaded
+    // tables (e.g. MealsServed/DailyMenu [date, location]); surface that
+    // clearly instead of a generic 500.
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Cannot rename location: a conflicting record already exists under the new name",
+        },
+        { status: 409 }
+      );
+    }
     return NextResponse.json(
       { error: "Failed to update location" },
       { status: 500 }

--- a/web/src/app/api/admin/locations/route.ts
+++ b/web/src/app/api/admin/locations/route.ts
@@ -110,9 +110,56 @@ export async function PATCH(request: NextRequest) {
     if (targetPerNight !== undefined)
       updateData.targetPerNight = parseTarget(targetPerNight);
 
-    const location = await prisma.location.update({
+    // The location name is stored as a free-text string (no FK) across many
+    // tables, so a rename must cascade to keep them in sync — otherwise old
+    // records keep the previous name and surface as a duplicate location.
+    const existing = await prisma.location.findUnique({
       where: { id },
-      data: updateData,
+      select: { name: true },
+    });
+
+    if (!existing) {
+      return NextResponse.json(
+        { error: "Location not found" },
+        { status: 404 }
+      );
+    }
+
+    const oldName = existing.name;
+    const newName = typeof name === "string" ? name : undefined;
+    const isRename = newName !== undefined && newName !== oldName;
+
+    const location = await prisma.$transaction(async (tx) => {
+      const updated = await tx.location.update({
+        where: { id },
+        data: updateData,
+      });
+
+      if (isRename) {
+        const where = { location: oldName };
+        const data = { location: newName };
+        await Promise.all([
+          tx.shift.updateMany({ where, data }),
+          tx.shiftTemplate.updateMany({ where, data }),
+          tx.regularVolunteer.updateMany({ where, data }),
+          tx.autoAcceptRule.updateMany({ where, data }),
+          tx.mealsServed.updateMany({ where, data }),
+          tx.dailyMenu.updateMany({ where, data }),
+          tx.messagingHours.updateMany({ where, data }),
+          tx.user.updateMany({
+            where: { defaultLocation: oldName },
+            data: { defaultLocation: newName },
+          }),
+          // RestaurantManager.locations is a string[] — replace in place.
+          tx.$executeRaw`
+            UPDATE "RestaurantManager"
+            SET "locations" = array_replace("locations", ${oldName}, ${newName})
+            WHERE ${oldName} = ANY("locations")
+          `,
+        ]);
+      }
+
+      return updated;
     });
 
     return NextResponse.json(location);


### PR DESCRIPTION
## Description

Renaming a restaurant `Location` previously updated only the `Location` row. Because the location name is stored as a **free-text string (no foreign key)** across many tables, existing references kept the old name.

This surfaced as a **duplicate location in the mobile app** — e.g. both "Hopper" and "Hopper Cafe" appearing in the shift location filter. The mobile app derives its location list from distinct `Shift.location` strings ([`mobile/app/(tabs)/shifts.tsx`](https://github.com/everybody-eats-nz/volunteer-portal/blob/claude/focused-cohen-25909b/mobile/app/(tabs)/shifts.tsx)), while the web app reads the authoritative `Location` table ([`web/src/lib/locations.ts`](https://github.com/everybody-eats-nz/volunteer-portal/blob/claude/focused-cohen-25909b/web/src/lib/locations.ts)) — so the web app showed only the new name and mobile showed both.

## What changed

The admin `PATCH /api/admin/locations` handler now, **when the name actually changes**, runs a single transaction that:
1. Updates the `Location` row, and
2. Cascades the new name to every table storing the location as free text:
   - `Shift`, `ShiftTemplate`, `RegularVolunteer`, `AutoAcceptRule`, `MealsServed`, `DailyMenu`, `MessagingHours`
   - `User.defaultLocation`
   - `RestaurantManager.locations[]` (array element replaced in place via `array_replace`)

The transaction makes the rename atomic — if any update hits a unique constraint, the whole rename rolls back rather than leaving a half-applied state.

## Reviewer notes

- This prevents **future** renames from orphaning references. **Existing** stale rows (the current "Hopper" data) still need a one-off production cleanup — a corresponding SQL script renames `'Hopper'` → `'Hopper Cafe'` across the same tables and is being run separately against prod.
- `MealsServed`, `DailyMenu`, `ShiftTemplate`, and `MessagingHours` have unique constraints involving `location`; a real-world conflict during rename is practically impossible since the new name didn't exist as a `Location` before (which is uniquely constrained).

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Typecheck passes for the edited file

## Additional Notes
Longer-term, normalizing `Shift.location` (and siblings) to a foreign key on `Location` would remove this class of bug entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)