### PR TITLE
feat(admin): shortage notifications analytics report with effectiveness drill-down

### DIFF
--- a/web/src/app/admin/analytics/shortage-notifications/page.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/page.tsx
@@ -1,0 +1,53 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { PageContainer } from "@/components/page-container";
+import { ShortageNotificationsAnalyticsClient } from "./shortage-notifications-analytics-client";
+import { LOCATIONS } from "@/lib/locations";
+import { getShortageNotificationAnalytics } from "@/lib/shortage-analytics";
+
+export default async function ShortageNotificationsAnalyticsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user) {
+    redirect("/login?callbackUrl=/admin/analytics/shortage-notifications");
+  }
+
+  if (session.user.role !== "ADMIN") {
+    redirect("/dashboard");
+  }
+
+  const params = await searchParams;
+
+  const months = (params.months as string) || "12";
+  const location = (params.location as string) || "all";
+  const monthsNum = months === "all" ? 0 : parseInt(months, 10) || 12;
+
+  const data = await getShortageNotificationAnalytics(monthsNum, location);
+
+  const locationOptions = LOCATIONS.map((loc) => ({
+    value: loc,
+    label: loc,
+  }));
+
+  return (
+    <AdminPageWrapper
+      title="Shortage Notifications"
+      description="Shift-shortage alerts sent to volunteers and the signups they drove, org-wide and by restaurant"
+    >
+      <PageContainer testid="shortage-notifications-analytics-page">
+        <ShortageNotificationsAnalyticsClient
+          data={data}
+          months={months}
+          location={location}
+          locations={locationOptions}
+        />
+      </PageContainer>
+    </AdminPageWrapper>
+  );
+}

--- a/web/src/app/admin/analytics/shortage-notifications/page.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/page.tsx
@@ -5,7 +5,10 @@ import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { ShortageNotificationsAnalyticsClient } from "./shortage-notifications-analytics-client";
 import { LOCATIONS } from "@/lib/locations";
