### PR TITLE
feat(admin): cap shortage-alert conversions to a 3-day success window

### DIFF
--- a/web/src/app/admin/analytics/shortage-notifications/page.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/page.tsx
@@ -8,6 +8,7 @@ import { LOCATIONS } from "@/lib/locations";
 import {
   getShortageNotificationAnalytics,
   parseMonthsParam,
+  CONVERSION_WINDOW_DAYS,
 } from "@/lib/shortage-analytics";
 
 export default async function ShortageNotificationsAnalyticsPage({
@@ -49,6 +50,7 @@ export default async function ShortageNotificationsAnalyticsPage({
           months={months}
           location={location}
           locations={locationOptions}
+          windowDays={CONVERSION_WINDOW_DAYS}
         />
       </PageContainer>
     </AdminPageWrapper>

--- a/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
@@ -57,6 +57,8 @@ interface Props {
   months: string;
   location: string;
   locations: Array<{ value: string; label: string }>;
+  /** Days after an alert within which a signup still counts as driven by it. */
+  windowDays: number;
 }
 
 const MONTHS_LABELS: Record<string, string> = {
@@ -242,6 +244,7 @@ export function ShortageNotificationsAnalyticsClient({
   months: initialMonths,
   location: initialLocation,
   locations,
+  windowDays,
 }: Props) {
   const router = useRouter();
   const { resolvedTheme } = useTheme();
@@ -296,6 +299,8 @@ export function ShortageNotificationsAnalyticsClient({
   const convTrend = trend.map((t) =>
     t.deliveredEmails > 0 ? Math.round((t.signups / t.deliveredEmails) * 100) : 0
   );
+
+  const windowLabel = `${windowDays} day${windowDays === 1 ? "" : "s"}`;
 
   const modalTitle =
     modalLocation === "all"
@@ -394,7 +399,7 @@ export function ShortageNotificationsAnalyticsClient({
                 <span aria-hidden>→</span>
               </span>
             }
-            tooltip="Volunteers who signed up for a shift after a delivered alert. This is a correlation - some may have signed up regardless. Click to see who."
+            tooltip={`Volunteers who signed up for a shift within ${windowLabel} of a delivered alert. This is a correlation - some may have signed up regardless. Click to see who.`}
             onClick={() => openConversions(initialLocation)}
           />
           <KpiCard
@@ -407,7 +412,7 @@ export function ShortageNotificationsAnalyticsClient({
             sparkColor="#8b5cf6"
             mode={mode}
             footer={`${num(totals.converted)} of ${num(totals.successfulEmails)} delivered`}
-            tooltip="Share of delivered alerts that led to a signup (signups ÷ delivered alerts). A correlation, not proof of cause."
+            tooltip={`Share of delivered alerts that led to a signup within ${windowLabel} (signups ÷ delivered alerts). A correlation, not proof of cause.`}
           />
         </div>
 
@@ -463,8 +468,8 @@ export function ShortageNotificationsAnalyticsClient({
                   concentrated.
                 </p>
                 <p>
-                  The line shows how many of those alerts led to a signup across
-                  the whole org.
+                  The line shows how many of those alerts led to a signup within
+                  {` ${windowLabel}`} across the whole org.
                 </p>
                 <p>
                   A single alert covering shifts at more than one restaurant
@@ -537,8 +542,8 @@ export function ShortageNotificationsAnalyticsClient({
             body: (
               <>
                 <p>
-                  Click a row to see the volunteers who signed up after an alert
-                  at that restaurant.
+                  Click a row to see the volunteers who signed up within
+                  {` ${windowLabel}`} of an alert at that restaurant.
                 </p>
                 <p>
                   A single alert covering shifts at more than one restaurant
@@ -659,7 +664,7 @@ export function ShortageNotificationsAnalyticsClient({
         months={initialMonths}
         location={modalLocation}
         title={modalTitle}
-        subtitle="Volunteers who signed up for a shift after getting a shortage alert"
+        subtitle={`Volunteers who signed up for a shift within ${windowLabel} of getting a shortage alert`}
       />
     </div>
   );

--- a/web/src/lib/shortage-analytics.test.ts
+++ b/web/src/lib/shortage-analytics.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   aggregateShortageLogs,
+  CONVERSION_WINDOW_DAYS,
   parseMonthsParam,
   percentage,
   sitesForLog,
@@ -9,6 +10,8 @@ import {
   type ShortageLogRow,
   type SignupIndex,
 } from "./shortage-analytics";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** Build a log row, defaulting the fields a test doesn't care about. */
 function log(overrides: Partial<ShortageLogRow>): ShortageLogRow {
@@ -293,6 +296,42 @@ describe("aggregateShortageLogs — conversions (effectiveness)", () => {
     const signups = index([
       ["vol-1", "shift-a", new Date("2026-01-09T09:00:00.000Z")], // before
     ]);
+
+    const { totals } = aggregateShortageLogs(logs, null, signups);
+    expect(totals.converted).toBe(0);
+    expect(totals.conversionRate).toBe(0);
+  });
+
+  it(`counts a signup exactly ${CONVERSION_WINDOW_DAYS} days after the alert`, () => {
+    const logs = [
+      log({
+        sentAt,
+        recipientId: "vol-1",
+        shifts: [{ shiftId: "shift-a", shiftLocation: "Wellington" }],
+      }),
+    ];
+    const atBoundary = new Date(
+      sentAt.getTime() + CONVERSION_WINDOW_DAYS * DAY_MS
+    );
+    const signups = index([["vol-1", "shift-a", atBoundary]]);
+
+    const { totals } = aggregateShortageLogs(logs, null, signups);
+    expect(totals.converted).toBe(1);
+  });
+
+  it(`does not count a signup more than ${CONVERSION_WINDOW_DAYS} days after the alert`, () => {
+    const logs = [
+      log({
+        sentAt,
+        recipientId: "vol-1",
+        shifts: [{ shiftId: "shift-a", shiftLocation: "Wellington" }],
+      }),
+    ];
+    // One hour past the window.
+    const tooLate = new Date(
+      sentAt.getTime() + CONVERSION_WINDOW_DAYS * DAY_MS + 60 * 60 * 1000
+    );
+    const signups = index([["vol-1", "shift-a", tooLate]]);
 
     const { totals } = aggregateShortageLogs(logs, null, signups);
     expect(totals.converted).toBe(0);

--- a/web/src/lib/shortage-analytics.ts
+++ b/web/src/lib/shortage-analytics.ts
@@ -171,9 +171,28 @@ export function signupKey(userId: string, shiftId: string): string {
 }
 
 /**
- * True if `recipientId` signed up for any of `shiftIds` strictly after
- * `sentAt` — i.e. the alert plausibly drove the signup. Signups made before
- * the alert (already-committed volunteers) don't count.
+ * How soon after a delivered alert a signup must land to be credited to it.
+ * A signup weeks later almost certainly wasn't driven by the alert, so only
+ * signups within this window count toward effectiveness.
+ */
+export const CONVERSION_WINDOW_DAYS = 3;
+const CONVERSION_WINDOW_MS = CONVERSION_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+/**
+ * True if `signedUpAt` falls in the crediting window for an alert sent at
+ * `sentAt`: strictly after the alert and no more than
+ * {@link CONVERSION_WINDOW_DAYS} days later.
+ */
+function withinConversionWindow(sentAt: Date, signedUpAt: Date): boolean {
+  const gap = signedUpAt.getTime() - sentAt.getTime();
+  return gap > 0 && gap <= CONVERSION_WINDOW_MS;
+}
+
+/**
+ * True if `recipientId` signed up for any of `shiftIds` within the crediting
+ * window after `sentAt` — i.e. the alert plausibly drove the signup. Signups
+ * before the alert (already-committed volunteers) or more than
+ * {@link CONVERSION_WINDOW_DAYS} days later don't count.
  */
 function convertedForShifts(
   recipientId: string,
@@ -183,7 +202,7 @@ function convertedForShifts(
 ): boolean {
   for (const shiftId of shiftIds) {
     const signedUpAt = signups.get(signupKey(recipientId, shiftId));
-    if (signedUpAt && signedUpAt.getTime() > sentAt.getTime()) return true;
+    if (signedUpAt && withinConversionWindow(sentAt, signedUpAt)) return true;
   }
   return false;
 }
@@ -459,9 +478,9 @@ interface LoggedShiftDetail {
 
 /**
  * The list behind the "signups from alerts" figure: volunteers who signed up
- * for a shift after a delivered alert about it. One row per distinct
- * (volunteer, shift); when several alerts covered the same shift, the earliest
- * delivered one is treated as the nudge.
+ * for a shift within {@link CONVERSION_WINDOW_DAYS} days of a delivered alert
+ * about it. One row per distinct (volunteer, shift); when several alerts
+ * covered the same shift, the earliest qualifying one is treated as the nudge.
  *
  * @param months Length of the trailing window; `0` means all time.
  * @param location A specific restaurant, or `null`/`"all"` for the whole org.
@@ -541,7 +560,7 @@ export async function getShortageConversions(
       const shiftId = s?.shiftId;
       if (!shiftId) continue;
       const signedUpAt = signups.get(signupKey(log.recipientId, shiftId));
-      if (!signedUpAt || signedUpAt.getTime() <= log.sentAt.getTime()) continue;
+      if (!signedUpAt || !withinConversionWindow(log.sentAt, signedUpAt)) continue;
 
       const site = (s.shiftLocation ?? "").trim() || UNKNOWN_SITE;
       if (isSiteFiltered && site !== location) continue;


### PR DESCRIPTION
# Pull Request

## Description
Follow-up to #1070. Tightens the shortage-notification **success criteria**: a signup now only counts as driven by an alert if it happens **within 3 days** of the delivered alert.

Previously any signup after the alert counted (naturally bounded only by the shift date), which credited signups that happened weeks later and weren't plausibly caused by the alert. This makes the "Signups from Alerts" / conversion-rate figures a tighter, more honest proxy for effectiveness.

**Changes**
- Add `CONVERSION_WINDOW_DAYS = 3` and a shared `withinConversionWindow` check, used by the totals / per-site / trend aggregation **and** the conversions drill-down list, so the metric and the modal stay consistent.
- Thread the window length from the server page to the client, so the KPI tooltips, chart/table info popovers, and modal subtitle all read "within 3 days" from a single source of truth (no magic string duplicated in the UI).
- Unit tests for the window boundary (exactly 3 days counts) and exclusion (more than 3 days doesn't).

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Unit tests pass (23 total; +2 for the window boundary/exclusion)
- [x] Manual testing completed - verified against seeded data: org conversion dropped 51% -> 46% (signups 36 -> 33) and Glen Innes 60% -> 45% as the >3-day signups dropped out; the drill-down modal now lists only within-window signups and its count matches the KPI. Light + dark, no console errors.
- [x] New tests added

`typecheck` and `lint` clean.

## Additional Notes
- No schema changes.
- The window is defined once (`CONVERSION_WINDOW_DAYS`) and drives both the logic and the UI copy, so changing it later updates everything.
