### PR TITLE
test(e2e): fix flaky restaurant-manager Select interactions

### DIFF
--- a/web/tests/e2e/helpers/select.ts
+++ b/web/tests/e2e/helpers/select.ts
@@ -1,0 +1,60 @@
+import type { Locator } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+/**
+ * Helpers for interacting with Radix/shadcn `<Select>` components in e2e tests.
+ *
+ * Radix renders the option list into a portal with an open animation, and the
+ * options themselves are frequently populated from an async fetch. A naive
+ * `trigger.click()` followed by `page.locator('[role="option"]').first().click()`
+ * is racy: the generic, un-scoped option locator can resolve against a portal
+ * that is still animating open (or a stale, hidden one), causing intermittent
+ * click timeouts. These helpers open the listbox, wait for it to be visible and
+ * populated, and scope the option lookup to that open listbox.
+ */
+
+interface SelectOptionTarget {
+  /** Pick the option at this index within the open listbox. Defaults to 0. */
+  index?: number;
+  /** Pick the first option whose text matches. Takes precedence over `index`. */
+  name?: string | RegExp;
+}
+
+/**
+ * Opens the Select identified by `trigger`, waits for the listbox portal to be
+ * open and populated, then clicks the requested option scoped to that listbox.
+ */
+export async function selectOption(
+  trigger: Locator,
+  target: SelectOptionTarget = {}
+): Promise<void> {
+  const page = trigger.page();
+
+  await trigger.click();
+
+  // Wait for the portal listbox to finish opening before touching options.
+  const listbox = page.getByRole("listbox");
+  await expect(listbox).toBeVisible();
+
+  // Scope option lookups to the open listbox so we can never match a stale or
+  // hidden portal left over from a previous interaction.
+  const options = listbox.getByRole("option");
+  await expect(options.first()).toBeVisible();
+
+  const option =
+    target.name !== undefined
+      ? options.filter({ hasText: target.name }).first()
+      : options.nth(target.index ?? 0);
+
+  await expect(option).toBeVisible();
+  await option.click();
+
+  // The Radix popover closes on selection; wait for it so a following
+  // interaction isn't blocked by the closing overlay.
+  await expect(listbox).toBeHidden();
+}
+
+/** Convenience wrapper for the common "open and pick the first option" case. */
+export async function selectFirstOption(trigger: Locator): Promise<void> {
+  await selectOption(trigger, { index: 0 });
+}

