### PR TITLE
feat(admin): redesign surveys list and responses pages

### DIFF
--- a/web/src/app/admin/surveys/[id]/responses/page.tsx
+++ b/web/src/app/admin/surveys/[id]/responses/page.tsx
@@ -220,7 +220,7 @@ export default async function SurveyResponsesPage({
   });
 
   return (
-    <AdminPageWrapper title={`Survey Responses: ${survey.title}`}>
+    <AdminPageWrapper title="Survey Responses">
       <PageContainer>
         <ResponsesContent
           survey={{

--- a/web/src/app/admin/surveys/[id]/responses/responses-content.tsx
+++ b/web/src/app/admin/surveys/[id]/responses/responses-content.tsx
@@ -200,21 +200,31 @@ export function ResponsesContent({
         ? respondents
         : respondents.filter((r) => statusOf(r) === statusFilter);
 
+    // Stable tie-breaker so equal primary keys keep a deterministic order
+    // (prevents rows reshuffling on re-render).
+    const tieBreak = (a: Respondent, b: Respondent) =>
+      (a.user.name || "").localeCompare(b.user.name || "") ||
+      a.id.localeCompare(b.id);
+
     const sorted = [...filtered].sort((a, b) => {
+      let cmp = 0;
       switch (sortKey) {
         case "name":
-          return (a.user.name || "").localeCompare(b.user.name || "");
+          cmp = (a.user.name || "").localeCompare(b.user.name || "");
+          break;
         case "shifts":
-          return (b.user.completedShifts || 0) - (a.user.completedShifts || 0);
+          cmp = (b.user.completedShifts || 0) - (a.user.completedShifts || 0);
+          break;
         case "member":
-          return (
+          cmp =
             new Date(a.user.createdAt).getTime() -
-            new Date(b.user.createdAt).getTime()
-          );
+            new Date(b.user.createdAt).getTime();
+          break;
         case "recent":
         default:
-          return updateTime(b) - updateTime(a);
+          cmp = updateTime(b) - updateTime(a);
       }
+      return cmp || tieBreak(a, b);
     });
     return sorted;
   }, [respondents, statusFilter, sortKey]);
@@ -271,8 +281,12 @@ export function ResponsesContent({
   };
 
   const exportCsv = () => {
-    const escapeCsv = (value: string) =>
-      /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+    const escapeCsv = (value: string) => {
+      // Neutralise CSV formula injection — spreadsheets execute cells that
+      // begin with =, +, -, @, tab or CR (e.g. a "=1+1" survey answer).
+      const safe = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+      return /[",\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
+    };
     const headers = [
       "Volunteer Name",
       "Email",

--- a/web/src/app/admin/surveys/[id]/responses/responses-content.tsx
+++ b/web/src/app/admin/surveys/[id]/responses/responses-content.tsx
@@ -1,17 +1,7 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import {
   Select,
   SelectContent,
@@ -19,16 +9,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Badge } from "@/components/ui/badge";
 import {
   BarChart3,
-  List,
   ChevronDown,
-  ChevronUp,
   ArrowLeft,
-  ArrowUpDown,
-  ArrowUp,
-  ArrowDown,
   MapPin,
   Users,
   CheckCircle2,
@@ -39,58 +23,30 @@ import {
   Shield,
   CalendarDays,
   Hash,
+  X,
+  MessageSquareQuote,
+  Star,
+  ListChecks,
+  ToggleLeft,
+  Type,
+  ArrowDownUp,
+  UserSearch,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
-import type { SurveyQuestion } from "@/types/survey";
+import type { SurveyQuestion, SurveyQuestionType } from "@/types/survey";
 import { formatDistanceToNow } from "date-fns";
+import { cn } from "@/lib/utils";
+import {
+  CompletionRing,
+  STATUS_META,
+  STATUS_ORDER,
+  type AssignmentStatusKey,
+} from "../../_components/survey-ui";
 
-type SortDirection = "asc" | "desc";
-type SortConfig<T extends string> = { key: T; direction: SortDirection } | null;
-
-function SortableHeader<T extends string>({
-  label,
-  sortKey,
-  sortConfig,
-  onSort,
-  className,
-}: {
-  label: string;
-  sortKey: T;
-  sortConfig: SortConfig<T>;
-  onSort: (key: T) => void;
-  className?: string;
-}) {
-  const isActive = sortConfig?.key === sortKey;
-  const Icon = isActive
-    ? sortConfig.direction === "asc"
-      ? ArrowUp
-      : ArrowDown
-    : ArrowUpDown;
-
-  return (
-    <TableHead className={className}>
-      <button
-        className="flex items-center gap-1 hover:text-foreground transition-colors -ml-1 px-1 py-0.5 rounded"
-        onClick={() => onSort(sortKey)}
-      >
-        {label}
-        <Icon className={`h-3 w-3 ${isActive ? "text-foreground" : "text-muted-foreground/50"}`} />
-      </button>
-    </TableHead>
-  );
-}
-
-function toggleSort<T extends string>(
-  current: SortConfig<T>,
-  key: T
-): SortConfig<T> {
-  if (current?.key === key) {
-    if (current.direction === "asc") return { key, direction: "desc" };
-    return null; // third click clears sort
-  }
-  return { key, direction: "asc" };
-}
+/* -------------------------------------------------------------------------- */
+/*  Types                                                                       */
+/* -------------------------------------------------------------------------- */
 
 interface QuestionStats {
   questionId: string;
@@ -112,14 +68,13 @@ interface UserData {
   completedShifts?: number;
 }
 
+type AnswerValue = string | string[] | number | boolean | null;
+
 interface ResponseData {
   id: string;
   user: UserData;
   completedAt: Date | null;
-  answers?: Array<{
-    questionId: string;
-    value: string | string[] | number | boolean | null;
-  }>;
+  answers?: Array<{ questionId: string; value: AnswerValue }>;
 }
 
 interface AssignmentData {
@@ -130,6 +85,11 @@ interface AssignmentData {
   dismissedAt: Date | null;
   user: UserData;
 }
+
+/** A single person the survey reached, plus their answers if completed. */
+type Respondent = AssignmentData & {
+  answers?: Array<{ questionId: string; value: AnswerValue }>;
+};
 
 interface ResponsesContentProps {
   survey: {
@@ -149,6 +109,30 @@ interface ResponsesContentProps {
   selectedShifts?: string;
 }
 
+const QUESTION_ICON: Record<SurveyQuestionType, typeof Type> = {
+  text_short: Type,
+  text_long: MessageSquareQuote,
+  multiple_choice_single: ListChecks,
+  multiple_choice_multi: ListChecks,
+  rating_scale: Star,
+  yes_no: ToggleLeft,
+};
+
+type View = "insights" | "respondents";
+type StatusFilter = "all" | AssignmentStatusKey;
+type SortKey = "recent" | "name" | "shifts" | "member";
+
+const SORT_LABELS: Record<SortKey, string> = {
+  recent: "Latest activity",
+  name: "Name",
+  shifts: "Shifts completed",
+  member: "Time as member",
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Main                                                                        */
+/* -------------------------------------------------------------------------- */
+
 export function ResponsesContent({
   survey,
   totalResponses,
@@ -163,80 +147,79 @@ export function ResponsesContent({
 }: ResponsesContentProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const [expandedResponses, setExpandedResponses] = useState<Set<string>>(
-    new Set()
+
+  const [view, setView] = useState<View>(
+    totalResponses > 0 ? "insights" : "respondents"
   );
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [sortKey, setSortKey] = useState<SortKey>("recent");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
-  type ResponseSortKey = "name" | "location" | "shifts" | "member" | "completed";
-  type AssignmentSortKey = "name" | "location" | "shifts" | "member" | "status" | "assigned" | "updated";
+  /* ----------------------------- merge data ------------------------------ */
 
-  const [responseSortConfig, setResponseSortConfig] =
-    useState<SortConfig<ResponseSortKey>>(null);
-  const [assignmentSortConfig, setAssignmentSortConfig] =
-    useState<SortConfig<AssignmentSortKey>>(null);
+  const respondents = useMemo<Respondent[]>(() => {
+    const answersById = new Map(responses.map((r) => [r.id, r.answers]));
+    return assignments.map((a) => ({ ...a, answers: answersById.get(a.id) }));
+  }, [assignments, responses]);
 
-  const sortedResponses = useMemo(() => {
-    if (!responseSortConfig) return responses;
-    const { key, direction } = responseSortConfig;
-    const sorted = [...responses].sort((a, b) => {
-      let cmp = 0;
-      if (key === "name") {
-        cmp = (a.user.name || "").localeCompare(b.user.name || "");
-      } else if (key === "location") {
-        cmp = (a.user.defaultLocation || "").localeCompare(
-          b.user.defaultLocation || ""
-        );
-      } else if (key === "shifts") {
-        cmp = (a.user.completedShifts || 0) - (b.user.completedShifts || 0);
-      } else if (key === "member") {
-        cmp =
-          new Date(a.user.createdAt).getTime() -
-          new Date(b.user.createdAt).getTime();
-      } else if (key === "completed") {
-        const dateA = a.completedAt ? new Date(a.completedAt).getTime() : 0;
-        const dateB = b.completedAt ? new Date(b.completedAt).getTime() : 0;
-        cmp = dateA - dateB;
+  const statusOf = (a: AssignmentData): AssignmentStatusKey =>
+    a.status.toLowerCase() as AssignmentStatusKey;
+
+  const updateTime = (a: AssignmentData) =>
+    a.completedAt
+      ? new Date(a.completedAt).getTime()
+      : a.dismissedAt
+      ? new Date(a.dismissedAt).getTime()
+      : new Date(a.assignedAt).getTime();
+
+  /* ----------------------------- stats ----------------------------------- */
+
+  const counts = useMemo(() => {
+    const c: Record<AssignmentStatusKey, number> = {
+      completed: 0,
+      pending: 0,
+      dismissed: 0,
+      expired: 0,
+    };
+    assignments.forEach((a) => {
+      const k = statusOf(a);
+      if (k in c) c[k] += 1;
+    });
+    return c;
+  }, [assignments]);
+
+  const total = assignments.length;
+  const completionRate =
+    total > 0 ? Math.round((counts.completed / total) * 100) : 0;
+
+  /* ----------------------------- filtered list --------------------------- */
+
+  const visibleRespondents = useMemo(() => {
+    const filtered =
+      statusFilter === "all"
+        ? respondents
+        : respondents.filter((r) => statusOf(r) === statusFilter);
+
+    const sorted = [...filtered].sort((a, b) => {
+      switch (sortKey) {
+        case "name":
+          return (a.user.name || "").localeCompare(b.user.name || "");
+        case "shifts":
+          return (b.user.completedShifts || 0) - (a.user.completedShifts || 0);
+        case "member":
+          return (
+            new Date(a.user.createdAt).getTime() -
+            new Date(b.user.createdAt).getTime()
+          );
+        case "recent":
+        default:
+          return updateTime(b) - updateTime(a);
       }
-      return direction === "asc" ? cmp : -cmp;
     });
     return sorted;
-  }, [responses, responseSortConfig]);
+  }, [respondents, statusFilter, sortKey]);
 
-  const sortedAssignments = useMemo(() => {
-    if (!assignmentSortConfig) return assignments;
-    const { key, direction } = assignmentSortConfig;
-    const sorted = [...assignments].sort((a, b) => {
-      let cmp = 0;
-      if (key === "name") {
-        cmp = (a.user.name || "").localeCompare(b.user.name || "");
-      } else if (key === "location") {
-        cmp = (a.user.defaultLocation || "").localeCompare(
-          b.user.defaultLocation || ""
-        );
-      } else if (key === "shifts") {
-        cmp = (a.user.completedShifts || 0) - (b.user.completedShifts || 0);
-      } else if (key === "member") {
-        cmp =
-          new Date(a.user.createdAt).getTime() -
-          new Date(b.user.createdAt).getTime();
-      } else if (key === "status") {
-        cmp = a.status.localeCompare(b.status);
-      } else if (key === "assigned") {
-        cmp =
-          new Date(a.assignedAt).getTime() - new Date(b.assignedAt).getTime();
-      } else if (key === "updated") {
-        const getUpdateTime = (item: AssignmentData) =>
-          item.completedAt
-            ? new Date(item.completedAt).getTime()
-            : item.dismissedAt
-            ? new Date(item.dismissedAt).getTime()
-            : 0;
-        cmp = getUpdateTime(a) - getUpdateTime(b);
-      }
-      return direction === "asc" ? cmp : -cmp;
-    });
-    return sorted;
-  }, [assignments, assignmentSortConfig]);
+  /* ----------------------------- filters --------------------------------- */
 
   const handleFilterChange = (key: string, value: string) => {
     const params = new URLSearchParams();
@@ -247,52 +230,40 @@ export function ResponsesContent({
       shifts: selectedShifts,
     };
     filters[key] = value === "all" ? undefined : value;
-
     Object.entries(filters).forEach(([k, v]) => {
       if (v) params.set(k, v);
     });
-
-    const queryString = params.toString();
-    router.push(queryString ? `${pathname}?${queryString}` : pathname);
+    const qs = params.toString();
+    router.push(qs ? `${pathname}?${qs}` : pathname);
   };
 
-  const activeFilterCount = [
-    selectedLocation,
-    selectedGrade,
-    selectedTenure,
-    selectedShifts,
-  ].filter(Boolean).length;
+  const activeFilters = [
+    selectedLocation && { key: "location", label: selectedLocation },
+    selectedGrade && {
+      key: "grade",
+      label: selectedGrade.charAt(0) + selectedGrade.slice(1).toLowerCase(),
+    },
+    selectedTenure && {
+      key: "tenure",
+      label: TENURE_LABELS[selectedTenure] ?? selectedTenure,
+    },
+    selectedShifts && {
+      key: "shifts",
+      label: SHIFT_LABELS[selectedShifts] ?? selectedShifts,
+    },
+  ].filter(Boolean) as { key: string; label: string }[];
 
-  const clearAllFilters = () => {
-    router.push(pathname);
-  };
+  /* ----------------------------- helpers --------------------------------- */
 
-  // Calculate assignment stats
-  const stats = {
-    total: assignments.length,
-    completed: assignments.filter((a) => a.status === "COMPLETED").length,
-    pending: assignments.filter((a) => a.status === "PENDING").length,
-    dismissed: assignments.filter((a) => a.status === "DISMISSED").length,
-    expired: assignments.filter((a) => a.status === "EXPIRED").length,
-  };
-  const completionRate =
-    stats.total > 0 ? Math.round((stats.completed / stats.total) * 100) : 0;
-
-  const toggleResponse = (id: string) => {
-    setExpandedResponses((prev) => {
+  const toggleExpand = (id: string) =>
+    setExpanded((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
-  };
 
-  const formatValue = (
-    value: string | string[] | number | boolean | null | undefined
-  ): string => {
+  const formatValue = (value: AnswerValue | undefined): string => {
     if (value === null || value === undefined) return "-";
     if (typeof value === "boolean") return value ? "Yes" : "No";
     if (Array.isArray(value)) return value.join(", ");
@@ -300,35 +271,27 @@ export function ResponsesContent({
   };
 
   const exportCsv = () => {
-    const escapeCsv = (value: string) => {
-      if (value.includes(",") || value.includes('"') || value.includes("\n")) {
-        return `"${value.replace(/"/g, '""')}"`;
-      }
-      return value;
-    };
-
+    const escapeCsv = (value: string) =>
+      /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
     const headers = [
       "Volunteer Name",
       "Email",
       "Completed At",
       ...survey.questions.map((q) => q.text),
     ];
-
     const rows = responses.map((response) => [
       response.user.name || "Unknown",
       response.user.email,
-      response.completedAt
-        ? new Date(response.completedAt).toISOString()
-        : "-",
-      ...survey.questions.map((question) => {
-        const answer = response.answers?.find(
-          (a) => a.questionId === question.id
-        );
-        return formatValue(answer?.value);
-      }),
+      response.completedAt ? new Date(response.completedAt).toISOString() : "-",
+      ...survey.questions.map((question) =>
+        formatValue(
+          response.answers?.find((a) => a.questionId === question.id)?.value
+        )
+      ),
     ]);
-
-    const csv = [headers, ...rows].map((row) => row.map(escapeCsv).join(",")).join("\n");
+    const csv = [headers, ...rows]
+      .map((row) => row.map(escapeCsv).join(","))
+      .join("\n");
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
@@ -338,593 +301,993 @@ export function ResponsesContent({
     URL.revokeObjectURL(url);
   };
 
+  /* ------------------------------ render --------------------------------- */
+
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <div className="flex items-center gap-2 mb-2">
-            <Button variant="ghost" size="sm" asChild>
-              <Link href="/admin/surveys">
-                <ArrowLeft className="h-4 w-4 mr-1" />
-                Back to Surveys
-              </Link>
-            </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        asChild
+        className="-ml-2 h-8 text-muted-foreground hover:text-foreground"
+      >
+        <Link href="/admin/surveys">
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          Back to surveys
+        </Link>
+      </Button>
+
+      {/* Hero */}
+      <section className="overflow-hidden rounded-2xl border bg-card shadow-sm">
+        <div className="flex flex-col gap-6 p-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex items-center gap-5">
+            <CompletionRing
+              value={completionRate}
+              size={104}
+              stroke={9}
+              sublabel="complete"
+            />
+            <div className="min-w-0">
+              <h2 className="text-xl font-bold tracking-tight sm:text-2xl">
+                {survey.title}
+              </h2>
+              {survey.description && (
+                <p className="mt-1 line-clamp-2 max-w-xl text-sm text-muted-foreground">
+                  {survey.description}
+                </p>
+              )}
+              <p className="mt-2 text-sm text-muted-foreground">
+                <span className="font-semibold tabular-nums text-foreground">
+                  {counts.completed}
+                </span>{" "}
+                of{" "}
+                <span className="font-semibold tabular-nums text-foreground">
+                  {total}
+                </span>{" "}
+                volunteers responded
+                {activeFilters.length > 0 && (
+                  <span className="ml-1 text-xs">(filtered)</span>
+                )}
+              </p>
+            </div>
           </div>
-          <h2 className="text-2xl font-bold">{survey.title}</h2>
-          {survey.description && (
-            <p className="text-muted-foreground mt-1">{survey.description}</p>
+
+          {totalResponses > 0 && (
+            <Button
+              variant="outline"
+              onClick={exportCsv}
+              data-testid="survey-export-csv"
+              className="shrink-0 self-start lg:self-center"
+            >
+              <Download className="mr-2 h-4 w-4" />
+              Export CSV
+            </Button>
           )}
-          <p className="text-sm text-muted-foreground mt-2">
-            {totalResponses} response{totalResponses !== 1 ? "s" : ""}{" "}
-            {activeFilterCount > 0 ? "(filtered)" : "received"}
-          </p>
         </div>
 
-        {totalResponses > 0 && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={exportCsv}
-            data-testid="survey-export-csv"
-          >
-            <Download className="h-4 w-4 mr-2" />
-            Export CSV
-          </Button>
+        {total > 0 && (
+          <div className="grid grid-cols-2 divide-x divide-y border-t sm:grid-cols-4 sm:divide-y-0">
+            <StatusCell
+              icon={CheckCircle2}
+              label="Completed"
+              value={counts.completed}
+              statusKey="completed"
+              extra={`${completionRate}%`}
+            />
+            <StatusCell
+              icon={Clock}
+              label="Pending"
+              value={counts.pending}
+              statusKey="pending"
+            />
+            <StatusCell
+              icon={XCircle}
+              label="Dismissed"
+              value={counts.dismissed}
+              statusKey="dismissed"
+            />
+            <StatusCell
+              icon={AlertCircle}
+              label="Expired"
+              value={counts.expired}
+              statusKey="expired"
+            />
+          </div>
         )}
-      </div>
+      </section>
 
-      {/* Filters */}
-      <div className="flex flex-wrap items-center gap-3">
-        {locations.length > 0 && (
-          <div className="flex items-center gap-1.5">
-            <MapPin className="h-4 w-4 text-muted-foreground" />
-            <Select
+      {/* Demographic filters */}
+      <div className="space-y-3 rounded-xl border bg-card p-4 shadow-sm">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Filter
+          </span>
+          {locations.length > 0 && (
+            <FilterSelect
+              icon={MapPin}
               value={selectedLocation || "all"}
               onValueChange={(v) => handleFilterChange("location", v)}
-            >
-              <SelectTrigger
-                className="w-auto h-9 text-sm"
-                data-testid="survey-location-filter"
-              >
-                <SelectValue placeholder="Location" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Locations</SelectItem>
-                {locations.map((loc) => (
-                  <SelectItem key={loc} value={loc}>
-                    {loc}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
-
-        <div className="flex items-center gap-1.5">
-          <Shield className="h-4 w-4 text-muted-foreground" />
-          <Select
+              placeholder="Location"
+              testId="survey-location-filter"
+              options={[
+                { value: "all", label: "All locations" },
+                ...locations.map((loc) => ({ value: loc, label: loc })),
+              ]}
+            />
+          )}
+          <FilterSelect
+            icon={Shield}
             value={selectedGrade || "all"}
             onValueChange={(v) => handleFilterChange("grade", v)}
-          >
-            <SelectTrigger className="w-auto h-9 text-sm" data-testid="survey-grade-filter">
-              <SelectValue placeholder="Grade" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Grades</SelectItem>
-              <SelectItem value="GREEN">Green</SelectItem>
-              <SelectItem value="YELLOW">Yellow</SelectItem>
-              <SelectItem value="PINK">Pink</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="flex items-center gap-1.5">
-          <CalendarDays className="h-4 w-4 text-muted-foreground" />
-          <Select
+            placeholder="Grade"
+            testId="survey-grade-filter"
+            options={[
+              { value: "all", label: "All grades" },
+              { value: "GREEN", label: "Green" },
+              { value: "YELLOW", label: "Yellow" },
+              { value: "PINK", label: "Pink" },
+            ]}
+          />
+          <FilterSelect
+            icon={CalendarDays}
             value={selectedTenure || "all"}
             onValueChange={(v) => handleFilterChange("tenure", v)}
-          >
-            <SelectTrigger className="w-auto h-9 text-sm" data-testid="survey-tenure-filter">
-              <SelectValue placeholder="Tenure" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Tenures</SelectItem>
-              <SelectItem value="lt1m">Less than 1 month</SelectItem>
-              <SelectItem value="1-3m">1-3 months</SelectItem>
-              <SelectItem value="3-6m">3-6 months</SelectItem>
-              <SelectItem value="6-12m">6-12 months</SelectItem>
-              <SelectItem value="gt1y">Over 1 year</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="flex items-center gap-1.5">
-          <Hash className="h-4 w-4 text-muted-foreground" />
-          <Select
+            placeholder="Tenure"
+            testId="survey-tenure-filter"
+            options={[
+              { value: "all", label: "All tenures" },
+              { value: "lt1m", label: "Less than 1 month" },
+              { value: "1-3m", label: "1-3 months" },
+              { value: "3-6m", label: "3-6 months" },
+              { value: "6-12m", label: "6-12 months" },
+              { value: "gt1y", label: "Over 1 year" },
+            ]}
+          />
+          <FilterSelect
+            icon={Hash}
             value={selectedShifts || "all"}
             onValueChange={(v) => handleFilterChange("shifts", v)}
-          >
-            <SelectTrigger className="w-auto h-9 text-sm" data-testid="survey-shifts-filter">
-              <SelectValue placeholder="Shifts" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Shift Counts</SelectItem>
-              <SelectItem value="0-5">0-5 shifts</SelectItem>
-              <SelectItem value="6-15">6-15 shifts</SelectItem>
-              <SelectItem value="16-30">16-30 shifts</SelectItem>
-              <SelectItem value="31-50">31-50 shifts</SelectItem>
-              <SelectItem value="gt50">50+ shifts</SelectItem>
-            </SelectContent>
-          </Select>
+            placeholder="Shifts"
+            testId="survey-shifts-filter"
+            options={[
+              { value: "all", label: "All shift counts" },
+              { value: "0-5", label: "0-5 shifts" },
+              { value: "6-15", label: "6-15 shifts" },
+              { value: "16-30", label: "16-30 shifts" },
+              { value: "31-50", label: "31-50 shifts" },
+              { value: "gt50", label: "50+ shifts" },
+            ]}
+          />
         </div>
 
-        {activeFilterCount > 0 && (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={clearAllFilters}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            Clear filters
-          </Button>
+        {activeFilters.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 border-t pt-3">
+            {activeFilters.map((f) => (
+              <button
+                key={f.key}
+                onClick={() => handleFilterChange(f.key, "all")}
+                className="inline-flex items-center gap-1 rounded-full bg-[var(--ee-primary-light)] px-2.5 py-1 text-xs font-medium text-[var(--ee-primary-text)] transition-colors hover:bg-[var(--ee-primary-light)]/70"
+              >
+                {f.label}
+                <X className="h-3 w-3" />
+              </button>
+            ))}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => router.push(pathname)}
+              className="h-7 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Clear all
+            </Button>
+          </div>
         )}
       </div>
 
-      {/* Stats Cards */}
-      {stats.total > 0 && (
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-          <Card>
-            <CardContent className="pt-4 pb-4">
-              <div className="flex items-center gap-2">
-                <Users className="h-4 w-4 text-muted-foreground" />
-                <span className="text-sm text-muted-foreground">Total</span>
-              </div>
-              <p className="text-2xl font-bold mt-1">{stats.total}</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-4 pb-4">
-              <div className="flex items-center gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-600" />
-                <span className="text-sm text-muted-foreground">Completed</span>
-              </div>
-              <p className="text-2xl font-bold mt-1 text-green-600">
-                {stats.completed}
-                <span className="text-sm font-normal text-muted-foreground ml-1">
-                  ({completionRate}%)
-                </span>
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-4 pb-4">
-              <div className="flex items-center gap-2">
-                <Clock className="h-4 w-4 text-amber-600" />
-                <span className="text-sm text-muted-foreground">Pending</span>
-              </div>
-              <p className="text-2xl font-bold mt-1 text-amber-600">
-                {stats.pending}
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-4 pb-4">
-              <div className="flex items-center gap-2">
-                <XCircle className="h-4 w-4 text-slate-500" />
-                <span className="text-sm text-muted-foreground">Dismissed</span>
-              </div>
-              <p className="text-2xl font-bold mt-1 text-slate-500">
-                {stats.dismissed}
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="pt-4 pb-4">
-              <div className="flex items-center gap-2">
-                <AlertCircle className="h-4 w-4 text-red-500" />
-                <span className="text-sm text-muted-foreground">Expired</span>
-              </div>
-              <p className="text-2xl font-bold mt-1 text-red-500">
-                {stats.expired}
-              </p>
-            </CardContent>
-          </Card>
+      {/* View switcher */}
+      <div className="inline-flex w-full rounded-xl border bg-muted/40 p-1 sm:w-auto">
+        <ViewTab
+          active={view === "insights"}
+          onClick={() => setView("insights")}
+          icon={BarChart3}
+          label="Insights"
+          disabled={totalResponses === 0}
+        />
+        <ViewTab
+          active={view === "respondents"}
+          onClick={() => setView("respondents")}
+          icon={Users}
+          label={`Respondents · ${total}`}
+        />
+      </div>
+
+      {/* Insights */}
+      {view === "insights" &&
+        (totalResponses === 0 ? (
+          <EmptyPanel
+            icon={BarChart3}
+            title="No responses yet"
+            body="Once volunteers complete this survey, aggregated insights will appear here."
+          />
+        ) : (
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {questionStats.map((qStats, idx) => (
+              <QuestionSummaryCard
+                key={qStats.questionId}
+                index={idx + 1}
+                stats={qStats}
+                question={survey.questions.find(
+                  (q) => q.id === qStats.questionId
+                )}
+              />
+            ))}
+          </div>
+        ))}
+
+      {/* Respondents */}
+      {view === "respondents" && (
+        <div className="space-y-3">
+          {/* status filter + sort */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <StatusChip
+                label="All"
+                count={total}
+                active={statusFilter === "all"}
+                onClick={() => setStatusFilter("all")}
+              />
+              {STATUS_ORDER.map((key) => (
+                <StatusChip
+                  key={key}
+                  label={STATUS_META[key].label}
+                  count={counts[key]}
+                  swatch={STATUS_META[key].swatch}
+                  active={statusFilter === key}
+                  onClick={() => setStatusFilter(key)}
+                  disabled={counts[key] === 0}
+                />
+              ))}
+            </div>
+
+            <div className="flex items-center gap-2">
+              <ArrowDownUp className="h-4 w-4 text-muted-foreground" />
+              <Select
+                value={sortKey}
+                onValueChange={(v) => setSortKey(v as SortKey)}
+              >
+                <SelectTrigger className="h-9 w-[180px] text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(SORT_LABELS) as SortKey[]).map((k) => (
+                    <SelectItem key={k} value={k}>
+                      {SORT_LABELS[k]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* list */}
+          {visibleRespondents.length === 0 ? (
+            <EmptyPanel
+              icon={UserSearch}
+              title="No one here"
+              body={
+                statusFilter === "all"
+                  ? "This survey hasn't been assigned to anyone matching the current filters."
+                  : `No ${statusFilter} respondents match the current filters.`
+              }
+            />
+          ) : (
+            <div className="divide-y overflow-hidden rounded-xl border bg-card shadow-sm">
+              {visibleRespondents.map((r) => (
+                <RespondentRow
+                  key={r.id}
+                  respondent={r}
+                  questions={survey.questions}
+                  expanded={expanded.has(r.id)}
+                  onToggle={() => toggleExpand(r.id)}
+                  updateLabel={respondentTimeLabel(r)}
+                />
+              ))}
+            </div>
+          )}
         </div>
       )}
+    </div>
+  );
+}
 
-      <Tabs defaultValue={totalResponses > 0 ? "summary" : "assignments"}>
-        <TabsList className="w-full sm:w-auto">
-          <TabsTrigger value="summary" disabled={totalResponses === 0} className="flex-1 sm:flex-initial">
-            <BarChart3 className="h-4 w-4 mr-2 hidden sm:block" />
-            Summary
-          </TabsTrigger>
-          <TabsTrigger value="individual" disabled={totalResponses === 0} className="flex-1 sm:flex-initial">
-            <List className="h-4 w-4 mr-2 hidden sm:block" />
-            Responses ({totalResponses})
-          </TabsTrigger>
-          <TabsTrigger value="assignments" className="flex-1 sm:flex-initial">
-            <Users className="h-4 w-4 mr-2 hidden sm:block" />
-            Assignments ({assignments.length})
-          </TabsTrigger>
-        </TabsList>
+/* -------------------------------------------------------------------------- */
+/*  Respondent row                                                              */
+/* -------------------------------------------------------------------------- */
 
-        <TabsContent value="summary" className="space-y-4 mt-4">
-          {questionStats.map((stats) => (
-            <Card key={stats.questionId}>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-base font-medium">
-                  {stats.questionText}
-                </CardTitle>
-                <p className="text-sm text-muted-foreground">
-                  {stats.totalResponses} response
-                  {stats.totalResponses !== 1 ? "s" : ""}
-                </p>
-              </CardHeader>
-              <CardContent>
-                {/* Rating scale average */}
-                {stats.questionType === "rating_scale" && stats.average && (
-                  <div className="mb-4">
-                    <div className="text-3xl font-bold text-primary">
-                      {stats.average.toFixed(1)}
-                    </div>
-                    <p className="text-sm text-muted-foreground">
-                      Average rating
-                    </p>
-                  </div>
+function respondentTimeLabel(r: AssignmentData): string {
+  if (r.status === "COMPLETED" && r.completedAt)
+    return `Completed ${formatDistanceToNow(new Date(r.completedAt), {
+      addSuffix: true,
+    })}`;
+  if (r.status === "DISMISSED" && r.dismissedAt)
+    return `Dismissed ${formatDistanceToNow(new Date(r.dismissedAt), {
+      addSuffix: true,
+    })}`;
+  return `Assigned ${formatDistanceToNow(new Date(r.assignedAt), {
+    addSuffix: true,
+  })}`;
+}
+
+function RespondentRow({
+  respondent: r,
+  questions,
+  expanded,
+  onToggle,
+  updateLabel,
+}: {
+  respondent: Respondent;
+  questions: SurveyQuestion[];
+  expanded: boolean;
+  onToggle: () => void;
+  updateLabel: string;
+}) {
+  const isCompleted = r.status === "COMPLETED";
+  const canExpand = isCompleted && !!r.answers;
+  const meta = STATUS_META[r.status.toLowerCase() as AssignmentStatusKey];
+
+  return (
+    <div className={cn(expanded && "bg-muted/30")}>
+      <div
+        className={cn(
+          "flex items-center gap-3 px-4 py-3 transition-colors",
+          canExpand && "cursor-pointer hover:bg-muted/40"
+        )}
+        onClick={canExpand ? onToggle : undefined}
+        role={canExpand ? "button" : undefined}
+        aria-expanded={canExpand ? expanded : undefined}
+      >
+        <Avatar name={r.user.name} />
+
+        <div className="min-w-0 flex-1">
+          <Link
+            href={`/admin/volunteers/${r.user.id}`}
+            className="font-medium hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {r.user.name || "Unknown"}
+          </Link>
+          <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+            <span className="truncate">{r.user.email}</span>
+          </div>
+        </div>
+
+        {/* meta — hidden on small screens */}
+        <div className="hidden w-40 shrink-0 flex-col items-end gap-0.5 text-xs text-muted-foreground lg:flex">
+          <span className="inline-flex items-center gap-1">
+            <MapPin className="h-3 w-3" />
+            {r.user.defaultLocation || "No location"}
+          </span>
+          <span className="tabular-nums">
+            {r.user.completedShifts ?? 0} shifts ·{" "}
+            {formatDistanceToNow(new Date(r.user.createdAt))} member
+          </span>
+        </div>
+
+        {/* status + time */}
+        <div className="flex w-36 shrink-0 flex-col items-end gap-1">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium capitalize",
+              meta.soft,
+              meta.text
+            )}
+          >
+            <span className={cn("h-1.5 w-1.5 rounded-full", meta.swatch)} />
+            {r.status.toLowerCase()}
+          </span>
+          <span className="text-right text-[11px] text-muted-foreground">
+            {updateLabel}
+          </span>
+        </div>
+
+        <div className="w-5 shrink-0">
+          {canExpand && (
+            <ChevronDown
+              className={cn(
+                "h-4 w-4 text-muted-foreground transition-transform",
+                expanded && "rotate-180"
+              )}
+            />
+          )}
+        </div>
+      </div>
+
+      {expanded && canExpand && (
+        <div className="border-t bg-muted/20 px-4 py-1.5 sm:pl-16">
+          <AnswerList questions={questions} answers={r.answers} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Answer transcript                                                           */
+/* -------------------------------------------------------------------------- */
+
+type AnswerKind = "scalar" | "chips" | "prose";
+
+function answerKind(type: string): AnswerKind {
+  if (type === "multiple_choice_multi") return "chips";
+  if (type === "text_short" || type === "text_long") return "prose";
+  return "scalar"; // yes_no, rating_scale, multiple_choice_single
+}
+
+function AnswerList({
+  questions,
+  answers,
+}: {
+  questions: SurveyQuestion[];
+  answers?: Array<{ questionId: string; value: AnswerValue }>;
+}) {
+  return (
+    <dl className="divide-y divide-border/50">
+      {questions.map((q) => {
+        const value = answers?.find((a) => a.questionId === q.id)?.value;
+        const kind = answerKind(q.type);
+
+        if (kind === "scalar") {
+          return (
+            <div
+              key={q.id}
+              className="flex items-start justify-between gap-4 py-3 first:pt-1 last:pb-1"
+            >
+              <dt className="text-sm font-medium leading-snug text-foreground/90">
+                {q.text}
+              </dt>
+              <dd className="shrink-0">
+                <ScalarValue question={q} value={value} />
+              </dd>
+            </div>
+          );
+        }
+
+        return (
+          <div key={q.id} className="py-3 first:pt-1 last:pb-1">
+            <dt className="text-sm font-medium leading-snug text-foreground/90">
+              {q.text}
+            </dt>
+            <dd className="mt-2">
+              {kind === "chips" ? (
+                <ChipsValue value={value} />
+              ) : (
+                <ProseValue value={value} />
+              )}
+            </dd>
+          </div>
+        );
+      })}
+    </dl>
+  );
+}
+
+function NoAnswer({ block = false }: { block?: boolean }) {
+  return (
+    <span
+      className={cn(
+        "text-sm italic text-muted-foreground/50",
+        block && "block"
+      )}
+    >
+      No answer
+    </span>
+  );
+}
+
+const BADGE = "inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-sm font-medium";
+
+function ScalarValue({
+  question,
+  value,
+}: {
+  question: SurveyQuestion;
+  value: AnswerValue | undefined;
+}) {
+  if (value === null || value === undefined || value === "") return <NoAnswer />;
+
+  if (question.type === "yes_no") {
+    const yes = value === true || value === "Yes" || value === "yes";
+    return (
+      <span
+        className={cn(
+          BADGE,
+          yes
+            ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+            : "bg-slate-400/10 text-slate-500 dark:text-slate-400"
+        )}
+      >
+        {yes ? "Yes" : "No"}
+      </span>
+    );
+  }
+
+  if (question.type === "rating_scale") {
+    const max = question.maxValue ?? 5;
+    return (
+      <span
+        className={cn(
+          BADGE,
+          "bg-[var(--ee-primary-light)] text-[var(--ee-primary-text)]"
+        )}
+      >
+        <Star className="h-3.5 w-3.5 fill-current" />
+        <span className="tabular-nums">{String(value)}</span>
+        <span className="font-normal opacity-60">/ {max}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className={cn(BADGE, "bg-muted text-foreground")}>
+      {String(value)}
+    </span>
+  );
+}
+
+function ChipsValue({ value }: { value: AnswerValue | undefined }) {
+  const values = Array.isArray(value)
+    ? value
+    : value === null || value === undefined || value === ""
+    ? []
+    : [value];
+
+  if (values.length === 0) return <NoAnswer block />;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {values.map((v, i) => (
+        <span
+          key={i}
+          className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-sm font-medium text-foreground"
+        >
+          {String(v)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function ProseValue({ value }: { value: AnswerValue | undefined }) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) return <NoAnswer block />;
+  return (
+    <p className="max-w-prose whitespace-pre-wrap border-l-2 border-[var(--ee-primary-text)]/30 pl-3 text-sm leading-relaxed text-foreground/80">
+      {text}
+    </p>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Small components                                                            */
+/* -------------------------------------------------------------------------- */
+
+const TENURE_LABELS: Record<string, string> = {
+  lt1m: "< 1 month",
+  "1-3m": "1-3 months",
+  "3-6m": "3-6 months",
+  "6-12m": "6-12 months",
+  gt1y: "Over 1 year",
+};
+
+const SHIFT_LABELS: Record<string, string> = {
+  "0-5": "0-5 shifts",
+  "6-15": "6-15 shifts",
+  "16-30": "16-30 shifts",
+  "31-50": "31-50 shifts",
+  gt50: "50+ shifts",
+};
+
+function ViewTab({
+  active,
+  onClick,
+  icon: Icon,
+  label,
+  disabled,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: typeof BarChart3;
+  label: string;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors sm:flex-initial",
+        active
+          ? "bg-background text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+        disabled && "cursor-not-allowed opacity-40 hover:text-muted-foreground"
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      {label}
+    </button>
+  );
+}
+
+function StatusChip({
+  label,
+  count,
+  swatch,
+  active,
+  onClick,
+  disabled,
+}: {
+  label: string;
+  count: number;
+  swatch?: string;
+  active: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors",
+        active
+          ? "border-transparent bg-foreground text-background"
+          : "border-border bg-background text-muted-foreground hover:text-foreground",
+        disabled && "cursor-not-allowed opacity-40 hover:text-muted-foreground"
+      )}
+    >
+      {swatch && (
+        <span
+          className={cn(
+            "h-1.5 w-1.5 rounded-full",
+            active ? "bg-background" : swatch
+          )}
+        />
+      )}
+      {label}
+      <span
+        className={cn(
+          "tabular-nums",
+          active ? "text-background/70" : "text-muted-foreground/70"
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+function StatusCell({
+  icon: Icon,
+  label,
+  value,
+  statusKey,
+  extra,
+}: {
+  icon: typeof CheckCircle2;
+  label: string;
+  value: number;
+  statusKey: AssignmentStatusKey;
+  extra?: string;
+}) {
+  const meta = STATUS_META[statusKey];
+  return (
+    <div className="flex items-center gap-3 p-4">
+      <span
+        className={cn(
+          "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+          meta.soft,
+          meta.text
+        )}
+      >
+        <Icon className="h-4 w-4" />
+      </span>
+      <div>
+        <div className="flex items-baseline gap-1.5">
+          <span className={cn("text-xl font-bold tabular-nums", meta.text)}>
+            {value}
+          </span>
+          {extra && (
+            <span className="text-xs font-medium text-muted-foreground">
+              {extra}
+            </span>
+          )}
+        </div>
+        <span className="text-xs text-muted-foreground">{label}</span>
+      </div>
+    </div>
+  );
+}
+
+function FilterSelect({
+  icon: Icon,
+  value,
+  onValueChange,
+  placeholder,
+  testId,
+  options,
+}: {
+  icon: typeof MapPin;
+  value: string;
+  onValueChange: (v: string) => void;
+  placeholder: string;
+  testId: string;
+  options: { value: string; label: string }[];
+}) {
+  const isActive = value !== "all";
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger
+        className={cn(
+          "h-9 w-auto gap-1.5 text-sm",
+          isActive &&
+            "border-[var(--ee-primary-text)]/40 bg-[var(--ee-primary-light)]"
+        )}
+        data-testid={testId}
+      >
+        <Icon
+          className={cn(
+            "h-4 w-4",
+            isActive ? "text-[var(--ee-primary-text)]" : "text-muted-foreground"
+          )}
+        />
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {o.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function Avatar({ name }: { name: string | null }) {
+  const initials = (name || "?")
+    .split(" ")
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+  return (
+    <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--ee-primary-light)] text-xs font-semibold text-[var(--ee-primary-text)]">
+      {initials}
+    </span>
+  );
+}
+
+function EmptyPanel({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: typeof BarChart3;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed bg-card/50 py-16 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+        <Icon className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-semibold">{title}</p>
+        <p className="mx-auto max-w-sm text-sm text-muted-foreground">{body}</p>
+      </div>
+    </div>
+  );
+}
+
+/* ----------------------------- summary card ----------------------------- */
+
+function QuestionSummaryCard({
+  index,
+  stats,
+  question,
+}: {
+  index: number;
+  stats: QuestionStats;
+  question?: SurveyQuestion;
+}) {
+  const Icon =
+    QUESTION_ICON[(stats.questionType as SurveyQuestionType) ?? "text_short"] ??
+    Type;
+  const isText =
+    stats.questionType === "text_short" || stats.questionType === "text_long";
+  const isRating = stats.questionType === "rating_scale";
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col overflow-hidden rounded-xl border bg-card shadow-sm",
+        isText && "lg:col-span-2"
+      )}
+    >
+      <header className="flex items-start gap-3 border-b p-4">
+        <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-[var(--ee-primary-light)] text-[var(--ee-primary-text)]">
+          <Icon className="h-4 w-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold leading-snug">
+            <span className="text-muted-foreground">Q{index}. </span>
+            {stats.questionText}
+          </h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {stats.totalResponses} response
+            {stats.totalResponses !== 1 ? "s" : ""}
+          </p>
+        </div>
+      </header>
+
+      <div className="flex-1 p-4">
+        {stats.totalResponses === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No responses yet
+          </p>
+        ) : isRating ? (
+          <RatingSummary stats={stats} question={question} />
+        ) : isText ? (
+          <TextResponses textResponses={stats.textResponses ?? []} />
+        ) : stats.distribution ? (
+          <DistributionBars
+            distribution={stats.distribution}
+            total={stats.totalResponses}
+          />
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function DistributionBars({
+  distribution,
+  total,
+  numeric = false,
+}: {
+  distribution: Record<string, number>;
+  total: number;
+  numeric?: boolean;
+}) {
+  const entries = Object.entries(distribution).sort(([a, av], [b, bv]) => {
+    if (numeric) {
+      const na = Number(a);
+      const nb = Number(b);
+      if (!isNaN(na) && !isNaN(nb)) return na - nb;
+    }
+    return bv - av;
+  });
+  const max = Math.max(...entries.map(([, v]) => v), 1);
+
+  return (
+    <div className="space-y-2.5">
+      {entries.map(([key, count]) => {
+        const percentage = Math.round((count / total) * 100);
+        const isTop = count === max;
+        return (
+          <div key={key} className="space-y-1">
+            <div className="flex items-center justify-between gap-2 text-sm">
+              <span className="truncate font-medium">{key}</span>
+              <span className="shrink-0 tabular-nums text-muted-foreground">
+                {count} <span className="text-xs">({percentage}%)</span>
+              </span>
+            </div>
+            <div className="h-2.5 overflow-hidden rounded-full bg-muted">
+              <div
+                className={cn(
+                  "h-full rounded-full transition-[width] duration-700 ease-out motion-reduce:transition-none",
+                  isTop
+                    ? "bg-[var(--ee-primary-text)]"
+                    : "bg-[var(--ee-primary-text)]/45"
                 )}
+                style={{ width: `${(count / total) * 100}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
 
-                {/* Distribution for choice/rating questions */}
-                {stats.distribution && (
-                  <div className="space-y-2">
-                    {Object.entries(stats.distribution)
-                      .sort(([a], [b]) => {
-                        // Sort numerically for ratings, alphabetically otherwise
-                        const numA = Number(a);
-                        const numB = Number(b);
-                        if (!isNaN(numA) && !isNaN(numB)) return numA - numB;
-                        return a.localeCompare(b);
-                      })
-                      .map(([key, count]) => {
-                        const percentage = Math.round(
-                          (count / stats.totalResponses) * 100
-                        );
-                        return (
-                          <div key={key} className="space-y-1">
-                            <div className="flex justify-between text-sm">
-                              <span>{key}</span>
-                              <span className="text-muted-foreground">
-                                {count} ({percentage}%)
-                              </span>
-                            </div>
-                            <div className="h-2 bg-muted rounded-full overflow-hidden">
-                              <div
-                                className="h-full bg-primary rounded-full transition-all"
-                                style={{ width: `${percentage}%` }}
-                              />
-                            </div>
-                          </div>
-                        );
-                      })}
-                  </div>
-                )}
+function RatingSummary({
+  stats,
+  question,
+}: {
+  stats: QuestionStats;
+  question?: SurveyQuestion;
+}) {
+  const max = question?.maxValue ?? 5;
+  const min = question?.minValue ?? 1;
+  const average = stats.average ?? 0;
+  const pct = ((average - min) / (max - min)) * 100;
 
-                {/* Text responses */}
-                {stats.textResponses && stats.textResponses.length > 0 && (
-                  <div className="space-y-2">
-                    {stats.textResponses.slice(0, 10).map((text, idx) => (
-                      <div
-                        key={idx}
-                        className="p-3 bg-muted rounded-lg text-sm"
-                      >
-                        &ldquo;{text}&rdquo;
-                      </div>
-                    ))}
-                    {stats.textResponses.length > 10 && (
-                      <p className="text-sm text-muted-foreground">
-                        And {stats.textResponses.length - 10} more responses...
-                      </p>
-                    )}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          ))}
-        </TabsContent>
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-4 rounded-lg bg-muted/40 p-4">
+        <div className="flex items-baseline gap-1">
+          <span className="text-4xl font-bold tabular-nums text-[var(--ee-primary-text)]">
+            {average.toFixed(1)}
+          </span>
+          <span className="text-sm text-muted-foreground">/ {max}</span>
+        </div>
+        <div className="flex-1">
+          <div className="mb-1.5 flex items-center justify-between text-xs text-muted-foreground">
+            <span>{question?.minLabel ?? min}</span>
+            <span>{question?.maxLabel ?? max}</span>
+          </div>
+          <div className="relative h-2 rounded-full bg-muted">
+            <div
+              className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-[var(--ee-primary-text)]/50 to-[var(--ee-primary-text)] transition-[width] duration-700 ease-out motion-reduce:transition-none"
+              style={{ width: `${Math.max(0, Math.min(100, pct))}%` }}
+            />
+          </div>
+          <p className="mt-1.5 text-xs text-muted-foreground">Average rating</p>
+        </div>
+      </div>
+      {stats.distribution && (
+        <DistributionBars
+          distribution={stats.distribution}
+          total={stats.totalResponses}
+          numeric
+        />
+      )}
+    </div>
+  );
+}
 
-        <TabsContent value="individual" className="mt-4">
-          <Card className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-[50px]"></TableHead>
-                  <SortableHeader
-                    label="Volunteer"
-                    sortKey="name"
-                    sortConfig={responseSortConfig}
-                    onSort={(key) =>
-                      setResponseSortConfig(toggleSort(responseSortConfig, key))
-                    }
-                  />
-                  <SortableHeader
-                    label="Location"
-                    sortKey="location"
-                    sortConfig={responseSortConfig}
-                    onSort={(key) =>
-                      setResponseSortConfig(toggleSort(responseSortConfig, key))
-                    }
-                  />
-                  <SortableHeader
-                    label="Shifts"
-                    sortKey="shifts"
-                    sortConfig={responseSortConfig}
-                    onSort={(key) =>
-                      setResponseSortConfig(toggleSort(responseSortConfig, key))
-                    }
-                  />
-                  <SortableHeader
-                    label="Member For"
-                    sortKey="member"
-                    sortConfig={responseSortConfig}
-                    onSort={(key) =>
-                      setResponseSortConfig(toggleSort(responseSortConfig, key))
-                    }
-                  />
-                  <SortableHeader
-                    label="Completed"
-                    sortKey="completed"
-                    sortConfig={responseSortConfig}
-                    onSort={(key) =>
-                      setResponseSortConfig(toggleSort(responseSortConfig, key))
-                    }
-                  />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sortedResponses.map((response) => (
-                  <>
-                    <TableRow
-                      key={response.id}
-                      className="cursor-pointer hover:bg-muted/50"
-                      onClick={() => toggleResponse(response.id)}
-                    >
-                      <TableCell>
-                        {expandedResponses.has(response.id) ? (
-                          <ChevronUp className="h-4 w-4" />
-                        ) : (
-                          <ChevronDown className="h-4 w-4" />
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        <div>
-                          <Link
-                            href={`/admin/volunteers/${response.user.id}`}
-                            className="font-medium hover:underline"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            {response.user.name || "Unknown"}
-                          </Link>
-                          <div className="text-sm text-muted-foreground">
-                            {response.user.email}
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <span className="text-sm text-muted-foreground">
-                          {response.user.defaultLocation || "-"}
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        <span className="text-sm text-muted-foreground">
-                          {response.user.completedShifts ?? "-"}
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        <span className="text-sm text-muted-foreground">
-                          {formatDistanceToNow(new Date(response.user.createdAt))}
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        {response.completedAt
-                          ? formatDistanceToNow(
-                              new Date(response.completedAt),
-                              { addSuffix: true }
-                            )
-                          : "-"}
-                      </TableCell>
-                    </TableRow>
-                    {expandedResponses.has(response.id) && response.answers && (
-                      <TableRow key={`${response.id}-details`}>
-                        <TableCell colSpan={6} className="bg-muted/30 whitespace-normal">
-                          <div className="p-4 space-y-4 break-words">
-                            {survey.questions.map((question) => {
-                              const answer = response.answers?.find(
-                                (a) => a.questionId === question.id
-                              );
-                              return (
-                                <div key={question.id}>
-                                  <div className="text-sm font-medium mb-1">
-                                    {question.text}
-                                  </div>
-                                  <div className="text-sm text-muted-foreground">
-                                    {formatValue(answer?.value)}
-                                  </div>
-                                </div>
-                              );
-                            })}
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </>
-                ))}
-              </TableBody>
-            </Table>
-          </Card>
-        </TabsContent>
+function TextResponses({ textResponses }: { textResponses: string[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? textResponses : textResponses.slice(0, 6);
 
-        <TabsContent value="assignments" className="mt-4">
-          <Card className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <SortableHeader
-                    label="Volunteer"
-                    sortKey="name"
-                    sortConfig={assignmentSortConfig}
-                    onSort={(key) =>
-                      setAssignmentSortConfig(
-                        toggleSort(assignmentSortConfig, key)
-                      )
-                    }
-                  />
-                  <SortableHeader
-                    label="Location"
-                    sortKey="location"
-                    sortConfig={assignmentSortConfig}
-                    onSort={(key) =>
-                      setAssignmentSortConfig(
-                        toggleSort(assignmentSortConfig, key)
-                      )
-                    }
-                  />
-                  <SortableHeader
-                    label="Shifts"
-                    sortKey="shifts"
-                    sortConfig={assignmentSortConfig}
-                    onSort={(key) =>
-                      setAssignmentSortConfig(
-                        toggleSort(assignmentSortConfig, key)
-                      )
-                    }
-                  />
-                  <SortableHeader
-                    label="Member For"
-                    sortKey="member"
-                    sortConfig={assignmentSortConfig}
-                    onSort={(key) =>
-                      setAssignmentSortConfig(
-                        toggleSort(assignmentSortConfig, key)
-                      )
-                    }
-                  />
-                  <SortableHeader
-                    label="Status"
-                    sortKey="status"
-                    sortConfig={assignmentSortConfig}
-                    onSort={(key) =>
-                      setAssignmentSortConfig(
-                        toggleSort(assignmentSortConfig, key)
-                      )
-                    }
-                  />
-                  <SortableHeader
-                    label="Assigned"
-                    sortKey="assigned"
-                    sortConfig={assignmentSortConfig}
-                    onSort={(key) =>
-                      setAssignmentSortConfig(
-                        toggleSort(assignmentSortConfig, key)
-                      )
-                    }
-                  />
-                  <SortableHeader
-                    label="Updated"
-                    sortKey="updated"
-                    sortConfig={assignmentSortConfig}
-                    onSort={(key) =>
-                      setAssignmentSortConfig(
-                        toggleSort(assignmentSortConfig, key)
-                      )
-                    }
-                  />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {assignments.length === 0 ? (
-                  <TableRow>
-                    <TableCell
-                      colSpan={7}
-                      className="text-center py-8 text-muted-foreground"
-                    >
-                      No assignments yet. Use the &quot;Assign Survey&quot;
-                      button to assign this survey to volunteers.
-                    </TableCell>
-                  </TableRow>
-                ) : (
-                  sortedAssignments.map((assignment) => (
-                    <TableRow key={assignment.id}>
-                      <TableCell>
-                        <div>
-                          <Link
-                            href={`/admin/volunteers/${assignment.user.id}`}
-                            className="font-medium hover:underline"
-                          >
-                            {assignment.user.name || "Unknown"}
-                          </Link>
-                          <div className="text-sm text-muted-foreground">
-                            {assignment.user.email}
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <span className="text-sm text-muted-foreground">
-                          {assignment.user.defaultLocation || "-"}
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        <span className="text-sm text-muted-foreground">
-                          {assignment.user.completedShifts ?? "-"}
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        <span className="text-sm text-muted-foreground">
-                          {formatDistanceToNow(new Date(assignment.user.createdAt))}
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant={
-                            assignment.status === "COMPLETED"
-                              ? "default"
-                              : assignment.status === "PENDING"
-                              ? "secondary"
-                              : assignment.status === "DISMISSED"
-                              ? "outline"
-                              : "destructive"
-                          }
-                        >
-                          {assignment.status.toLowerCase()}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {formatDistanceToNow(new Date(assignment.assignedAt), {
-                          addSuffix: true,
-                        })}
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground">
-                        {assignment.status === "COMPLETED" &&
-                        assignment.completedAt
-                          ? formatDistanceToNow(
-                              new Date(assignment.completedAt),
-                              { addSuffix: true }
-                            )
-                          : assignment.status === "DISMISSED" &&
-                            assignment.dismissedAt
-                          ? formatDistanceToNow(
-                              new Date(assignment.dismissedAt),
-                              { addSuffix: true }
-                            )
-                          : "-"}
-                      </TableCell>
-                    </TableRow>
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </Card>
-        </TabsContent>
-      </Tabs>
+  if (textResponses.length === 0) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        No written responses
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-2">
+        {visible.map((text, idx) => (
+          <figure
+            key={idx}
+            className="relative rounded-lg border bg-muted/30 p-3 pl-9 text-sm"
+          >
+            <MessageSquareQuote className="absolute left-3 top-3 h-4 w-4 text-[var(--ee-primary-text)]/50" />
+            <blockquote className="break-words leading-relaxed text-foreground/90">
+              {text}
+            </blockquote>
+          </figure>
+        ))}
+      </div>
+      {textResponses.length > 6 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setShowAll((v) => !v)}
+          className="text-[var(--ee-primary-text)]"
+        >
+          {showAll ? "Show fewer" : `Show all ${textResponses.length} responses`}
+        </Button>
+      )}
     </div>
   );
 }

--- a/web/src/app/admin/surveys/_components/survey-ui.tsx
+++ b/web/src/app/admin/surveys/_components/survey-ui.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  CalendarCheck,
+  Clock,
+  Sparkles,
+  Hand,
+  type LucideIcon,
+} from "lucide-react";
+import type { SurveyTriggerType } from "@/generated/client";
+
+/* -------------------------------------------------------------------------- */
+/*  Status semantics — one source of truth for assignment-status colours       */
+/* -------------------------------------------------------------------------- */
+
+export type AssignmentStatusKey =
+  | "completed"
+  | "pending"
+  | "dismissed"
+  | "expired";
+
+export const STATUS_META: Record<
+  AssignmentStatusKey,
+  {
+    label: string;
+    /** solid swatch used for dots and bar segments */
+    swatch: string;
+    /** readable text colour for counts */
+    text: string;
+    /** soft tinted surface */
+    soft: string;
+    ring: string;
+  }
+> = {
+  completed: {
+    label: "Completed",
+    swatch: "bg-emerald-500",
+    text: "text-emerald-600 dark:text-emerald-400",
+    soft: "bg-emerald-500/10",
+    ring: "ring-emerald-500/20",
+  },
+  pending: {
+    label: "Pending",
+    swatch: "bg-amber-500",
+    text: "text-amber-600 dark:text-amber-400",
+    soft: "bg-amber-500/10",
+    ring: "ring-amber-500/20",
+  },
+  dismissed: {
+    label: "Dismissed",
+    swatch: "bg-slate-400 dark:bg-slate-500",
+    text: "text-slate-500 dark:text-slate-400",
+    soft: "bg-slate-400/10",
+    ring: "ring-slate-400/20",
+  },
+  expired: {
+    label: "Expired",
+    swatch: "bg-rose-500",
+    text: "text-rose-600 dark:text-rose-400",
+    soft: "bg-rose-500/10",
+    ring: "ring-rose-500/20",
+  },
+};
+
+export const STATUS_ORDER: AssignmentStatusKey[] = [
+  "completed",
+  "pending",
+  "dismissed",
+  "expired",
+];
+
+/* -------------------------------------------------------------------------- */
+/*  Trigger semantics                                                          */
+/* -------------------------------------------------------------------------- */
+
+export const TRIGGER_META: Record<
+  SurveyTriggerType,
+  { label: string; icon: LucideIcon; accent: string }
+> = {
+  SHIFTS_COMPLETED: {
+    label: "Shifts completed",
+    icon: CalendarCheck,
+    accent: "text-emerald-600 dark:text-emerald-400",
+  },
+  HOURS_VOLUNTEERED: {
+    label: "Hours volunteered",
+    icon: Clock,
+    accent: "text-sky-600 dark:text-sky-400",
+  },
+  FIRST_SHIFT: {
+    label: "First shift",
+    icon: Sparkles,
+    accent: "text-violet-600 dark:text-violet-400",
+  },
+  MANUAL: {
+    label: "Manual",
+    icon: Hand,
+    accent: "text-slate-500 dark:text-slate-400",
+  },
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Completion ring — the recurring motif across both pages                    */
+/* -------------------------------------------------------------------------- */
+
+export function CompletionRing({
+  value,
+  size = 72,
+  stroke = 7,
+  label,
+  sublabel,
+  className,
+}: {
+  /** 0–100 */
+  value: number;
+  size?: number;
+  stroke?: number;
+  label?: string;
+  sublabel?: string;
+  className?: string;
+}) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    const t = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(t);
+  }, []);
+
+  const clamped = Math.max(0, Math.min(100, value));
+  const r = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * r;
+  const offset = circumference * (1 - (mounted ? clamped : 0) / 100);
+
+  return (
+    <div
+      className={cn("relative shrink-0", className)}
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={`${Math.round(clamped)}% complete`}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        className="-rotate-90"
+      >
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          strokeWidth={stroke}
+          className="stroke-muted"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          style={{
+            stroke: "var(--ee-primary-text)",
+            transition:
+              "stroke-dashoffset 900ms cubic-bezier(0.22, 1, 0.36, 1)",
+          }}
+          className="motion-reduce:transition-none"
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-sm font-bold tabular-nums leading-none text-foreground">
+          {label ?? `${Math.round(clamped)}%`}
+        </span>
+        {sublabel && (
+          <span className="mt-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            {sublabel}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Segmented status bar                                                        */
+/* -------------------------------------------------------------------------- */
+
+export function StatusBar({
+  segments,
+  className,
+}: {
+  segments: { key: AssignmentStatusKey; value: number }[];
+  className?: string;
+}) {
+  const total = segments.reduce((sum, s) => sum + s.value, 0);
+
+  return (
+    <div
+      className={cn(
+        "flex h-2 w-full overflow-hidden rounded-full bg-muted",
+        className
+      )}
+    >
+      {total === 0
+        ? null
+        : segments.map((s) =>
+            s.value > 0 ? (
+              <div
+                key={s.key}
+                className={cn(
+                  STATUS_META[s.key].swatch,
+                  "h-full transition-[width] duration-700 ease-out first:rounded-l-full last:rounded-r-full motion-reduce:transition-none"
+                )}
+                style={{ width: `${(s.value / total) * 100}%` }}
+                title={`${STATUS_META[s.key].label}: ${s.value}`}
+              />
+            ) : null
+          )}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Count chip with status dot                                                  */
+/* -------------------------------------------------------------------------- */
+
+export function CountChip({
+  status,
+  value,
+}: {
+  status: AssignmentStatusKey;
+  value: number;
+}) {
+  const meta = STATUS_META[status];
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+      <span className={cn("h-2 w-2 rounded-full", meta.swatch)} />
+      <span className="tabular-nums text-foreground">{value}</span>
+      <span>{meta.label.toLowerCase()}</span>
+    </span>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  KPI stat tile (overview strips)                                             */
+/* -------------------------------------------------------------------------- */
+
+export function StatTile({
+  icon: Icon,
+  label,
+  value,
+  hint,
+  accent = "text-foreground",
+  iconWrap = "bg-muted/60 text-muted-foreground",
+  className,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: React.ReactNode;
+  hint?: React.ReactNode;
+  accent?: string;
+  iconWrap?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "relative flex flex-col gap-3 rounded-xl border bg-card p-4 shadow-sm transition-shadow hover:shadow-md",
+        className
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </span>
+        <span
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-lg",
+            iconWrap
+          )}
+        >
+          <Icon className="h-4 w-4" />
+        </span>
+      </div>
+      <div className="flex items-end gap-2">
+        <span className={cn("text-2xl font-bold tabular-nums leading-none", accent)}>
+          {value}
+        </span>
+      </div>
+      {hint && (
+        <span className="text-xs text-muted-foreground">{hint}</span>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/admin/surveys/page.tsx
+++ b/web/src/app/admin/surveys/page.tsx
@@ -30,36 +30,34 @@ export default async function SurveysPage() {
     orderBy: { createdAt: "desc" },
   });
 
-  // Get stats for each survey
-  const surveysWithStats = await Promise.all(
-    surveys.map(async (survey) => {
-      const [pending, completed, dismissed, expired] = await Promise.all([
-        prisma.surveyAssignment.count({
-          where: { surveyId: survey.id, status: "PENDING" },
-        }),
-        prisma.surveyAssignment.count({
-          where: { surveyId: survey.id, status: "COMPLETED" },
-        }),
-        prisma.surveyAssignment.count({
-          where: { surveyId: survey.id, status: "DISMISSED" },
-        }),
-        prisma.surveyAssignment.count({
-          where: { surveyId: survey.id, status: "EXPIRED" },
-        }),
-      ]);
+  // Aggregate per-status assignment counts for every survey in a single query
+  // (avoids an N+1 of four count() calls per survey).
+  const statusGroups = await prisma.surveyAssignment.groupBy({
+    by: ["surveyId", "status"],
+    _count: { _all: true },
+  });
 
-      return {
-        ...survey,
-        stats: {
-          totalAssignments: survey._count.assignments,
-          pending,
-          completed,
-          dismissed,
-          expired,
-        },
-      };
-    })
-  );
+  const emptyStats = () => ({
+    pending: 0,
+    completed: 0,
+    dismissed: 0,
+    expired: 0,
+  });
+  const statsBySurvey = new Map<string, ReturnType<typeof emptyStats>>();
+  for (const group of statusGroups) {
+    const entry = statsBySurvey.get(group.surveyId) ?? emptyStats();
+    const key = group.status.toLowerCase() as keyof ReturnType<typeof emptyStats>;
+    if (key in entry) entry[key] = group._count._all;
+    statsBySurvey.set(group.surveyId, entry);
+  }
+
+  const surveysWithStats = surveys.map((survey) => ({
+    ...survey,
+    stats: {
+      totalAssignments: survey._count.assignments,
+      ...(statsBySurvey.get(survey.id) ?? emptyStats()),
+    },
+  }));
 
   return (
     <PageContainer>

--- a/web/src/app/admin/surveys/page.tsx
+++ b/web/src/app/admin/surveys/page.tsx
@@ -2,7 +2,6 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { redirect } from "next/navigation";
-import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { SurveysContent } from "./surveys-content";
 
@@ -63,10 +62,8 @@ export default async function SurveysPage() {
   );
 
   return (
-    <AdminPageWrapper title="Surveys">
-      <PageContainer>
-        <SurveysContent initialSurveys={surveysWithStats} />
-      </PageContainer>
-    </AdminPageWrapper>
+    <PageContainer>
+      <SurveysContent initialSurveys={surveysWithStats} />
+    </PageContainer>
   );
 }

--- a/web/src/app/admin/surveys/surveys-content.tsx
+++ b/web/src/app/admin/surveys/surveys-content.tsx
@@ -47,6 +47,7 @@ import {
   TRIGGER_META,
 } from "./_components/survey-ui";
 import { useToast } from "@/hooks/use-toast";
+import { useAdminPageTitle } from "@/hooks/use-admin-page-title";
 import { cn } from "@/lib/utils";
 import type { Survey, SurveyTriggerType } from "@/generated/client";
 import Link from "next/link";
@@ -259,6 +260,29 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
     setDialogOpen(true);
   };
 
+  const headerActions = useMemo(
+    () => (
+      <Button
+        size="sm"
+        onClick={() => {
+          setEditingSurvey(null);
+          setDialogOpen(true);
+        }}
+        data-testid="create-survey-button"
+      >
+        <Plus className="mr-2 h-4 w-4" />
+        Create survey
+      </Button>
+    ),
+    []
+  );
+
+  useAdminPageTitle(
+    "Surveys",
+    "Design, deploy and track volunteer feedback across the motu.",
+    headerActions
+  );
+
   const handleAssignmentComplete = () => {
     window.location.reload();
   };
@@ -304,24 +328,6 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
 
   return (
     <div className="space-y-6">
-      {/* Intro */}
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h2 className="text-2xl font-bold tracking-tight">Surveys</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Design, deploy and track volunteer feedback across the motu.
-          </p>
-        </div>
-        <Button
-          onClick={openCreateDialog}
-          data-testid="create-survey-button"
-          className="w-full sm:w-auto"
-        >
-          <Plus className="mr-2 h-4 w-4" />
-          Create survey
-        </Button>
-      </div>
-
       {/* Overview KPIs */}
       {surveys.length > 0 && (
         <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">

--- a/web/src/app/admin/surveys/surveys-content.tsx
+++ b/web/src/app/admin/surveys/surveys-content.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import {
   AlertDialog,
@@ -15,26 +15,39 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Plus,
   Edit,
   Trash2,
-  Eye,
   Users,
   ClipboardList,
-  ToggleLeft,
-  ToggleRight,
+  Power,
   UserPlus,
+  MoreHorizontal,
+  Search,
+  BarChart3,
+  ArrowRight,
+  Inbox,
 } from "lucide-react";
 import { SurveyDialog } from "./survey-dialog";
 import { AssignSurveyDialog } from "./assign-survey-dialog";
 import { BulkAssignSurveyDialog } from "./bulk-assign-survey-dialog";
+import {
+  CompletionRing,
+  CountChip,
+  StatTile,
+  StatusBar,
+  TRIGGER_META,
+} from "./_components/survey-ui";
 import { useToast } from "@/hooks/use-toast";
-import { SURVEY_TRIGGER_DISPLAY } from "@/types/survey";
+import { cn } from "@/lib/utils";
 import type { Survey, SurveyTriggerType } from "@/generated/client";
 import Link from "next/link";
 
@@ -60,17 +73,41 @@ interface SurveysContentProps {
   initialSurveys: SurveyWithStats[];
 }
 
+type StatusFilter = "all" | "active" | "inactive";
+
+function completionRate(s: SurveyWithStats["stats"]) {
+  return s.totalAssignments > 0
+    ? Math.round((s.completed / s.totalAssignments) * 100)
+    : 0;
+}
+
 export function SurveysContent({ initialSurveys }: SurveysContentProps) {
   const [surveys, setSurveys] = useState<SurveyWithStats[]>(initialSurveys);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingSurvey, setEditingSurvey] = useState<SurveyWithStats | null>(null);
+  const [editingSurvey, setEditingSurvey] = useState<SurveyWithStats | null>(
+    null
+  );
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [surveyToDelete, setSurveyToDelete] = useState<SurveyWithStats | null>(null);
+  const [surveyToDelete, setSurveyToDelete] = useState<SurveyWithStats | null>(
+    null
+  );
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
-  const [surveyToAssign, setSurveyToAssign] = useState<SurveyWithStats | null>(null);
+  const [surveyToAssign, setSurveyToAssign] = useState<SurveyWithStats | null>(
+    null
+  );
   const [bulkAssignDialogOpen, setBulkAssignDialogOpen] = useState(false);
-  const [surveyToBulkAssign, setSurveyToBulkAssign] = useState<SurveyWithStats | null>(null);
+  const [surveyToBulkAssign, setSurveyToBulkAssign] =
+    useState<SurveyWithStats | null>(null);
+
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [triggerFilter, setTriggerFilter] = useState<SurveyTriggerType | "all">(
+    "all"
+  );
+
   const { toast } = useToast();
+
+  /* ----------------------------- mutations ------------------------------- */
 
   const handleCreateSurvey = async (data: {
     title: string;
@@ -109,11 +146,7 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
         ...prev,
       ]);
 
-      toast({
-        title: "Success",
-        description: "Survey created successfully",
-      });
-
+      toast({ title: "Success", description: "Survey created successfully" });
       setDialogOpen(false);
     } catch (error) {
       toast({
@@ -158,11 +191,7 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
         )
       );
 
-      toast({
-        title: "Success",
-        description: "Survey updated successfully",
-      });
-
+      toast({ title: "Success", description: "Survey updated successfully" });
       setDialogOpen(false);
       setEditingSurvey(null);
     } catch (error) {
@@ -193,7 +222,6 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
       const result = await response.json();
 
       if (result.deactivated) {
-        // Survey was deactivated instead of deleted
         setSurveys((prev) =>
           prev.map((survey) =>
             survey.id === id ? { ...survey, isActive: false } : survey
@@ -205,12 +233,8 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
             "Survey has existing responses and was deactivated instead of deleted",
         });
       } else {
-        // Survey was deleted
         setSurveys((prev) => prev.filter((survey) => survey.id !== id));
-        toast({
-          title: "Success",
-          description: "Survey deleted successfully",
-        });
+        toast({ title: "Success", description: "Survey deleted successfully" });
       }
     } catch (error) {
       toast({
@@ -222,11 +246,6 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
     }
   };
 
-  const openDeleteDialog = (survey: SurveyWithStats) => {
-    setSurveyToDelete(survey);
-    setDeleteDialogOpen(true);
-  };
-
   const confirmDeleteSurvey = async () => {
     if (surveyToDelete) {
       await handleDeleteSurvey(surveyToDelete.id);
@@ -235,209 +254,223 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
     }
   };
 
-  const openEditDialog = (survey: SurveyWithStats) => {
-    setEditingSurvey(survey);
-    setDialogOpen(true);
-  };
-
   const openCreateDialog = () => {
     setEditingSurvey(null);
     setDialogOpen(true);
   };
 
-  const openAssignDialog = (survey: SurveyWithStats) => {
-    setSurveyToAssign(survey);
-    setAssignDialogOpen(true);
-  };
-
-  const openBulkAssignDialog = (survey: SurveyWithStats) => {
-    setSurveyToBulkAssign(survey);
-    setBulkAssignDialogOpen(true);
-  };
-
   const handleAssignmentComplete = () => {
-    // Refresh surveys to update assignment counts
     window.location.reload();
   };
 
+  /* ----------------------------- derived --------------------------------- */
+
+  const overview = useMemo(() => {
+    const active = surveys.filter((s) => s.isActive).length;
+    const responses = surveys.reduce((sum, s) => sum + s.stats.completed, 0);
+    const totalAssigned = surveys.reduce(
+      (sum, s) => sum + s.stats.totalAssignments,
+      0
+    );
+    const avgCompletion =
+      totalAssigned > 0 ? Math.round((responses / totalAssigned) * 100) : 0;
+    return { active, responses, avgCompletion, total: surveys.length };
+  }, [surveys]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return surveys.filter((s) => {
+      if (statusFilter === "active" && !s.isActive) return false;
+      if (statusFilter === "inactive" && s.isActive) return false;
+      if (triggerFilter !== "all" && s.triggerType !== triggerFilter)
+        return false;
+      if (q) {
+        const haystack = `${s.title} ${s.description ?? ""}`.toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [surveys, query, statusFilter, triggerFilter]);
+
+  const triggerOptions: (SurveyTriggerType | "all")[] = [
+    "all",
+    "SHIFTS_COMPLETED",
+    "HOURS_VOLUNTEERED",
+    "FIRST_SHIFT",
+    "MANUAL",
+  ];
+
+  /* ------------------------------ render --------------------------------- */
+
   return (
     <div className="space-y-6">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+      {/* Intro */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-2xl font-bold">Surveys</h2>
-          <p className="text-slate-600 mt-1">
-            Create and manage volunteer feedback surveys
+          <h2 className="text-2xl font-bold tracking-tight">Surveys</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Design, deploy and track volunteer feedback across the motu.
           </p>
         </div>
-        <Button onClick={openCreateDialog} data-testid="create-survey-button" className="w-full sm:w-auto">
-          <Plus className="h-4 w-4 mr-2" />
-          Create Survey
+        <Button
+          onClick={openCreateDialog}
+          data-testid="create-survey-button"
+          className="w-full sm:w-auto"
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          Create survey
         </Button>
       </div>
 
-      <div className="grid gap-4">
-        {surveys.length === 0 ? (
-          <Card>
-            <CardContent className="py-8 text-center">
-              <div className="h-12 w-12 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <ClipboardList className="h-6 w-6 text-slate-400" />
-              </div>
-              <h3 className="text-lg font-semibold text-slate-900 mb-2">
-                No surveys yet
-              </h3>
-              <p className="text-slate-600 mb-6">
-                Create your first survey to gather feedback from volunteers.
-              </p>
-              <Button onClick={openCreateDialog}>
-                <Plus className="h-4 w-4 mr-2" />
-                Create First Survey
-              </Button>
-            </CardContent>
-          </Card>
-        ) : (
-          surveys.map((survey) => (
-            <Card
-              key={survey.id}
-              className={!survey.isActive ? "opacity-60" : ""}
-            >
-              <CardContent className="py-4">
-                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex flex-wrap items-center gap-2 mb-1">
-                      <h3 className="font-semibold text-lg">{survey.title}</h3>
-                      {!survey.isActive && (
-                        <Badge variant="secondary">Inactive</Badge>
-                      )}
-                      <Badge variant="outline">
-                        {SURVEY_TRIGGER_DISPLAY[survey.triggerType]?.label}
-                        {survey.triggerType !== "MANUAL" && (
-                          survey.triggerMaxValue
-                            ? ` (${survey.triggerValue}-${survey.triggerMaxValue})`
-                            : ` (${survey.triggerValue}+)`
-                        )}
-                      </Badge>
-                    </div>
-                    {survey.description && (
-                      <p className="text-sm text-slate-600 mb-2">
-                        {survey.description}
-                      </p>
-                    )}
-                    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-slate-500">
-                      <span className="flex items-center gap-1">
-                        <Users className="h-4 w-4" />
-                        {survey.stats.totalAssignments} assigned
-                      </span>
-                      <span className="text-green-600">
-                        {survey.stats.completed} completed
-                      </span>
-                      <span className="text-blue-600">
-                        {survey.stats.pending} pending
-                      </span>
-                      {survey.stats.expired > 0 && (
-                        <span className="text-orange-600">
-                          {survey.stats.expired} expired
-                        </span>
-                      )}
-                    </div>
-                    <p className="text-xs text-slate-400 mt-2">
-                      Created by {survey.creator.name || survey.creator.email}
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    {survey.triggerType !== "MANUAL" && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => openBulkAssignDialog(survey)}
-                            data-testid={`bulk-assign-survey-${survey.id}`}
-                          >
-                            <Users className="h-4 w-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>Bulk Assign</TooltipContent>
-                      </Tooltip>
-                    )}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant={survey.triggerType === "MANUAL" ? "default" : "outline"}
-                          size="sm"
-                          onClick={() => openAssignDialog(survey)}
-                          data-testid={`assign-survey-${survey.id}`}
-                        >
-                          <UserPlus className="h-4 w-4" />
-                          {survey.triggerType === "MANUAL" && (
-                            <span className="ml-1">Assign</span>
-                          )}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Assign to Users</TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button variant="outline" size="sm" asChild data-testid={`view-responses-${survey.id}`}>
-                          <Link href={`/admin/surveys/${survey.id}/responses`}>
-                            <Eye className="h-4 w-4" />
-                          </Link>
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>View Responses</TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleToggleActive(survey)}
-                          data-testid={`toggle-survey-${survey.id}`}
-                        >
-                          {survey.isActive ? (
-                            <ToggleRight className="h-4 w-4 text-green-600" />
-                          ) : (
-                            <ToggleLeft className="h-4 w-4 text-slate-400" />
-                          )}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        {survey.isActive ? "Deactivate" : "Activate"}
-                      </TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => openEditDialog(survey)}
-                          data-testid={`edit-survey-${survey.id}`}
-                        >
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Edit</TooltipContent>
-                    </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => openDeleteDialog(survey)}
-                          data-testid={`delete-survey-${survey.id}`}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Delete</TooltipContent>
-                    </Tooltip>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          ))
-        )}
-      </div>
+      {/* Overview KPIs */}
+      {surveys.length > 0 && (
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <StatTile
+            icon={ClipboardList}
+            label="Surveys"
+            value={overview.total}
+            hint={`${overview.active} active`}
+            iconWrap="bg-[var(--ee-primary-light)] text-[var(--ee-primary-text)]"
+          />
+          <StatTile
+            icon={Power}
+            label="Active"
+            value={overview.active}
+            hint={
+              overview.total - overview.active > 0
+                ? `${overview.total - overview.active} paused`
+                : "all live"
+            }
+            accent="text-emerald-600 dark:text-emerald-400"
+            iconWrap="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+          />
+          <StatTile
+            icon={Inbox}
+            label="Responses"
+            value={overview.responses.toLocaleString()}
+            hint="completed to date"
+            iconWrap="bg-sky-500/10 text-sky-600 dark:text-sky-400"
+          />
+          <StatTile
+            icon={BarChart3}
+            label="Avg completion"
+            value={`${overview.avgCompletion}%`}
+            hint="across all assignments"
+            accent="text-[var(--ee-primary-text)]"
+            iconWrap="bg-amber-500/10 text-amber-600 dark:text-amber-400"
+          />
+        </div>
+      )}
 
+      {/* Toolbar */}
+      {surveys.length > 0 && (
+        <div className="space-y-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search surveys…"
+              className="pl-9"
+              data-testid="survey-search"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="inline-flex rounded-lg border bg-muted/40 p-0.5">
+              {(["all", "active", "inactive"] as StatusFilter[]).map((opt) => (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() => setStatusFilter(opt)}
+                  className={cn(
+                    "rounded-md px-3 py-1.5 text-xs font-medium capitalize transition-colors",
+                    statusFilter === opt
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-1">
+              {triggerOptions.map((opt) => {
+                const active = triggerFilter === opt;
+                const label =
+                  opt === "all" ? "All triggers" : TRIGGER_META[opt].label;
+                return (
+                  <button
+                    key={opt}
+                    type="button"
+                    onClick={() => setTriggerFilter(opt)}
+                    className={cn(
+                      "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                      active
+                        ? "border-transparent bg-foreground text-background"
+                        : "border-border bg-background text-muted-foreground hover:text-foreground"
+                    )}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Empty / list */}
+      {surveys.length === 0 ? (
+        <EmptyState onCreate={openCreateDialog} />
+      ) : filtered.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed py-16 text-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+            <Search className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <p className="text-sm font-medium">No surveys match your filters</p>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setQuery("");
+              setStatusFilter("all");
+              setTriggerFilter("all");
+            }}
+          >
+            Clear filters
+          </Button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+          {filtered.map((survey) => (
+            <SurveyCard
+              key={survey.id}
+              survey={survey}
+              onEdit={() => {
+                setEditingSurvey(survey);
+                setDialogOpen(true);
+              }}
+              onAssign={() => {
+                setSurveyToAssign(survey);
+                setAssignDialogOpen(true);
+              }}
+              onBulkAssign={() => {
+                setSurveyToBulkAssign(survey);
+                setBulkAssignDialogOpen(true);
+              }}
+              onToggle={() => handleToggleActive(survey)}
+              onDelete={() => {
+                setSurveyToDelete(survey);
+                setDeleteDialogOpen(true);
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Dialogs */}
       <SurveyDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
@@ -454,13 +487,15 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2 text-destructive">
               <Trash2 className="h-5 w-5" />
-              Delete Survey
+              Delete survey
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {surveyToDelete?.stats.totalAssignments && surveyToDelete.stats.totalAssignments > 0 ? (
+              {surveyToDelete?.stats.totalAssignments &&
+              surveyToDelete.stats.totalAssignments > 0 ? (
                 <>
-                  This survey has {surveyToDelete.stats.totalAssignments} assignment(s).
-                  It will be deactivated instead of deleted to preserve historical data.
+                  This survey has {surveyToDelete.stats.totalAssignments}{" "}
+                  assignment(s). It will be deactivated instead of deleted to
+                  preserve historical data.
                 </>
               ) : (
                 "Are you sure you want to delete this survey? This action cannot be undone."
@@ -473,8 +508,9 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
               onClick={confirmDeleteSurvey}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              <Trash2 className="h-4 w-4 mr-2" />
-              {surveyToDelete?.stats.totalAssignments && surveyToDelete.stats.totalAssignments > 0
+              <Trash2 className="mr-2 h-4 w-4" />
+              {surveyToDelete?.stats.totalAssignments &&
+              surveyToDelete.stats.totalAssignments > 0
                 ? "Deactivate"
                 : "Delete"}
             </AlertDialogAction>
@@ -505,6 +541,239 @@ export function SurveysContent({ initialSurveys }: SurveysContentProps) {
           onAssigned={handleAssignmentComplete}
         />
       )}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Survey card                                                                 */
+/* -------------------------------------------------------------------------- */
+
+function SurveyCard({
+  survey,
+  onEdit,
+  onAssign,
+  onBulkAssign,
+  onToggle,
+  onDelete,
+}: {
+  survey: SurveyWithStats;
+  onEdit: () => void;
+  onAssign: () => void;
+  onBulkAssign: () => void;
+  onToggle: () => void;
+  onDelete: () => void;
+}) {
+  const trigger = TRIGGER_META[survey.triggerType];
+  const TriggerIcon = trigger.icon;
+  const rate = completionRate(survey.stats);
+  const triggerRange =
+    survey.triggerType === "MANUAL"
+      ? null
+      : survey.triggerMaxValue
+      ? `${survey.triggerValue}–${survey.triggerMaxValue}`
+      : `${survey.triggerValue}+`;
+
+  return (
+    <article
+      className={cn(
+        "group relative flex flex-col overflow-hidden rounded-xl border bg-card shadow-sm transition-all hover:shadow-md",
+        !survey.isActive && "opacity-75"
+      )}
+      data-testid={`survey-card-${survey.id}`}
+    >
+      {/* status accent rail */}
+      <span
+        aria-hidden
+        className={cn(
+          "absolute inset-y-0 left-0 w-1",
+          survey.isActive ? "bg-[var(--ee-primary-text)]" : "bg-muted"
+        )}
+      />
+
+      <div className="flex flex-col gap-4 p-5 pl-6">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="truncate text-base font-semibold leading-tight">
+                {survey.title}
+              </h3>
+              {survey.isActive ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[11px] font-semibold text-emerald-600 dark:text-emerald-400">
+                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                  Active
+                </span>
+              ) : (
+                <Badge variant="secondary" className="text-[11px]">
+                  Paused
+                </Badge>
+              )}
+            </div>
+            <div className="mt-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+              <TriggerIcon className={cn("h-3.5 w-3.5", trigger.accent)} />
+              <span className="font-medium text-foreground/80">
+                {trigger.label}
+              </span>
+              {triggerRange && (
+                <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] tabular-nums">
+                  {triggerRange}
+                </span>
+              )}
+            </div>
+          </div>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0 text-muted-foreground"
+                data-testid={`survey-actions-${survey.id}`}
+              >
+                <MoreHorizontal className="h-4 w-4" />
+                <span className="sr-only">Survey actions</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuLabel>Manage</DropdownMenuLabel>
+              <DropdownMenuItem
+                onClick={onEdit}
+                data-testid={`edit-survey-${survey.id}`}
+              >
+                <Edit className="mr-2 h-4 w-4" />
+                Edit survey
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={onAssign}
+                data-testid={`assign-survey-${survey.id}`}
+              >
+                <UserPlus className="mr-2 h-4 w-4" />
+                Assign to users
+              </DropdownMenuItem>
+              {survey.triggerType !== "MANUAL" && (
+                <DropdownMenuItem
+                  onClick={onBulkAssign}
+                  data-testid={`bulk-assign-survey-${survey.id}`}
+                >
+                  <Users className="mr-2 h-4 w-4" />
+                  Bulk assign
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem
+                onClick={onToggle}
+                data-testid={`toggle-survey-${survey.id}`}
+              >
+                <Power className="mr-2 h-4 w-4" />
+                {survey.isActive ? "Deactivate" : "Activate"}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onClick={onDelete}
+                className="text-destructive focus:text-destructive"
+                data-testid={`delete-survey-${survey.id}`}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {survey.description && (
+          <p className="line-clamp-2 text-sm text-muted-foreground">
+            {survey.description}
+          </p>
+        )}
+
+        {/* Metrics */}
+        <div className="flex items-center gap-4 rounded-lg bg-muted/40 p-3">
+          <CompletionRing value={rate} sublabel="done" />
+          <div className="min-w-0 flex-1 space-y-2">
+            {survey.stats.totalAssignments === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Not assigned to anyone yet.
+              </p>
+            ) : (
+              <>
+                <div className="flex items-center justify-between text-xs">
+                  <span className="font-medium text-foreground">
+                    {survey.stats.totalAssignments} assigned
+                  </span>
+                  <span className="tabular-nums text-muted-foreground">
+                    {survey.stats.completed}/{survey.stats.totalAssignments}
+                  </span>
+                </div>
+                <StatusBar
+                  segments={[
+                    { key: "completed", value: survey.stats.completed },
+                    { key: "pending", value: survey.stats.pending },
+                    { key: "dismissed", value: survey.stats.dismissed },
+                    { key: "expired", value: survey.stats.expired },
+                  ]}
+                />
+                <div className="flex flex-wrap gap-x-3 gap-y-1 pt-0.5">
+                  <CountChip status="completed" value={survey.stats.completed} />
+                  <CountChip status="pending" value={survey.stats.pending} />
+                  {survey.stats.dismissed > 0 && (
+                    <CountChip
+                      status="dismissed"
+                      value={survey.stats.dismissed}
+                    />
+                  )}
+                  {survey.stats.expired > 0 && (
+                    <CountChip status="expired" value={survey.stats.expired} />
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between gap-3 border-t pt-3">
+          <p className="truncate text-xs text-muted-foreground">
+            By {survey.creator.name || survey.creator.email}
+          </p>
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            data-testid={`view-responses-${survey.id}`}
+          >
+            <Link href={`/admin/surveys/${survey.id}/responses`}>
+              View responses
+              <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Empty state                                                                 */
+/* -------------------------------------------------------------------------- */
+
+function EmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 rounded-xl border border-dashed bg-card/50 py-16 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-[var(--ee-primary-light)]">
+        <ClipboardList className="h-7 w-7 text-[var(--ee-primary-text)]" />
+      </div>
+      <div className="space-y-1">
+        <h3 className="text-lg font-semibold">No surveys yet</h3>
+        <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+          Create your first survey to start gathering feedback from your
+          volunteer whānau.
+        </p>
+      </div>
+      <Button onClick={onCreate}>
+        <Plus className="mr-2 h-4 w-4" />
+        Create first survey
+      </Button>
     </div>
   );
 }

--- a/web/src/app/admin/surveys/surveys-content.tsx
+++ b/web/src/app/admin/surveys/surveys-content.tsx
@@ -612,7 +612,7 @@ function SurveyCard({
                 </span>
               ) : (
                 <Badge variant="secondary" className="text-[11px]">
-                  Paused
+                  Inactive
                 </Badge>
               )}
             </div>

--- a/web/tests/e2e/admin-surveys.spec.ts
+++ b/web/tests/e2e/admin-surveys.spec.ts
@@ -9,6 +9,16 @@ import {
   deleteTestSurveys,
 } from "./helpers/test-helpers";
 import { randomUUID } from "crypto";
+import type { Page } from "@playwright/test";
+
+/**
+ * Row actions (edit, assign, bulk assign, activate/deactivate, delete) live
+ * inside a per-card "..." dropdown in the redesigned surveys list. Open it
+ * before interacting with any of those actions.
+ */
+async function openSurveyActions(page: Page, surveyId: string) {
+  await page.getByTestId(`survey-actions-${surveyId}`).click();
+}
 
 test.describe("Admin Surveys Management", () => {
   test.describe("Page Access and Authentication", () => {
@@ -336,6 +346,7 @@ test.describe("Admin Surveys Management", () => {
       page,
     }) => {
       // Find the edit button on the survey card
+      await openSurveyActions(page, surveyIds[0]);
       const editButton = page.getByTestId(`edit-survey-${surveyIds[0]}`);
       await editButton.click();
 
@@ -348,6 +359,7 @@ test.describe("Admin Surveys Management", () => {
     });
 
     test("should allow updating survey title", async ({ page }) => {
+      await openSurveyActions(page, surveyIds[0]);
       const editButton = page.getByTestId(`edit-survey-${surveyIds[0]}`);
       await editButton.click();
 
@@ -370,6 +382,7 @@ test.describe("Admin Surveys Management", () => {
     test("should allow adding new questions to existing survey", async ({
       page,
     }) => {
+      await openSurveyActions(page, surveyIds[0]);
       const editButton = page.getByTestId(`edit-survey-${surveyIds[0]}`);
       await editButton.click();
 
@@ -386,6 +399,7 @@ test.describe("Admin Surveys Management", () => {
 
     test("should allow removing questions from survey", async ({ page }) => {
       // First add a second question so we can remove one
+      await openSurveyActions(page, surveyIds[0]);
       const editButton = page.getByTestId(`edit-survey-${surveyIds[0]}`);
       await editButton.click();
 
@@ -403,6 +417,7 @@ test.describe("Admin Surveys Management", () => {
     });
 
     test("should allow changing trigger type", async ({ page }) => {
+      await openSurveyActions(page, surveyIds[0]);
       const editButton = page.getByTestId(`edit-survey-${surveyIds[0]}`);
       await editButton.click();
 
@@ -456,6 +471,7 @@ test.describe("Admin Surveys Management", () => {
       await expect(page.getByText("Toggle Active Survey")).toBeVisible();
 
       // Click deactivate button
+      await openSurveyActions(page, surveyIds[0]);
       const toggleButton = page.getByTestId(`toggle-survey-${surveyIds[0]}`);
       await toggleButton.click();
 
@@ -465,6 +481,7 @@ test.describe("Admin Surveys Management", () => {
 
     test("should show inactive badge after deactivation", async ({ page }) => {
       // Deactivate the survey
+      await openSurveyActions(page, surveyIds[0]);
       const toggleButton = page.getByTestId(`toggle-survey-${surveyIds[0]}`);
       await toggleButton.click();
 
@@ -514,11 +531,13 @@ test.describe("Admin Surveys Management", () => {
       await expect(page.getByText("Delete Confirm Survey")).toBeVisible();
 
       // Click delete button
+      await openSurveyActions(page, survey.id);
       const deleteButton = page.getByTestId(`delete-survey-${survey.id}`);
       await deleteButton.click();
 
       // Confirmation dialog should appear
-      await expect(page.getByText("Delete Survey")).toBeVisible();
+      await expect(page.getByRole("alertdialog")).toBeVisible();
+      await expect(page.getByText(/delete survey/i)).toBeVisible();
     });
 
     test("should delete survey with no assignments", async ({ page }) => {
@@ -536,6 +555,7 @@ test.describe("Admin Surveys Management", () => {
       await expect(page.getByText("Delete No Assign Survey")).toBeVisible();
 
       // Click delete
+      await openSurveyActions(page, survey.id);
       const deleteButton = page.getByTestId(`delete-survey-${survey.id}`);
       await deleteButton.click();
 
@@ -574,6 +594,7 @@ test.describe("Admin Surveys Management", () => {
       await expect(page.getByText("Delete With Assign Survey")).toBeVisible();
 
       // Click delete
+      await openSurveyActions(page, survey.id);
       const deleteButton = page.getByTestId(`delete-survey-${survey.id}`);
       await deleteButton.click();
 
@@ -596,6 +617,7 @@ test.describe("Admin Surveys Management", () => {
       await expect(page.getByText("Cancel Delete Survey")).toBeVisible();
 
       // Click delete
+      await openSurveyActions(page, survey.id);
       const deleteButton = page.getByTestId(`delete-survey-${survey.id}`);
       await deleteButton.click();
 
@@ -644,6 +666,7 @@ test.describe("Admin Surveys Management", () => {
     test("should open assign dialog when clicking assign button", async ({
       page,
     }) => {
+      await openSurveyActions(page, surveyIds[0]);
       const assignButton = page.getByTestId(new RegExp(`assign-survey-${surveyIds[0]}`));
       await assignButton.click();
 
@@ -655,6 +678,7 @@ test.describe("Admin Surveys Management", () => {
     test("should search and filter users in assign dialog", async ({
       page,
     }) => {
+      await openSurveyActions(page, surveyIds[0]);
       const assignButton = page.getByTestId(new RegExp(`assign-survey-${surveyIds[0]}`));
       await assignButton.click();
 
@@ -675,6 +699,7 @@ test.describe("Admin Surveys Management", () => {
     test("should allow selecting multiple users for assignment", async ({
       page,
     }) => {
+      await openSurveyActions(page, surveyIds[0]);
       const assignButton = page.getByTestId(new RegExp(`assign-survey-${surveyIds[0]}`));
       await assignButton.click();
 
@@ -707,6 +732,7 @@ test.describe("Admin Surveys Management", () => {
 
       await page.reload();
 
+      await openSurveyActions(page, surveyIds[0]);
       const assignButton = page.getByTestId(new RegExp(`assign-survey-${surveyIds[0]}`));
       await assignButton.click();
 
@@ -722,6 +748,7 @@ test.describe("Admin Surveys Management", () => {
     });
 
     test("should assign survey to selected users", async ({ page }) => {
+      await openSurveyActions(page, surveyIds[0]);
       const assignButton = page.getByTestId(new RegExp(`assign-survey-${surveyIds[0]}`));
       await assignButton.click();
 
@@ -746,11 +773,14 @@ test.describe("Admin Surveys Management", () => {
       }
     });
 
-    test("should show MANUAL surveys with prominent assign button", async ({
+    test("should expose assign action for MANUAL surveys", async ({
       page,
     }) => {
-      // MANUAL trigger surveys should have the assign button visible
-      const assignButton = page.getByTestId(new RegExp(`assign-survey-${surveyIds[0]}`));
+      // Assign lives in the per-card actions dropdown in the redesign.
+      await openSurveyActions(page, surveyIds[0]);
+      const assignButton = page.getByTestId(
+        new RegExp(`assign-survey-${surveyIds[0]}`)
+      );
       await expect(assignButton).toBeVisible();
     });
   });
@@ -801,11 +831,11 @@ test.describe("Admin Surveys Management", () => {
       await page.goto(`/admin/surveys/${surveyIds[0]}/responses`);
       await page.waitForLoadState("load");
 
-      // Should show the survey title
+      // Should show the survey title in the hero
       await expect(page.getByText("Responses Test Survey").first()).toBeVisible();
 
-      // Should show tabs (Summary, Responses, Assignments)
-      await expect(page.getByText(/responses/i).first()).toBeVisible();
+      // Should show the two-lens view switcher (Insights / Respondents)
+      await expect(page.getByRole("tab", { name: /respondents/i })).toBeVisible();
     });
 
     test("should show response details when clicking a response", async ({
@@ -814,22 +844,25 @@ test.describe("Admin Surveys Management", () => {
       await page.goto(`/admin/surveys/${surveyIds[0]}/responses`);
       await page.waitForLoadState("load");
 
-      // Verify tabs are present
-      await expect(page.getByRole("tab", { name: /assignments/i })).toBeVisible();
+      // Verify the view switcher tabs are present
+      await expect(page.getByRole("tab", { name: /insights/i })).toBeVisible();
+      await expect(page.getByRole("tab", { name: /respondents/i })).toBeVisible();
     });
 
-    test("should allow filtering responses by status", async ({ page }) => {
+    test("should allow filtering respondents by status", async ({ page }) => {
       await page.goto(`/admin/surveys/${surveyIds[0]}/responses`);
       await page.waitForLoadState("load");
 
-      // Check for the assignments tab which shows status
-      const assignmentsTab = page.getByRole("tab", { name: /assignments/i });
-      await assignmentsTab.click();
+      // Open the Respondents lens (default when there are no responses)
+      await page.getByRole("tab", { name: /respondents/i }).click();
 
-      // Should show the assignments list (may be empty)
-      const hasNoAssignments = await page.getByText(/no assignments yet/i).count() > 0;
-      const hasTable = await page.locator("table").count() > 0;
-      expect(hasNoAssignments || hasTable).toBeTruthy();
+      // Status filter chips replace the old Assignments tab/table
+      await expect(
+        page.getByRole("button", { name: /^All/ }).first()
+      ).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: /Completed/ }).first()
+      ).toBeVisible();
     });
   });
 
@@ -858,9 +891,12 @@ test.describe("Admin Surveys Management", () => {
       page,
     }) => {
       // We need a survey to edit - check if any exist
-      const editButton = page.locator('[data-testid^="edit-survey-"]').first();
-      if ((await editButton.count()) > 0) {
-        await editButton.click();
+      const actionsTrigger = page
+        .locator('[data-testid^="survey-actions-"]')
+        .first();
+      if ((await actionsTrigger.count()) > 0) {
+        await actionsTrigger.click();
+        await page.locator('[data-testid^="edit-survey-"]').first().click();
 
         const dialog = page.getByRole("dialog");
         await expect(dialog).toBeVisible();
@@ -874,9 +910,12 @@ test.describe("Admin Surveys Management", () => {
     test("should show preview email button in assign dialog", async ({
       page,
     }) => {
-      const assignButton = page.locator('[data-testid^="assign-survey-"]').first();
-      if ((await assignButton.count()) > 0) {
-        await assignButton.click();
+      const actionsTrigger = page
+        .locator('[data-testid^="survey-actions-"]')
+        .first();
+      if ((await actionsTrigger.count()) > 0) {
+        await actionsTrigger.click();
+        await page.locator('[data-testid^="assign-survey-"]').first().click();
 
         const dialog = page.getByRole("dialog");
         await expect(dialog).toBeVisible();


### PR DESCRIPTION
## Description
Complete visual + information-architecture overhaul of the two survey admin pages (`/admin/surveys` and `/admin/surveys/[id]/responses`), in the Everybody Eats brand language (forest green / cream / sun accent) with a recurring **completion-ring** motif. Shared primitives extracted to `web/src/app/admin/surveys/_components/survey-ui.tsx`.

### Surveys list
- New **overview band**: 4 KPI tiles (surveys, active, responses collected, avg completion) — there was no aggregate view before.
- New **controls**: search + status segmented control + trigger-type filter pills.
- **Rebuilt cards**: completion ring, segmented status bar (completed/pending/dismissed/expired), count chips, status accent rail. The cryptic row of 6 icon-only buttons is replaced by a clear **View responses** action + a **⋯ dropdown** (Edit, Assign, Bulk assign, Activate/Deactivate, Delete).

### Survey responses
- **Hero** with large completion ring + 4-up status breakdown strip.
- **Collapsed 3 tabs → 2 lenses**: *Insights* (per-question viz — ranked distribution bars, rating gauges, quoted text) and *Respondents* (people).
- **Merged the two redundant, horizontally-scrolling tables** (Responses + Assignments) into a single unified respondent list with a **status filter** replacing the tab split, a **sort control**, and a responsive layout with **no horizontal scroll**.
- **Expanded answers** render as a clean **Q&A transcript**: short answers (ratings, yes/no, choices) as compact inline badges; long free-text as readable quote blocks with constrained measure and preserved paragraph breaks.

All existing functionality preserved: CSV export, demographic filters via URL params, create/edit/assign/bulk-assign/toggle/delete, volunteer profile links.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Code refactoring (no functional changes)

## Version Bump Required
`version:minor`

## Testing
- [x] Manual testing completed
- [x] My changes generate no new warnings (typecheck + lint clean)

Verified in **dark, light, and mobile (390px)**, including a long multi-paragraph free-text answer (temporarily injected into the dev DB, then reverted).

## Screenshots (if applicable)
Redesigned surveys list (overview KPIs, filters, rich cards), responses hero + Insights, and the Respondents list with an expanded Q&A transcript — all verified locally in both themes and mobile.

## Additional Notes
- Pure presentation/IA change — no API, schema, or server-action changes.
- Note: the local dev DB on this branch showed minor schema drift vs. shared Postgres on an unrelated `SurveyResponse` column; it didn't affect these pages but is worth being aware of when running migrations.