### PR TITLE
Redesign custom labels admin page with members modal

### DIFF
--- a/web/src/app/admin/custom-labels/custom-label-dialog.tsx
+++ b/web/src/app/admin/custom-labels/custom-label-dialog.tsx
@@ -6,12 +6,16 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { CustomLabelBadge } from "@/components/custom-label-badge";
+import { Check, Ban } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { type CustomLabel } from "@/generated/client";
+import { COLOR_OPTIONS, ICON_OPTIONS, FAMILY_THEME } from "./label-colors";
 
 interface CustomLabelDialogProps {
   open: boolean;
@@ -23,70 +27,6 @@ interface CustomLabelDialogProps {
     icon?: string;
   }) => Promise<void>;
 }
-
-// Predefined color options that match volunteer grade colors
-const COLOR_OPTIONS = [
-  {
-    name: "Purple",
-    value:
-      "bg-purple-50 dark:bg-purple-950/20 text-purple-700 dark:text-purple-400 border-purple-200 dark:border-purple-800 hover:bg-purple-100 dark:hover:bg-purple-950/30",
-  },
-  {
-    name: "Blue",
-    value:
-      "bg-blue-50 dark:bg-blue-950/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-950/30",
-  },
-  {
-    name: "Green",
-    value:
-      "bg-emerald-50 dark:bg-emerald-950/20 text-emerald-700 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800 hover:bg-emerald-100 dark:hover:bg-emerald-950/30",
-  },
-  {
-    name: "Yellow",
-    value:
-      "bg-amber-50 dark:bg-amber-950/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800 hover:bg-amber-100 dark:hover:bg-amber-950/30",
-  },
-  {
-    name: "Pink",
-    value:
-      "bg-rose-50 dark:bg-rose-950/20 text-rose-700 dark:text-rose-400 border-rose-200 dark:border-rose-800 hover:bg-rose-100 dark:hover:bg-rose-950/30",
-  },
-  {
-    name: "Indigo",
-    value:
-      "bg-indigo-50 dark:bg-indigo-950/20 text-indigo-700 dark:text-indigo-400 border-indigo-200 dark:border-indigo-800 hover:bg-indigo-100 dark:hover:bg-indigo-950/30",
-  },
-  {
-    name: "Teal",
-    value:
-      "bg-teal-50 dark:bg-teal-950/20 text-teal-700 dark:text-teal-400 border-teal-200 dark:border-teal-800 hover:bg-teal-100 dark:hover:bg-teal-950/30",
-  },
-  {
-    name: "Orange",
-    value:
-      "bg-orange-50 dark:bg-orange-950/20 text-orange-700 dark:text-orange-400 border-orange-200 dark:border-orange-800 hover:bg-orange-100 dark:hover:bg-orange-950/30",
-  },
-];
-
-// Common emoji options for icons
-const ICON_OPTIONS = [
-  "⭐",
-  "🔥",
-  "💎",
-  "🏆",
-  "🎯",
-  "⚡",
-  "🌟",
-  "🎖️",
-  "👑",
-  "🔔",
-  "📌",
-  "🚀",
-  "✨",
-  "💝",
-  "🎪",
-  "🌈",
-];
 
 export function CustomLabelDialog({
   open,
@@ -113,11 +53,7 @@ export function CustomLabelDialog({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (!name.trim() || !color) {
-      return;
-    }
-
+    if (!name.trim() || !color) return;
     setIsSubmitting(true);
     try {
       await onSave({
@@ -132,7 +68,7 @@ export function CustomLabelDialog({
 
   const previewLabel: CustomLabel = {
     id: "preview",
-    name: name.trim() || "Label Name",
+    name: name.trim() || "Label name",
     color,
     icon: icon.trim() || null,
     isActive: true,
@@ -142,87 +78,120 @@ export function CustomLabelDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[460px]">
         <DialogHeader>
-          <DialogTitle>{label ? "Edit Label" : "Create Label"}</DialogTitle>
+          <DialogTitle className="font-accent text-xl">
+            {label ? "Edit label" : "Create a label"}
+          </DialogTitle>
+          <DialogDescription>
+            {label
+              ? "Update the name, colour or icon for this label."
+              : "Name it, pick a colour, and add an optional icon."}
+          </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Live preview */}
+        <div className="flex items-center justify-center rounded-xl border border-border bg-gradient-to-br from-muted/60 to-muted/20 py-6">
+          <CustomLabelBadge label={previewLabel} size="lg" />
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-5">
           <div className="space-y-2">
-            <Label htmlFor="label-name">Label Name</Label>
+            <Label htmlFor="label-name">Label name</Label>
             <Input
               id="label-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="Enter label name"
+              placeholder="e.g. Kitchen lead, First aider…"
               required
+              autoFocus
+              maxLength={40}
               data-testid="label-name-input"
             />
           </div>
 
           <div className="space-y-2">
-            <Label>Color</Label>
+            <Label>Colour</Label>
             <div className="grid grid-cols-4 gap-2">
-              {COLOR_OPTIONS.map((option) => (
+              {COLOR_OPTIONS.map((option) => {
+                const theme = FAMILY_THEME[option.family];
+                const selected = color === option.value;
+                return (
+                  <button
+                    key={option.name}
+                    type="button"
+                    onClick={() => setColor(option.value)}
+                    aria-pressed={selected}
+                    className={cn(
+                      "group flex flex-col items-center gap-1.5 rounded-xl border p-2.5 transition-all",
+                      selected
+                        ? "border-transparent ring-2 ring-[#1d5337] ring-offset-2 ring-offset-background dark:ring-emerald-400"
+                        : "border-border hover:border-foreground/20 hover:bg-muted/50"
+                    )}
+                    data-testid={`color-option-${option.name.toLowerCase()}`}
+                  >
+                    <span
+                      className={cn(
+                        "flex h-7 w-7 items-center justify-center rounded-full text-white shadow-sm",
+                        theme.dot
+                      )}
+                    >
+                      {selected && <Check className="h-4 w-4" />}
+                    </span>
+                    <span className="text-[11px] font-medium text-muted-foreground">
+                      {option.name}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Icon</Label>
+            <div className="flex flex-wrap gap-1.5">
+              <button
+                type="button"
+                onClick={() => setIcon("")}
+                aria-label="No icon"
+                className={cn(
+                  "flex h-9 w-9 items-center justify-center rounded-lg border text-muted-foreground transition-colors",
+                  icon === ""
+                    ? "border-[#1d5337] bg-[#1d5337]/10 text-[#1d5337] dark:border-emerald-400 dark:text-emerald-300"
+                    : "border-border hover:bg-muted"
+                )}
+                data-testid="icon-option-none"
+              >
+                <Ban className="h-4 w-4" />
+              </button>
+              {ICON_OPTIONS.map((emoji) => (
                 <button
-                  key={option.name}
+                  key={emoji}
                   type="button"
-                  onClick={() => setColor(option.value)}
-                  className={`
-                    p-3 rounded border-2 text-xs font-medium
-                    ${option.value}
-                    ${
-                      color === option.value
-                        ? "ring-2 ring-offset-2 ring-slate-400"
-                        : ""
-                    }
-                  `}
-                  data-testid={`color-option-${option.name.toLowerCase()}`}
+                  onClick={() => setIcon(emoji)}
+                  className={cn(
+                    "flex h-9 w-9 items-center justify-center rounded-lg border text-lg transition-all",
+                    icon === emoji
+                      ? "border-[#1d5337] bg-[#1d5337]/10 ring-1 ring-[#1d5337] dark:border-emerald-400 dark:ring-emerald-400"
+                      : "border-border hover:scale-105 hover:bg-muted"
+                  )}
+                  data-testid={`icon-option-${emoji}`}
                 >
-                  {option.name}
+                  {emoji}
                 </button>
               ))}
             </div>
+            <Input
+              value={icon}
+              onChange={(e) => setIcon(e.target.value)}
+              placeholder="…or paste your own emoji"
+              maxLength={2}
+              className="mt-1"
+              data-testid="label-icon-input"
+            />
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="label-icon">Icon (optional)</Label>
-            <div className="space-y-2">
-              <Input
-                id="label-icon"
-                value={icon}
-                onChange={(e) => setIcon(e.target.value)}
-                placeholder="Enter emoji or leave blank"
-                maxLength={2}
-                data-testid="label-icon-input"
-              />
-              <div className="grid grid-cols-8 gap-1">
-                {ICON_OPTIONS.map((emoji) => (
-                  <button
-                    key={emoji}
-                    type="button"
-                    onClick={() => setIcon(emoji)}
-                    className={`
-                      p-1 text-lg hover:bg-slate-100 dark:hover:bg-zinc-800 rounded
-                      ${icon === emoji ? "bg-slate-200 dark:bg-zinc-700" : ""}
-                    `}
-                    data-testid={`icon-option-${emoji}`}
-                  >
-                    {emoji}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Preview</Label>
-            <div className="p-3 bg-slate-50 dark:bg-zinc-900 rounded">
-              <CustomLabelBadge label={previewLabel} />
-            </div>
-          </div>
-
-          <div className="flex justify-end gap-3 pt-4">
+          <div className="flex justify-end gap-3 pt-2">
             <Button
               type="button"
               variant="outline"
@@ -234,9 +203,14 @@ export function CustomLabelDialog({
             <Button
               type="submit"
               disabled={!name.trim() || isSubmitting}
+              className="bg-[#1d5337] text-white hover:bg-[#1d5337]/90"
               data-testid="save-label-button"
             >
-              {isSubmitting ? "Saving..." : label ? "Update" : "Create"}
+              {isSubmitting
+                ? "Saving…"
+                : label
+                  ? "Save changes"
+                  : "Create label"}
             </Button>
           </div>
         </form>

--- a/web/src/app/admin/custom-labels/custom-label-dialog.tsx
+++ b/web/src/app/admin/custom-labels/custom-label-dialog.tsx
@@ -15,7 +15,12 @@ import { CustomLabelBadge } from "@/components/custom-label-badge";
 import { Check, Ban } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { type CustomLabel } from "@/generated/client";
-import { COLOR_OPTIONS, ICON_OPTIONS, FAMILY_THEME } from "./label-colors";
+import {
+  COLOR_OPTIONS,
+  ICON_OPTIONS,
+  FAMILY_THEME,
+  firstGrapheme,
+} from "./label-colors";
 
 interface CustomLabelDialogProps {
   open: boolean;
@@ -183,9 +188,8 @@ export function CustomLabelDialog({
             </div>
             <Input
               value={icon}
-              onChange={(e) => setIcon(e.target.value)}
+              onChange={(e) => setIcon(firstGrapheme(e.target.value))}
               placeholder="…or paste your own emoji"
-              maxLength={2}
               className="mt-1"
               data-testid="label-icon-input"
             />

--- a/web/src/app/admin/custom-labels/custom-labels-content.tsx
+++ b/web/src/app/admin/custom-labels/custom-labels-content.tsx
@@ -217,6 +217,10 @@ export function CustomLabelsContent({
   };
 
   const handleMemberRemoved = (labelId: string, userId: string) => {
+    // Removing a member always decrements the count. The avatar preview only
+    // holds the 5 most-recent members, so filtering by userId is a no-op when
+    // the removed volunteer wasn't in that preview — which is fine: the stack
+    // still reflects "recent members", just one fewer in the total count.
     setLabels((prev) =>
       prev.map((label) =>
         label.id === labelId

--- a/web/src/app/admin/custom-labels/custom-labels-content.tsx
+++ b/web/src/app/admin/custom-labels/custom-labels-content.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { motion } from "motion/react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { AvatarList } from "@/components/ui/avatar-list";
+import { CustomLabelBadge } from "@/components/custom-label-badge";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,35 +17,109 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Plus, Edit, Trash2, Megaphone } from "lucide-react";
-import Link from "next/link";
-import { CustomLabelBadge } from "@/components/custom-label-badge";
-import { CustomLabelDialog } from "./custom-label-dialog";
-import { type CustomLabel } from "@/generated/client";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  Megaphone,
+  Tag,
+  Tags,
+  Users,
+  Sparkles,
+  Search,
+  ArrowUpDown,
+  ChevronRight,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
+import { type CustomLabel } from "@/generated/client";
+import { CustomLabelDialog } from "./custom-label-dialog";
+import { LabelMembersDialog } from "./label-members-dialog";
+import { getLabelTheme } from "./label-colors";
 
-type LabelWithCount = CustomLabel & {
-  _count: {
-    users: number;
-  };
+export interface PreviewUser {
+  id: string;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  email: string;
+  profilePhotoUrl: string | null;
+}
+
+export type LabelWithMeta = CustomLabel & {
+  _count: { users: number };
+  previewUsers: PreviewUser[];
 };
 
 interface CustomLabelsContentProps {
-  initialLabels: LabelWithCount[];
+  initialLabels: LabelWithMeta[];
+  taggedVolunteers: number;
 }
+
+type SortKey = "most" | "newest" | "az";
+
+const SORTS: { key: SortKey; label: string }[] = [
+  { key: "most", label: "Most volunteers" },
+  { key: "newest", label: "Newest" },
+  { key: "az", label: "A–Z" },
+];
 
 export function CustomLabelsContent({
   initialLabels,
+  taggedVolunteers,
 }: CustomLabelsContentProps) {
-  const [labels, setLabels] = useState<LabelWithCount[]>(initialLabels);
+  const [labels, setLabels] = useState<LabelWithMeta[]>(initialLabels);
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortKey>("most");
+
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingLabel, setEditingLabel] = useState<LabelWithCount | null>(null);
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [labelToDelete, setLabelToDelete] = useState<LabelWithCount | null>(
-    null
-  );
+  const [editingLabel, setEditingLabel] = useState<LabelWithMeta | null>(null);
+  const [labelToDelete, setLabelToDelete] = useState<LabelWithMeta | null>(null);
+  const [membersLabel, setMembersLabel] = useState<LabelWithMeta | null>(null);
+
   const { toast } = useToast();
 
+  // ----- Derived stats -----
+  const totalAssignments = useMemo(
+    () => labels.reduce((sum, l) => sum + l._count.users, 0),
+    [labels]
+  );
+  const unusedCount = useMemo(
+    () => labels.filter((l) => l._count.users === 0).length,
+    [labels]
+  );
+  const maxUsers = useMemo(
+    () => Math.max(1, ...labels.map((l) => l._count.users)),
+    [labels]
+  );
+
+  const visibleLabels = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = q
+      ? labels.filter((l) => l.name.toLowerCase().includes(q))
+      : labels;
+    const sorted = [...filtered];
+    sorted.sort((a, b) => {
+      if (sort === "az") return a.name.localeCompare(b.name);
+      if (sort === "newest")
+        return (
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+      // most
+      if (b._count.users !== a._count.users)
+        return b._count.users - a._count.users;
+      return a.name.localeCompare(b.name);
+    });
+    return sorted;
+  }, [labels, query, sort]);
+
+  // ----- CRUD -----
   const handleCreateLabel = async (data: {
     name: string;
     color: string;
@@ -50,31 +128,19 @@ export function CustomLabelsContent({
     try {
       const response = await fetch("/api/admin/custom-labels", {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
       });
-
       if (!response.ok) {
         const error = await response.json();
         throw new Error(error.error || "Failed to create label");
       }
-
-      const newLabel = await response.json();
+      const newLabel: CustomLabel = await response.json();
       setLabels((prev) => [
-        {
-          ...newLabel,
-          _count: { users: 0 },
-        },
+        { ...newLabel, _count: { users: 0 }, previewUsers: [] },
         ...prev,
       ]);
-
-      toast({
-        title: "Success",
-        description: "Custom label created successfully",
-      });
-
+      toast({ title: "Label created", description: `“${newLabel.name}” is ready to use.` });
       setDialogOpen(false);
     } catch (error) {
       toast({
@@ -93,29 +159,26 @@ export function CustomLabelsContent({
     try {
       const response = await fetch(`/api/admin/custom-labels/${id}`, {
         method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(data),
       });
-
       if (!response.ok) {
         const error = await response.json();
         throw new Error(error.error || "Failed to update label");
       }
-
-      const updatedLabel = await response.json();
+      const updatedLabel: CustomLabel = await response.json();
       setLabels((prev) =>
         prev.map((label) =>
-          label.id === id ? { ...updatedLabel, _count: label._count } : label
+          label.id === id
+            ? {
+                ...updatedLabel,
+                _count: label._count,
+                previewUsers: label.previewUsers,
+              }
+            : label
         )
       );
-
-      toast({
-        title: "Success",
-        description: "Custom label updated successfully",
-      });
-
+      toast({ title: "Label updated", description: "Your changes are saved." });
       setDialogOpen(false);
       setEditingLabel(null);
     } catch (error) {
@@ -128,23 +191,19 @@ export function CustomLabelsContent({
     }
   };
 
-  const handleDeleteLabel = async (id: string) => {
+  const confirmDeleteLabel = async () => {
+    if (!labelToDelete) return;
     try {
-      const response = await fetch(`/api/admin/custom-labels/${id}`, {
-        method: "DELETE",
-      });
-
+      const response = await fetch(
+        `/api/admin/custom-labels/${labelToDelete.id}`,
+        { method: "DELETE" }
+      );
       if (!response.ok) {
         const error = await response.json();
         throw new Error(error.error || "Failed to delete label");
       }
-
-      setLabels((prev) => prev.filter((label) => label.id !== id));
-
-      toast({
-        title: "Success",
-        description: "Custom label deleted successfully",
-      });
+      setLabels((prev) => prev.filter((label) => label.id !== labelToDelete.id));
+      toast({ title: "Label deleted", description: `“${labelToDelete.name}” was removed.` });
     } catch (error) {
       toast({
         title: "Error",
@@ -152,25 +211,23 @@ export function CustomLabelsContent({
           error instanceof Error ? error.message : "Failed to delete label",
         variant: "destructive",
       });
-    }
-  };
-
-  const openDeleteDialog = (label: LabelWithCount) => {
-    setLabelToDelete(label);
-    setDeleteDialogOpen(true);
-  };
-
-  const confirmDeleteLabel = async () => {
-    if (labelToDelete) {
-      await handleDeleteLabel(labelToDelete.id);
-      setDeleteDialogOpen(false);
+    } finally {
       setLabelToDelete(null);
     }
   };
 
-  const openEditDialog = (label: LabelWithCount) => {
-    setEditingLabel(label);
-    setDialogOpen(true);
+  const handleMemberRemoved = (labelId: string, userId: string) => {
+    setLabels((prev) =>
+      prev.map((label) =>
+        label.id === labelId
+          ? {
+              ...label,
+              _count: { users: Math.max(0, label._count.users - 1) },
+              previewUsers: label.previewUsers.filter((u) => u.id !== userId),
+            }
+          : label
+      )
+    );
   };
 
   const openCreateDialog = () => {
@@ -179,97 +236,141 @@ export function CustomLabelsContent({
   };
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold">Custom Labels</h2>
-          <p className="text-slate-600 mt-1">
-            Create and manage custom labels for volunteers (admin-only)
-          </p>
+    <div className="space-y-6" data-testid="custom-labels-page">
+      {/* ===== Hero ===== */}
+      <motion.section
+        initial={{ opacity: 0, y: -8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+        className="relative overflow-hidden rounded-2xl border border-[#1d5337]/15 bg-gradient-to-br from-[#1d5337] to-[#2e6438] p-6 text-white sm:p-8"
+      >
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -right-10 -top-16 h-48 w-48 rounded-full bg-[#f8fb69]/20 blur-3xl"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -bottom-20 left-1/3 h-44 w-44 rounded-full bg-white/5 blur-3xl"
+        />
+        <div className="relative flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+          <div className="max-w-xl">
+            <h1 className="font-accent text-2xl font-semibold leading-tight sm:text-3xl">
+              Group your whānau with custom labels
+            </h1>
+            <p className="mt-2 text-sm text-white/80 sm:text-base">
+              Tag volunteers to segment announcements, spotlight specialists,
+              and keep your community organised at a glance.
+            </p>
+          </div>
+          <Button
+            onClick={openCreateDialog}
+            size="lg"
+            className="shrink-0 self-start bg-[#f8fb69] font-semibold text-[#1d3a26] shadow-sm hover:bg-[#f8fb69]/90 sm:self-auto"
+            data-testid="create-label-button"
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            New label
+          </Button>
         </div>
-        <Button onClick={openCreateDialog} data-testid="create-label-button">
-          <Plus className="h-4 w-4 mr-2" />
-          Add Label
-        </Button>
+      </motion.section>
+
+      {/* ===== KPI tiles ===== */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <KpiTile
+          icon={<Tag className="h-4 w-4" />}
+          label="Labels"
+          value={labels.length}
+          tone="forest"
+        />
+        <KpiTile
+          icon={<Users className="h-4 w-4" />}
+          label="Volunteers tagged"
+          value={taggedVolunteers}
+          tone="blue"
+        />
+        <KpiTile
+          icon={<Sparkles className="h-4 w-4" />}
+          label="Total assignments"
+          value={totalAssignments}
+          tone="violet"
+        />
+        <KpiTile
+          icon={<Tags className="h-4 w-4" />}
+          label="Unused"
+          value={unusedCount}
+          tone={unusedCount > 0 ? "amber" : "neutral"}
+        />
       </div>
 
-      <div className="grid gap-4">
-        {labels.length === 0 ? (
-          <Card>
-            <CardContent className="py-8 text-center">
-              <div className="h-12 w-12 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Plus className="h-6 w-6 text-slate-400" />
-              </div>
-              <h3 className="text-lg font-semibold text-slate-900 mb-2">
-                No labels yet
-              </h3>
-              <p className="text-slate-600 mb-6">
-                Create your first custom label to help categorize volunteers.
-              </p>
-              <Button onClick={openCreateDialog} className="btn-primary">
-                <Plus className="h-4 w-4 mr-2" />
-                Create First Label
-              </Button>
-            </CardContent>
-          </Card>
-        ) : (
-          labels.map((label) => (
-            <Card key={label.id}>
-              <CardContent className="py-4">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <CustomLabelBadge label={label} />
-                    <div className="text-sm text-slate-600">
-                      {label._count.users} volunteer
-                      {label._count.users !== 1 ? "s" : ""}
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {label._count.users > 0 && (
-                      <Button
-                        asChild
-                        variant="outline"
-                        size="sm"
-                        data-testid={`announce-label-${label.id}`}
-                      >
-                        <Link
-                          href={`/admin/announcements?labels=${label.id}`}
-                          aria-label={`Announce to ${label.name} volunteers`}
-                        >
-                          <Megaphone className="h-4 w-4" />
-                        </Link>
-                      </Button>
-                    )}
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => openEditDialog(label)}
-                      data-testid={`edit-label-${label.id}`}
-                    >
-                      <Edit className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => openDeleteDialog(label)}
-                      disabled={label._count.users > 0}
-                      data-testid={`delete-label-${label.id}`}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                </div>
-                {label._count.users > 0 && (
-                  <div className="mt-2 text-xs text-slate-500">
-                    Remove from all volunteers before deleting
-                  </div>
+      {/* ===== Toolbar ===== */}
+      {labels.length > 0 && (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="relative w-full sm:max-w-xs">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search labels…"
+              className="pl-9"
+              data-testid="label-search-input"
+            />
+          </div>
+          <div className="flex items-center gap-1 rounded-full border border-border bg-card p-1">
+            <ArrowUpDown className="ml-2 h-3.5 w-3.5 text-muted-foreground" />
+            {SORTS.map((s) => (
+              <button
+                key={s.key}
+                type="button"
+                onClick={() => setSort(s.key)}
+                className={cn(
+                  "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                  sort === s.key
+                    ? "bg-[#1d5337] text-white shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
                 )}
-              </CardContent>
-            </Card>
-          ))
-        )}
-      </div>
+                data-testid={`sort-${s.key}`}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
+      {/* ===== Gallery ===== */}
+      {labels.length === 0 ? (
+        <EmptyState onCreate={openCreateDialog} />
+      ) : visibleLabels.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-border bg-card/50 py-16 text-center">
+          <p className="font-medium">No labels match “{query}”.</p>
+          <Button
+            variant="link"
+            onClick={() => setQuery("")}
+            className="mt-1"
+          >
+            Clear search
+          </Button>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {visibleLabels.map((label, i) => (
+            <LabelCard
+              key={label.id}
+              label={label}
+              index={i}
+              maxUsers={maxUsers}
+              onViewMembers={() => setMembersLabel(label)}
+              onEdit={() => {
+                setEditingLabel(label);
+                setDialogOpen(true);
+              }}
+              onDelete={() => setLabelToDelete(label)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* ===== Dialogs ===== */}
       <CustomLabelDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
@@ -281,16 +382,27 @@ export function CustomLabelsContent({
         }
       />
 
-      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+      <LabelMembersDialog
+        open={membersLabel !== null}
+        onOpenChange={(o) => !o && setMembersLabel(null)}
+        label={membersLabel}
+        onMemberRemoved={handleMemberRemoved}
+      />
+
+      <AlertDialog
+        open={labelToDelete !== null}
+        onOpenChange={(o) => !o && setLabelToDelete(null)}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2 text-destructive">
               <Trash2 className="h-5 w-5" />
-              Delete Custom Label
+              Delete custom label
             </AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to delete this label? It will be removed
-              from all users.
+              Are you sure you want to delete “{labelToDelete?.name}”? This
+              hides it everywhere. You can recreate it later, but it won&apos;t
+              reappear on volunteers automatically.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -299,12 +411,310 @@ export function CustomLabelsContent({
               onClick={confirmDeleteLabel}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              <Trash2 className="h-4 w-4 mr-2" />
-              Delete Label
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete label
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
     </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Label card                                                                */
+/* -------------------------------------------------------------------------- */
+
+interface LabelCardProps {
+  label: LabelWithMeta;
+  index: number;
+  maxUsers: number;
+  onViewMembers: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+function LabelCard({
+  label,
+  index,
+  maxUsers,
+  onViewMembers,
+  onEdit,
+  onDelete,
+}: LabelCardProps) {
+  const theme = getLabelTheme(label.color);
+  const count = label._count.users;
+  const hasMembers = count > 0;
+  const pct = Math.round((count / maxUsers) * 100);
+  const created = new Date(label.createdAt).toLocaleDateString("en-NZ", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.28, delay: Math.min(index * 0.04, 0.32) }}
+      className={cn(
+        "group relative flex flex-col overflow-hidden rounded-2xl bg-card shadow-sm ring-1 transition-shadow hover:shadow-md",
+        theme.ring
+      )}
+      data-testid={`label-card-${label.id}`}
+    >
+      {/* Coloured spine */}
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-x-0 top-0 h-24 bg-gradient-to-b to-transparent",
+          theme.glow
+        )}
+      />
+
+      <div className="relative flex flex-1 flex-col p-5">
+        {/* Header: swatch + badge + actions */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <CustomLabelBadge label={label} />
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              Created {created}
+            </p>
+          </div>
+
+          <TooltipProvider delayDuration={200}>
+            <div className="flex items-center gap-0.5">
+              {hasMembers && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      asChild
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground hover:text-[#1d5337] dark:hover:text-emerald-300"
+                    >
+                      <Link
+                        href={`/admin/announcements?labels=${label.id}`}
+                        aria-label={`Announce to ${label.name} volunteers`}
+                        data-testid={`announce-label-${label.id}`}
+                      >
+                        <Megaphone className="h-4 w-4" />
+                      </Link>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Announce to this group</TooltipContent>
+                </Tooltip>
+              )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                    onClick={onEdit}
+                    data-testid={`edit-label-${label.id}`}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Edit label</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-40"
+                      onClick={onDelete}
+                      disabled={hasMembers}
+                      data-testid={`delete-label-${label.id}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {hasMembers
+                    ? "Remove all volunteers first"
+                    : "Delete label"}
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
+        </div>
+
+        {/* Usage bar */}
+        <div className="mt-4">
+          <div className="flex items-center justify-between text-xs">
+            <span className="font-medium text-foreground">
+              {count} {count === 1 ? "volunteer" : "volunteers"}
+            </span>
+            {hasMembers && (
+              <span className="tabular-nums text-muted-foreground">{pct}%</span>
+            )}
+          </div>
+          <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            {hasMembers && (
+              <motion.div
+                initial={{ width: 0 }}
+                animate={{ width: `${pct}%` }}
+                transition={{ duration: 0.5, delay: 0.1 }}
+                className={cn("h-full rounded-full", theme.bar)}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Members footer — clickable */}
+        <div className="mt-auto pt-4">
+          {hasMembers ? (
+            <button
+              type="button"
+              onClick={onViewMembers}
+              className="flex w-full items-center justify-between rounded-xl border border-border/70 bg-background/50 px-3 py-2.5 text-left transition-colors hover:border-border hover:bg-muted/60"
+              data-testid={`view-members-${label.id}`}
+            >
+              <span className="flex items-center gap-3">
+                <AvatarList
+                  users={label.previewUsers}
+                  size="sm"
+                  maxDisplay={4}
+                  totalCount={count}
+                  enableLinks={false}
+                />
+                <span className="text-sm font-medium text-foreground">
+                  View members
+                </span>
+              </span>
+              <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+            </button>
+          ) : (
+            <div className="flex items-center gap-2 rounded-xl border border-dashed border-border bg-background/30 px-3 py-2.5 text-sm text-muted-foreground">
+              <Users className="h-4 w-4" />
+              No volunteers yet
+            </div>
+          )}
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  KPI tile                                                                   */
+/* -------------------------------------------------------------------------- */
+
+type Tone = "forest" | "blue" | "violet" | "amber" | "neutral";
+
+const TONE_STYLES: Record<Tone, { ring: string; iconWrap: string; value: string }> = {
+  forest: {
+    ring: "ring-[#1d5337]/12",
+    iconWrap:
+      "bg-[#1d5337]/10 text-[#1d5337] dark:bg-emerald-400/15 dark:text-emerald-300",
+    value: "text-[#1d5337] dark:text-emerald-200",
+  },
+  blue: {
+    ring: "ring-blue-400/20",
+    iconWrap: "bg-blue-500/10 text-blue-600 dark:text-blue-300",
+    value: "text-blue-700 dark:text-blue-200",
+  },
+  violet: {
+    ring: "ring-violet-400/20",
+    iconWrap: "bg-violet-500/10 text-violet-600 dark:text-violet-300",
+    value: "text-violet-700 dark:text-violet-200",
+  },
+  amber: {
+    ring: "ring-amber-400/30",
+    iconWrap: "bg-amber-400/15 text-amber-600 dark:text-amber-400",
+    value: "text-amber-600 dark:text-amber-400",
+  },
+  neutral: {
+    ring: "ring-border",
+    iconWrap: "bg-muted text-muted-foreground",
+    value: "text-foreground",
+  },
+};
+
+function KpiTile({
+  icon,
+  label,
+  value,
+  tone,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  tone: Tone;
+}) {
+  const styles = TONE_STYLES[tone];
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className={cn(
+        "rounded-2xl bg-card p-4 shadow-sm ring-1 dark:bg-white/[0.02]",
+        styles.ring
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {label}
+        </span>
+        <span
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-lg",
+            styles.iconWrap
+          )}
+        >
+          {icon}
+        </span>
+      </div>
+      <div className="mt-3">
+        <span
+          className={cn(
+            "font-accent text-3xl font-semibold tabular-nums leading-none",
+            styles.value
+          )}
+        >
+          {value}
+        </span>
+      </div>
+    </motion.div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Empty state                                                               */
+/* -------------------------------------------------------------------------- */
+
+function EmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="rounded-2xl border border-dashed border-border bg-card/50 px-6 py-16 text-center"
+    >
+      <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-[#1d5337]/10 text-[#1d5337] dark:bg-emerald-400/15 dark:text-emerald-300">
+        <Tags className="h-7 w-7" />
+      </div>
+      <h3 className="mt-4 font-accent text-xl font-semibold">
+        No labels yet
+      </h3>
+      <p className="mx-auto mt-1.5 max-w-sm text-sm text-muted-foreground">
+        Create your first custom label to group volunteers — handy for targeted
+        announcements and spotting specialists.
+      </p>
+      <Button
+        onClick={onCreate}
+        className="mt-6 bg-[#1d5337] text-white hover:bg-[#1d5337]/90"
+        data-testid="create-first-label-button"
+      >
+        <Plus className="mr-2 h-4 w-4" />
+        Create first label
+      </Button>
+    </motion.div>
   );
 }

--- a/web/src/app/admin/custom-labels/label-colors.test.ts
+++ b/web/src/app/admin/custom-labels/label-colors.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  getColorFamily,
+  getLabelTheme,
+  firstGrapheme,
+  COLOR_OPTIONS,
+  FAMILY_THEME,
+} from "./label-colors";
+
+describe("getColorFamily", () => {
+  it("extracts the family from the text- token", () => {
+    expect(getColorFamily("bg-purple-50 text-purple-700 border-purple-200")).toBe(
+      "purple"
+    );
+  });
+
+  it("handles colour strings that include dark-mode classes", () => {
+    expect(
+      getColorFamily(
+        "bg-blue-50 dark:bg-blue-950/20 text-blue-700 dark:text-blue-400"
+      )
+    ).toBe("blue");
+  });
+
+  it("recognises every palette option", () => {
+    for (const option of COLOR_OPTIONS) {
+      expect(getColorFamily(option.value)).toBe(option.family);
+    }
+  });
+
+  it("falls back to slate for unknown colours", () => {
+    expect(getColorFamily("bg-cornflower-50 text-cornflower-700")).toBe("slate");
+  });
+
+  it("falls back to slate for null/empty input", () => {
+    expect(getColorFamily(null)).toBe("slate");
+    expect(getColorFamily(undefined)).toBe("slate");
+    expect(getColorFamily("")).toBe("slate");
+  });
+
+  it("falls back to a family found anywhere when no text- token exists", () => {
+    expect(getColorFamily("bg-teal-100 border-teal-200")).toBe("teal");
+  });
+});
+
+describe("getLabelTheme", () => {
+  it("returns the theme tokens for the derived family", () => {
+    expect(getLabelTheme("text-emerald-700")).toBe(FAMILY_THEME.emerald);
+  });
+
+  it("returns the slate theme as a safe default", () => {
+    expect(getLabelTheme("not-a-colour")).toBe(FAMILY_THEME.slate);
+  });
+});
+
+describe("firstGrapheme", () => {
+  it("returns an empty string for empty input", () => {
+    expect(firstGrapheme("")).toBe("");
+  });
+
+  it("keeps a simple emoji intact", () => {
+    expect(firstGrapheme("⭐")).toBe("⭐");
+  });
+
+  it("preserves a multi-code-unit emoji (variation selector)", () => {
+    expect(firstGrapheme("🎖️")).toBe("🎖️");
+  });
+
+  it("preserves a skin-tone modified emoji as one grapheme", () => {
+    expect(firstGrapheme("👍🏽")).toBe("👍🏽");
+  });
+
+  it("takes only the first grapheme when several are pasted", () => {
+    expect(firstGrapheme("⭐🔥💎")).toBe("⭐");
+  });
+
+  it("takes the first character of plain text", () => {
+    expect(firstGrapheme("AB")).toBe("A");
+  });
+});

--- a/web/src/app/admin/custom-labels/label-colors.ts
+++ b/web/src/app/admin/custom-labels/label-colors.ts
@@ -1,0 +1,210 @@
+// Shared colour intelligence for the custom-labels admin experience.
+//
+// Labels persist their colour as a full Tailwind class string (e.g.
+// "bg-purple-50 text-purple-700 border-purple-200 ..."). To theme the
+// redesigned cards, swatches and member modal we derive a single colour
+// "family" from that string and map it to a richer set of tokens (solid
+// swatch, soft surface, ring, accent text, usage bar).
+
+export type ColorFamily =
+  | "purple"
+  | "blue"
+  | "emerald"
+  | "amber"
+  | "rose"
+  | "indigo"
+  | "teal"
+  | "orange"
+  | "slate";
+
+export interface FamilyTheme {
+  /** Solid swatch dot, e.g. on the picker + card colour chip */
+  dot: string;
+  /** Soft tinted surface for card headers / icon wells */
+  soft: string;
+  /** Ring/border tint that pairs with the soft surface */
+  ring: string;
+  /** Accent text colour */
+  text: string;
+  /** Solid fill for the usage progress bar */
+  bar: string;
+  /** Subtle gradient wash for the card spine */
+  glow: string;
+}
+
+export const FAMILY_THEME: Record<ColorFamily, FamilyTheme> = {
+  purple: {
+    dot: "bg-purple-500",
+    soft: "bg-purple-50 dark:bg-purple-950/30",
+    ring: "ring-purple-200/70 dark:ring-purple-900/50",
+    text: "text-purple-700 dark:text-purple-300",
+    bar: "bg-purple-500",
+    glow: "from-purple-400/25",
+  },
+  blue: {
+    dot: "bg-blue-500",
+    soft: "bg-blue-50 dark:bg-blue-950/30",
+    ring: "ring-blue-200/70 dark:ring-blue-900/50",
+    text: "text-blue-700 dark:text-blue-300",
+    bar: "bg-blue-500",
+    glow: "from-blue-400/25",
+  },
+  emerald: {
+    dot: "bg-emerald-500",
+    soft: "bg-emerald-50 dark:bg-emerald-950/30",
+    ring: "ring-emerald-200/70 dark:ring-emerald-900/50",
+    text: "text-emerald-700 dark:text-emerald-300",
+    bar: "bg-emerald-500",
+    glow: "from-emerald-400/25",
+  },
+  amber: {
+    dot: "bg-amber-500",
+    soft: "bg-amber-50 dark:bg-amber-950/30",
+    ring: "ring-amber-200/70 dark:ring-amber-900/50",
+    text: "text-amber-700 dark:text-amber-300",
+    bar: "bg-amber-500",
+    glow: "from-amber-400/25",
+  },
+  rose: {
+    dot: "bg-rose-500",
+    soft: "bg-rose-50 dark:bg-rose-950/30",
+    ring: "ring-rose-200/70 dark:ring-rose-900/50",
+    text: "text-rose-700 dark:text-rose-300",
+    bar: "bg-rose-500",
+    glow: "from-rose-400/25",
+  },
+  indigo: {
+    dot: "bg-indigo-500",
+    soft: "bg-indigo-50 dark:bg-indigo-950/30",
+    ring: "ring-indigo-200/70 dark:ring-indigo-900/50",
+    text: "text-indigo-700 dark:text-indigo-300",
+    bar: "bg-indigo-500",
+    glow: "from-indigo-400/25",
+  },
+  teal: {
+    dot: "bg-teal-500",
+    soft: "bg-teal-50 dark:bg-teal-950/30",
+    ring: "ring-teal-200/70 dark:ring-teal-900/50",
+    text: "text-teal-700 dark:text-teal-300",
+    bar: "bg-teal-500",
+    glow: "from-teal-400/25",
+  },
+  orange: {
+    dot: "bg-orange-500",
+    soft: "bg-orange-50 dark:bg-orange-950/30",
+    ring: "ring-orange-200/70 dark:ring-orange-900/50",
+    text: "text-orange-700 dark:text-orange-300",
+    bar: "bg-orange-500",
+    glow: "from-orange-400/25",
+  },
+  slate: {
+    dot: "bg-slate-400",
+    soft: "bg-slate-50 dark:bg-slate-900/40",
+    ring: "ring-slate-200/70 dark:ring-slate-800/60",
+    text: "text-slate-700 dark:text-slate-300",
+    bar: "bg-slate-400",
+    glow: "from-slate-400/20",
+  },
+};
+
+const KNOWN_FAMILIES = Object.keys(FAMILY_THEME) as ColorFamily[];
+
+/**
+ * Extract the colour family from a stored Tailwind colour string.
+ * The `text-{family}-{shade}` token is the most reliable signal.
+ */
+export function getColorFamily(color: string | null | undefined): ColorFamily {
+  if (!color) return "slate";
+  const textMatch = color.match(/text-([a-z]+)-\d/);
+  const candidate = textMatch?.[1];
+  if (candidate && (KNOWN_FAMILIES as string[]).includes(candidate)) {
+    return candidate as ColorFamily;
+  }
+  // Fall back to any recognised family appearing anywhere in the string.
+  const found = KNOWN_FAMILIES.find((f) => color.includes(`-${f}-`));
+  return found ?? "slate";
+}
+
+export function getLabelTheme(color: string | null | undefined): FamilyTheme {
+  return FAMILY_THEME[getColorFamily(color)];
+}
+
+export interface ColorOption {
+  name: string;
+  family: ColorFamily;
+  /** Full Tailwind badge class string persisted to the database. */
+  value: string;
+}
+
+// The eight palette options offered when creating/editing a label. The
+// `value` strings remain byte-compatible with previously stored labels.
+export const COLOR_OPTIONS: ColorOption[] = [
+  {
+    name: "Purple",
+    family: "purple",
+    value:
+      "bg-purple-50 dark:bg-purple-950/20 text-purple-700 dark:text-purple-400 border-purple-200 dark:border-purple-800 hover:bg-purple-100 dark:hover:bg-purple-950/30",
+  },
+  {
+    name: "Blue",
+    family: "blue",
+    value:
+      "bg-blue-50 dark:bg-blue-950/20 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800 hover:bg-blue-100 dark:hover:bg-blue-950/30",
+  },
+  {
+    name: "Green",
+    family: "emerald",
+    value:
+      "bg-emerald-50 dark:bg-emerald-950/20 text-emerald-700 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800 hover:bg-emerald-100 dark:hover:bg-emerald-950/30",
+  },
+  {
+    name: "Amber",
+    family: "amber",
+    value:
+      "bg-amber-50 dark:bg-amber-950/20 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800 hover:bg-amber-100 dark:hover:bg-amber-950/30",
+  },
+  {
+    name: "Pink",
+    family: "rose",
+    value:
+      "bg-rose-50 dark:bg-rose-950/20 text-rose-700 dark:text-rose-400 border-rose-200 dark:border-rose-800 hover:bg-rose-100 dark:hover:bg-rose-950/30",
+  },
+  {
+    name: "Indigo",
+    family: "indigo",
+    value:
+      "bg-indigo-50 dark:bg-indigo-950/20 text-indigo-700 dark:text-indigo-400 border-indigo-200 dark:border-indigo-800 hover:bg-indigo-100 dark:hover:bg-indigo-950/30",
+  },
+  {
+    name: "Teal",
+    family: "teal",
+    value:
+      "bg-teal-50 dark:bg-teal-950/20 text-teal-700 dark:text-teal-400 border-teal-200 dark:border-teal-800 hover:bg-teal-100 dark:hover:bg-teal-950/30",
+  },
+  {
+    name: "Orange",
+    family: "orange",
+    value:
+      "bg-orange-50 dark:bg-orange-950/20 text-orange-700 dark:text-orange-400 border-orange-200 dark:border-orange-800 hover:bg-orange-100 dark:hover:bg-orange-950/30",
+  },
+];
+
+// Emoji glyphs offered in the icon picker.
+export const ICON_OPTIONS = [
+  "⭐",
+  "🔥",
+  "💎",
+  "🏆",
+  "🎯",
+  "⚡",
+  "🌟",
+  "🎖️",
+  "👑",
+  "🔔",
+  "📌",
+  "🚀",
+  "✨",
+  "💝",
+  "🎪",
+  "🌈",
+];

--- a/web/src/app/admin/custom-labels/label-colors.ts
+++ b/web/src/app/admin/custom-labels/label-colors.ts
@@ -189,6 +189,28 @@ export const COLOR_OPTIONS: ColorOption[] = [
   },
 ];
 
+/**
+ * Return the first grapheme cluster of a string. A label icon is a single
+ * emoji, but many emoji span multiple UTF-16 code units (skin tones, flags,
+ * ZWJ sequences), so a naïve `slice(0, 2)` would corrupt them. Uses
+ * `Intl.Segmenter` where available and falls back to the raw input otherwise.
+ */
+export function firstGrapheme(input: string): string {
+  if (!input) return "";
+  const Segmenter = (
+    Intl as typeof Intl & { Segmenter?: typeof Intl.Segmenter }
+  ).Segmenter;
+  if (typeof Segmenter === "function") {
+    const segmenter = new Segmenter(undefined, { granularity: "grapheme" });
+    for (const { segment } of segmenter.segment(input)) {
+      return segment;
+    }
+    return "";
+  }
+  // Fallback: take the first code point (handles surrogate pairs).
+  return Array.from(input)[0] ?? "";
+}
+
 // Emoji glyphs offered in the icon picker.
 export const ICON_OPTIONS = [
   "⭐",

--- a/web/src/app/admin/custom-labels/label-members-dialog.tsx
+++ b/web/src/app/admin/custom-labels/label-members-dialog.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { motion, AnimatePresence } from "motion/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { CustomLabelBadge } from "@/components/custom-label-badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Search,
+  Megaphone,
+  ExternalLink,
+  UserMinus,
+  Users,
+  AlertCircle,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useToast } from "@/hooks/use-toast";
+import { getLabelTheme } from "./label-colors";
+import type { LabelWithMeta } from "./custom-labels-content";
+
+export interface LabelMember {
+  id: string;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  email: string;
+  profilePhotoUrl: string | null;
+  volunteerGrade: "GREEN" | "YELLOW" | "PINK";
+  assignedAt: string;
+}
+
+interface LabelMembersDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  label: LabelWithMeta | null;
+  /** Notify the parent that a member was removed so counts stay in sync. */
+  onMemberRemoved: (labelId: string, userId: string) => void;
+}
+
+const GRADE_STYLES: Record<LabelMember["volunteerGrade"], string> = {
+  GREEN:
+    "bg-emerald-50 text-emerald-700 ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-900/50",
+  YELLOW:
+    "bg-amber-50 text-amber-700 ring-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900/50",
+  PINK: "bg-rose-50 text-rose-700 ring-rose-200 dark:bg-rose-950/40 dark:text-rose-300 dark:ring-rose-900/50",
+};
+
+const GRADE_LABEL: Record<LabelMember["volunteerGrade"], string> = {
+  GREEN: "Standard",
+  YELLOW: "Experienced",
+  PINK: "Shift leader",
+};
+
+function displayName(m: LabelMember) {
+  return (
+    m.name || `${m.firstName || ""} ${m.lastName || ""}`.trim() || m.email
+  );
+}
+
+function initials(m: LabelMember) {
+  return (m.firstName?.[0] || m.name?.[0] || m.email[0]).toUpperCase();
+}
+
+export function LabelMembersDialog({
+  open,
+  onOpenChange,
+  label,
+  onMemberRemoved,
+}: LabelMembersDialogProps) {
+  const { toast } = useToast();
+  const [members, setMembers] = useState<LabelMember[]>([]);
+  const [status, setStatus] = useState<"idle" | "loading" | "error" | "ready">(
+    "idle"
+  );
+  const [query, setQuery] = useState("");
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<LabelMember | null>(null);
+
+  const theme = getLabelTheme(label?.color);
+
+  const loadMembers = useCallback(async () => {
+    if (!label) return;
+    setStatus("loading");
+    try {
+      const res = await fetch(`/api/admin/custom-labels/${label.id}/users`);
+      if (!res.ok) throw new Error("Failed to load");
+      const data = await res.json();
+      setMembers(data.members ?? []);
+      setStatus("ready");
+    } catch {
+      setStatus("error");
+    }
+  }, [label]);
+
+  useEffect(() => {
+    if (open && label) {
+      setQuery("");
+      loadMembers();
+    } else if (!open) {
+      // Reset after the close animation so content doesn't flash empty.
+      const t = setTimeout(() => {
+        setMembers([]);
+        setStatus("idle");
+      }, 200);
+      return () => clearTimeout(t);
+    }
+  }, [open, label, loadMembers]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return members;
+    return members.filter((m) =>
+      [displayName(m), m.email].some((v) => v.toLowerCase().includes(q))
+    );
+  }, [members, query]);
+
+  const handleRemove = async (member: LabelMember) => {
+    if (!label) return;
+    setRemovingId(member.id);
+    try {
+      const res = await fetch(`/api/admin/users/${member.id}/labels`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ labelId: label.id }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to remove label");
+      }
+      setMembers((prev) => prev.filter((m) => m.id !== member.id));
+      onMemberRemoved(label.id, member.id);
+      toast({
+        title: "Label removed",
+        description: `${displayName(member)} no longer has “${label.name}”.`,
+      });
+    } catch (error) {
+      toast({
+        title: "Couldn't remove label",
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setRemovingId(null);
+      setConfirmRemove(null);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          showCloseButton={false}
+          className="gap-0 overflow-hidden p-0 sm:max-w-lg"
+          data-testid="label-members-dialog"
+        >
+          {/* Themed header */}
+          <div
+            className={cn(
+              "relative border-b px-6 pb-5 pt-6",
+              theme.soft,
+              "border-black/[0.04] dark:border-white/[0.06]"
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/5 dark:hover:bg-white/10"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </button>
+            <DialogHeader className="space-y-2 text-left">
+              <DialogTitle className="flex items-center gap-2 font-accent text-lg">
+                {label && (
+                  <CustomLabelBadge label={label} size="lg" />
+                )}
+              </DialogTitle>
+              <DialogDescription asChild>
+                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+                  <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+                    <Users className="h-3.5 w-3.5" />
+                    {members.length}{" "}
+                    {members.length === 1 ? "volunteer" : "volunteers"}
+                  </span>
+                  <span aria-hidden>·</span>
+                  <span>carrying this label</span>
+                </div>
+              </DialogDescription>
+            </DialogHeader>
+
+            {label && members.length > 0 && (
+              <Button
+                asChild
+                size="sm"
+                variant="outline"
+                className="mt-4 bg-background/70 backdrop-blur"
+              >
+                <Link
+                  href={`/admin/announcements?labels=${label.id}`}
+                  data-testid="members-announce-button"
+                >
+                  <Megaphone className="mr-2 h-4 w-4" />
+                  Announce to this group
+                </Link>
+              </Button>
+            )}
+          </div>
+
+          {/* Search */}
+          {status === "ready" && members.length > 0 && (
+            <div className="border-b border-border/60 px-6 py-3">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search by name or email…"
+                  className="pl-9"
+                  data-testid="members-search-input"
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Member list */}
+          <div className="max-h-[min(60vh,26rem)] overflow-y-auto px-3 py-3">
+            {status === "loading" && <MembersSkeleton />}
+
+            {status === "error" && (
+              <div className="flex flex-col items-center gap-3 px-6 py-12 text-center">
+                <AlertCircle className="h-8 w-8 text-destructive" />
+                <p className="text-sm text-muted-foreground">
+                  We couldn&apos;t load this group right now.
+                </p>
+                <Button variant="outline" size="sm" onClick={loadMembers}>
+                  Try again
+                </Button>
+              </div>
+            )}
+
+            {status === "ready" && members.length === 0 && (
+              <div className="flex flex-col items-center gap-2 px-6 py-12 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+                  <Users className="h-6 w-6 text-muted-foreground" />
+                </div>
+                <p className="font-medium">No volunteers yet</p>
+                <p className="max-w-xs text-sm text-muted-foreground">
+                  Assign this label from a volunteer&apos;s profile to start
+                  building the group.
+                </p>
+              </div>
+            )}
+
+            {status === "ready" && members.length > 0 && filtered.length === 0 && (
+              <div className="px-6 py-10 text-center text-sm text-muted-foreground">
+                No volunteers match “{query}”.
+              </div>
+            )}
+
+            <AnimatePresence initial={false}>
+              {status === "ready" &&
+                filtered.map((member) => (
+                  <motion.div
+                    key={member.id}
+                    layout
+                    initial={{ opacity: 0, y: 4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, height: 0, marginTop: 0 }}
+                    transition={{ duration: 0.18 }}
+                    className="group flex items-center gap-3 rounded-xl px-3 py-2 transition-colors hover:bg-muted/60"
+                    data-testid={`member-row-${member.id}`}
+                  >
+                    <Avatar className="h-10 w-10 ring-2 ring-background">
+                      <AvatarImage
+                        src={member.profilePhotoUrl || undefined}
+                        alt={displayName(member)}
+                      />
+                      <AvatarFallback className="bg-primary/10 text-sm font-semibold text-primary">
+                        {initials(member)}
+                      </AvatarFallback>
+                    </Avatar>
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <Link
+                          href={`/admin/users/${member.id}`}
+                          className="truncate font-medium hover:underline"
+                        >
+                          {displayName(member)}
+                        </Link>
+                        <span
+                          className={cn(
+                            "hidden shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 sm:inline-block",
+                            GRADE_STYLES[member.volunteerGrade]
+                          )}
+                        >
+                          {GRADE_LABEL[member.volunteerGrade]}
+                        </span>
+                      </div>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {member.email}
+                      </p>
+                    </div>
+
+                    <div className="flex shrink-0 items-center gap-0.5">
+                      <Button
+                        asChild
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
+                      >
+                        <Link
+                          href={`/admin/users/${member.id}`}
+                          aria-label={`Open ${displayName(member)}'s profile`}
+                        >
+                          <ExternalLink className="h-4 w-4" />
+                        </Link>
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                        disabled={removingId === member.id}
+                        onClick={() => setConfirmRemove(member)}
+                        aria-label={`Remove label from ${displayName(member)}`}
+                        data-testid={`remove-member-${member.id}`}
+                      >
+                        <UserMinus className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </motion.div>
+                ))}
+            </AnimatePresence>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={confirmRemove !== null}
+        onOpenChange={(o) => !o && setConfirmRemove(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove label?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes “{label?.name}” from{" "}
+              {confirmRemove ? displayName(confirmRemove) : "this volunteer"}.
+              They keep their account and every other label.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => confirmRemove && handleRemove(confirmRemove)}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              <UserMinus className="mr-2 h-4 w-4" />
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function MembersSkeleton() {
+  return (
+    <div className="space-y-1">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3 px-3 py-2">
+          <div className="h-10 w-10 shrink-0 animate-pulse rounded-full bg-muted" />
+          <div className="flex-1 space-y-2">
+            <div
+              className="h-3.5 animate-pulse rounded bg-muted"
+              style={{ width: `${55 - i * 5}%` }}
+            />
+            <div
+              className="h-2.5 animate-pulse rounded bg-muted/70"
+              style={{ width: `${75 - i * 6}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/app/admin/custom-labels/page.tsx
+++ b/web/src/app/admin/custom-labels/page.tsx
@@ -13,26 +13,50 @@ export default async function CustomLabelsPage() {
     redirect("/dashboard");
   }
 
-  const labels = await prisma.customLabel.findMany({
-    where: {
-      isActive: true,
-    },
-    include: {
-      _count: {
-        select: {
-          users: true,
+  // Fetch labels alongside a small preview of recently-tagged volunteers so
+  // each card can show an avatar stack without loading every member upfront.
+  const [labels, taggedVolunteers] = await Promise.all([
+    prisma.customLabel.findMany({
+      where: { isActive: true },
+      include: {
+        _count: { select: { users: true } },
+        users: {
+          take: 5,
+          orderBy: { assignedAt: "desc" },
+          select: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                firstName: true,
+                lastName: true,
+                email: true,
+                profilePhotoUrl: true,
+              },
+            },
+          },
         },
       },
-    },
-    orderBy: [
-      { createdAt: "desc" },
-    ],
-  });
+      orderBy: [{ createdAt: "desc" }],
+    }),
+    // Distinct volunteers carrying at least one active label.
+    prisma.user.count({
+      where: { customLabels: { some: { label: { isActive: true } } } },
+    }),
+  ]);
+
+  const initialLabels = labels.map((label) => ({
+    ...label,
+    previewUsers: label.users.map((u) => u.user),
+  }));
 
   return (
     <AdminPageWrapper title="Custom Labels">
       <PageContainer>
-        <CustomLabelsContent initialLabels={labels} />
+        <CustomLabelsContent
+          initialLabels={initialLabels}
+          taggedVolunteers={taggedVolunteers}
+        />
       </PageContainer>
     </AdminPageWrapper>
   );

--- a/web/src/app/api/admin/custom-labels/[id]/users/route.ts
+++ b/web/src/app/api/admin/custom-labels/[id]/users/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+
+// List every volunteer assigned a given custom label.
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session || session.user.role !== "ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+    }
+
+    const { id } = await params;
+
+    const label = await prisma.customLabel.findUnique({
+      where: { id },
+      select: { id: true, name: true, color: true, icon: true },
+    });
+
+    if (!label) {
+      return NextResponse.json({ error: "Label not found" }, { status: 404 });
+    }
+
+    const assignments = await prisma.userCustomLabel.findMany({
+      where: { labelId: id },
+      orderBy: { assignedAt: "desc" },
+      select: {
+        assignedAt: true,
+        user: {
+          select: {
+            id: true,
+            name: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+            profilePhotoUrl: true,
+            volunteerGrade: true,
+          },
+        },
+      },
+    });
+
+    const members = assignments.map((a) => ({
+      ...a.user,
+      assignedAt: a.assignedAt,
+    }));
+
+    return NextResponse.json({ label, members });
+  } catch (error) {
+    console.error("Error fetching label members:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch label members" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Description
Complete visual and information-architecture overhaul of `/admin/custom-labels`, plus a new **"list people with a label"** modal. The page was previously a flat vertical list of near-empty rows; it's now a themed gallery with an overview, search/sort, and per-label member management.

### What changed
- **Hero band** — branded forest-gradient header with the primary *New label* CTA.
- **KPI overview** — Labels, Volunteers tagged (distinct), Total assignments, Unused labels.
- **Toolbar** — live label search + sort (Most volunteers / Newest / A–Z).
- **Themed gallery cards** — each label is themed by its own colour (glow spine, relative usage bar, recent-member avatar stack, created date, quick actions).
- **New members modal** — lists every volunteer with a label: avatars, volunteer-grade chips, profile links, in-modal search, an *Announce to this group* action, and inline **remove** (with confirmation) that keeps card counts and usage bars in sync.
- **Redesigned create/edit dialog** — live preview, solid-swatch colour picker, icon grid with a no-icon option.
- **New API route** — `GET /api/admin/custom-labels/[id]/users`.
- **Shared colour helper** (`label-colors.ts`) — derives a colour family from the stored Tailwind colour string, fully back-compatible with existing labels.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Manual testing completed

Verified live (logged in as admin): typecheck + lint pass; cards render with correct per-label theming and relative usage bars; the members modal loads, searches, and removes (count syncs to the card and KPIs); create flow works end-to-end; holds up in **dark mode, light mode, and at 390px mobile**; no console errors.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes
- The members modal reuses the existing `DELETE /api/admin/users/[id]/labels` endpoint to remove a label from a volunteer; only safe columns are selected in the new query, so it's unaffected by any local DB schema drift.
- No schema/migration changes — uses the existing `CustomLabel` / `UserCustomLabel` models.