### PR TITLE
chore(mobile): add .easignore to shrink EAS build uploads

### DIFF
--- a/mobile/.easignore
+++ b/mobile/.easignore
@@ -55,6 +55,7 @@ STYLE_GUIDE.md
 posthog-setup-report.md
 
 # --- debug logs ---
+*.log
 npm-debug.*
 yarn-debug.*
 yarn-error.*

--- a/mobile/.easignore
+++ b/mobile/.easignore
@@ -1,0 +1,63 @@
+# EAS upload ignore list.
+# NOTE: when this file exists, EAS uses it INSTEAD of .gitignore (it does not
+# extend it), so every pattern needed to keep the upload small must live here.
+# Goal: only ship the JS/TS source + config EAS needs to build in the cloud.
+
+# --- dependencies (installed fresh on the build worker) ---
+node_modules/
+
+# --- generated native projects (rebuilt by prebuild on the worker) ---
+# These are the main culprits for multi-GB uploads: Pods, Gradle caches,
+# build outputs, .cxx, DerivedData, etc.
+/ios
+/android
+.kotlin/
+
+# --- Expo / Metro / build outputs ---
+.expo/
+dist/
+web-build/
+expo-env.d.ts
+.metro-health-check*
+
+# --- TypeScript / lint caches ---
+*.tsbuildinfo
+
+# --- env & secrets (provided via EAS env / secrets, not the archive) ---
+.env
+.env*.local
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.pem
+*.mobileprovision
+everybody-eats-play.json
+
+# --- store / marketing assets not needed to build the app ---
+android-screenshots/
+ios-screenshots.pco/
+Unlinked Picasso App/
+*.png.import
+
+# --- tests & local-only tooling ---
+test-utils/
+**/*.test.ts
+**/*.test.tsx
+vitest.config.ts
+.vscode/
+.claude/
+
+# --- docs / reports ---
+README.md
+STYLE_GUIDE.md
+posthog-setup-report.md
+
+# --- debug logs ---
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# --- OS cruft ---
+.DS_Store

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Everybody Eats",
     "slug": "everybody-eats",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "everybody-eats",


### PR DESCRIPTION
## What changed

Adds `mobile/.easignore` so EAS only uploads the JS/TS source and config it needs to build in the cloud.

## Why

Mobile EAS builds were failing because the upload archive had grown to ~7GB. EAS had only `.gitignore` to go on, and the worktree/monorepo **root** `.gitignore` is minimal — it ignores `node_modules`/`.DS_Store` globally but nothing else. The patterns that actually exclude the heavy generated native folders (`ios/` with Pods + DerivedData, `android/` with `.gradle`/`build`/`.cxx`, `.expo/`, caches) live only in `mobile/.gitignore`. After a local `expo prebuild`/build those dirs are multiple GB, which bloated the upload.

## Reviewer notes

- **Key gotcha:** once an `.easignore` exists, EAS uses it **instead of** `.gitignore` (it does not extend it). So this file re-lists every essential ignore (`node_modules/`, generated `/ios` + `/android`, Expo/Metro outputs, env/secrets) and then adds the non-build extras that were being shipped:
  - `android-screenshots/`, `ios-screenshots.pco/`, `Unlinked Picasso App/` (tracked store/marketing assets)
  - tests, `test-utils/`, `.vscode/`, `.claude/`, docs/reports
- Deliberately **keeps** `assets/` (app icon/splash), `app/`, `components/`, `lib/`, `hooks/`, `constants/`, and all config (`app.json`, `eas.json`, `package.json`, `tsconfig.json`).
- Lives in `mobile/` because there is no root `package.json`/workspaces config, so EAS treats `mobile/` as the project root.