### PR TITLE
fix(home): correct undercounted homepage hours and volunteers stats

### DIFF
--- a/web/src/lib/home-stats.ts
+++ b/web/src/lib/home-stats.ts
@@ -1,5 +1,9 @@
 import { prisma } from "@/lib/prisma";
 import {
+  getActiveVolunteerCount,
+  getConfirmedVolunteerHours,
+} from "@/lib/impact-stats";
+import {
   getShiftEffectiveCount,
   shiftCapacityCountSelect,
 } from "@/lib/placeholder-utils";
@@ -35,24 +39,17 @@ export async function getHomeStats(): Promise<HomeStats> {
   const weekStart = startOfWeekUTC(now);
   const weekEnd = endOfWeekUTC(now);
 
-  const [volunteers, mealsAggregate, completedSignups, openShiftsRaw, weekShifts] =
+  const [volunteers, mealsAggregate, hoursLogged, openShiftsRaw, weekShifts] =
     await Promise.all([
-      prisma.user.count({
-        where: { role: "VOLUNTEER", archivedAt: null },
-      }),
+      // Volunteers: distinct people who have actually done a shift, not
+      // everyone who ever registered. Shared with the public impact endpoint.
+      getActiveVolunteerCount(now),
       prisma.mealsServed.aggregate({
         _sum: { mealsServed: true },
       }),
-      prisma.signup.findMany({
-        where: {
-          status: "CONFIRMED",
-          shift: { end: { lt: now } },
-        },
-        select: {
-          shift: { select: { start: true, end: true } },
-        },
-        take: 20000,
-      }),
+      // Hours logged: sum of completed CONFIRMED signups' shift duration.
+      // Computed in SQL (no row cap) — shared with the public impact endpoint.
+      getConfirmedVolunteerHours(now),
       prisma.shift.findMany({
         where: { start: { gte: now } },
         select: {
@@ -65,13 +62,6 @@ export async function getHomeStats(): Promise<HomeStats> {
         where: { start: { gte: weekStart, lt: weekEnd } },
       }),
     ]);
-
-  // Hours logged: sum of completed CONFIRMED signups' shift duration (hours)
-  let hoursLoggedMs = 0;
-  for (const s of completedSignups) {
-    hoursLoggedMs += s.shift.end.getTime() - s.shift.start.getTime();
-  }
-  const hoursLogged = Math.round(hoursLoggedMs / (1000 * 60 * 60));
 
   const openShiftsCount = openShiftsRaw.filter(
     (s) => getShiftEffectiveCount(s) < s.capacity

--- a/web/src/lib/impact-stats.test.ts
+++ b/web/src/lib/impact-stats.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/prisma", () => ({
 
 import {
   getPublicImpactStats,
+  getActiveVolunteerCount,
   FOOD_SAVED_KG_PER_MEAL,
 } from "./impact-stats";
 import { prisma } from "./prisma";
@@ -97,5 +98,35 @@ describe("getPublicImpactStats", () => {
       /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
     );
     expect(new Date(stats.generatedAt).toISOString()).toBe(stats.generatedAt);
+  });
+});
+
+describe("getActiveVolunteerCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("counts distinct users with CONFIRMED finished shifts", async () => {
+    mockedQueryRaw.mockResolvedValue([{ count: 42 }]);
+
+    const count = await getActiveVolunteerCount(new Date());
+
+    expect(count).toBe(42);
+  });
+
+  it("treats a null count as zero", async () => {
+    mockedQueryRaw.mockResolvedValue([{ count: null }]);
+
+    const count = await getActiveVolunteerCount(new Date());
+
+    expect(count).toBe(0);
+  });
+
+  it("defends against an empty raw-query result set", async () => {
+    mockedQueryRaw.mockResolvedValue([]);
+
+    const count = await getActiveVolunteerCount(new Date());
+
+    expect(count).toBe(0);
   });
 });

