### PR TITLE
feat(analytics): add Bookings column to Summary by Location table

### DIFF
--- a/web/src/app/admin/analytics/_components/tab-donations.tsx
+++ b/web/src/app/admin/analytics/_components/tab-donations.tsx
@@ -473,6 +473,7 @@ function SummaryByLocation({ reports }: { reports: RestaurantReports }) {
               <TableHead className="text-right text-xs">Total koha</TableHead>
               <TableHead className="text-right text-xs">Avg koha/night</TableHead>
               <TableHead className="text-right text-xs">Customers</TableHead>
+              <TableHead className="text-right text-xs">Bookings</TableHead>
               <TableHead className="text-right text-xs">$ / head</TableHead>
               <TableHead className="text-right text-xs">Avg non-paying</TableHead>
               <TableHead className="text-right text-xs">Avg customers</TableHead>
@@ -486,6 +487,7 @@ function SummaryByLocation({ reports }: { reports: RestaurantReports }) {
                 <TableCell className="text-right text-sm tabular-nums">{money0(r.totalKoha)}</TableCell>
                 <TableCell className="text-right text-sm tabular-nums">{money2(r.avgKohaPerNight)}</TableCell>
                 <TableCell className="text-right text-sm tabular-nums">{num(r.customers)}</TableCell>
+                <TableCell className="text-right text-sm tabular-nums">{num(r.bookings)}</TableCell>
                 <TableCell className="text-right text-sm tabular-nums">{money2(r.perHead)}</TableCell>
                 <TableCell className="text-right text-sm tabular-nums">{oneDp(r.aveNonPaying)}</TableCell>
                 <TableCell className="text-right text-sm tabular-nums">{oneDp(r.aveCustomers)}</TableCell>
@@ -497,6 +499,7 @@ function SummaryByLocation({ reports }: { reports: RestaurantReports }) {
               <TableCell className="text-right text-sm tabular-nums">{money0(grand.totalKoha)}</TableCell>
               <TableCell className="text-right text-sm tabular-nums">{money2(grand.avgKohaPerNight)}</TableCell>
               <TableCell className="text-right text-sm tabular-nums">{num(grand.customers)}</TableCell>
+              <TableCell className="text-right text-sm tabular-nums">{num(grand.bookings)}</TableCell>
               <TableCell className="text-right text-sm tabular-nums">{money2(grand.perHead)}</TableCell>
               <TableCell className="text-right text-sm tabular-nums">{oneDp(grand.aveNonPaying)}</TableCell>
               <TableCell className="text-right text-sm tabular-nums">{oneDp(grand.aveCustomers)}</TableCell>

--- a/web/src/lib/restaurant-reports.ts
+++ b/web/src/lib/restaurant-reports.ts
@@ -27,6 +27,7 @@ export interface SummaryRow {
   totalKoha: number;
   avgKohaPerNight: number | null;
   customers: number;
+  bookings: number;
   perHead: number | null;
   aveNonPaying: number | null;
   aveCustomers: number | null;
@@ -233,6 +234,7 @@ export async function getRestaurantReports(
     totalKoha: round2(b.koha),
     avgKohaPerNight: div(b.koha, b.nights),
     customers: b.customers,
+    bookings: b.bookings,
     perHead: div(b.koha, b.customers),
     aveNonPaying: div(b.nonPaying, b.nights),
     aveCustomers: div(b.customers, b.nights),
@@ -246,6 +248,7 @@ export async function getRestaurantReports(
     grandBucket.koha += b.koha;
     grandBucket.nights += b.nights;
     grandBucket.nonPaying += b.nonPaying;
+    grandBucket.bookings += b.bookings;
   });
   const grand = summaryRow("Grand total", grandBucket);
 


### PR DESCRIPTION
## Description
Adds a **Bookings** column to the "Summary by Location" table in the koha & donations tab of admin analytics (`/admin/analytics?tab=donations`).

The booked-pax total was already aggregated from `MealsServed.bookingsPax` into each location bucket (used by the existing bookings-vs-donations scatter chart), but it was never surfaced in the summary table. This wires that existing value through to the table so admins can compare booked pax against actual meals served per location.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Changes
- **`web/src/lib/restaurant-reports.ts`**
  - Add `bookings: number` to the `SummaryRow` interface
  - Populate it in `summaryRow()` from the bucket's `bookings`
  - Include `bookings` in the grand-total accumulation so the totals row sums correctly
- **`web/src/app/admin/analytics/_components/tab-donations.tsx`**
  - New "Bookings" column header, placed right after "Customers"
  - Render the value (formatted as an integer via `num()`) in each location row and the grand-total row

The new column reads: Location · Nights · Total koha · Avg koha/night · **Customers · Bookings** · $ / head · Avg non-paying · Avg customers.

## Testing
- [x] Typecheck clean for both changed files (the only flagged line is a pre-existing worktree artifact from the un-generated Prisma client, unrelated to this change)
- [ ] Manual browser verification not run — this worktree has no installed dependencies; the change is purely additive (surfacing an already-computed value)

## Additional Notes
Possible follow-ups, not included here:
- A matching **"Avg bookings"** per-night column to mirror "Avg customers"
- A derived **attendance / no-show rate** column (customers vs. bookings)
