### PR TITLE
feat(analytics): add month/year dropdowns to custom date range picker

### DIFF
--- a/web/src/app/admin/analytics/_components/filter-bar.tsx
+++ b/web/src/app/admin/analytics/_components/filter-bar.tsx
@@ -68,6 +68,12 @@ export function FilterBar({
   const fromDate = state.from ? new Date(`${state.from}T00:00:00`) : undefined;
   const toDate = state.to ? new Date(`${state.to}T00:00:00`) : undefined;
 
+  // Bound the calendar's month/year dropdowns to the range of available data
+  // (the restaurant has operated since 2017) so admins can jump straight to a
+  // year instead of clicking back one month at a time.
+  const calendarStartMonth = new Date(2017, 0, 1);
+  const calendarEndMonth = new Date();
+
   return (
     <div className="sticky top-2 z-30 rounded-xl border bg-card/95 shadow-md supports-[backdrop-filter]:bg-card/80 supports-[backdrop-filter]:backdrop-blur">
       <div className="flex flex-col gap-3 p-3">
@@ -120,6 +126,9 @@ export function FilterBar({
             <PopoverContent className="w-auto p-0" align="start">
               <CalendarComponent
                 mode="range"
+                captionLayout="dropdown"
+                startMonth={calendarStartMonth}
+                endMonth={calendarEndMonth}
                 defaultMonth={fromDate}
                 selected={{ from: fromDate, to: toDate }}
                 onSelect={(range) => {


### PR DESCRIPTION
## Description
The restaurant analytics **custom date range** calendar previously only had prev/next arrows. Jumping to an earlier year (e.g. 2020) meant clicking back one month at a time - roughly 70 clicks to reach 2020 from today.

This enables react-day-picker's dropdown caption layout so each month in the popover shows a **Month** picker and a **Year** picker. The year dropdown is bounded to **2017** (the start of the restaurant's data history) through **today**, so any year is a single click away. The prev/next arrows remain for fine month-by-month stepping.

The underlying `Calendar` component (`src/components/ui/calendar.tsx`) already supported `captionLayout="dropdown"` and styled the dropdowns - this change just opts the analytics range picker into it and provides the `startMonth`/`endMonth` bounds.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Manual testing completed
- [x] Typecheck passes (no new errors)

Verified locally: logged in as admin, opened the analytics custom range picker, confirmed both months render Month + Year dropdowns, and selecting **2020** in the year dropdown jumps the calendar straight there in one click.

## Screenshots

Year dropdown spans 2017-2026; selecting 2020 jumps the calendar instantly (both panes shown):

| Dropdowns visible | After selecting 2020 |
|---|---|
| May/2026 - Jun/2026 with Month + Year selects | May/2020 - Jun/2020 |

## Additional Notes
- Only `web/src/app/admin/analytics/_components/filter-bar.tsx` is changed (2 small additions: the `startMonth`/`endMonth` bounds and the three calendar props).
- If the year range should differ (e.g. only back to 2020), it's a one-line tweak to `calendarStartMonth`.