--- a/web/tests/e2e/helpers/select.ts
+++ b/web/tests/e2e/helpers/select.ts
@@ -23,6 +23,10 @@ interface SelectOptionTarget {
 /**
  * Opens the Select identified by `trigger`, waits for the listbox portal to be
  * open and populated, then clicks the requested option scoped to that listbox.
+ *
+ * Assumes the listbox has at least one option: if it opens empty (e.g. every
+ * choice has already been picked), the populated-check below times out rather
+ * than failing fast. Callers that can hit an empty list should guard for it.
  */
 export async function selectOption(
   trigger: Locator,
@@ -42,7 +46,7 @@ export async function selectOption(
   await expect(options.first()).toBeVisible();
 
   const option =
-    target.name !== undefined
+    target.name != null
       ? options.filter({ hasText: target.name }).first()
       : options.nth(target.index ?? 0);
 

--- a/web/tests/e2e/restaurant-manager-notifications.spec.ts
+++ b/web/tests/e2e/restaurant-manager-notifications.spec.ts
@@ -1,10 +1,33 @@
+import type { Page } from "@playwright/test";
 import { test, expect } from "./base";
 import { loginAsAdmin, loginAsVolunteer } from "./helpers/auth";
+import { selectFirstOption } from "./helpers/select";
+
+/**
+ * Removes every restaurant-manager assignment via the authenticated admin API so
+ * each test starts from a known-empty state. Without this the assignment tests
+ * are order-dependent: they pick the "first admin" and "first location", so a
+ * prior run leaves that admin already assigned - which flips the success toast to
+ * an update, the notifications checkbox to the stored value, and (because the
+ * selectable-location pool is small) eventually empties the location dropdown.
+ * Requires an active admin session, so call after loginAsAdmin().
+ */
+async function clearRestaurantManagerAssignments(page: Page) {
+  const res = await page.request.get("/api/admin/restaurant-managers");
+  if (!res.ok()) return;
+  const managers: Array<{ id: string }> = await res.json();
+  for (const manager of managers) {
+    await page.request.delete(`/api/admin/restaurant-managers/${manager.id}`);
+  }
+}
 
 test.describe("Restaurant Manager Shift Cancellation Notifications", () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to admin dashboard
     await loginAsAdmin(page);
+    // Start each test from a clean slate so the "first admin/first location"
+    // assignment flow is deterministic and order-independent.
+    await clearRestaurantManagerAssignments(page);
   });
 
   test("admin can assign restaurant managers to locations", async ({
@@ -39,12 +62,10 @@ test.describe("Restaurant Manager Shift Cancellation Notifications", () => {
     await page.waitForLoadState("load");
 
     // Select an admin user (assuming we have at least one admin)
-    await page.getByTestId("user-select").click();
-    await page.locator('[role="option"]').first().click();
+    await selectFirstOption(page.getByTestId("user-select"));
 
     // Add a location
-    await page.getByTestId("location-select").click();
-    await page.locator('[role="option"]').first().click();
+    await selectFirstOption(page.getByTestId("location-select"));
 
     // Check notification preference is enabled by default
     const notificationCheckbox = page.getByTestId("notifications-checkbox");
@@ -54,7 +75,8 @@ test.describe("Restaurant Manager Shift Cancellation Notifications", () => {
     await page.getByTestId("assign-manager-button").click();
 
     // Should show success message (assuming toast notifications)
-    // Note: This might need to be adjusted based on your actual toast implementation
+    // The beforeEach clears assignments, so this is always a fresh "create"
+    // and the toast reads "Successfully assigned …".
     await expect(page.getByText(/successfully assigned/i)).toBeVisible({
       timeout: 5000,
     });
@@ -113,10 +135,8 @@ test.describe("Restaurant Manager Shift Cancellation Notifications", () => {
 
     if (!hasAssignments) {
       // Create a manager assignment first
-      await page.getByTestId("user-select").click();
-      await page.locator('[role="option"]').first().click();
-      await page.getByTestId("location-select").click();
-      await page.locator('[role="option"]').first().click();
+      await selectFirstOption(page.getByTestId("user-select"));
+      await selectFirstOption(page.getByTestId("location-select"));
       await page.getByTestId("assign-manager-button").click();
       await page.waitForTimeout(2000);
 
@@ -158,10 +178,8 @@ test.describe("Restaurant Manager Shift Cancellation Notifications", () => {
 
     if (!hasAssignments) {
       // Create a manager assignment first
-      await page.getByTestId("user-select").click();
-      await page.locator('[role="option"]').first().click();
-      await page.getByTestId("location-select").click();
-      await page.locator('[role="option"]').first().click();
+      await selectFirstOption(page.getByTestId("user-select"));
+      await selectFirstOption(page.getByTestId("location-select"));
       await page.getByTestId("assign-manager-button").click();
       await page.waitForTimeout(2000);
 
@@ -269,6 +287,7 @@ test.describe("Shift Cancellation Notification Flow", () => {
 test.describe("Restaurant Manager Assignment Data Validation", () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
+    await clearRestaurantManagerAssignments(page);
   });
 
   test("form validates required fields", async ({ page }) => {
@@ -280,8 +299,7 @@ test.describe("Restaurant Manager Assignment Data Validation", () => {
     await expect(submitButton).toBeDisabled();
 
     // Select a user
-    await page.getByTestId("user-select").click();
-    await page.locator('[role="option"]').first().click();
+    await selectFirstOption(page.getByTestId("user-select"));
 
     // Selecting an admin who already has an assignment pre-fills their existing
     // locations; clear any so we can assert the "no locations" invariant.
@@ -299,15 +317,10 @@ test.describe("Restaurant Manager Assignment Data Validation", () => {
     await page.waitForLoadState("load");
 
     // Select a user first
-    await page.getByTestId("user-select").click();
-    await page.locator('[role="option"]').first().click();
-
-    // Add multiple locations
-    const locationDropdown = page.getByTestId("location-select");
+    await selectFirstOption(page.getByTestId("user-select"));
 
     // Add first location
-    await locationDropdown.click();
-    await page.locator('[role="option"]').first().click();
+    await selectFirstOption(page.getByTestId("location-select"));
 
     // Should show selected location as badge
     await expect(page.getByTestId("selected-locations")).toBeVisible();
@@ -323,11 +336,9 @@ test.describe("Restaurant Manager Assignment Data Validation", () => {
     await page.waitForLoadState("load");
 
     // Fill out form
-    await page.getByTestId("user-select").click();
-    await page.locator('[role="option"]').first().click();
+    await selectFirstOption(page.getByTestId("user-select"));
 
-    await page.getByTestId("location-select").click();
-    await page.locator('[role="option"]').first().click();
+    await selectFirstOption(page.getByTestId("location-select"));
 
     // Submit form
     await page.getByTestId("assign-manager-button").click();

--- a/web/tests/e2e/restaurant-manager-notifications.spec.ts
+++ b/web/tests/e2e/restaurant-manager-notifications.spec.ts
@@ -138,7 +138,10 @@ test.describe("Restaurant Manager Shift Cancellation Notifications", () => {
       await selectFirstOption(page.getByTestId("user-select"));
       await selectFirstOption(page.getByTestId("location-select"));
       await page.getByTestId("assign-manager-button").click();
-      await page.waitForTimeout(2000);
+      // Wait for the create to confirm rather than a fixed delay.
+      await expect(page.getByText(/successfully assigned/i)).toBeVisible({
+        timeout: 5000,
+      });
 
       // Reload to see the table
       await page.goto("/admin/restaurant-managers");
@@ -181,7 +184,10 @@ test.describe("Restaurant Manager Shift Cancellation Notifications", () => {
       await selectFirstOption(page.getByTestId("user-select"));
       await selectFirstOption(page.getByTestId("location-select"));
       await page.getByTestId("assign-manager-button").click();
-      await page.waitForTimeout(2000);
+      // Wait for the create to confirm rather than a fixed delay.
+      await expect(page.getByText(/successfully assigned/i)).toBeVisible({
+        timeout: 5000,
+      });
 
       await page.goto("/admin/restaurant-managers");
       await page.waitForLoadState("load");


### PR DESCRIPTION
## What

Fixes the flaky `restaurant-manager-notifications.spec.ts` › **restaurant manager assignment workflow** e2e test (and hardens the rest of the spec).

## Why

The test failed once in CI then passed on rerun with no code change. Root cause is a classic Radix/shadcn `Select` timing race: after clicking the trigger the options render in a portal with an open animation, and the user list is fetched async. The test used a generic, un-scoped `page.locator('[role="option"]').first().click()`, which could resolve/click before the listbox was fully open and populated - timing out, and then failing the downstream form assertions. The same pattern was repeated throughout the file.

## Changes

- **New shared helper [`tests/e2e/helpers/select.ts`](web/tests/e2e/helpers/select.ts)** - there was no existing select helper (other specs inline the same fragile pattern). `selectOption`/`selectFirstOption`:
  - click the trigger, then wait for `getByRole("listbox")` to be **visible** (open animation done);
  - scope the option lookup to that open listbox so it can't match a stale/hidden portal;
  - wait for the option to be visible before clicking, then wait for the listbox to close.
- **Replaced every fragile `[role="option"]` pattern** in the spec with the helper.
- **Made the admin `describe` blocks idempotent** via `clearRestaurantManagerAssignments()` in `beforeEach`. While verifying with `--repeat-each` I found a second latent fragility: the tests pick "first admin / first location", so a pre-existing assignment flips the success toast to "Updated", flips the notifications checkbox to the stored value, and (with only ~3 selectable locations) eventually empties the dropdown. Clearing first makes every run a deterministic "create new" path - preserving the checkbox-default and "Successfully assigned" coverage rather than weakening it.

## Verification

Playwright, chromium:
- Target test `--repeat-each=5 --workers=1` on a fresh server: **5/5 pass**.
- Full file with the CI config (`--workers=2 --retries=2 --timeout=30000`): **all pass**. The Select interactions never failed once after the fix.
- `tsc --noEmit` and `eslint` clean on both files.

## Note for reviewers

This is unrelated to #1053 (notification-cleanup bugfix) - it is a pre-existing flaky test surfaced by that PR's CI run.

While running locally I observed occasional `page.goto: net::ERR_ABORTED`, traced to the app's SSE notification streams accumulating on a long-lived dev server. It is environmental (hits untouched tests too), not test logic, and CI's `retries: 2` + fresh-per-run server absorbs it.
