### PR TITLE
fix(admin): make DEFAULT location pill readable in dark mode

### DIFF
--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -933,21 +933,19 @@ export default async function AdminVolunteerPage({
                             className={cn(
                               "inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-sm font-medium",
                               isDefault
-                                ? "border-primary/30 bg-primary/5 text-primary"
+                                ? "border-green-600/30 bg-green-600/10 text-green-700 dark:border-green-400/40 dark:bg-green-400/10 dark:text-green-300"
                                 : "border-border bg-muted/40 text-foreground"
                             )}
                           >
                             <MapPin
                               className={cn(
                                 "h-3.5 w-3.5",
-                                isDefault
-                                  ? "text-primary"
-                                  : "text-green-600 dark:text-green-400"
+                                "text-green-600 dark:text-green-400"
                               )}
                             />
                             {locationLabels[location] || location}
                             {isDefault && (
-                              <span className="inline-flex items-center gap-0.5 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                              <span className="inline-flex items-center gap-0.5 rounded-full bg-green-600/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-700 dark:bg-green-400/15 dark:text-green-300">
                                 <Star className="h-2.5 w-2.5 fill-current" />
                                 Default
                               </span>
@@ -969,11 +967,11 @@ export default async function AdminVolunteerPage({
                         Default Location
                       </label>
                       <div>
-                        <span className="inline-flex items-center gap-1.5 rounded-lg border border-primary/30 bg-primary/5 px-2.5 py-1.5 text-sm font-medium text-primary">
-                          <MapPin className="h-3.5 w-3.5" />
+                        <span className="inline-flex items-center gap-1.5 rounded-lg border border-green-600/30 bg-green-600/10 px-2.5 py-1.5 text-sm font-medium text-green-700 dark:border-green-400/40 dark:bg-green-400/10 dark:text-green-300">
+                          <MapPin className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
                           {locationLabels[volunteer.defaultLocation] ||
                             volunteer.defaultLocation}
-                          <span className="inline-flex items-center gap-0.5 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                          <span className="inline-flex items-center gap-0.5 rounded-full bg-green-600/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-700 dark:bg-green-400/15 dark:text-green-300">
                             <Star className="h-2.5 w-2.5 fill-current" />
                             Default
                           </span>


### PR DESCRIPTION
The default-location pill on the admin volunteer profile used text-primary on bg-primary/5. In this design system --primary is a background color that resolves to a very dark green in dark mode, so using it as text gave near-zero contrast (~2:1) and read as disabled/greyed out.

Switch the pill and DEFAULT badge to the green scale already used by the non-default pills in the same component, with proper dark-mode variants (bright green-300 text). Applied to both the available-locations list and the default-not-in-list fallback. Text contrast improves from ~2:1 to ~12:1.

# Pull Request

## Description
Brief description of the changes made in this PR.

## Type of Change
Please check the type of change your PR introduces:
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes

## Version Bump Required
**Important**: Please add the appropriate version label to this PR:

- `version:major` - Breaking changes (1.0.0 → 2.0.0)
- `version:minor` - New features, backward compatible (1.0.0 → 1.1.0)
- `version:patch` - Bug fixes, small improvements (1.0.0 → 1.0.1)
- `version:skip` - No version bump (documentation, tests, etc.)

**Default**: If no version label is added, a patch bump will be automatically applied.

## Testing
- [ ] Unit tests pass
- [ ] E2E tests pass
- [ ] Manual testing completed
- [ ] New tests added (if applicable)

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information or context about the PR.