### PR TITLE
feat(admin): redesign volunteer availability card

### DIFF
--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -32,6 +32,7 @@ import { cn } from "@/lib/utils";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { safeParseAvailability } from "@/lib/parse-availability";
+import { WeekAvailability } from "@/components/week-availability";
 import { VolunteerGradeToggle } from "@/components/volunteer-grade-toggle";
 import { VolunteerGradeBadge } from "@/components/volunteer-grade-badge";
 import { getDisplayGradeInfo } from "@/lib/volunteer-grades";
@@ -267,16 +268,6 @@ export default async function AdminVolunteerPage({
   const noShows = allSignups.filter(
     (signup: (typeof allSignups)[0]) => signup.status === "NO_SHOW"
   ).length;
-
-  const dayLabels: Record<string, string> = {
-    monday: "Monday",
-    tuesday: "Tuesday",
-    wednesday: "Wednesday",
-    thursday: "Thursday",
-    friday: "Friday",
-    saturday: "Saturday",
-    sunday: "Sunday",
-  };
 
   const locationLabels: Record<string, string> = {
     wellington: "Wellington",
@@ -857,17 +848,9 @@ export default async function AdminVolunteerPage({
                         <label className="text-sm font-medium">
                           Available Days
                         </label>
-                        <div className="flex flex-wrap gap-2">
-                          {regularVolunteer.availableDays.map((day: string) => (
-                            <Badge
-                              key={day}
-                              variant="outline"
-                              className="border-yellow-500/20 text-yellow-700 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-950/20"
-                            >
-                              {day}
-                            </Badge>
-                          ))}
-                        </div>
+                        <WeekAvailability
+                          availableDays={regularVolunteer.availableDays}
+                        />
                       </div>
 
                       {regularVolunteer.notes && (
@@ -923,76 +906,96 @@ export default async function AdminVolunteerPage({
               <CardContent className="space-y-6">
                 <div className="space-y-3">
                   <label className="text-sm font-medium">Available Days</label>
-                  <div className="flex flex-wrap gap-2">
-                    {availableDays.length > 0 ? (
-                      availableDays.map((day: string) => (
-                        <Badge
-                          key={day}
-                          variant="outline"
-                          className="border-blue-500/20 text-blue-700 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/20"
-                        >
-                          {dayLabels[day] || day}
-                        </Badge>
-                      ))
-                    ) : (
-                      <span className="text-sm text-muted-foreground italic">
-                        Not specified
+                  <WeekAvailability availableDays={availableDays} />
+                </div>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <label className="text-sm font-medium">
+                      Available Locations
+                    </label>
+                    {availableLocations.length > 0 && (
+                      <span className="text-xs text-muted-foreground">
+                        {availableLocations.length}{" "}
+                        {availableLocations.length === 1
+                          ? "location"
+                          : "locations"}
                       </span>
                     )}
                   </div>
-                </div>
-                <div className="space-y-3">
-                  <label className="text-sm font-medium">
-                    Available Locations
-                  </label>
-                  <div className="flex flex-wrap gap-2">
-                    {availableLocations.length > 0 ? (
-                      availableLocations.map((location: string) => (
-                        <Badge
-                          key={location}
-                          variant="outline"
-                          className="border-green-500/20 text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950/20"
-                        >
-                          <MapPin className="h-3 w-3 mr-1" />
-                          {locationLabels[location] || location}
-                        </Badge>
-                      ))
-                    ) : (
-                      <span className="text-sm text-muted-foreground italic">
-                        Not specified
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div className="space-y-3">
-                  <label className="text-sm font-medium">
-                    Default Location
-                  </label>
-                  {volunteer.defaultLocation ? (
-                    <Badge
-                      variant="outline"
-                      className="border-primary/30 text-primary bg-primary/5"
-                    >
-                      <MapPin className="h-3 w-3 mr-1" />
-                      {locationLabels[volunteer.defaultLocation] ||
-                        volunteer.defaultLocation}
-                    </Badge>
+                  {availableLocations.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {availableLocations.map((location: string) => {
+                        const isDefault =
+                          volunteer.defaultLocation === location;
+                        return (
+                          <span
+                            key={location}
+                            className={cn(
+                              "inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-sm font-medium",
+                              isDefault
+                                ? "border-primary/30 bg-primary/5 text-primary"
+                                : "border-border bg-muted/40 text-foreground"
+                            )}
+                          >
+                            <MapPin
+                              className={cn(
+                                "h-3.5 w-3.5",
+                                isDefault
+                                  ? "text-primary"
+                                  : "text-green-600 dark:text-green-400"
+                              )}
+                            />
+                            {locationLabels[location] || location}
+                            {isDefault && (
+                              <span className="inline-flex items-center gap-0.5 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                                <Star className="h-2.5 w-2.5 fill-current" />
+                                Default
+                              </span>
+                            )}
+                          </span>
+                        );
+                      })}
+                    </div>
                   ) : (
-                    <span className="text-sm text-muted-foreground italic">
-                      Not set
-                    </span>
+                    <p className="rounded-lg border border-dashed border-border bg-muted/30 px-3 py-2.5 text-sm italic text-muted-foreground">
+                      No locations specified
+                    </p>
                   )}
                 </div>
-                <div className="pt-4 border-t space-y-1">
-                  <label className="text-sm font-medium">
-                    How did they hear about us?
-                  </label>
-                  <p className="text-sm text-muted-foreground">
-                    {volunteer.howDidYouHearAboutUs
-                      ? hearAboutLabels[volunteer.howDidYouHearAboutUs] ||
-                        volunteer.howDidYouHearAboutUs
-                      : "Not specified"}
-                  </p>
+                {volunteer.defaultLocation &&
+                  !availableLocations.includes(volunteer.defaultLocation) && (
+                    <div className="space-y-3">
+                      <label className="block text-sm font-medium">
+                        Default Location
+                      </label>
+                      <div>
+                        <span className="inline-flex items-center gap-1.5 rounded-lg border border-primary/30 bg-primary/5 px-2.5 py-1.5 text-sm font-medium text-primary">
+                          <MapPin className="h-3.5 w-3.5" />
+                          {locationLabels[volunteer.defaultLocation] ||
+                            volunteer.defaultLocation}
+                          <span className="inline-flex items-center gap-0.5 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                            <Star className="h-2.5 w-2.5 fill-current" />
+                            Default
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                <div className="flex items-start gap-3 border-t pt-4">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                    <Megaphone className="h-4 w-4" />
+                  </span>
+                  <div className="space-y-0.5">
+                    <label className="text-sm font-medium">
+                      How did they hear about us?
+                    </label>
+                    <p className="text-sm text-muted-foreground">
+                      {volunteer.howDidYouHearAboutUs
+                        ? hearAboutLabels[volunteer.howDidYouHearAboutUs] ||
+                          volunteer.howDidYouHearAboutUs
+                        : "Not specified"}
+                    </p>
+                  </div>
                 </div>
               </CardContent>
             </Card>

--- a/web/src/components/week-availability.tsx
+++ b/web/src/components/week-availability.tsx
@@ -1,15 +1,6 @@
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-const DAYS_OF_WEEK = [
-  { key: "monday", short: "Mon", full: "Monday" },
-  { key: "tuesday", short: "Tue", full: "Tuesday" },
-  { key: "wednesday", short: "Wed", full: "Wednesday" },
-  { key: "thursday", short: "Thu", full: "Thursday" },
-  { key: "friday", short: "Fri", full: "Friday" },
-  { key: "saturday", short: "Sat", full: "Saturday" },
-  { key: "sunday", short: "Sun", full: "Sunday" },
-] as const;
+import { getWeekAvailability } from "@/lib/week-availability";
 
 interface WeekAvailabilityProps {
   /** Available days in any casing (e.g. "monday" or "Monday"). Order is ignored. */
@@ -26,53 +17,49 @@ export function WeekAvailability({
   availableDays,
   className,
 }: WeekAvailabilityProps) {
-  const available = new Set(availableDays.map((day) => day.toLowerCase().trim()));
-  const count = DAYS_OF_WEEK.filter((day) => available.has(day.key)).length;
+  const { days, count } = getWeekAvailability(availableDays);
 
   return (
     <div className={cn("space-y-2.5", className)}>
       <div className="grid grid-cols-7 gap-1.5">
-        {DAYS_OF_WEEK.map((day) => {
-          const isAvailable = available.has(day.key);
-          return (
-            <div
-              key={day.key}
-              title={`${day.full}: ${isAvailable ? "Available" : "Unavailable"}`}
-              aria-label={`${day.full}: ${isAvailable ? "Available" : "Unavailable"}`}
+        {days.map((day) => (
+          <div
+            key={day.key}
+            title={`${day.full}: ${day.isAvailable ? "Available" : "Unavailable"}`}
+            aria-label={`${day.full}: ${day.isAvailable ? "Available" : "Unavailable"}`}
+            className={cn(
+              "flex flex-col items-center gap-1.5 rounded-xl border py-2.5 transition-colors",
+              day.isAvailable
+                ? "border-emerald-500/30 bg-emerald-50 dark:border-emerald-500/25 dark:bg-emerald-950/40"
+                : "border-dashed border-border bg-muted/30"
+            )}
+          >
+            <span
               className={cn(
-                "flex flex-col items-center gap-1.5 rounded-xl border py-2.5 transition-colors",
-                isAvailable
-                  ? "border-emerald-500/30 bg-emerald-50 dark:border-emerald-500/25 dark:bg-emerald-950/40"
-                  : "border-dashed border-border bg-muted/30"
+                "text-[11px] font-semibold uppercase tracking-wide",
+                day.isAvailable
+                  ? "text-emerald-700 dark:text-emerald-300"
+                  : "text-muted-foreground/60"
               )}
             >
-              <span
-                className={cn(
-                  "text-[11px] font-semibold uppercase tracking-wide",
-                  isAvailable
-                    ? "text-emerald-700 dark:text-emerald-300"
-                    : "text-muted-foreground/60"
-                )}
-              >
-                {day.short}
-              </span>
-              <span
-                className={cn(
-                  "flex h-4 w-4 items-center justify-center rounded-full",
-                  isAvailable
-                    ? "bg-emerald-500 text-white dark:bg-emerald-500"
-                    : "bg-transparent"
-                )}
-              >
-                {isAvailable ? (
-                  <Check className="h-3 w-3" strokeWidth={3} />
-                ) : (
-                  <span className="h-1 w-1 rounded-full bg-muted-foreground/30" />
-                )}
-              </span>
-            </div>
-          );
-        })}
+              {day.short}
+            </span>
+            <span
+              className={cn(
+                "flex h-4 w-4 items-center justify-center rounded-full",
+                day.isAvailable
+                  ? "bg-emerald-500 text-white dark:bg-emerald-500"
+                  : "bg-transparent"
+              )}
+            >
+              {day.isAvailable ? (
+                <Check className="h-3 w-3" strokeWidth={3} />
+              ) : (
+                <span className="h-1 w-1 rounded-full bg-muted-foreground/30" />
+              )}
+            </span>
+          </div>
+        ))}
       </div>
       <p className="text-xs text-muted-foreground">
         {count === 0 ? (

--- a/web/src/components/week-availability.tsx
+++ b/web/src/components/week-availability.tsx
@@ -1,0 +1,92 @@
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const DAYS_OF_WEEK = [
+  { key: "monday", short: "Mon", full: "Monday" },
+  { key: "tuesday", short: "Tue", full: "Tuesday" },
+  { key: "wednesday", short: "Wed", full: "Wednesday" },
+  { key: "thursday", short: "Thu", full: "Thursday" },
+  { key: "friday", short: "Fri", full: "Friday" },
+  { key: "saturday", short: "Sat", full: "Saturday" },
+  { key: "sunday", short: "Sun", full: "Sunday" },
+] as const;
+
+interface WeekAvailabilityProps {
+  /** Available days in any casing (e.g. "monday" or "Monday"). Order is ignored. */
+  availableDays: string[];
+  className?: string;
+}
+
+/**
+ * Renders a Monday-first week strip. Every day Mon-Sun is always shown in order,
+ * with available days highlighted - so the data is always presented consistently
+ * regardless of how it was stored.
+ */
+export function WeekAvailability({
+  availableDays,
+  className,
+}: WeekAvailabilityProps) {
+  const available = new Set(availableDays.map((day) => day.toLowerCase().trim()));
+  const count = DAYS_OF_WEEK.filter((day) => available.has(day.key)).length;
+
+  return (
+    <div className={cn("space-y-2.5", className)}>
+      <div className="grid grid-cols-7 gap-1.5">
+        {DAYS_OF_WEEK.map((day) => {
+          const isAvailable = available.has(day.key);
+          return (
+            <div
+              key={day.key}
+              title={`${day.full}: ${isAvailable ? "Available" : "Unavailable"}`}
+              aria-label={`${day.full}: ${isAvailable ? "Available" : "Unavailable"}`}
+              className={cn(
+                "flex flex-col items-center gap-1.5 rounded-xl border py-2.5 transition-colors",
+                isAvailable
+                  ? "border-emerald-500/30 bg-emerald-50 dark:border-emerald-500/25 dark:bg-emerald-950/40"
+                  : "border-dashed border-border bg-muted/30"
+              )}
+            >
+              <span
+                className={cn(
+                  "text-[11px] font-semibold uppercase tracking-wide",
+                  isAvailable
+                    ? "text-emerald-700 dark:text-emerald-300"
+                    : "text-muted-foreground/60"
+                )}
+              >
+                {day.short}
+              </span>
+              <span
+                className={cn(
+                  "flex h-4 w-4 items-center justify-center rounded-full",
+                  isAvailable
+                    ? "bg-emerald-500 text-white dark:bg-emerald-500"
+                    : "bg-transparent"
+                )}
+              >
+                {isAvailable ? (
+                  <Check className="h-3 w-3" strokeWidth={3} />
+                ) : (
+                  <span className="h-1 w-1 rounded-full bg-muted-foreground/30" />
+                )}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {count === 0 ? (
+          <span className="italic">No days specified</span>
+        ) : (
+          <>
+            Available{" "}
+            <span className="font-medium text-foreground">
+              {count} {count === 1 ? "day" : "days"}
+            </span>{" "}
+            a week
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/web/src/lib/week-availability.test.ts
+++ b/web/src/lib/week-availability.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { getWeekAvailability } from "./week-availability";
+
+const order = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"];
+
+describe("getWeekAvailability", () => {
+  it("always returns all seven days in Monday-first order", () => {
+    const { days } = getWeekAvailability([]);
+    expect(days.map((d) => d.key)).toEqual(order);
+  });
+
+  it("returns an empty count and no available days for empty input", () => {
+    const { days, count } = getWeekAvailability([]);
+    expect(count).toBe(0);
+    expect(days.every((d) => !d.isAvailable)).toBe(true);
+  });
+
+  it("flags available days and counts them", () => {
+    const { days, count } = getWeekAvailability(["monday", "wednesday", "friday"]);
+    expect(count).toBe(3);
+    expect(days.filter((d) => d.isAvailable).map((d) => d.key)).toEqual([
+      "monday",
+      "wednesday",
+      "friday",
+    ]);
+  });
+
+  it("orders out-of-order, capitalised input Monday-first", () => {
+    const { days, count } = getWeekAvailability(["Saturday", "Wednesday", "Monday"]);
+    expect(count).toBe(3);
+    expect(days.filter((d) => d.isAvailable).map((d) => d.key)).toEqual([
+      "monday",
+      "wednesday",
+      "saturday",
+    ]);
+  });
+
+  it("matches case-insensitively and trims whitespace", () => {
+    const { count, days } = getWeekAvailability([" Monday ", "TUESDAY", "wEdNeSdAy"]);
+    expect(count).toBe(3);
+    expect(days.filter((d) => d.isAvailable).map((d) => d.key)).toEqual([
+      "monday",
+      "tuesday",
+      "wednesday",
+    ]);
+  });
+
+  it("handles a full week", () => {
+    const { count } = getWeekAvailability(order);
+    expect(count).toBe(7);
+  });
+
+  it("ignores unknown day values", () => {
+    const { count } = getWeekAvailability(["someday", "monday"]);
+    expect(count).toBe(1);
+  });
+
+  it("treats null/undefined as no availability", () => {
+    expect(getWeekAvailability(null).count).toBe(0);
+    expect(getWeekAvailability(undefined).count).toBe(0);
+  });
+});

--- a/web/src/lib/week-availability.ts
+++ b/web/src/lib/week-availability.ts
@@ -1,0 +1,44 @@
+export interface DayOfWeek {
+  key: string;
+  short: string;
+  full: string;
+}
+
+/** Canonical Monday-first week. */
+export const DAYS_OF_WEEK: readonly DayOfWeek[] = [
+  { key: "monday", short: "Mon", full: "Monday" },
+  { key: "tuesday", short: "Tue", full: "Tuesday" },
+  { key: "wednesday", short: "Wed", full: "Wednesday" },
+  { key: "thursday", short: "Thu", full: "Thursday" },
+  { key: "friday", short: "Fri", full: "Friday" },
+  { key: "saturday", short: "Sat", full: "Saturday" },
+  { key: "sunday", short: "Sun", full: "Sunday" },
+] as const;
+
+export interface WeekDay extends DayOfWeek {
+  isAvailable: boolean;
+}
+
+export interface WeekAvailability {
+  /** All seven days, always Monday-first, flagged by availability. */
+  days: WeekDay[];
+  count: number;
+}
+
+/**
+ * Maps availability data (in any casing/order) onto the canonical Monday-first
+ * week. The result is always seven days in order, so presentation never depends
+ * on how the data was stored.
+ */
+export function getWeekAvailability(
+  availableDays: readonly string[] | null | undefined
+): WeekAvailability {
+  const available = new Set(
+    (availableDays ?? []).map((day) => day.toLowerCase().trim())
+  );
+  const days = DAYS_OF_WEEK.map((day) => ({
+    ...day,
+    isAvailable: available.has(day.key),
+  }));
+  return { days, count: days.filter((day) => day.isAvailable).length };
+}


### PR DESCRIPTION
## Summary

Redesigns the **Availability & Preferences** card on the admin volunteer profile (`/admin/volunteers/[id]`) - it looked cluttered, and the "Available Days" badges appeared in an inconsistent order.

### Available Days
- New reusable `WeekAvailability` component renders a canonical **Monday-first week strip** (Mon → Sun), highlighting available days.
- **Fixes ordering structurally**: because it renders the full week and checks membership, the display is always Monday-first regardless of how the data was stored (lowercase `"monday"`, capitalised `"Monday"`, or out-of-order).
- Accessible: availability conveyed by **icon + colour** (not colour alone), with per-day `aria-label`s; plus an *"Available N days a week"* summary.
- Reused in both the regular-volunteer card and the main availability card for consistency.

### Available Locations
- Cleaner chips with a count summary (*"3 locations"*).
- The default location is highlighted inline with a ⭐ **Default** tag.
- Proper bordered empty state.

### Default Location
- Only shown as its own row when the default **isn't** already in the available list (avoids redundancy).
- Fixed the gap between the label and its value.

### How did they hear about us?
- Grouped into a tidy iconed row.

## Testing
- `npm run typecheck` and `eslint` pass on the changed files.
- Structure verified in-browser across all data scenarios (default-in-list, default-not-in-list edge case, single location, empty states); the Monday-first week strip verified styled in light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)