### PR TITLE
fix(flaky): make admin e2e locators deterministic under streaming

### DIFF
--- a/web/src/app/api/admin/shifts/route.ts
+++ b/web/src/app/api/admin/shifts/route.ts
@@ -16,20 +16,19 @@ export async function POST(request: NextRequest) {
     let { shiftTypeId } = body;
     const { location, start, end, capacity, notes } = body;
 
-    // If no shiftTypeId provided, find or create a default one for tests
+    // If no shiftTypeId provided, find or create a default one for tests.
+    // Use an atomic upsert on the unique `name` field: a non-atomic
+    // findFirst-then-create races when e2e tests run in parallel, with the
+    // losing request failing on the ShiftType.name unique constraint.
     if (!shiftTypeId) {
-      let defaultShiftType = await prisma.shiftType.findFirst({
+      const defaultShiftType = await prisma.shiftType.upsert({
         where: { name: "Kitchen" },
+        update: {},
+        create: {
+          name: "Kitchen",
+          description: "Kitchen duties",
+        },
       });
-
-      if (!defaultShiftType) {
-        defaultShiftType = await prisma.shiftType.create({
-          data: {
-            name: "Kitchen",
-            description: "Kitchen duties",
-          },
-        });
-      }
 
       shiftTypeId = defaultShiftType.id;
     }

--- a/web/tests/e2e/admin-users.spec.ts
+++ b/web/tests/e2e/admin-users.spec.ts
@@ -133,7 +133,10 @@ test.describe("Admin Users Management", () => {
       await page.goto("/admin/users");
 
       // Check if users list exists
-      const usersList = page.getByTestId("users-list");
+      // Scope to the visible instance to stay deterministic under streaming.
+      const usersList = page
+        .locator('[data-testid="users-list"]:visible')
+        .first();
 
       if (await usersList.isVisible()) {
         // Get all user rows
@@ -351,7 +354,10 @@ test.describe("Admin Users Management", () => {
     test("should navigate to user details page", async ({ page }) => {
       await page.goto("/admin/users");
 
-      const usersList = page.getByTestId("users-list");
+      // Scope to the visible instance to stay deterministic under streaming.
+      const usersList = page
+        .locator('[data-testid="users-list"]:visible')
+        .first();
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -394,7 +400,10 @@ test.describe("Admin Users Management", () => {
     }) => {
       await page.goto("/admin/users");
 
-      const usersList = page.getByTestId("users-list");
+      // Scope to the visible instance to stay deterministic under streaming.
+      const usersList = page
+        .locator('[data-testid="users-list"]:visible')
+        .first();
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -430,7 +439,10 @@ test.describe("Admin Users Management", () => {
     test("should open delete confirmation dialog", async ({ page }) => {
       await page.goto("/admin/users");
 
-      const usersList = page.getByTestId("users-list");
+      // Scope to the visible instance to stay deterministic under streaming.
+      const usersList = page
+        .locator('[data-testid="users-list"]:visible')
+        .first();
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -493,7 +505,10 @@ test.describe("Admin Users Management", () => {
     test("should validate email confirmation requirement", async ({ page }) => {
       await page.goto("/admin/users");
 
-      const usersList = page.getByTestId("users-list");
+      // Scope to the visible instance to stay deterministic under streaming.
+      const usersList = page
+        .locator('[data-testid="users-list"]:visible')
+        .first();
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -549,7 +564,10 @@ test.describe("Admin Users Management", () => {
     test("should handle delete API errors gracefully", async ({ page }) => {
       await page.goto("/admin/users");
 
-      const usersList = page.getByTestId("users-list");
+      // Scope to the visible instance to stay deterministic under streaming.
+      const usersList = page
+        .locator('[data-testid="users-list"]:visible')
+        .first();
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -695,7 +713,10 @@ test.describe("Admin Users Management", () => {
       // The implementation would depend on how we identify the current user
       // in the test environment
 
-      const usersList = page.getByTestId("users-list");
+      // Scope to the visible instance to stay deterministic under streaming.
+      const usersList = page
+        .locator('[data-testid="users-list"]:visible')
+        .first();
       await expect(usersList).toBeVisible();
 
       // In a complete implementation, we would:

--- a/web/tests/e2e/admin-users.spec.ts
+++ b/web/tests/e2e/admin-users.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { test, expect } from "./base";
 import { loginAsAdmin, loginAsVolunteer } from "./helpers/auth";
 import {
@@ -5,6 +6,17 @@ import {
   deleteTestUsers,
 } from "./helpers/test-helpers";
 import { randomUUID } from "crypto";
+
+/**
+ * Locate the users list scoped to the visible instance.
+ *
+ * During Next.js streaming the page and its loading fallback can momentarily
+ * coexist, so the same testid can appear twice and trip Playwright strict
+ * mode. Matching the visible instance keeps the locator deterministic.
+ */
+function visibleUsersList(page: Page) {
+  return page.locator('[data-testid="users-list"]:visible').first();
+}
 
 test.describe("Admin Users Management", () => {
   test.beforeEach(async ({ page }) => {
@@ -133,10 +145,7 @@ test.describe("Admin Users Management", () => {
       await page.goto("/admin/users");
 
       // Check if users list exists
-      // Scope to the visible instance to stay deterministic under streaming.
-      const usersList = page
-        .locator('[data-testid="users-list"]:visible')
-        .first();
+      const usersList = visibleUsersList(page);
 
       if (await usersList.isVisible()) {
         // Get all user rows
@@ -354,10 +363,7 @@ test.describe("Admin Users Management", () => {
     test("should navigate to user details page", async ({ page }) => {
       await page.goto("/admin/users");
 
-      // Scope to the visible instance to stay deterministic under streaming.
-      const usersList = page
-        .locator('[data-testid="users-list"]:visible')
-        .first();
+      const usersList = visibleUsersList(page);
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -400,10 +406,7 @@ test.describe("Admin Users Management", () => {
     }) => {
       await page.goto("/admin/users");
 
-      // Scope to the visible instance to stay deterministic under streaming.
-      const usersList = page
-        .locator('[data-testid="users-list"]:visible')
-        .first();
+      const usersList = visibleUsersList(page);
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -439,10 +442,7 @@ test.describe("Admin Users Management", () => {
     test("should open delete confirmation dialog", async ({ page }) => {
       await page.goto("/admin/users");
 
-      // Scope to the visible instance to stay deterministic under streaming.
-      const usersList = page
-        .locator('[data-testid="users-list"]:visible')
-        .first();
+      const usersList = visibleUsersList(page);
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -505,10 +505,7 @@ test.describe("Admin Users Management", () => {
     test("should validate email confirmation requirement", async ({ page }) => {
       await page.goto("/admin/users");
 
-      // Scope to the visible instance to stay deterministic under streaming.
-      const usersList = page
-        .locator('[data-testid="users-list"]:visible')
-        .first();
+      const usersList = visibleUsersList(page);
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -564,10 +561,7 @@ test.describe("Admin Users Management", () => {
     test("should handle delete API errors gracefully", async ({ page }) => {
       await page.goto("/admin/users");
 
-      // Scope to the visible instance to stay deterministic under streaming.
-      const usersList = page
-        .locator('[data-testid="users-list"]:visible')
-        .first();
+      const usersList = visibleUsersList(page);
 
       if (await usersList.isVisible()) {
         const userRows = page.locator("[data-testid^='user-row-']");
@@ -713,10 +707,7 @@ test.describe("Admin Users Management", () => {
       // The implementation would depend on how we identify the current user
       // in the test environment
 
-      // Scope to the visible instance to stay deterministic under streaming.
-      const usersList = page
-        .locator('[data-testid="users-list"]:visible')
-        .first();
+      const usersList = visibleUsersList(page);
       await expect(usersList).toBeVisible();
 
       // In a complete implementation, we would:

--- a/web/tests/e2e/admin-volunteer-profile.spec.ts
+++ b/web/tests/e2e/admin-volunteer-profile.spec.ts
@@ -540,8 +540,9 @@ test.describe("Admin Volunteer Profile View", () => {
       await page.goto("/admin/volunteers/non-existent-id-12345");
       await waitForPageLoad(page);
 
-      // Should show 404 or not found page
-      const notFoundText = page.getByText(/not found|404/i);
+      // Should show 404 or not found page. The regex matches nested ancestor
+      // elements too, so scope to the first match to avoid strict-mode errors.
+      const notFoundText = page.getByText(/not found|404/i).first();
       await expect(notFoundText).toBeVisible();
     });
 
@@ -566,7 +567,7 @@ test.describe("Admin Volunteer Profile View", () => {
         const isErrorPage =
           currentUrl.includes("404") ||
           currentUrl.includes("error") ||
-          (await page.getByText(/not found|error|404/i).isVisible());
+          (await page.getByText(/not found|error|404/i).first().isVisible());
 
         expect(isErrorPage).toBe(true);
       }

--- a/web/tests/e2e/volunteer-movement.spec.ts
+++ b/web/tests/e2e/volunteer-movement.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from "@playwright/test";
 import { test, expect } from "./base";
 import {
   createTestUser,
@@ -13,6 +14,20 @@ import {
 } from "./helpers/test-helpers";
 import { loginAsAdmin, loginAsVolunteer } from "./helpers/auth";
 import { randomUUID } from "crypto";
+
+/**
+ * Locate a shift card scoped to the visible instance.
+ *
+ * On the admin shifts page the same `shift-card-<id>` testid can briefly
+ * appear twice in the DOM during Next.js streaming / motion exit transitions
+ * (one copy hidden or animating out). Matching the visible instance keeps the
+ * locator deterministic and avoids Playwright strict-mode violations.
+ */
+function visibleShiftCard(page: Page, shiftId: string) {
+  return page
+    .locator(`[data-testid="shift-card-${shiftId}"]:visible`)
+    .first();
+}
 
 test.describe.configure({ timeout: 60_000 });
 test.describe("General Volunteer Movement System", () => {
@@ -127,9 +142,7 @@ test.describe("General Volunteer Movement System", () => {
       await page.waitForLoadState("load");
 
       // Find this test's specific source shift card
-      const shiftCard = page.locator(
-        `[data-testid="shift-card-${sourceShiftId}"]`
-      );
+      const shiftCard = visibleShiftCard(page, sourceShiftId);
 
       await expect(shiftCard).toBeVisible({ timeout: 15000 });
 
@@ -172,9 +185,7 @@ test.describe("General Volunteer Movement System", () => {
       await page.waitForLoadState("load");
 
       // Find and click the move button on this test's source shift card
-      const shiftCard = page.locator(
-        `[data-testid="shift-card-${sourceShiftId}"]`
-      );
+      const shiftCard = visibleShiftCard(page, sourceShiftId);
 
       await expect(shiftCard).toBeVisible({ timeout: 15000 });
 
@@ -222,9 +233,7 @@ test.describe("General Volunteer Movement System", () => {
       await page.goto(`/admin/shifts?date=${tomorrowStr}&location=Wellington`);
       await page.waitForLoadState("load");
 
-      const fohShiftCard = page.locator(
-        `[data-testid="shift-card-${targetShiftId}"]`
-      );
+      const fohShiftCard = visibleShiftCard(page, targetShiftId);
 
       await expect(fohShiftCard).toBeVisible({ timeout: 15000 });
       await expect(fohShiftCard.getByText("Test User")).toBeVisible({
@@ -253,9 +262,7 @@ test.describe("General Volunteer Movement System", () => {
       await page.waitForLoadState("load");
 
       // Find this test's specific target shift card
-      const fohShiftCard = page.locator(
-        `[data-testid="shift-card-${targetShiftId}"]`
-      );
+      const fohShiftCard = visibleShiftCard(page, targetShiftId);
 
       await expect(fohShiftCard).toBeVisible({ timeout: 15000 });
       await expect(fohShiftCard.getByText("Test User")).toBeVisible({
@@ -266,9 +273,7 @@ test.describe("General Volunteer Movement System", () => {
       });
 
       // This test's source shift should no longer have the volunteer
-      const originalShiftCard = page.locator(
-        `[data-testid="shift-card-${sourceShiftId}"]`
-      );
+      const originalShiftCard = visibleShiftCard(page, sourceShiftId);
 
       if (await originalShiftCard.isVisible()) {
         await expect(
@@ -378,9 +383,7 @@ test.describe("General Volunteer Movement System", () => {
       await page.waitForLoadState("load");
 
       // Verify volunteer is in this test's specific target shift
-      const fohShiftCard = page.locator(
-        `[data-testid="shift-card-${targetShiftId}"]`
-      );
+      const fohShiftCard = visibleShiftCard(page, targetShiftId);
 
       await expect(fohShiftCard).toBeVisible({ timeout: 15000 });
       await expect(fohShiftCard.getByText("Test User")).toBeVisible({


### PR DESCRIPTION
## Description

Fixes intermittent `strict mode violation: locator resolved to N elements` failures in several admin Playwright e2e specs. These passed on `main` but flaked in CI (`--project=chromium`).

**Root causes (investigated, not papered over):**

1. **Transient duplicate testids, not responsive dual-layout.** `shift-card-<id>` and `users-list` each render exactly once in source - there is no hidden desktop/mobile copy. The duplication is a transient artifact of Next.js App Router streaming (a page and its `loading.tsx` fallback briefly coexist) combined with motion's `AnimatePresence` keeping an exiting copy during transitions. Notably, motion's JS-driven exit animations are **not** disabled by the `.e2e-testing` CSS (which only zeroes CSS transition/animation durations). The fix scopes the affected locators to the visible instance (`:visible` + `.first()`), matching the convention already used in `tests/e2e/helpers/auth.ts`.

2. **Over-broad regex.** `getByText(/not found|error|404/i)` matches nested ancestor elements too (5 matches on the default 404 page). Scoped to `.first()`.

3. **`createShift` 500 race (source fix).** `POST /api/admin/shifts` did a non-atomic `findFirst`-then-`create` for a `ShiftType` named `"Kitchen"` (`name` is `@unique`). Under parallel tests both requests saw `null` and both created, so the loser failed on the unique constraint (`Unique constraint failed on (name)`). Replaced with an atomic `prisma.shiftType.upsert`.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Tests (correcting existing tests / flakiness)

## Changes
- `web/src/app/api/admin/shifts/route.ts` - atomic `upsert` for the default "Kitchen" ShiftType (race-safe).
- `web/tests/e2e/volunteer-movement.spec.ts` - added `visibleShiftCard()` helper; routed all 6 shift-card locators through it.
- `web/tests/e2e/admin-users.spec.ts` - all 7 `users-list` locators scoped to the visible instance.
- `web/tests/e2e/admin-volunteer-profile.spec.ts` - two broad 404/not-found regexes scoped with `.first()`.

## Testing
- [x] ESLint passes on all changed files
- [ ] E2E not run locally: this worktree has no `node_modules`/generated Prisma client, and the shared local server was serving a different branch's data. Relying on CI to exercise the specs. To verify locally: `npx playwright test volunteer-movement.spec.ts admin-users.spec.ts admin-volunteer-profile.spec.ts --project=chromium --repeat-each=3`.

## Additional Notes
One related latent case was left untouched to keep the change minimal: `admin-volunteer-profile.spec.ts:644` uses the same broad-regex pattern with `.not.toBeVisible()`. It was not in the reported failures, and adding `.first()` there would subtly weaken its "no error text anywhere" intent. Happy to harden it too if desired.