-import { getShortageNotificationAnalytics } from "@/lib/shortage-analytics";
+import {
+  getShortageNotificationAnalytics,
+  parseMonthsParam,
+} from "@/lib/shortage-analytics";
 
 export default async function ShortageNotificationsAnalyticsPage({
   searchParams,
@@ -26,7 +29,7 @@ export default async function ShortageNotificationsAnalyticsPage({
 
   const months = (params.months as string) || "12";
   const location = (params.location as string) || "all";
-  const monthsNum = months === "all" ? 0 : parseInt(months, 10) || 12;
+  const monthsNum = parseMonthsParam(months);
 
   const data = await getShortageNotificationAnalytics(monthsNum, location);
 

--- a/web/src/app/admin/analytics/shortage-notifications/shortage-conversions-dialog.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/shortage-conversions-dialog.tsx
@@ -145,6 +145,13 @@ function DialogBody({
   );
 }
 
+/** Compact shift date, adding the year only when it isn't the current year. */
+function formatShiftDate(iso: string): string {
+  const currentYear = formatInNZT(new Date(), "yyyy");
+  const shiftYear = formatInNZT(iso, "yyyy");
+  return formatInNZT(iso, shiftYear === currentYear ? "d MMM" : "d MMM yyyy");
+}
+
 function getInitials(name: string, email: string): string {
   const source = name.trim() || email;
   const parts = source.split(/\s+/).filter(Boolean);
@@ -191,7 +198,7 @@ function ConversionRow({ conversion: c }: { conversion: ShortageConversion }) {
             </Badge>
           </div>
           <p className="text-[11px] text-muted-foreground tabular-nums">
-            {formatInNZT(c.shiftDate, "d MMM")} · {lag}
+            {formatShiftDate(c.shiftDate)} · {lag}
           </p>
         </div>
       </Link>

--- a/web/src/app/admin/analytics/shortage-notifications/shortage-conversions-dialog.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/shortage-conversions-dialog.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Loader2, AlertTriangle, UserCheck } from "lucide-react";
+import { formatInNZT } from "@/lib/timezone";
+import type {
+  ShortageConversion,
+  ShortageConversionsResult,
+} from "@/lib/shortage-analytics";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  months: string;
+  /** "all" or a specific restaurant. */
+  location: string;
+  title: string;
+  subtitle?: string;
+}
+
+export function ShortageConversionsDialog({
+  open,
+  onOpenChange,
+  months,
+  location,
+  title,
+  subtitle,
+}: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl p-0 gap-0 max-h-[85vh] flex flex-col">
+        {open ? (
+          <DialogBody
+            key={`${months}-${location}`}
+            months={months}
+            location={location}
+            title={title}
+            subtitle={subtitle}
+          />
+        ) : (
+          <DialogHeader className="px-6 py-4">
+            <DialogTitle>{title || "Signups from alerts"}</DialogTitle>
+          </DialogHeader>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DialogBody({
+  months,
+  location,
+  title,
+  subtitle,
+}: {
+  months: string;
+  location: string;
+  title: string;
+  subtitle?: string;
+}) {
+  const [data, setData] = useState<ShortageConversionsResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const ac = new AbortController();
+    const params = new URLSearchParams({ months, location });
+
+    fetch(`/api/admin/analytics/shortage-notifications/conversions?${params}`, {
+      signal: ac.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? "Failed to load signups");
+        }
+        return res.json() as Promise<ShortageConversionsResult>;
+      })
+      .then((result) => {
+        if (ac.signal.aborted) return;
+        setData(result);
+      })
+      .catch((err: Error) => {
+        if (err.name === "AbortError") return;
+        setError(err.message);
+      })
+      .finally(() => {
+        if (ac.signal.aborted) return;
+        setLoading(false);
+      });
+
+    return () => ac.abort();
+  }, [months, location]);
+
+  return (
+    <>
+      <DialogHeader className="px-6 py-4 border-b">
+        <DialogTitle className="flex items-center gap-2 text-lg">
+          <UserCheck className="h-4 w-4 text-emerald-500" />
+          {title}
+        </DialogTitle>
+        {subtitle && (
+          <DialogDescription className="text-sm">{subtitle}</DialogDescription>
+        )}
+        {data && (
+          <p className="text-xs text-muted-foreground pt-1 tabular-nums">
+            {data.total.toLocaleString()} signup
+            {data.total === 1 ? "" : "s"} from alerts
+            {data.total > data.cap && (
+              <span> · showing first {data.cap.toLocaleString()}</span>
+            )}
+          </p>
+        )}
+      </DialogHeader>
+
+      <div className="flex-1 min-h-0">
+        {loading && <DialogLoading />}
+        {!loading && error && <DialogError message={error} />}
+        {!loading && !error && data && data.conversions.length === 0 && (
+          <DialogEmpty />
+        )}
+        {!loading && !error && data && data.conversions.length > 0 && (
+          <ScrollArea className="h-[60vh]">
+            <ul className="px-4 py-3 space-y-1">
+              {data.conversions.map((c) => (
+                <ConversionRow key={`${c.userId}-${c.shiftId}`} conversion={c} />
+              ))}
+            </ul>
+          </ScrollArea>
+        )}
+      </div>
+    </>
+  );
+}
+
+function getInitials(name: string, email: string): string {
+  const source = name.trim() || email;
+  const parts = source.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return source.slice(0, 2).toUpperCase();
+}
+
+function ConversionRow({ conversion: c }: { conversion: ShortageConversion }) {
+  const lag =
+    c.daysToSignup === 0
+      ? "signed up same day"
+      : `signed up ${c.daysToSignup} day${c.daysToSignup === 1 ? "" : "s"} later`;
+
+  return (
+    <li>
+      <Link
+        href={`/admin/volunteers/${c.userId}`}
+        className="flex items-center gap-3 px-2 py-2 rounded-md hover:bg-slate-50 dark:hover:bg-zinc-900/60 transition-colors group"
+      >
+        <Avatar className="h-8 w-8 shadow-sm">
+          <AvatarImage src={c.profilePhotoUrl ?? ""} alt={c.name} />
+          <AvatarFallback className="bg-gradient-to-br from-emerald-500 to-teal-600 text-white text-xs font-semibold">
+            {getInitials(c.name, c.email)}
+          </AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium truncate group-hover:text-foreground">
+            {c.name}
+          </p>
+          <p className="text-xs text-muted-foreground truncate">{c.email}</p>
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="flex items-center justify-end gap-1.5">
+            <span className="text-xs font-medium truncate max-w-[9rem]">
+              {c.shiftTypeName}
+            </span>
+            <Badge
+              variant="outline"
+              className="text-[10px] font-medium px-1.5 py-0"
+            >
+              {c.shiftLocation}
+            </Badge>
+          </div>
+          <p className="text-[11px] text-muted-foreground tabular-nums">
+            {formatInNZT(c.shiftDate, "d MMM")} · {lag}
+          </p>
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+function DialogLoading() {
+  return (
+    <div className="px-6 py-6 space-y-4">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading signups…
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 px-2 py-2">
+            <Skeleton className="h-8 w-8 rounded-full" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3.5 w-32" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DialogError({ message }: { message: string }) {
+  return (
+    <div className="px-6 py-10 flex flex-col items-center text-center gap-2 text-sm">
+      <AlertTriangle className="h-5 w-5 text-amber-500" />
+      <p className="font-medium">Couldn&rsquo;t load signups</p>
+      <p className="text-xs text-muted-foreground max-w-sm">{message}</p>
+    </div>
+  );
+}
+
+function DialogEmpty() {
+  return (
+    <div className="px-6 py-10 flex flex-col items-center text-center gap-2 text-sm">
+      <UserCheck className="h-5 w-5 text-muted-foreground" />
+      <p className="font-medium">No signups from alerts yet</p>
+      <p className="text-xs text-muted-foreground">
+        No volunteers signed up after an alert in this period.
+      </p>
+    </div>
+  );
+}

--- a/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
@@ -394,7 +394,7 @@ export function ShortageNotificationsAnalyticsClient({
                 <span aria-hidden>→</span>
               </span>
             }
-            tooltip="Volunteers who signed up for a shift after a delivered alert. Click to see who."
+            tooltip="Volunteers who signed up for a shift after a delivered alert. This is a correlation - some may have signed up regardless. Click to see who."
             onClick={() => openConversions(initialLocation)}
           />
           <KpiCard
@@ -407,7 +407,7 @@ export function ShortageNotificationsAnalyticsClient({
             sparkColor="#8b5cf6"
             mode={mode}
             footer={`${num(totals.converted)} of ${num(totals.successfulEmails)} delivered`}
-            tooltip="Share of delivered alerts that led to a signup (signups ÷ delivered alerts)."
+            tooltip="Share of delivered alerts that led to a signup (signups ÷ delivered alerts). A correlation, not proof of cause."
           />
         </div>
 

--- a/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
@@ -1,0 +1,650 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useTheme } from "next-themes";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Bell,
+  Send,
+  Users,
+  UserCheck,
+  MailCheck,
+  Gauge,
+  MapPin,
+  Percent,
+  Loader2,
+  TrendingUp,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ChartCard, ChartEmpty, ApexChart } from "../_components/primitives";
+import {
+  baseOptions,
+  chartTokens,
+  compactCount,
+  num,
+  PALETTE,
+} from "../_lib/chart-theme";
+import { ShortageConversionsDialog } from "./shortage-conversions-dialog";
+import type {
+  ShortageNotificationAnalytics,
+  ShortageSiteRow,
+} from "@/lib/shortage-analytics";
+
+interface Props {
+  data: ShortageNotificationAnalytics;
+  months: string;
+  location: string;
+  locations: Array<{ value: string; label: string }>;
+}
+
+const MONTHS_LABELS: Record<string, string> = {
+  "3": "3 months",
+  "6": "6 months",
+  "12": "12 months",
+  all: "all time",
+};
+
+/** Small area sparkline, matching the Restaurant Analytics KPI cards. */
+function Sparkline({
+  data,
+  color,
+  mode,
+}: {
+  data: number[];
+  color: string;
+  mode: "light" | "dark";
+}) {
+  if (!data.some((v) => v > 0)) return <div className="h-10" />;
+  return (
+    <ApexChart
+      type="area"
+      height={40}
+      options={{
+        chart: {
+          sparkline: { enabled: true },
+          animations: { enabled: false },
+          background: "transparent",
+        },
+        colors: [color],
+        stroke: { curve: "smooth", width: 2 },
+        fill: {
+          type: "gradient",
+          gradient: { opacityFrom: 0.4, opacityTo: 0.02, stops: [0, 100] },
+        },
+        tooltip: { enabled: false },
+        theme: { mode },
+      }}
+      series={[{ data }]}
+    />
+  );
+}
+
+function KpiCard({
+  icon: Icon,
+  label,
+  value,
+  accent,
+  tint,
+  spark,
+  sparkColor,
+  mode,
+  footer,
+  tooltip,
+  onClick,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  accent: string;
+  tint: string;
+  spark: number[];
+  sparkColor: string;
+  mode: "light" | "dark";
+  footer?: React.ReactNode;
+  tooltip: string;
+  onClick?: () => void;
+}) {
+  const body = (
+    <>
+      <div
+        className={cn(
+          "pointer-events-none absolute -right-6 -top-6 h-20 w-20 rounded-full opacity-[0.08] blur-2xl",
+          tint
+        )}
+      />
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <span
+          className={cn(
+            "flex h-7 w-7 items-center justify-center rounded-lg bg-muted/60",
+            accent
+          )}
+        >
+          <Icon className="h-4 w-4" />
+        </span>
+        <span className="text-[11px] font-semibold uppercase tracking-wide">
+          {label}
+        </span>
+      </div>
+      <p className="mt-3 text-3xl font-bold leading-none tracking-tight tabular-nums">
+        {value}
+      </p>
+      <div className="mt-2 min-h-5 text-xs text-muted-foreground">{footer}</div>
+      <div className="-mx-1 mt-2">
+        <Sparkline data={spark} color={sparkColor} mode={mode} />
+      </div>
+    </>
+  );
+
+  const base =
+    "relative flex h-full flex-col overflow-hidden rounded-xl border bg-card p-4 text-left shadow-sm transition-shadow hover:shadow-md";
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={tooltip}
+        className={cn(
+          base,
+          "cursor-pointer hover:border-emerald-300 dark:hover:border-emerald-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+        )}
+      >
+        {body}
+      </button>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className={cn(base, "cursor-help")}>{body}</div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-60">
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function StatChip({
+  icon: Icon,
+  label,
+  value,
+  accent,
+  sub,
+  tooltip,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+  accent: string;
+  sub?: string;
+  tooltip: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex h-full cursor-help items-center gap-3 rounded-xl border bg-card px-4 py-3 shadow-sm transition-shadow hover:shadow-md">
+          <span
+            className={cn(
+              "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted/60",
+              accent
+            )}
+          >
+            <Icon className="h-4 w-4" />
+          </span>
+          <div className="min-w-0">
+            <p className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              {label}
+            </p>
+            <p className="text-lg font-bold leading-tight tabular-nums">
+              {value}
+              {sub && (
+                <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+                  {sub}
+                </span>
+              )}
+            </p>
+          </div>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-60">
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function ShortageNotificationsAnalyticsClient({
+  data,
+  months: initialMonths,
+  location: initialLocation,
+  locations,
+}: Props) {
+  const router = useRouter();
+  const { resolvedTheme } = useTheme();
+  const [isPending, startTransition] = useTransition();
+  const [months, setMonths] = useState(initialMonths);
+  const [location, setLocation] = useState(initialLocation);
+
+  // Drill-down modal: which site's signups to show ("all" or a restaurant).
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalLocation, setModalLocation] = useState("all");
+
+  const mode = resolvedTheme === "dark" ? "dark" : "light";
+  const tokens = chartTokens(mode);
+
+  const handleApplyFilters = () => {
+    const params = new URLSearchParams({ months, location });
+    startTransition(() => {
+      router.push(`/admin/analytics/shortage-notifications?${params}`);
+    });
+  };
+
+  const openConversions = (loc: string) => {
+    setModalLocation(loc);
+    setModalOpen(true);
+  };
+
+  const { totals, bySite, trend } = data;
+  const hasData = totals.emails > 0;
+  const avgPerSend =
+    totals.sendEvents > 0 ? Math.round(totals.emails / totals.sendEvents) : 0;
+  const periodLabel = MONTHS_LABELS[initialMonths] ?? "the period";
+  const filterKey = `${initialMonths}-${initialLocation}`;
+
+  const convTrend = trend.map((t) =>
+    t.deliveredEmails > 0 ? Math.round((t.signups / t.deliveredEmails) * 100) : 0
+  );
+
+  const modalTitle =
+    modalLocation === "all"
+      ? "Signups from alerts"
+      : `${modalLocation} — signups from alerts`;
+
+  return (
+    <div className="space-y-4">
+      {/* Filters */}
+      <div className="rounded-xl border bg-card p-4 shadow-sm">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+          <div className="grid flex-1 grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="months">Time Period</Label>
+              <Select value={months} onValueChange={setMonths}>
+                <SelectTrigger id="months">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="3">Last 3 months</SelectItem>
+                  <SelectItem value="6">Last 6 months</SelectItem>
+                  <SelectItem value="12">Last 12 months</SelectItem>
+                  <SelectItem value="all">All time</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="location">Location</Label>
+              <Select value={location} onValueChange={setLocation}>
+                <SelectTrigger id="location">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Locations</SelectItem>
+                  {locations.map((loc) => (
+                    <SelectItem key={loc.value} value={loc.value}>
+                      {loc.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <Button
+            onClick={handleApplyFilters}
+            className="w-full sm:w-auto"
+            disabled={isPending}
+          >
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Apply Filters
+          </Button>
+        </div>
+      </div>
+
+      <div
+        className={`space-y-4 transition-opacity ${isPending ? "pointer-events-none opacity-50" : ""}`}
+      >
+        {/* KPI cards */}
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <KpiCard
+            icon={Bell}
+            label="Notifications Sent"
+            value={num(totals.sendEvents)}
+            accent="text-sky-600 dark:text-sky-400"
+            tint="bg-sky-500"
+            spark={trend.map((t) => t.sendEvents)}
+            sparkColor="#0ea5e9"
+            mode={mode}
+            footer={`Send events · last ${periodLabel}`}
+            tooltip="Each time an admin sends a shortage alert counts as one send event, no matter how many volunteers it reaches."
+          />
+          <KpiCard
+            icon={Send}
+            label="Alerts Delivered"
+            value={num(totals.successfulEmails)}
+            accent="text-blue-600 dark:text-blue-400"
+            tint="bg-blue-500"
+            spark={trend.map((t) => t.deliveredEmails)}
+            sparkColor="#3b82f6"
+            mode={mode}
+            footer={`of ${num(totals.emails)} emails sent`}
+            tooltip="Notification emails successfully delivered to volunteers across all send events."
+          />
+          <KpiCard
+            icon={UserCheck}
+            label="Signups from Alerts"
+            value={num(totals.converted)}
+            accent="text-emerald-600 dark:text-emerald-400"
+            tint="bg-emerald-500"
+            spark={trend.map((t) => t.signups)}
+            sparkColor="#10b981"
+            mode={mode}
+            footer={
+              <span className="inline-flex items-center gap-1 font-medium text-emerald-600 dark:text-emerald-400">
+                View volunteers
+                <span aria-hidden>→</span>
+              </span>
+            }
+            tooltip="Volunteers who signed up for a shift after a delivered alert. Click to see who."
+            onClick={() => openConversions(initialLocation)}
+          />
+          <KpiCard
+            icon={Percent}
+            label="Conversion Rate"
+            value={`${totals.conversionRate}%`}
+            accent="text-violet-600 dark:text-violet-400"
+            tint="bg-violet-500"
+            spark={convTrend}
+            sparkColor="#8b5cf6"
+            mode={mode}
+            footer={`${num(totals.converted)} of ${num(totals.successfulEmails)} delivered`}
+            tooltip="Share of delivered alerts that led to a signup (signups ÷ delivered alerts)."
+          />
+        </div>
+
+        {/* Secondary stat chips */}
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <StatChip
+            icon={MailCheck}
+            label="Delivery Rate"
+            value={`${totals.successRate}%`}
+            accent="text-emerald-600 dark:text-emerald-400"
+            sub={`${num(totals.successfulEmails)}/${num(totals.emails)}`}
+            tooltip="Share of notification emails accepted for delivery (the rest bounced or errored)."
+          />
+          <StatChip
+            icon={Users}
+            label="Volunteers Reached"
+            value={num(totals.volunteersReached)}
+            accent="text-sky-600 dark:text-sky-400"
+            sub="reached"
+            tooltip="Distinct volunteers who received at least one shortage alert in this period."
+          />
+          <StatChip
+            icon={Gauge}
+            label="Avg per Send"
+            value={num(avgPerSend)}
+            accent="text-amber-600 dark:text-amber-400"
+            sub="per alert"
+            tooltip="Average number of volunteers emailed each time a shortage alert goes out."
+          />
+          <StatChip
+            icon={MapPin}
+            label="Sites Notified"
+            value={num(bySite.length)}
+            accent="text-violet-600 dark:text-violet-400"
+            sub={bySite.length === 1 ? "restaurant" : "restaurants"}
+            tooltip="Distinct restaurants that had at least one shortage alert in this period."
+          />
+        </div>
+
+        {/* Trend over time */}
+        <ChartCard
+          title="Notifications Over Time"
+          icon={TrendingUp}
+          accent="text-sky-600 dark:text-sky-400"
+          info={{
+            title: "Notifications Over Time",
+            description: "Alerts delivered vs signups they drove, by month",
+            body: (
+              <>
+                <p>
+                  Columns show notification emails delivered each month; the line
+                  shows how many of those alerts led to a signup.
+                </p>
+                <p>
+                  The gap between the two is the share of alerts that
+                  didn&rsquo;t convert.
+                </p>
+              </>
+            ),
+          }}
+        >
+          {hasData ? (
+            <ApexChart
+              key={`shortage-trend-${filterKey}`}
+              type="line"
+              height={300}
+              options={{
+                ...baseOptions(tokens),
+                chart: {
+                  ...baseOptions(tokens).chart,
+                  type: "line",
+                  stacked: false,
+                },
+                stroke: { width: [0, 3], curve: "smooth" },
+                plotOptions: {
+                  bar: {
+                    columnWidth: "45%",
+                    borderRadius: 4,
+                    borderRadiusApplication: "end",
+                  },
+                },
+                xaxis: {
+                  categories: trend.map((t) => t.label),
+                  labels: { style: tokens.axisStyle },
+                  axisBorder: { show: false },
+                  axisTicks: { show: false },
+                },
+                yaxis: {
+                  min: 0,
+                  forceNiceScale: true,
+                  labels: { formatter: compactCount, style: tokens.axisStyle },
+                },
+                colors: [PALETTE.eftpos, PALETTE.guests],
+                fill: { opacity: [0.85, 1] },
+                markers: {
+                  size: [0, 5],
+                  strokeWidth: 2,
+                  strokeColors: tokens.mode === "dark" ? "#0f1114" : "#fff",
+                },
+                tooltip: { shared: true, intersect: false },
+              }}
+              series={[
+                {
+                  name: "Alerts delivered",
+                  type: "column",
+                  data: trend.map((t) => t.deliveredEmails),
+                },
+                {
+                  name: "Signups from alerts",
+                  type: "line",
+                  data: trend.map((t) => t.signups),
+                },
+              ]}
+            />
+          ) : (
+            <ChartEmpty message="No shortage notifications sent in the selected period" />
+          )}
+        </ChartCard>
+
+        {/* Per-restaurant breakdown */}
+        <ChartCard
+          title="Per-Restaurant Breakdown"
+          icon={MapPin}
+          accent="text-violet-600 dark:text-violet-400"
+          bodyClassName="px-2"
+          info={{
+            title: "Per-Restaurant Breakdown",
+            description: "Alerts and signups by restaurant",
+            body: (
+              <>
+                <p>
+                  Click a row to see the volunteers who signed up after an alert
+                  at that restaurant.
+                </p>
+                <p>
+                  A single alert covering shifts at more than one restaurant
+                  counts toward each of them, so rows can add up to more than the
+                  org total.
+                </p>
+              </>
+            ),
+          }}
+        >
+          <div className="overflow-x-auto px-2 pb-1">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Restaurant</TableHead>
+                  <TableHead className="text-right">Send Events</TableHead>
+                  <TableHead className="text-right">Delivered</TableHead>
+                  <TableHead className="text-right">Failed</TableHead>
+                  <TableHead className="text-right">Volunteers</TableHead>
+                  <TableHead className="text-right">Signups</TableHead>
+                  <TableHead className="text-right">Conversion</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {bySite.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="py-8 text-center text-muted-foreground"
+                    >
+                      No shortage notifications sent in the selected period
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  <>
+                    {bySite.map((row: ShortageSiteRow) => (
+                      <TableRow
+                        key={row.location}
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => openConversions(row.location)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            openConversions(row.location);
+                          }
+                        }}
+                        className="cursor-pointer transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none"
+                        title={`View volunteers who signed up after an alert at ${row.location}`}
+                      >
+                        <TableCell className="font-medium">
+                          {row.location}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {row.sendEvents}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums text-emerald-600 dark:text-emerald-400">
+                          {row.successfulEmails}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums text-red-600 dark:text-red-400">
+                          {row.failedEmails}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          {row.volunteersReached}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums font-medium text-emerald-700 dark:text-emerald-400 underline decoration-dotted underline-offset-2">
+                          {row.converted}
+                        </TableCell>
+                        <TableCell className="text-right font-semibold tabular-nums">
+                          {row.conversionRate}%
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                    <TableRow
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => openConversions(initialLocation)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          openConversions(initialLocation);
+                        }
+                      }}
+                      className="cursor-pointer border-t-2 font-semibold transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none"
+                      title="View all volunteers who signed up after an alert"
+                    >
+                      <TableCell>All Locations</TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {totals.sendEvents}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-emerald-600 dark:text-emerald-400">
+                        {totals.successfulEmails}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-red-600 dark:text-red-400">
+                        {totals.failedEmails}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {totals.volunteersReached}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-emerald-700 dark:text-emerald-400 underline decoration-dotted underline-offset-2">
+                        {totals.converted}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {totals.conversionRate}%
+                      </TableCell>
+                    </TableRow>
+                  </>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </ChartCard>
+      </div>
+
+      <ShortageConversionsDialog
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        months={initialMonths}
+        location={modalLocation}
+        title={modalTitle}
+        subtitle="Volunteers who signed up for a shift after getting a shortage alert"
+      />
+    </div>
+  );
+}

--- a/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
@@ -44,7 +44,7 @@ import {
   chartTokens,
   compactCount,
   num,
-  PALETTE,
+  SERIES_COLORS,
 } from "../_lib/chart-theme";
 import { ShortageConversionsDialog } from "./shortage-conversions-dialog";
 import type {
@@ -268,8 +268,26 @@ export function ShortageNotificationsAnalyticsClient({
     setModalOpen(true);
   };
 
-  const { totals, bySite, trend } = data;
+  const { totals, bySite, trend, trendByLocation } = data;
   const hasData = totals.emails > 0;
+
+  // Stacked "delivered by restaurant" columns + a total signups line on top.
+  const locationColors = trendByLocation.map(
+    (_, i) => SERIES_COLORS[i % SERIES_COLORS.length]
+  );
+  const signupsColor = mode === "dark" ? "#e2e8f0" : "#0f172a";
+  const trendSeries = [
+    ...trendByLocation.map((l) => ({
+      name: l.location,
+      type: "column" as const,
+      data: l.delivered,
+    })),
+    {
+      name: "Signups from alerts",
+      type: "line" as const,
+      data: trend.map((t) => t.signups),
+    },
+  ];
   const avgPerSend =
     totals.sendEvents > 0 ? Math.round(totals.emails / totals.sendEvents) : 0;
   const periodLabel = MONTHS_LABELS[initialMonths] ?? "the period";
@@ -436,16 +454,22 @@ export function ShortageNotificationsAnalyticsClient({
           accent="text-sky-600 dark:text-sky-400"
           info={{
             title: "Notifications Over Time",
-            description: "Alerts delivered vs signups they drove, by month",
+            description: "Alerts delivered each month, stacked by restaurant",
             body: (
               <>
                 <p>
-                  Columns show notification emails delivered each month; the line
-                  shows how many of those alerts led to a signup.
+                  Each column is the notification emails delivered that month,
+                  stacked by restaurant so you can see where shortages are
+                  concentrated.
                 </p>
                 <p>
-                  The gap between the two is the share of alerts that
-                  didn&rsquo;t convert.
+                  The line shows how many of those alerts led to a signup across
+                  the whole org.
+                </p>
+                <p>
+                  A single alert covering shifts at more than one restaurant
+                  counts toward each, so a month&rsquo;s stack can exceed its
+                  delivered total.
                 </p>
               </>
             ),
@@ -461,13 +485,16 @@ export function ShortageNotificationsAnalyticsClient({
                 chart: {
                   ...baseOptions(tokens).chart,
                   type: "line",
-                  stacked: false,
+                  stacked: true,
                 },
-                stroke: { width: [0, 3], curve: "smooth" },
+                stroke: {
+                  width: [...trendByLocation.map(() => 0), 3],
+                  curve: "smooth",
+                },
                 plotOptions: {
                   bar: {
-                    columnWidth: "45%",
-                    borderRadius: 4,
+                    columnWidth: "55%",
+                    borderRadius: 3,
                     borderRadiusApplication: "end",
                   },
                 },
@@ -482,27 +509,16 @@ export function ShortageNotificationsAnalyticsClient({
                   forceNiceScale: true,
                   labels: { formatter: compactCount, style: tokens.axisStyle },
                 },
-                colors: [PALETTE.eftpos, PALETTE.guests],
-                fill: { opacity: [0.85, 1] },
+                colors: [...locationColors, signupsColor],
+                fill: { opacity: 1 },
                 markers: {
-                  size: [0, 5],
+                  size: [...trendByLocation.map(() => 0), 5],
                   strokeWidth: 2,
                   strokeColors: tokens.mode === "dark" ? "#0f1114" : "#fff",
                 },
                 tooltip: { shared: true, intersect: false },
               }}
-              series={[
-                {
-                  name: "Alerts delivered",
-                  type: "column",
-                  data: trend.map((t) => t.deliveredEmails),
-                },
-                {
-                  name: "Signups from alerts",
-                  type: "line",
-                  data: trend.map((t) => t.signups),
-                },
-              ]}
+              series={trendSeries}
             />
           ) : (
             <ChartEmpty message="No shortage notifications sent in the selected period" />

--- a/web/src/app/api/admin/analytics/shortage-notifications/conversions/route.ts
+++ b/web/src/app/api/admin/analytics/shortage-notifications/conversions/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
-import { getShortageConversions } from "@/lib/shortage-analytics";
+import {
+  getShortageConversions,
+  parseMonthsParam,
+} from "@/lib/shortage-analytics";
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -11,8 +14,7 @@ export async function GET(request: NextRequest) {
   }
 
   const searchParams = request.nextUrl.searchParams;
-  const monthsParam = searchParams.get("months") || "12";
-  const months = monthsParam === "all" ? 0 : parseInt(monthsParam, 10) || 12;
+  const months = parseMonthsParam(searchParams.get("months"));
   const location = searchParams.get("location");
 
   try {

--- a/web/src/app/api/admin/analytics/shortage-notifications/conversions/route.ts
+++ b/web/src/app/api/admin/analytics/shortage-notifications/conversions/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { getShortageConversions } from "@/lib/shortage-analytics";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const monthsParam = searchParams.get("months") || "12";
+  const months = monthsParam === "all" ? 0 : parseInt(monthsParam, 10) || 12;
+  const location = searchParams.get("location");
+
+  try {
+    const data = await getShortageConversions(months, location);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error fetching shortage notification conversions:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch conversions" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/app/api/admin/analytics/shortage-notifications/route.ts
+++ b/web/src/app/api/admin/analytics/shortage-notifications/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { getShortageNotificationAnalytics } from "@/lib/shortage-analytics";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  // "all" (or 0) means all time — no lower bound on the window.
+  const monthsParam = searchParams.get("months") || "12";
+  const months = monthsParam === "all" ? 0 : parseInt(monthsParam, 10) || 12;
+  const location = searchParams.get("location");
+
+  try {
+    const data = await getShortageNotificationAnalytics(months, location);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error("Error fetching shortage notification analytics:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch shortage notification data" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/app/api/admin/analytics/shortage-notifications/route.ts
+++ b/web/src/app/api/admin/analytics/shortage-notifications/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
-import { getShortageNotificationAnalytics } from "@/lib/shortage-analytics";
+import {
+  getShortageNotificationAnalytics,
+  parseMonthsParam,
+} from "@/lib/shortage-analytics";
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -12,8 +15,7 @@ export async function GET(request: NextRequest) {
 
   const searchParams = request.nextUrl.searchParams;
   // "all" (or 0) means all time — no lower bound on the window.
-  const monthsParam = searchParams.get("months") || "12";
-  const months = monthsParam === "all" ? 0 : parseInt(monthsParam, 10) || 12;
+  const months = parseMonthsParam(searchParams.get("months"));
   const location = searchParams.get("location");
 
   try {

--- a/web/src/lib/admin-navigation.ts
+++ b/web/src/lib/admin-navigation.ts
@@ -103,6 +103,14 @@ export const adminNavCategories: AdminNavCategory[] = [
           "Shifts run, positions filled, and understaffing by restaurant",
         commandKey: "coverage",
       },
+      {
+        title: "Shortage Notifications",
+        href: "/admin/analytics/shortage-notifications",
+        icon: Bell,
+        description:
+          "Shortage alerts sent and the signups they drove, org-wide and by restaurant",
+        commandKey: "shortage-notifications",
+      },
     ],
   },
   {

--- a/web/src/lib/shortage-analytics.test.ts
+++ b/web/src/lib/shortage-analytics.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   aggregateShortageLogs,
+  parseMonthsParam,
   percentage,
   sitesForLog,
   signupKey,
@@ -31,6 +32,26 @@ describe("percentage", () => {
   it("returns 0 rather than dividing by zero", () => {
     expect(percentage(0, 0)).toBe(0);
     expect(percentage(5, 0)).toBe(0);
+  });
+});
+
+describe("parseMonthsParam", () => {
+  it("returns 0 for all-time", () => {
+    expect(parseMonthsParam("all")).toBe(0);
+  });
+
+  it("accepts positive integers", () => {
+    expect(parseMonthsParam("3")).toBe(3);
+    expect(parseMonthsParam("12")).toBe(12);
+  });
+
+  it("falls back to 12 for missing, invalid, or non-positive values", () => {
+    expect(parseMonthsParam(null)).toBe(12);
+    expect(parseMonthsParam(undefined)).toBe(12);
+    expect(parseMonthsParam("")).toBe(12);
+    expect(parseMonthsParam("abc")).toBe(12);
+    expect(parseMonthsParam("-3")).toBe(12);
+    expect(parseMonthsParam("0")).toBe(12);
   });
 });
 

--- a/web/src/lib/shortage-analytics.test.ts
+++ b/web/src/lib/shortage-analytics.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateShortageLogs,
+  percentage,
+  sitesForLog,
+  signupKey,
+  UNKNOWN_SITE,
+  type ShortageLogRow,
+  type SignupIndex,
+} from "./shortage-analytics";
+
+/** Build a log row, defaulting the fields a test doesn't care about. */
+function log(overrides: Partial<ShortageLogRow>): ShortageLogRow {
+  return {
+    sentAt: new Date("2026-01-10T02:00:00.000Z"),
+    sentBy: "admin-1",
+    recipientId: "vol-1",
+    success: true,
+    shifts: [{ shiftLocation: "Wellington" }],
+    ...overrides,
+  };
+}
+
+describe("percentage", () => {
+  it("rounds to a whole percentage", () => {
+    expect(percentage(1, 3)).toBe(33);
+    expect(percentage(2, 3)).toBe(67);
+    expect(percentage(3, 4)).toBe(75);
+  });
+
+  it("returns 0 rather than dividing by zero", () => {
+    expect(percentage(0, 0)).toBe(0);
+    expect(percentage(5, 0)).toBe(0);
+  });
+});
+
+describe("sitesForLog", () => {
+  it("returns the distinct locations from the shifts JSON", () => {
+    const sites = sitesForLog(
+      log({
+        shifts: [
+          { shiftLocation: "Wellington" },
+          { shiftLocation: "Glen Innes" },
+          { shiftLocation: "Wellington" },
+        ],
+      })
+    );
+    expect(sites.sort()).toEqual(["Glen Innes", "Wellington"]);
+  });
+
+  it("falls back to Unknown for blank, missing, or empty shifts", () => {
+    expect(sitesForLog(log({ shifts: [{ shiftLocation: "" }] }))).toEqual([
+      UNKNOWN_SITE,
+    ]);
+    expect(sitesForLog(log({ shifts: [{}] }))).toEqual([UNKNOWN_SITE]);
+    expect(sitesForLog(log({ shifts: [] }))).toEqual([UNKNOWN_SITE]);
+    expect(sitesForLog(log({ shifts: null }))).toEqual([UNKNOWN_SITE]);
+  });
+});
+
+describe("aggregateShortageLogs — totals", () => {
+  it("is empty for no logs", () => {
+    const { totals, bySite, trend } = aggregateShortageLogs([]);
+    expect(totals).toEqual({
+      sendEvents: 0,
+      emails: 0,
+      successfulEmails: 0,
+      failedEmails: 0,
+      volunteersReached: 0,
+      successRate: 0,
+      converted: 0,
+      conversionRate: 0,
+    });
+    expect(bySite).toEqual([]);
+    expect(trend).toEqual([]);
+  });
+
+  it("counts one send event per (sentAt, sentBy) batch and one email per row", () => {
+    const sentAt = new Date("2026-01-10T02:00:00.000Z");
+    const { totals } = aggregateShortageLogs([
+      // One batch → three recipients.
+      log({ sentAt, sentBy: "admin-1", recipientId: "vol-1" }),
+      log({ sentAt, sentBy: "admin-1", recipientId: "vol-2" }),
+      log({ sentAt, sentBy: "admin-1", recipientId: "vol-3" }),
+      // A separate send by a different admin at a different time.
+      log({
+        sentAt: new Date("2026-01-12T03:00:00.000Z"),
+        sentBy: "admin-2",
+        recipientId: "vol-1",
+      }),
+    ]);
+
+    expect(totals.sendEvents).toBe(2);
+    expect(totals.emails).toBe(4);
+    // vol-1 appears in both batches but is one distinct volunteer.
+    expect(totals.volunteersReached).toBe(3);
+  });
+
+  it("tracks delivery success and failure and the success rate", () => {
+    const sentAt = new Date("2026-02-01T02:00:00.000Z");
+    const { totals } = aggregateShortageLogs([
+      log({ sentAt, recipientId: "vol-1", success: true }),
+      log({ sentAt, recipientId: "vol-2", success: true }),
+      log({ sentAt, recipientId: "vol-3", success: true }),
+      log({ sentAt, recipientId: "vol-4", success: false }),
+    ]);
+    expect(totals.successfulEmails).toBe(3);
+    expect(totals.failedEmails).toBe(1);
+    expect(totals.successRate).toBe(75);
+  });
+});
+
+describe("aggregateShortageLogs — per site", () => {
+  it("counts a multi-site send toward each site but once org-wide", () => {
+    const { totals, bySite } = aggregateShortageLogs([
+      log({
+        recipientId: "vol-1",
+        shifts: [{ shiftLocation: "Wellington" }, { shiftLocation: "Glen Innes" }],
+      }),
+    ]);
+
+    // Org-wide: a single send event and a single email.
+    expect(totals.sendEvents).toBe(1);
+    expect(totals.emails).toBe(1);
+
+    // Per site: the send counts toward both restaurants.
+    const wellington = bySite.find((s) => s.location === "Wellington");
+    const glenInnes = bySite.find((s) => s.location === "Glen Innes");
+    expect(wellington?.sendEvents).toBe(1);
+    expect(wellington?.emails).toBe(1);
+    expect(glenInnes?.sendEvents).toBe(1);
+    expect(glenInnes?.emails).toBe(1);
+  });
+
+  it("sorts sites by email volume descending", () => {
+    const sentAt = new Date("2026-03-01T02:00:00.000Z");
+    const { bySite } = aggregateShortageLogs([
+      log({ sentAt, recipientId: "w1", shifts: [{ shiftLocation: "Wellington" }] }),
+      log({ sentAt, recipientId: "w2", shifts: [{ shiftLocation: "Wellington" }] }),
+      log({ sentAt, recipientId: "g1", shifts: [{ shiftLocation: "Glen Innes" }] }),
+    ]);
+    expect(bySite.map((s) => s.location)).toEqual(["Wellington", "Glen Innes"]);
+    expect(bySite[0].emails).toBe(2);
+    expect(bySite[1].emails).toBe(1);
+  });
+
+  it("keeps only the requested site when filtered", () => {
+    const { totals, bySite } = aggregateShortageLogs(
+      [
+        log({ recipientId: "w1", shifts: [{ shiftLocation: "Wellington" }] }),
+        log({
+          recipientId: "g1",
+          shifts: [{ shiftLocation: "Glen Innes" }],
+        }),
+        log({
+          recipientId: "wg1",
+          shifts: [
+            { shiftLocation: "Wellington" },
+            { shiftLocation: "Glen Innes" },
+          ],
+        }),
+      ],
+      "Wellington"
+    );
+
+    // Only rows that covered Wellington count: the Wellington-only row and the
+    // multi-site row (not the Glen-Innes-only row).
+    expect(totals.emails).toBe(2);
+    expect(bySite).toHaveLength(1);
+    expect(bySite[0].location).toBe("Wellington");
+    expect(bySite[0].emails).toBe(2);
+  });
+});
+
+describe("aggregateShortageLogs — monthly trend", () => {
+  it("buckets sends by NZ month, ordered chronologically", () => {
+    const { trend } = aggregateShortageLogs([
+      // 2026-02-01 13:00 UTC is still 2026-02-02 in NZ (UTC+13).
+      log({
+        sentAt: new Date("2026-02-01T13:00:00.000Z"),
+        sentBy: "admin-1",
+        recipientId: "a",
+      }),
+      log({
+        sentAt: new Date("2026-01-10T02:00:00.000Z"),
+        sentBy: "admin-1",
+        recipientId: "b",
+      }),
+      log({
+        sentAt: new Date("2026-01-10T02:00:00.000Z"),
+        sentBy: "admin-1",
+        recipientId: "c",
+      }),
+    ]);
+
+    expect(trend.map((t) => t.month)).toEqual(["2026-01", "2026-02"]);
+    const january = trend.find((t) => t.month === "2026-01");
+    expect(january?.sendEvents).toBe(1);
+    expect(january?.emails).toBe(2);
+  });
+});
+
+describe("aggregateShortageLogs — conversions (effectiveness)", () => {
+  const sentAt = new Date("2026-01-10T02:00:00.000Z");
+
+  function index(entries: Array<[string, string, Date]>): SignupIndex {
+    return new Map(entries.map(([u, s, at]) => [signupKey(u, s), at]));
+  }
+
+  it("counts a recipient who signed up after the alert as converted", () => {
+    const logs = [
+      log({
+        sentAt,
+        recipientId: "vol-1",
+        shifts: [{ shiftId: "shift-a", shiftLocation: "Wellington" }],
+      }),
+    ];
+    const signups = index([
+      ["vol-1", "shift-a", new Date("2026-01-10T09:00:00.000Z")], // after
+    ]);
+
+    const { totals, bySite } = aggregateShortageLogs(logs, null, signups);
+    expect(totals.converted).toBe(1);
+    expect(totals.conversionRate).toBe(100);
+    expect(bySite[0].converted).toBe(1);
+    expect(bySite[0].conversionRate).toBe(100);
+  });
+
+  it("does not count a signup made before the alert", () => {
+    const logs = [
+      log({
+        sentAt,
+        recipientId: "vol-1",
+        shifts: [{ shiftId: "shift-a", shiftLocation: "Wellington" }],
+      }),
+    ];
+    const signups = index([
+      ["vol-1", "shift-a", new Date("2026-01-09T09:00:00.000Z")], // before
+    ]);
+
+    const { totals } = aggregateShortageLogs(logs, null, signups);
+    expect(totals.converted).toBe(0);
+    expect(totals.conversionRate).toBe(0);
+  });
+
+  it("does not credit a failed (undelivered) alert even if they signed up", () => {
+    const logs = [
+      log({
+        sentAt,
+        recipientId: "vol-1",
+        success: false,
+        shifts: [{ shiftId: "shift-a", shiftLocation: "Wellington" }],
+      }),
+    ];
+    const signups = index([
+      ["vol-1", "shift-a", new Date("2026-01-10T09:00:00.000Z")], // after
+    ]);
+
+    const { totals } = aggregateShortageLogs(logs, null, signups);
+    expect(totals.successfulEmails).toBe(0);
+    expect(totals.converted).toBe(0);
+    expect(totals.conversionRate).toBe(0);
+  });
+
+  it("uses delivered alerts as the conversion-rate denominator", () => {
+    const logs = [
+      log({ sentAt, recipientId: "vol-1", success: true, shifts: [{ shiftId: "s", shiftLocation: "Wellington" }] }),
+      log({ sentAt, recipientId: "vol-2", success: true, shifts: [{ shiftId: "s", shiftLocation: "Wellington" }] }),
+      log({ sentAt, recipientId: "vol-3", success: true, shifts: [{ shiftId: "s", shiftLocation: "Wellington" }] }),
+      log({ sentAt, recipientId: "vol-4", success: true, shifts: [{ shiftId: "s", shiftLocation: "Wellington" }] }),
+    ];
+    // Only vol-1 signs up afterwards → 1 of 4 delivered = 25%.
+    const signups = index([
+      ["vol-1", "s", new Date("2026-01-11T09:00:00.000Z")],
+    ]);
+
+    const { totals } = aggregateShortageLogs(logs, null, signups);
+    expect(totals.converted).toBe(1);
+    expect(totals.conversionRate).toBe(25);
+  });
+
+  it("credits the conversion to the site of the shift the recipient signed up for", () => {
+    // One alert covering shifts at two restaurants; recipient signs up for the
+    // Glen Innes shift only.
+    const logs = [
+      log({
+        sentAt,
+        recipientId: "vol-1",
+        shifts: [
+          { shiftId: "wel-1", shiftLocation: "Wellington" },
+          { shiftId: "gi-1", shiftLocation: "Glen Innes" },
+        ],
+      }),
+    ];
+    const signups = index([
+      ["vol-1", "gi-1", new Date("2026-01-10T09:00:00.000Z")],
+    ]);
+
+    const { totals, bySite } = aggregateShortageLogs(logs, null, signups);
+    expect(totals.converted).toBe(1);
+    const wellington = bySite.find((s) => s.location === "Wellington");
+    const glenInnes = bySite.find((s) => s.location === "Glen Innes");
+    expect(glenInnes?.converted).toBe(1);
+    expect(wellington?.converted).toBe(0);
+  });
+
+  it("reports per-month signups on the trend", () => {
+    const logs = [
+      log({ sentAt, recipientId: "vol-1", shifts: [{ shiftId: "s1", shiftLocation: "Wellington" }] }),
+      log({ sentAt, recipientId: "vol-2", shifts: [{ shiftId: "s1", shiftLocation: "Wellington" }] }),
+    ];
+    const signups = index([
+      ["vol-1", "s1", new Date("2026-01-12T09:00:00.000Z")],
+    ]);
+
+    const { trend } = aggregateShortageLogs(logs, null, signups);
+    const january = trend.find((t) => t.month === "2026-01");
+    expect(january?.deliveredEmails).toBe(2);
+    expect(january?.signups).toBe(1);
+  });
+});

--- a/web/src/lib/shortage-analytics.test.ts
+++ b/web/src/lib/shortage-analytics.test.ts
@@ -198,6 +198,41 @@ describe("aggregateShortageLogs — monthly trend", () => {
     expect(january?.sendEvents).toBe(1);
     expect(january?.emails).toBe(2);
   });
+
+  it("splits delivered alerts per location aligned to the trend months", () => {
+    const jan = new Date("2026-01-10T02:00:00.000Z");
+    const feb = new Date("2026-02-10T02:00:00.000Z");
+    const { trend, trendByLocation } = aggregateShortageLogs([
+      log({
+        sentAt: jan,
+        recipientId: "a",
+        shifts: [{ shiftId: "s1", shiftLocation: "Wellington" }],
+      }),
+      log({
+        sentAt: jan,
+        recipientId: "b",
+        shifts: [{ shiftId: "s2", shiftLocation: "Glen Innes" }],
+      }),
+      log({
+        sentAt: feb,
+        recipientId: "c",
+        shifts: [{ shiftId: "s3", shiftLocation: "Wellington" }],
+      }),
+      // A failed alert must not contribute to the stacked delivered series.
+      log({
+        sentAt: feb,
+        recipientId: "d",
+        success: false,
+        shifts: [{ shiftId: "s4", shiftLocation: "Glen Innes" }],
+      }),
+    ]);
+
+    expect(trend.map((t) => t.month)).toEqual(["2026-01", "2026-02"]);
+    const wellington = trendByLocation.find((l) => l.location === "Wellington");
+    const glenInnes = trendByLocation.find((l) => l.location === "Glen Innes");
+    expect(wellington?.delivered).toEqual([1, 1]);
+    expect(glenInnes?.delivered).toEqual([1, 0]);
+  });
 });
 
 describe("aggregateShortageLogs — conversions (effectiveness)", () => {

--- a/web/src/lib/shortage-analytics.ts
+++ b/web/src/lib/shortage-analytics.ts
@@ -89,10 +89,22 @@ export interface ShortageTrendPoint {
   signups: number;
 }
 
+/** Delivered alerts for one restaurant across the trend months. */
+export interface ShortageTrendLocationSeries {
+  location: string;
+  /** Delivered alerts at this site per month, aligned to `trend[].month`. */
+  delivered: number[];
+}
+
 export interface ShortageNotificationAnalytics {
   totals: ShortageTotals;
   bySite: ShortageSiteRow[];
   trend: ShortageTrendPoint[];
+  /**
+   * Delivered alerts per month split by restaurant, in the same month order as
+   * `trend`, for the stacked "over time" chart. Location order matches `bySite`.
+   */
+  trendByLocation: ShortageTrendLocationSeries[];
   /** 0 means "all time" (no lower bound on the window). */
   periodMonths: number;
 }
@@ -275,6 +287,8 @@ export function aggregateShortageLogs(
 
   // ── Monthly trend (NZ time) ─────────────────────────────────────────────
   const trendMap = new Map<string, TrendAccumulator>();
+  // month → site → delivered alerts, for the stacked-by-location chart.
+  const monthSiteDelivered = new Map<string, Map<string, number>>();
   for (const row of rows) {
     const month = formatInNZT(row.sentAt, "yyyy-MM");
     let acc = trendMap.get(month);
@@ -292,9 +306,19 @@ export function aggregateShortageLogs(
     acc.emails += 1;
     if (row.success) {
       acc.delivered += 1;
-      const shiftIds = [...shiftsByLocationForLog(row).values()].flat();
+      const byLoc = shiftsByLocationForLog(row);
+      const shiftIds = [...byLoc.values()].flat();
       if (convertedForShifts(row.recipientId, shiftIds, row.sentAt, signups)) {
         acc.converted += 1;
+      }
+      // A delivered alert counts toward each site it covered (as in bySite).
+      let siteMonth = monthSiteDelivered.get(month);
+      if (!siteMonth) {
+        siteMonth = new Map();
+        monthSiteDelivered.set(month, siteMonth);
+      }
+      for (const site of byLoc.keys()) {
+        siteMonth.set(site, (siteMonth.get(site) ?? 0) + 1);
       }
     }
   }
@@ -309,7 +333,17 @@ export function aggregateShortageLogs(
     }))
     .sort((a, b) => a.month.localeCompare(b.month));
 
-  return { totals, bySite, trend };
+  // Per-location delivered series aligned to the sorted trend months; location
+  // order follows bySite (busiest first) so chart and table agree.
+  const monthOrder = trend.map((t) => t.month);
+  const trendByLocation: ShortageTrendLocationSeries[] = bySite.map((site) => ({
+    location: site.location,
+    delivered: monthOrder.map(
+      (month) => monthSiteDelivered.get(month)?.get(site.location) ?? 0
+    ),
+  }));
+
+  return { totals, bySite, trend, trendByLocation };
 }
 
 /**
@@ -367,13 +401,13 @@ export async function getShortageNotificationAnalytics(
     );
   }
 
-  const { totals, bySite, trend } = aggregateShortageLogs(
+  const { totals, bySite, trend, trendByLocation } = aggregateShortageLogs(
     logs,
     location,
     signups
   );
 
-  return { totals, bySite, trend, periodMonths: months };
+  return { totals, bySite, trend, trendByLocation, periodMonths: months };
 }
 
 /** One volunteer who signed up for a shift after being alerted about it. */

--- a/web/src/lib/shortage-analytics.ts
+++ b/web/src/lib/shortage-analytics.ts
@@ -1,0 +1,573 @@
+import { prisma } from "@/lib/prisma";
+import { formatInNZT } from "@/lib/timezone";
+
+/**
+ * Analytics over `ShortageNotificationLog` — how many shift-shortage
+ * notifications have gone out, org-wide and per restaurant.
+ *
+ * The log stores one row per recipient per send, so we distinguish two counts:
+ *  - **Send events**: distinct notification batches an admin dispatched. A batch
+ *    is identified by its `(sentAt, sentBy)` tuple — every recipient of one send
+ *    shares those values.
+ *  - **Emails**: individual notification emails, i.e. one per log row.
+ *
+ * A single send can cover shifts at more than one restaurant (the sites live
+ * denormalized inside the `shifts` JSON). Such a send counts once org-wide but
+ * toward *each* site it touched in the per-site breakdown.
+ */
+
+/** Fallback bucket for a shift whose location wasn't recorded on the log. */
+export const UNKNOWN_SITE = "Unknown";
+
+/** One shift entry inside a log's denormalized `shifts` JSON array. */
+interface LoggedShift {
+  shiftId?: string;
+  shiftTypeName?: string;
+  shiftDate?: string;
+  shiftLocation?: string;
+}
+
+/** The subset of `ShortageNotificationLog` columns the analytics rely on. */
+export interface ShortageLogRow {
+  sentAt: Date;
+  sentBy: string;
+  recipientId: string;
+  success: boolean;
+  /** JSON payload: an array of {@link LoggedShift}. */
+  shifts: unknown;
+}
+
+/** Notification figures for a single restaurant (or "Unknown"). */
+export interface ShortageSiteRow {
+  location: string;
+  /** Distinct send events (batches) that covered a shift at this site. */
+  sendEvents: number;
+  /** Notification emails whose send covered a shift at this site. */
+  emails: number;
+  /** Of those emails, how many were delivered successfully. */
+  successfulEmails: number;
+  /** Of those emails, how many failed to send. */
+  failedEmails: number;
+  /** Distinct volunteers emailed about a shortage at this site. */
+  volunteersReached: number;
+  /** successfulEmails / emails as a 0–100 percentage. */
+  successRate: number;
+  /** Delivered alerts here whose recipient then signed up for a shift here. */
+  converted: number;
+  /** converted / successfulEmails as a 0–100 percentage. */
+  conversionRate: number;
+}
+
+/** Org-wide notification figures for the period. */
+export interface ShortageTotals {
+  /** Distinct send events (batches) across the org. */
+  sendEvents: number;
+  /** Total notification emails sent. */
+  emails: number;
+  successfulEmails: number;
+  failedEmails: number;
+  /** Distinct volunteers emailed at least once. */
+  volunteersReached: number;
+  successRate: number;
+  /** Delivered alerts whose recipient then signed up for a notified shift. */
+  converted: number;
+  /** converted / successfulEmails as a 0–100 percentage. */
+  conversionRate: number;
+}
+
+/** A single month bucket for the trend chart. */
+export interface ShortageTrendPoint {
+  /** Sort key, e.g. "2026-01". */
+  month: string;
+  /** Display label, e.g. "Jan 2026". */
+  label: string;
+  sendEvents: number;
+  emails: number;
+  /** Successfully delivered emails that month. */
+  deliveredEmails: number;
+  /** Delivered alerts that led to a signup (conversions) that month. */
+  signups: number;
+}
+
+export interface ShortageNotificationAnalytics {
+  totals: ShortageTotals;
+  bySite: ShortageSiteRow[];
+  trend: ShortageTrendPoint[];
+  /** 0 means "all time" (no lower bound on the window). */
+  periodMonths: number;
+}
+
+/** Rounded 0–100 percentage that never divides by zero. */
+export function percentage(part: number, whole: number): number {
+  return whole > 0 ? Math.round((part / whole) * 100) : 0;
+}
+
+/** Stable identifier for the send batch a log row belongs to. */
+function batchKey(row: ShortageLogRow): string {
+  return `${row.sentAt.toISOString()}|${row.sentBy}`;
+}
+
+/**
+ * Map each restaurant site a log row covered to the notified shift IDs at that
+ * site, read from the denormalized `shifts` JSON. Blank or missing locations
+ * fall back to {@link UNKNOWN_SITE}; a row with no shifts at all still
+ * represents a send (a single Unknown bucket with no shift IDs).
+ */
+export function shiftsByLocationForLog(
+  row: ShortageLogRow
+): Map<string, string[]> {
+  const shifts: LoggedShift[] = Array.isArray(row.shifts)
+    ? (row.shifts as LoggedShift[])
+    : [];
+  const byLocation = new Map<string, string[]>();
+  for (const shift of shifts) {
+    const loc = (shift?.shiftLocation ?? "").trim() || UNKNOWN_SITE;
+    const id = (shift?.shiftId ?? "").trim();
+    const ids = byLocation.get(loc) ?? [];
+    if (id) ids.push(id);
+    byLocation.set(loc, ids);
+  }
+  if (byLocation.size === 0) byLocation.set(UNKNOWN_SITE, []);
+  return byLocation;
+}
+
+/** Distinct restaurant sites a single log row covered. */
+export function sitesForLog(row: ShortageLogRow): string[] {
+  return [...shiftsByLocationForLog(row).keys()];
+}
+
+/**
+ * When each volunteer signed up for each shift, keyed `${userId}|${shiftId}`.
+ * Used to detect whether an alert led to a signup afterwards.
+ */
+export type SignupIndex = Map<string, Date>;
+
+/** Key into a {@link SignupIndex}. */
+export function signupKey(userId: string, shiftId: string): string {
+  return `${userId}|${shiftId}`;
+}
+
+/**
+ * True if `recipientId` signed up for any of `shiftIds` strictly after
+ * `sentAt` — i.e. the alert plausibly drove the signup. Signups made before
+ * the alert (already-committed volunteers) don't count.
+ */
+function convertedForShifts(
+  recipientId: string,
+  shiftIds: string[],
+  sentAt: Date,
+  signups: SignupIndex
+): boolean {
+  for (const shiftId of shiftIds) {
+    const signedUpAt = signups.get(signupKey(recipientId, shiftId));
+    if (signedUpAt && signedUpAt.getTime() > sentAt.getTime()) return true;
+  }
+  return false;
+}
+
+interface SiteAccumulator {
+  emails: number;
+  successfulEmails: number;
+  converted: number;
+  batches: Set<string>;
+  volunteers: Set<string>;
+}
+
+interface TrendAccumulator {
+  label: string;
+  batches: Set<string>;
+  emails: number;
+  delivered: number;
+  converted: number;
+}
+
+/**
+ * Roll raw log rows up into org totals, a per-site breakdown, and a monthly
+ * trend. Pure (no DB, no clock) so it can be unit tested directly.
+ *
+ * When `location` names a specific site, only sends that covered that site are
+ * counted, and the breakdown surfaces just that site.
+ */
+export function aggregateShortageLogs(
+  logs: ShortageLogRow[],
+  location: string | null = null,
+  signups: SignupIndex = new Map()
+): Omit<ShortageNotificationAnalytics, "periodMonths"> {
+  const isSiteFiltered = !!location && location !== "all";
+  const rows = isSiteFiltered
+    ? logs.filter((row) => sitesForLog(row).includes(location as string))
+    : logs;
+
+  // ── Org totals ──────────────────────────────────────────────────────────
+  const totalBatches = new Set<string>();
+  const totalVolunteers = new Set<string>();
+  let emails = 0;
+  let successfulEmails = 0;
+  let converted = 0;
+  for (const row of rows) {
+    emails += 1;
+    totalBatches.add(batchKey(row));
+    totalVolunteers.add(row.recipientId);
+    if (row.success) {
+      successfulEmails += 1;
+      const shiftIds = [...shiftsByLocationForLog(row).values()].flat();
+      if (convertedForShifts(row.recipientId, shiftIds, row.sentAt, signups)) {
+        converted += 1;
+      }
+    }
+  }
+  const totals: ShortageTotals = {
+    sendEvents: totalBatches.size,
+    emails,
+    successfulEmails,
+    failedEmails: emails - successfulEmails,
+    volunteersReached: totalVolunteers.size,
+    successRate: percentage(successfulEmails, emails),
+    converted,
+    conversionRate: percentage(converted, successfulEmails),
+  };
+
+  // ── Per-site breakdown ──────────────────────────────────────────────────
+  // Each row counts toward every distinct site its shifts covered; a conversion
+  // is credited to the site of the shift the recipient actually signed up for.
+  const siteMap = new Map<string, SiteAccumulator>();
+  for (const row of rows) {
+    const key = batchKey(row);
+    for (const [site, shiftIds] of shiftsByLocationForLog(row)) {
+      if (isSiteFiltered && site !== location) continue;
+      let acc = siteMap.get(site);
+      if (!acc) {
+        acc = {
+          emails: 0,
+          successfulEmails: 0,
+          converted: 0,
+          batches: new Set(),
+          volunteers: new Set(),
+        };
+        siteMap.set(site, acc);
+      }
+      acc.emails += 1;
+      if (row.success) {
+        acc.successfulEmails += 1;
+        if (convertedForShifts(row.recipientId, shiftIds, row.sentAt, signups)) {
+          acc.converted += 1;
+        }
+      }
+      acc.batches.add(key);
+      acc.volunteers.add(row.recipientId);
+    }
+  }
+  const bySite: ShortageSiteRow[] = [...siteMap.entries()]
+    .map(([site, acc]) => ({
+      location: site,
+      sendEvents: acc.batches.size,
+      emails: acc.emails,
+      successfulEmails: acc.successfulEmails,
+      failedEmails: acc.emails - acc.successfulEmails,
+      volunteersReached: acc.volunteers.size,
+      successRate: percentage(acc.successfulEmails, acc.emails),
+      converted: acc.converted,
+      conversionRate: percentage(acc.converted, acc.successfulEmails),
+    }))
+    .sort(
+      (a, b) => b.emails - a.emails || a.location.localeCompare(b.location)
+    );
+
+  // ── Monthly trend (NZ time) ─────────────────────────────────────────────
+  const trendMap = new Map<string, TrendAccumulator>();
+  for (const row of rows) {
+    const month = formatInNZT(row.sentAt, "yyyy-MM");
+    let acc = trendMap.get(month);
+    if (!acc) {
+      acc = {
+        label: formatInNZT(row.sentAt, "MMM yyyy"),
+        batches: new Set(),
+        emails: 0,
+        delivered: 0,
+        converted: 0,
+      };
+      trendMap.set(month, acc);
+    }
+    acc.batches.add(batchKey(row));
+    acc.emails += 1;
+    if (row.success) {
+      acc.delivered += 1;
+      const shiftIds = [...shiftsByLocationForLog(row).values()].flat();
+      if (convertedForShifts(row.recipientId, shiftIds, row.sentAt, signups)) {
+        acc.converted += 1;
+      }
+    }
+  }
+  const trend: ShortageTrendPoint[] = [...trendMap.entries()]
+    .map(([month, acc]) => ({
+      month,
+      label: acc.label,
+      sendEvents: acc.batches.size,
+      emails: acc.emails,
+      deliveredEmails: acc.delivered,
+      signups: acc.converted,
+    }))
+    .sort((a, b) => a.month.localeCompare(b.month));
+
+  return { totals, bySite, trend };
+}
+
+/**
+ * Fetch and aggregate shortage-notification history for the admin report.
+ *
+ * @param months Length of the trailing window; `0` means all time.
+ * @param location A specific restaurant, or `null`/`"all"` for the whole org.
+ */
+export async function getShortageNotificationAnalytics(
+  months: number,
+  location: string | null = null
+): Promise<ShortageNotificationAnalytics> {
+  const now = new Date();
+  let where = {};
+  if (months > 0) {
+    const periodStart = new Date(now);
+    periodStart.setMonth(periodStart.getMonth() - months);
+    where = { sentAt: { gte: periodStart, lte: now } };
+  }
+
+  const logs = (await prisma.shortageNotificationLog.findMany({
+    where,
+    select: {
+      sentAt: true,
+      sentBy: true,
+      recipientId: true,
+      success: true,
+      shifts: true,
+    },
+  })) as ShortageLogRow[];
+
+  // To measure effectiveness, look up whether each notified volunteer signed up
+  // for the shift(s) they were alerted about. Collect the recipient/shift pairs
+  // in play, fetch those signups, and index them by (userId, shiftId).
+  const recipientIds = new Set<string>();
+  const shiftIds = new Set<string>();
+  for (const log of logs) {
+    recipientIds.add(log.recipientId);
+    for (const ids of shiftsByLocationForLog(log).values()) {
+      for (const id of ids) shiftIds.add(id);
+    }
+  }
+
+  let signups: SignupIndex = new Map();
+  if (recipientIds.size > 0 && shiftIds.size > 0) {
+    const rows = await prisma.signup.findMany({
+      where: {
+        userId: { in: [...recipientIds] },
+        shiftId: { in: [...shiftIds] },
+      },
+      select: { userId: true, shiftId: true, createdAt: true },
+    });
+    signups = new Map(
+      rows.map((row) => [signupKey(row.userId, row.shiftId), row.createdAt])
+    );
+  }
+
+  const { totals, bySite, trend } = aggregateShortageLogs(
+    logs,
+    location,
+    signups
+  );
+
+  return { totals, bySite, trend, periodMonths: months };
+}
+
+/** One volunteer who signed up for a shift after being alerted about it. */
+export interface ShortageConversion {
+  userId: string;
+  name: string;
+  email: string;
+  profilePhotoUrl: string | null;
+  shiftId: string;
+  shiftTypeName: string;
+  shiftLocation: string;
+  /** ISO date of the shift they signed up for. */
+  shiftDate: string;
+  /** ISO timestamp of the earliest delivered alert about that shift. */
+  notifiedAt: string;
+  /** ISO timestamp of when they signed up. */
+  signedUpAt: string;
+  /** Whole days between the first alert and the signup (0 = same day). */
+  daysToSignup: number;
+}
+
+export interface ShortageConversionsResult {
+  conversions: ShortageConversion[];
+  total: number;
+  /** Max rows returned; `total` may exceed this. */
+  cap: number;
+}
+
+const CONVERSIONS_CAP = 500;
+
+/** Raw `shifts` entry shape when we need per-shift detail, not just the site. */
+interface LoggedShiftDetail {
+  shiftId?: string;
+  shiftTypeName?: string;
+  shiftDate?: string;
+  shiftLocation?: string;
+}
+
+/**
+ * The list behind the "signups from alerts" figure: volunteers who signed up
+ * for a shift after a delivered alert about it. One row per distinct
+ * (volunteer, shift); when several alerts covered the same shift, the earliest
+ * delivered one is treated as the nudge.
+ *
+ * @param months Length of the trailing window; `0` means all time.
+ * @param location A specific restaurant, or `null`/`"all"` for the whole org.
+ */
+export async function getShortageConversions(
+  months: number,
+  location: string | null = null
+): Promise<ShortageConversionsResult> {
+  const now = new Date();
+  const where: { success: boolean; sentAt?: { gte: Date; lte: Date } } = {
+    success: true,
+  };
+  if (months > 0) {
+    const periodStart = new Date(now);
+    periodStart.setMonth(periodStart.getMonth() - months);
+    where.sentAt = { gte: periodStart, lte: now };
+  }
+
+  const logs = await prisma.shortageNotificationLog.findMany({
+    where,
+    select: {
+      sentAt: true,
+      recipientId: true,
+      recipientName: true,
+      recipientEmail: true,
+      shifts: true,
+    },
+  });
+
+  // Fetch signups for the notified (recipient, shift) pairs.
+  const recipientIds = new Set<string>();
+  const shiftIds = new Set<string>();
+  for (const log of logs) {
+    recipientIds.add(log.recipientId);
+    const shifts = Array.isArray(log.shifts)
+      ? (log.shifts as LoggedShiftDetail[])
+      : [];
+    for (const s of shifts) if (s?.shiftId) shiftIds.add(s.shiftId);
+  }
+  if (recipientIds.size === 0 || shiftIds.size === 0) {
+    return { conversions: [], total: 0, cap: CONVERSIONS_CAP };
+  }
+
+  const signupRows = await prisma.signup.findMany({
+    where: {
+      userId: { in: [...recipientIds] },
+      shiftId: { in: [...shiftIds] },
+    },
+    select: { userId: true, shiftId: true, createdAt: true },
+  });
+  const signups: SignupIndex = new Map(
+    signupRows.map((row) => [signupKey(row.userId, row.shiftId), row.createdAt])
+  );
+
+  const isSiteFiltered = !!location && location !== "all";
+
+  // Collapse to one entry per (volunteer, shift), keeping the earliest alert.
+  interface Draft {
+    userId: string;
+    name: string;
+    email: string;
+    shiftId: string;
+    shiftTypeName: string;
+    shiftLocation: string;
+    shiftDate: string;
+    notifiedAt: Date;
+    signedUpAt: Date;
+  }
+  const drafts = new Map<string, Draft>();
+  for (const log of logs) {
+    const shifts = Array.isArray(log.shifts)
+      ? (log.shifts as LoggedShiftDetail[])
+      : [];
+    for (const s of shifts) {
+      const shiftId = s?.shiftId;
+      if (!shiftId) continue;
+      const signedUpAt = signups.get(signupKey(log.recipientId, shiftId));
+      if (!signedUpAt || signedUpAt.getTime() <= log.sentAt.getTime()) continue;
+
+      const site = (s.shiftLocation ?? "").trim() || UNKNOWN_SITE;
+      if (isSiteFiltered && site !== location) continue;
+
+      const key = signupKey(log.recipientId, shiftId);
+      const existing = drafts.get(key);
+      if (existing) {
+        // Earliest delivered alert is the nudge.
+        if (log.sentAt.getTime() < existing.notifiedAt.getTime()) {
+          existing.notifiedAt = log.sentAt;
+        }
+        continue;
+      }
+      drafts.set(key, {
+        userId: log.recipientId,
+        name: log.recipientName,
+        email: log.recipientEmail,
+        shiftId,
+        shiftTypeName: s.shiftTypeName ?? "Shift",
+        shiftLocation: site,
+        shiftDate: s.shiftDate ?? signedUpAt.toISOString(),
+        notifiedAt: log.sentAt,
+        signedUpAt,
+      });
+    }
+  }
+
+  // Enrich with current name + photo from the User table.
+  const userIds = [...new Set([...drafts.values()].map((d) => d.userId))];
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds } },
+    select: {
+      id: true,
+      name: true,
+      firstName: true,
+      lastName: true,
+      profilePhotoUrl: true,
+    },
+  });
+  const userById = new Map(users.map((u) => [u.id, u]));
+
+  const dayMs = 24 * 60 * 60 * 1000;
+  const all = [...drafts.values()].map((d) => {
+    const u = userById.get(d.userId);
+    const currentName =
+      u?.name ||
+      [u?.firstName, u?.lastName].filter(Boolean).join(" ").trim() ||
+      d.name ||
+      d.email;
+    return {
+      userId: d.userId,
+      name: currentName,
+      email: d.email,
+      profilePhotoUrl: u?.profilePhotoUrl ?? null,
+      shiftId: d.shiftId,
+      shiftTypeName: d.shiftTypeName,
+      shiftLocation: d.shiftLocation,
+      shiftDate: d.shiftDate,
+      notifiedAt: d.notifiedAt.toISOString(),
+      signedUpAt: d.signedUpAt.toISOString(),
+      daysToSignup: Math.max(
+        0,
+        Math.floor((d.signedUpAt.getTime() - d.notifiedAt.getTime()) / dayMs)
+      ),
+    } satisfies ShortageConversion;
+  });
+
+  // Most recent signups first.
+  all.sort((a, b) => b.signedUpAt.localeCompare(a.signedUpAt));
+
+  return {
+    conversions: all.slice(0, CONVERSIONS_CAP),
+    total: all.length,
+    cap: CONVERSIONS_CAP,
+  };
+}

--- a/web/src/lib/shortage-analytics.ts
+++ b/web/src/lib/shortage-analytics.ts
@@ -114,6 +114,17 @@ export function percentage(part: number, whole: number): number {
   return whole > 0 ? Math.round((part / whole) * 100) : 0;
 }
 
+/**
+ * Parse a `months` query/search param into a trailing-window length. Returns
+ * `0` for "all" (all time); any missing, invalid, or non-positive value falls
+ * back to the 12-month default.
+ */
+export function parseMonthsParam(value: string | null | undefined): number {
+  if (value === "all") return 0;
+  const parsed = parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 12;
+}
+
 /** Stable identifier for the send batch a log row belongs to. */
 function batchKey(row: ShortageLogRow): string {
   return `${row.sentAt.toISOString()}|${row.sentBy}`;
@@ -480,7 +491,9 @@ export async function getShortageConversions(
     },
   });
 
-  // Fetch signups for the notified (recipient, shift) pairs.
+  // Fetch signups for the notified (recipient, shift) pairs. We deliberately
+  // fetch every status (including later-canceled ones): if a volunteer signed
+  // up after an alert, the nudge worked regardless of a subsequent cancellation.
   const recipientIds = new Set<string>();
   const shiftIds = new Set<string>();
   for (const log of logs) {


### PR DESCRIPTION
# Pull Request

## Description
Adds a new admin analytics report at **`/admin/analytics/shortage-notifications`** that shows both the **volume** and the **effectiveness** of shift-shortage alerts, org-wide and per restaurant. It is built entirely on the existing `ShortageNotificationLog` history plus `Signup` records - no schema changes.

**What it answers**
- How many shortage notifications are we sending (send events and individual emails), across the org and at each site?
- How effective are they - i.e. how many volunteers actually signed up for a shift *after* being alerted about it?

**Key pieces**
- **Aggregation lib** (`src/lib/shortage-analytics.ts`): send events (batched by `sentAt`+`sentBy`) vs delivered emails, per-site breakdown (a multi-site send counts toward each site but once org-wide), monthly trend, and delivery success rate - all bucketed in NZ time.
- **Effectiveness / conversion**: joins each notified `(recipient, shiftId)` pair against signups and counts a conversion when the volunteer signed up **after** a delivered alert (`Signup.createdAt > sentAt`). Surfaced as a headline "Signups from Alerts" count and a per-site conversion rate. Denominator is delivered alerts; later cancellations still count (the nudge worked).
- **Drill-down modal**: lists the volunteers who signed up from an alert (avatar, the shift, timing e.g. "signed up 2 days later", link to the volunteer profile). Opens from the "Signups from Alerts" KPI card or any restaurant row, and is filterable by site.
- **Design**: follows the Restaurant Analytics dashboard - shared KPI cards with sparklines, StatChips, the `ChartCard` chassis, `InfoHint` popovers, and the shared chart theme.
- Wired into the admin nav under **Analytics**.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor` - new backward-compatible feature.

## Testing
- [x] Unit tests pass (17 tests in `shortage-analytics.test.ts` covering batch vs email counts, multi-site attribution, site filtering, delivery rate, NZ-timezone month bucketing, and conversion detection: before/after the alert, failed-email exclusion, denominator, per-site credit).
- [ ] E2E tests pass (not added in this PR)
- [x] Manual testing completed - verified the report, both metrics, the trend chart, the per-site table, and both drill-down modal entry points (org + per-site) in light and dark mode. Confirmed the filtered modal count matches the table (e.g. Wellington row = 7 signups -> modal shows 7).
- [x] New tests added

`npm run typecheck` and `npm run lint` are clean for the changed files.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
- No schema/migration changes - the report reads existing `ShortageNotificationLog` and `Signup` data.
- The conversion metric is a correlation proxy: it counts a signup that post-dates a delivered alert for the same shift. It excludes already-committed volunteers (their signup pre-dates the alert) but cannot prove strict causation.
- Headline "Signups from Alerts" counts delivered alerts that converted, while the modal lists distinct volunteer+shift signups; in normal use (one alert per person per shift) these are identical.