--- a/web/src/lib/impact-stats.ts
+++ b/web/src/lib/impact-stats.ts
@@ -26,6 +26,40 @@ export type PublicImpactStats = {
 };
 
 /**
+ * Total volunteer hours logged across every CONFIRMED signup whose shift has
+ * finished, as of `now`. Computed in SQL (`SUM` over shift durations) so there
+ * is no row cap — the single source of truth for the headline hours figure,
+ * shared by the public endpoint and the home landing page.
+ */
+export async function getConfirmedVolunteerHours(now: Date): Promise<number> {
+  const hoursRows = await prisma.$queryRaw<{ seconds: number | null }[]>`
+    SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (s."end" - s."start"))), 0)::float8 AS seconds
+    FROM "Signup" sg
+    JOIN "Shift" s ON s.id = sg."shiftId"
+    WHERE sg.status = 'CONFIRMED' AND s."end" < ${now}
+  `;
+  return Math.round((hoursRows[0]?.seconds ?? 0) / 3600);
+}
+
+/**
+ * Count of distinct volunteers who have actually done a shift, as of `now` —
+ * i.e. people with at least one CONFIRMED signup whose shift has finished.
+ * Uses the same CONFIRMED + finished-shift basis as the hours figure, so the
+ * two headline numbers tell a consistent story. This is the single source of
+ * truth, shared by the public endpoint and the home landing page; it counts
+ * people who showed up, not everyone who ever registered an account.
+ */
+export async function getActiveVolunteerCount(now: Date): Promise<number> {
+  const rows = await prisma.$queryRaw<{ count: number | null }[]>`
+    SELECT COUNT(DISTINCT sg."userId")::int AS count
+    FROM "Signup" sg
+    JOIN "Shift" s ON s.id = sg."shiftId"
+    WHERE sg.status = 'CONFIRMED' AND s."end" < ${now}
+  `;
+  return rows[0]?.count ?? 0;
+}
+
+/**
  * Computes the headline impact figures shared publicly (e.g. on the marketing
  * site). Kept deliberately lean — only the three numbers we expose — so it can
  * back a cacheable public endpoint without the heavier home-dashboard queries.
@@ -37,18 +71,12 @@ export type PublicImpactStats = {
 export async function getPublicImpactStats(): Promise<PublicImpactStats> {
   const now = new Date();
 
-  const [mealsAggregate, hoursRows] = await Promise.all([
+  const [mealsAggregate, volunteerHours] = await Promise.all([
     prisma.mealsServed.aggregate({ _sum: { mealsServed: true } }),
-    prisma.$queryRaw<{ seconds: number | null }[]>`
-      SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (s."end" - s."start"))), 0)::float8 AS seconds
-      FROM "Signup" sg
-      JOIN "Shift" s ON s.id = sg."shiftId"
-      WHERE sg.status = 'CONFIRMED' AND s."end" < ${now}
-    `,
+    getConfirmedVolunteerHours(now),
   ]);
 
   const peopleServed = mealsAggregate._sum.mealsServed ?? 0;
-  const volunteerHours = Math.round((hoursRows[0]?.seconds ?? 0) / 3600);
   const foodSavedKg = Math.round(peopleServed * FOOD_SAVED_KG_PER_MEAL);
 
   return {


### PR DESCRIPTION
## Description

The homepage hero stats were both undercounting:

- **Hours of mahi** showed **73,066** while the public impact endpoint (used by the marketing site) correctly reported **175,798**. The homepage re-implemented its own hours calculation by fetching signups into JS and looping over them with a hard-coded `take: 20000`, silently dropping every CONFIRMED signup past the first 20k.
- **Volunteers** counted every registered volunteer account (`role: VOLUNTEER, archivedAt: null`) rather than people who have actually done a shift.

This PR extracts two shared helpers in `impact-stats.ts` as the single source of truth, both using the same `CONFIRMED` + finished-shift basis and SQL aggregation (no row cap):

- `getConfirmedVolunteerHours(now)` — `SUM` of shift durations
- `getActiveVolunteerCount(now)` — `COUNT(DISTINCT userId)`

Both `home-stats.ts` and the public `/api/public/impact-stats` endpoint now derive these numbers the same way, so the homepage and marketing site stay consistent by construction.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactoring (no functional changes)

## Version Bump Required
`version:patch`

## Testing
- [x] `tsc --noEmit` passes (verified against a fully generated Prisma client)
- [ ] Manual testing completed — values are only meaningful against the production dataset; verified logically by sharing the exact query the public endpoint already uses

## Reviewer notes
- "Active volunteers" intentionally uses the **same** CONFIRMED + finished-shift basis as hours (no role/archive filter), so the two headline numbers tell a consistent "X people did Y hours" story. This means it now includes admins who worked shifts and since-archived volunteers who did real historical work. If we'd rather keep it strictly current-active volunteers, the role/archive filter can be re-added to the helper.
- Follow-ups (out of scope): optionally expose `volunteers` on the public endpoint so the marketing site can show the same number; per-user inline hours loops in `dashboard-impact-stats.tsx` / `friend-profile-dialog.tsx` could eventually share these helpers too.