### PR TITLE
fix(admin): coerce numeric inputs in auto-accept rule form

### DIFF
--- a/web/src/components/auto-accept/rule-form-dialog.tsx
+++ b/web/src/components/auto-accept/rule-form-dialog.tsx
@@ -308,7 +308,18 @@ export function RuleFormDialog({
                   <FormItem>
                     <FormLabel>Priority</FormLabel>
                     <FormControl>
-                      <Input type="number" min="0" {...field} />
+                      <Input
+                        type="number"
+                        min="0"
+                        {...field}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value === ""
+                              ? 0
+                              : e.target.valueAsNumber
+                          )
+                        }
+                      />
                     </FormControl>
                     <FormDescription>
                       Higher priority rules are evaluated first
@@ -463,6 +474,13 @@ export function RuleFormDialog({
                           min="0"
                           placeholder="e.g., 5"
                           {...field}
+                          onChange={(e) =>
+                            field.onChange(
+                              e.target.value === ""
+                                ? ""
+                                : e.target.valueAsNumber
+                            )
+                          }
                         />
                       </FormControl>
                       <FormMessage />
@@ -483,6 +501,13 @@ export function RuleFormDialog({
                           max="100"
                           placeholder="e.g., 80"
                           {...field}
+                          onChange={(e) =>
+                            field.onChange(
+                              e.target.value === ""
+                                ? ""
+                                : e.target.valueAsNumber
+                            )
+                          }
                         />
                       </FormControl>
                       <FormMessage />
@@ -502,6 +527,13 @@ export function RuleFormDialog({
                           min="0"
                           placeholder="e.g., 30"
                           {...field}
+                          onChange={(e) =>
+                            field.onChange(
+                              e.target.value === ""
+                                ? ""
+                                : e.target.valueAsNumber
+                            )
+                          }
                         />
                       </FormControl>
                       <FormMessage />
@@ -521,6 +553,13 @@ export function RuleFormDialog({
                           min="0"
                           placeholder="e.g., 14"
                           {...field}
+                          onChange={(e) =>
+                            field.onChange(
+                              e.target.value === ""
+                                ? ""
+                                : e.target.valueAsNumber
+                            )
+                          }
                         />
                       </FormControl>
                       <FormDescription>
@@ -543,6 +582,13 @@ export function RuleFormDialog({
                           min="0"
                           placeholder="e.g., 18"
                           {...field}
+                          onChange={(e) =>
+                            field.onChange(
+                              e.target.value === ""
+                                ? ""
+                                : e.target.valueAsNumber
+                            )
+                          }
                         />
                       </FormControl>
                       <FormDescription>

--- a/web/src/components/auto-accept/rule-form-dialog.tsx
+++ b/web/src/components/auto-accept/rule-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, type ChangeEvent } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -64,6 +64,15 @@ const ruleFormSchema = z.object({
 });
 
 type RuleFormValues = z.infer<typeof ruleFormSchema>;
+
+// `<input type="number">` reports its value as a string, so convert it back
+// to a number before handing it to react-hook-form. `emptyValue` is what we
+// store when the field is cleared (0 for required priority, "" for optional
+// criteria — matching the schema and the onSubmit cleanup).
+const handleNumericChange =
+  (onChange: (value: number | "") => void, emptyValue: number | "") =>
+  (e: ChangeEvent<HTMLInputElement>) =>
+    onChange(e.target.value === "" ? emptyValue : e.target.valueAsNumber);
 
 interface RuleFormDialogProps {
   open: boolean;
@@ -312,13 +321,7 @@ export function RuleFormDialog({
                         type="number"
                         min="0"
                         {...field}
-                        onChange={(e) =>
-                          field.onChange(
-                            e.target.value === ""
-                              ? 0
-                              : e.target.valueAsNumber
-                          )
-                        }
+                        onChange={handleNumericChange(field.onChange, 0)}
                       />
                     </FormControl>
                     <FormDescription>
@@ -474,13 +477,7 @@ export function RuleFormDialog({
                           min="0"
                           placeholder="e.g., 5"
                           {...field}
-                          onChange={(e) =>
-                            field.onChange(
-                              e.target.value === ""
-                                ? ""
-                                : e.target.valueAsNumber
-                            )
-                          }
+                          onChange={handleNumericChange(field.onChange, "")}
                         />
                       </FormControl>
                       <FormMessage />
@@ -501,13 +498,7 @@ export function RuleFormDialog({
                           max="100"
                           placeholder="e.g., 80"
                           {...field}
-                          onChange={(e) =>
-                            field.onChange(
-                              e.target.value === ""
-                                ? ""
-                                : e.target.valueAsNumber
-                            )
-                          }
+                          onChange={handleNumericChange(field.onChange, "")}
                         />
                       </FormControl>
                       <FormMessage />
@@ -527,13 +518,7 @@ export function RuleFormDialog({
                           min="0"
                           placeholder="e.g., 30"
                           {...field}
-                          onChange={(e) =>
-                            field.onChange(
-                              e.target.value === ""
-                                ? ""
-                                : e.target.valueAsNumber
-                            )
-                          }
+                          onChange={handleNumericChange(field.onChange, "")}
                         />
                       </FormControl>
                       <FormMessage />
@@ -553,13 +538,7 @@ export function RuleFormDialog({
                           min="0"
                           placeholder="e.g., 14"
                           {...field}
-                          onChange={(e) =>
-                            field.onChange(
-                              e.target.value === ""
-                                ? ""
-                                : e.target.valueAsNumber
-                            )
-                          }
+                          onChange={handleNumericChange(field.onChange, "")}
                         />
                       </FormControl>
                       <FormDescription>
@@ -582,13 +561,7 @@ export function RuleFormDialog({
                           min="0"
                           placeholder="e.g., 18"
                           {...field}
-                          onChange={(e) =>
-                            field.onChange(
-                              e.target.value === ""
-                                ? ""
-                                : e.target.valueAsNumber
-                            )
-                          }
+                          onChange={handleNumericChange(field.onChange, "")}
                         />
                       </FormControl>
                       <FormDescription>

--- a/web/src/components/auto-accept/rule-form-dialog.tsx
+++ b/web/src/components/auto-accept/rule-form-dialog.tsx
@@ -68,11 +68,14 @@ type RuleFormValues = z.infer<typeof ruleFormSchema>;
 // `<input type="number">` reports its value as a string, so convert it back
 // to a number before handing it to react-hook-form. `emptyValue` is what we
 // store when the field is cleared (0 for required priority, "" for optional
-// criteria — matching the schema and the onSubmit cleanup).
+// criteria — matching the schema and the onSubmit cleanup). An unparseable
+// value (valueAsNumber === NaN) falls back to emptyValue too.
 const handleNumericChange =
   (onChange: (value: number | "") => void, emptyValue: number | "") =>
-  (e: ChangeEvent<HTMLInputElement>) =>
-    onChange(e.target.value === "" ? emptyValue : e.target.valueAsNumber);
+  (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.valueAsNumber;
+    onChange(e.target.value === "" || Number.isNaN(value) ? emptyValue : value);
+  };
 
 interface RuleFormDialogProps {
   open: boolean;


### PR DESCRIPTION
# Pull Request

## Description
Fixes a validation error when creating or editing auto-accept rules in the admin panel. Filling in any numeric field and submitting failed with `Invalid input: expected number, received string`.

The numeric inputs in the rule form (`web/src/components/auto-accept/rule-form-dialog.tsx`) rendered `<Input type="number" {...field} />`, spreading react-hook-form's `onChange` directly. That stores the raw DOM value as a **string**, so a typed `5` became `"5"`. The Zod schema expects a `number` (`priority`) or `number | ""` (optional criteria), which rejected the string. The defaults masked the bug — it only surfaced once a numeric field was edited.

Each numeric field now has an explicit `onChange` that converts the value to a number:
- **Priority** (required): empty → `0`, otherwise `e.target.valueAsNumber`
- **minCompletedShifts, minAttendanceRate, minAccountAgeDays, maxDaysInAdvance, minVolunteerAge** (optional): empty → `""`, otherwise `e.target.valueAsNumber`

The empty-string handling for optional fields matches the existing `onSubmit` cleanup that maps `""` → `null`.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
- `version:patch`

## Testing
- [ ] Unit tests pass
- [ ] E2E tests pass
- [x] Manual testing recommended (worktree has no installed deps; verify by creating a rule with numeric criteria filled in)

## Additional Notes
Could not run typecheck/dev server in the worktree (no `node_modules`), but the change is type-safe: `e.target.valueAsNumber` is `number`, satisfying both `priority: z.number()` and the `z.number() | z.literal("")` optional fields.
