### PR TITLE
Fix broken volunteer profile links in custom-label members modal

### DIFF
--- a/web/src/app/admin/custom-labels/label-members-dialog.tsx
+++ b/web/src/app/admin/custom-labels/label-members-dialog.tsx
@@ -304,7 +304,7 @@ export function LabelMembersDialog({
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <Link
-                          href={`/admin/users/${member.id}`}
+                          href={`/admin/volunteers/${member.id}`}
                           className="truncate font-medium hover:underline"
                         >
                           {displayName(member)}
@@ -331,7 +331,7 @@ export function LabelMembersDialog({
                         className="h-8 w-8 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
                       >
                         <Link
-                          href={`/admin/users/${member.id}`}
+                          href={`/admin/volunteers/${member.id}`}
                           aria-label={`Open ${displayName(member)}'s profile`}
                         >
                           <ExternalLink className="h-4 w-4" />


### PR DESCRIPTION
## Description
Follow-up fix for #1042. The custom-label **members modal** linked volunteer names and the open-profile button to `/admin/users/[id]`, but that route has no page (only the `/admin/users` list exists), so the links 404'd. Both now point at `/admin/volunteers/[id]` — the canonical volunteer profile route used throughout the rest of the admin area.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
`version:patch`

## Testing
- [x] typecheck + lint pass
- Verified `/admin/volunteers/[id]/page.tsx` exists and is the route 25+ other admin links already use; `/admin/users/[id]` has no page.

## Additional Notes
Two `href` strings changed in `label-members-dialog.tsx`; the API call on line 141 (`/api/admin/users/[id]/labels`) is unrelated and correct.