### PR TITLE
fix(analytics): use NZ calendar date for restaurant report bucketing & Service Nights table

### DIFF
--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -771,7 +771,7 @@ model SiteSetting {
 // Meals served tracking (per day, per location)
 model MealsServed {
   id          String   @id @default(cuid())
-  date        DateTime // Date for this record (stored as start of day in UTC)
+  date        DateTime // Service night, stored as NZ-midnight expressed in UTC (e.g. NZ Jul 1 -> 2024-06-30T12:00Z). Read with toNZT()/formatInNZT() — a raw UTC slice lands a day early.
   location    String // Location name (Wellington, Glen Innes, Onehunga)
   mealsServed Int? // Customers / people served that day — headline count (nullable — admins may save notes without a count)
   notes       String? // Optional notes about the day

--- a/web/src/app/api/admin/analytics/service-nights/route.ts
+++ b/web/src/app/api/admin/analytics/service-nights/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
-import { nowInNZT, toNZT } from "@/lib/timezone";
+import { formatInNZT, nowInNZT, toNZT } from "@/lib/timezone";
 import { parseDaysParam } from "@/lib/parse-days-param";
 
 const toNum = (v: unknown): number => {
@@ -174,7 +174,9 @@ export async function GET(request: NextRequest) {
           Math.round((toNum(cash) + toNum(eftpos) + toNum(stripe)) * 100) / 100;
         const customers = r.mealsServed;
         return {
-          date: r.date.toISOString().substring(0, 10),
+          // Stored as NZ-midnight in UTC, so format in NZT to recover the
+          // actual NZ calendar date (a raw UTC slice lands a day early).
+          date: formatInNZT(r.date, "yyyy-MM-dd"),
           location: r.location,
           customers,
           nonPaying: r.nonPayingCount,

--- a/web/src/lib/restaurant-reports.ts
+++ b/web/src/lib/restaurant-reports.ts
@@ -179,14 +179,15 @@ export async function getRestaurantReports(
   const scatter: Array<{ bookings: number; koha: number }> = [];
 
   records.forEach((rec) => {
-    if (daysFilter) {
-      const nzDay = toNZT(rec.date).getDay();
-      if (!daysFilter.includes(nzDay)) return;
-    }
-    const iso = rec.date.toISOString();
-    const ym = iso.substring(0, 7);
-    const year = iso.substring(0, 4);
-    const weekday = toNZT(rec.date).getDay();
+    // Bucket by the NZ calendar date. Records are stored as NZ-midnight
+    // expressed in UTC (e.g. NZ Jul 1 → 2024-06-30T12:00Z), so reading the
+    // month/year off the raw UTC instant would misfile 1st-of-month nights
+    // into the previous month (and Jan 1 into the previous year).
+    const nzDate = toNZT(rec.date);
+    const weekday = nzDate.getDay();
+    if (daysFilter && !daysFilter.includes(weekday)) return;
+    const year = String(nzDate.getFullYear());
+    const ym = `${year}-${String(nzDate.getMonth() + 1).padStart(2, "0")}`;
     const loc = rec.location;
     const customers = rec.mealsServed ?? 0;
     const koha = toNum(rec.cash) + toNum(rec.eftpos) + toNum(rec.stripe);


### PR DESCRIPTION
## Description
Fixes two related timezone bugs in the admin analytics restaurant reports, both rooted in the same storage detail: `MealsServed.date` is stored as **NZ-midnight expressed as a UTC instant** (e.g. a night on NZ calendar date **Jun 22** is stored as `2024-06-21T12:00:00Z`; **Jan 1** as `2023-12-31T11:00:00Z`). Reading the raw UTC components of that value lands a day (and sometimes a month/year) early.

### 1. Month/year bucketing (restaurant-reports.ts)
The report builder derived its month/year bucket keys from `rec.date.toISOString()`:

```ts
const iso = rec.date.toISOString();   // "2024-06-30T12:00:00.000Z"
const ym = iso.substring(0, 7);       // "2024-06"  ❌ should be 2024-07
const year = iso.substring(0, 4);     // Jan 1 → "2023" ❌ previous year
const weekday = toNZT(rec.date).getDay(); // NZT ✅ (already correct)
```

So **every night dated the 1st of a month was attributed to the previous month**, and **Jan 1 to the previous year**. Weekday bucketing already used NZT, so the handling was internally inconsistent. Fixed by deriving `year`, `ym`, and `weekday` all from `toNZT(rec.date)`.

### 2. Service Nights table date (service-nights/route.ts)
The per-night detail table emitted each row's date via `r.date.toISOString().substring(0, 10)`, so a night on **Jun 22** displayed as **Jun 21** (and likewise in the CSV export). Fixed by formatting the date in NZT (`formatInNZT(r.date, "yyyy-MM-dd")`).

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
`version:patch`

## Impact
Corrects in the analytics dashboard:
- Monthly & yearly trend series
- By-year and by-year-month tables
- New-volunteers-by-month series
- **Service Nights** detail table + CSV export date column

Not affected (and unchanged): the weekday `$/head` breakdown (already NZT) and the Summary by Location table (sums per location, no date attribution).

## Testing
- [x] Typecheck clean for both changed files (the only flagged lines are pre-existing worktree artifacts from the un-generated Prisma client typing `records` as `any`, unrelated to these changes)
- [ ] Manual browser verification not run — pure data-layer changes; this worktree has no DB/dev server. Behaviour is deterministic given the storage format documented above.

## Additional Notes
Separately worth hardening (not included here): the date-window bounds (`todayEnd`, custom `from`/`to`) in both the lib and this route are built with server-local `new Date(...)`, so they rely on the server process having `TZ=Pacific/Auckland`. On a non-NZ host this can drop boundary records. Happy to follow up if desired.
