### PR TITLE
feat(admin): converters table + create notification groups from responders

### DIFF
--- a/web/src/app/admin/analytics/shortage-notifications/create-notification-group-dialog.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/create-notification-group-dialog.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2, Users } from "lucide-react";
+import { toast } from "sonner";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Volunteer IDs to add to the new group. */
+  memberIds: string[];
+  /** Stored on the group for provenance (e.g. report filters). */
+  filters?: Record<string, unknown>;
+  /** Prefilled group name. */
+  defaultName?: string;
+  /** Called after the group is created successfully. */
+  onCreated?: () => void;
+}
+
+export function CreateNotificationGroupDialog({
+  open,
+  onOpenChange,
+  memberIds,
+  filters,
+  defaultName = "",
+  onCreated,
+}: Props) {
+  const [name, setName] = useState(defaultName);
+  const [description, setDescription] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const count = memberIds.length;
+
+  const handleSubmit = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      toast.error("Please give the group a name");
+      return;
+    }
+    if (count === 0) {
+      toast.error("Select at least one volunteer");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await fetch("/api/admin/notification-groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: trimmed,
+          description: description.trim() || undefined,
+          filters: filters ?? {},
+          memberIds,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? "Failed to create group");
+      }
+      toast.success(
+        `Created "${trimmed}" with ${count} volunteer${count === 1 ? "" : "s"}`
+      );
+      onCreated?.();
+      onOpenChange(false);
+      setName(defaultName);
+      setDescription("");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create group"
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-emerald-500" />
+            Create notification group
+          </DialogTitle>
+          <DialogDescription>
+            Save these {count} volunteer{count === 1 ? "" : "s"} as a group you
+            can target when sending shortage alerts.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-1">
+          <div className="space-y-2">
+            <Label htmlFor="group-name">
+              Group name<span className="text-red-500"> *</span>
+            </Label>
+            <Input
+              id="group-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Reliable shortage responders"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSubmit();
+                }
+              }}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="group-description">Description</Label>
+            <Textarea
+              id="group-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional — what this group is for"
+              rows={2}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saving || count === 0}>
+            {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Create group
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/app/admin/analytics/shortage-notifications/create-notification-group-dialog.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/create-notification-group-dialog.tsx
@@ -75,7 +75,9 @@ export function CreateNotificationGroupDialog({
       );
       onCreated?.();
       onOpenChange(false);
-      setName(defaultName);
+      // Clear the form so a re-open starts fresh rather than showing the
+      // just-used name (which would collide with the group we just created).
+      setName("");
       setDescription("");
     } catch (err) {
       toast.error(

--- a/web/src/app/admin/analytics/shortage-notifications/page.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/page.tsx
@@ -7,6 +7,7 @@ import { ShortageNotificationsAnalyticsClient } from "./shortage-notifications-a
 import { LOCATIONS } from "@/lib/locations";
 import {
   getShortageNotificationAnalytics,
+  getShortageConverters,
   parseMonthsParam,
   CONVERSION_WINDOW_DAYS,
 } from "@/lib/shortage-analytics";
@@ -32,7 +33,10 @@ export default async function ShortageNotificationsAnalyticsPage({
   const location = (params.location as string) || "all";
   const monthsNum = parseMonthsParam(months);
 
-  const data = await getShortageNotificationAnalytics(monthsNum, location);
+  const [data, convertersResult] = await Promise.all([
+    getShortageNotificationAnalytics(monthsNum, location),
+    getShortageConverters(monthsNum, location),
+  ]);
 
   const locationOptions = LOCATIONS.map((loc) => ({
     value: loc,
@@ -47,6 +51,7 @@ export default async function ShortageNotificationsAnalyticsPage({
       <PageContainer testid="shortage-notifications-analytics-page">
         <ShortageNotificationsAnalyticsClient
           data={data}
+          converters={convertersResult}
           months={months}
           location={location}
           locations={locationOptions}

--- a/web/src/app/admin/analytics/shortage-notifications/shortage-converters-table.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/shortage-converters-table.tsx
@@ -126,6 +126,7 @@ export function ShortageConvertersTable({
                     />
                   </TableHead>
                   <TableHead>Volunteer</TableHead>
+                  <TableHead>Home site</TableHead>
                   <TableHead className="text-right">Alerts</TableHead>
                   <TableHead className="text-right">Signups</TableHead>
                   <TableHead className="text-right">Rate</TableHead>
@@ -170,6 +171,9 @@ export function ShortageConvertersTable({
                             </p>
                           </div>
                         </Link>
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {c.defaultLocation ?? "—"}
                       </TableCell>
                       <TableCell className="text-right tabular-nums">
                         {c.alertsReceived}

--- a/web/src/app/admin/analytics/shortage-notifications/shortage-converters-table.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/shortage-converters-table.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { UserCheck, UsersRound } from "lucide-react";
+import { formatInNZT } from "@/lib/timezone";
+import { ChartCard, ChartEmpty } from "../_components/primitives";
+import { num } from "../_lib/chart-theme";
+import { CreateNotificationGroupDialog } from "./create-notification-group-dialog";
+import type { ShortageConvertersResult } from "@/lib/shortage-analytics";
+
+interface Props {
+  data: ShortageConvertersResult;
+  months: string;
+  location: string;
+  windowLabel: string;
+}
+
+function getInitials(name: string, email: string): string {
+  const source = name.trim() || email;
+  const parts = source.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return source.slice(0, 2).toUpperCase();
+}
+
+export function ShortageConvertersTable({
+  data,
+  months,
+  location,
+  windowLabel,
+}: Props) {
+  const { converters, total, cap } = data;
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const allSelected =
+    converters.length > 0 && selected.size === converters.length;
+  const someSelected = selected.size > 0 && !allSelected;
+
+  const toggleAll = () => {
+    setSelected(
+      allSelected ? new Set() : new Set(converters.map((c) => c.userId))
+    );
+  };
+
+  const toggleOne = (userId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+  };
+
+  const memberIds = useMemo(() => [...selected], [selected]);
+
+  const defaultName =
+    location === "all"
+      ? "Shortage responders"
+      : `Shortage responders — ${location}`;
+
+  return (
+    <ChartCard
+      title="Volunteers Who Convert"
+      icon={UserCheck}
+      accent="text-emerald-600 dark:text-emerald-400"
+      bodyClassName="px-2"
+      info={{
+        title: "Volunteers Who Convert",
+        description: "Who signs up after a shortage alert",
+        body: (
+          <>
+            <p>
+              Volunteers who signed up for a shift within {windowLabel} of a
+              delivered alert, ranked by how many alerts they converted.
+            </p>
+            <p>
+              Tick volunteers (or the header to select all) and{" "}
+              <span className="font-medium">Create group</span> to save them as a
+              notification group you can target when sending shortage alerts.
+            </p>
+          </>
+        ),
+      }}
+      action={
+        <Button
+          size="sm"
+          onClick={() => setDialogOpen(true)}
+          disabled={selected.size === 0}
+        >
+          <UsersRound className="mr-1.5 h-4 w-4" />
+          Create group
+          {selected.size > 0 && ` (${selected.size})`}
+        </Button>
+      }
+    >
+      {converters.length === 0 ? (
+        <ChartEmpty
+          message="No volunteers signed up from an alert in this period"
+          height={200}
+        />
+      ) : (
+        <>
+          <div className="max-h-[440px] overflow-auto px-2 pb-1">
+            <Table>
+              <TableHeader className="sticky top-0 z-10 bg-card">
+                <TableRow>
+                  <TableHead className="w-8">
+                    <Checkbox
+                      checked={
+                        allSelected ? true : someSelected ? "indeterminate" : false
+                      }
+                      onCheckedChange={toggleAll}
+                      aria-label="Select all volunteers"
+                    />
+                  </TableHead>
+                  <TableHead>Volunteer</TableHead>
+                  <TableHead className="text-right">Alerts</TableHead>
+                  <TableHead className="text-right">Signups</TableHead>
+                  <TableHead className="text-right">Rate</TableHead>
+                  <TableHead className="text-right">Last signup</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {converters.map((c) => {
+                  const checked = selected.has(c.userId);
+                  return (
+                    <TableRow
+                      key={c.userId}
+                      data-state={checked ? "selected" : undefined}
+                    >
+                      <TableCell>
+                        <Checkbox
+                          checked={checked}
+                          onCheckedChange={() => toggleOne(c.userId)}
+                          aria-label={`Select ${c.name}`}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Link
+                          href={`/admin/volunteers/${c.userId}`}
+                          className="group flex items-center gap-3"
+                        >
+                          <Avatar className="h-8 w-8 shadow-sm">
+                            <AvatarImage
+                              src={c.profilePhotoUrl ?? ""}
+                              alt={c.name}
+                            />
+                            <AvatarFallback className="bg-gradient-to-br from-emerald-500 to-teal-600 text-white text-xs font-semibold">
+                              {getInitials(c.name, c.email)}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium group-hover:underline">
+                              {c.name}
+                            </p>
+                            <p className="truncate text-xs text-muted-foreground">
+                              {c.email}
+                            </p>
+                          </div>
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {c.alertsReceived}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums font-medium text-emerald-700 dark:text-emerald-400">
+                        {c.signups}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums font-semibold">
+                        {c.conversionRate}%
+                      </TableCell>
+                      <TableCell className="text-right text-xs text-muted-foreground tabular-nums">
+                        {c.lastSignupAt
+                          ? formatInNZT(c.lastSignupAt, "d MMM yyyy")
+                          : "—"}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+          <p className="px-3 pt-2 text-xs text-muted-foreground">
+            {num(total)} volunteer{total === 1 ? "" : "s"} converted
+            {total > cap && <span> · showing first {num(cap)}</span>}
+            {selected.size > 0 && <span> · {selected.size} selected</span>}
+          </p>
+        </>
+      )}
+
+      <CreateNotificationGroupDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        memberIds={memberIds}
+        defaultName={defaultName}
+        filters={{ source: "shortage-converters", months, location }}
+        onCreated={() => setSelected(new Set())}
+      />
+    </ChartCard>
+  );
+}

--- a/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/shortage-notifications-analytics-client.tsx
@@ -47,13 +47,16 @@ import {
   SERIES_COLORS,
 } from "../_lib/chart-theme";
 import { ShortageConversionsDialog } from "./shortage-conversions-dialog";
+import { ShortageConvertersTable } from "./shortage-converters-table";
 import type {
   ShortageNotificationAnalytics,
+  ShortageConvertersResult,
   ShortageSiteRow,
 } from "@/lib/shortage-analytics";
 
 interface Props {
   data: ShortageNotificationAnalytics;
+  converters: ShortageConvertersResult;
   months: string;
   location: string;
   locations: Array<{ value: string; label: string }>;
@@ -241,6 +244,7 @@ function StatChip({
 
 export function ShortageNotificationsAnalyticsClient({
   data,
+  converters,
   months: initialMonths,
   location: initialLocation,
   locations,
@@ -656,6 +660,14 @@ export function ShortageNotificationsAnalyticsClient({
             </Table>
           </div>
         </ChartCard>
+
+        {/* Volunteers who convert + build a group from them */}
+        <ShortageConvertersTable
+          data={converters}
+          months={initialMonths}
+          location={initialLocation}
+          windowLabel={windowLabel}
+        />
       </div>
 
       <ShortageConversionsDialog

--- a/web/src/lib/shortage-analytics.test.ts
+++ b/web/src/lib/shortage-analytics.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  aggregateConverters,
   aggregateShortageLogs,
   CONVERSION_WINDOW_DAYS,
   parseMonthsParam,
@@ -412,5 +413,75 @@ describe("aggregateShortageLogs — conversions (effectiveness)", () => {
     const january = trend.find((t) => t.month === "2026-01");
     expect(january?.deliveredEmails).toBe(2);
     expect(january?.signups).toBe(1);
+  });
+});
+
+describe("aggregateConverters", () => {
+  const sentAt = new Date("2026-01-10T02:00:00.000Z");
+
+  function index(entries: Array<[string, string, Date]>): SignupIndex {
+    return new Map(entries.map(([u, s, at]) => [signupKey(u, s), at]));
+  }
+
+  it("returns only volunteers who signed up, with per-volunteer stats", () => {
+    const logs = [
+      // vol-1: two delivered alerts, converts on one → 1/2 = 50%.
+      log({ sentAt, recipientId: "vol-1", shifts: [{ shiftId: "s1", shiftLocation: "Wellington" }] }),
+      log({
+        sentAt: new Date("2026-01-20T02:00:00.000Z"),
+        recipientId: "vol-1",
+        shifts: [{ shiftId: "s2", shiftLocation: "Wellington" }],
+      }),
+      // vol-2: one delivered alert, never signs up → excluded.
+      log({ sentAt, recipientId: "vol-2", shifts: [{ shiftId: "s3", shiftLocation: "Wellington" }] }),
+      // vol-3: one delivered alert, converts → 1/1 = 100%.
+      log({ sentAt, recipientId: "vol-3", shifts: [{ shiftId: "s4", shiftLocation: "Wellington" }] }),
+    ];
+    const signups = index([
+      ["vol-1", "s1", new Date("2026-01-11T09:00:00.000Z")],
+      ["vol-3", "s4", new Date("2026-01-10T09:00:00.000Z")],
+    ]);
+
+    const converters = aggregateConverters(logs, null, signups);
+
+    expect(converters.map((c) => c.userId)).not.toContain("vol-2");
+    // Sorted by signups desc then rate desc: vol-3 (100%) before vol-1 (50%).
+    expect(converters.map((c) => c.userId)).toEqual(["vol-3", "vol-1"]);
+
+    const v1 = converters.find((c) => c.userId === "vol-1");
+    expect(v1?.alertsReceived).toBe(2);
+    expect(v1?.signups).toBe(1);
+    expect(v1?.conversionRate).toBe(50);
+    expect(v1?.lastSignupAt).toBe("2026-01-11T09:00:00.000Z");
+
+    const v3 = converters.find((c) => c.userId === "vol-3");
+    expect(v3?.conversionRate).toBe(100);
+  });
+
+  it("does not count signups outside the 3-day window toward a converter", () => {
+    const logs = [
+      log({ sentAt, recipientId: "vol-1", shifts: [{ shiftId: "s1", shiftLocation: "Wellington" }] }),
+    ];
+    const signups = index([
+      // 10 days later — outside the window.
+      ["vol-1", "s1", new Date("2026-01-20T09:00:00.000Z")],
+    ]);
+    expect(aggregateConverters(logs, null, signups)).toEqual([]);
+  });
+
+  it("only counts alerts and signups for the filtered site", () => {
+    const logs = [
+      log({ sentAt, recipientId: "vol-1", shifts: [{ shiftId: "wel-1", shiftLocation: "Wellington" }] }),
+      log({ sentAt, recipientId: "vol-1", shifts: [{ shiftId: "gi-1", shiftLocation: "Glen Innes" }] }),
+    ];
+    const signups = index([
+      ["vol-1", "wel-1", new Date("2026-01-11T00:00:00.000Z")],
+      ["vol-1", "gi-1", new Date("2026-01-11T00:00:00.000Z")],
+    ]);
+
+    const wellington = aggregateConverters(logs, "Wellington", signups);
+    expect(wellington).toHaveLength(1);
+    expect(wellington[0].alertsReceived).toBe(1);
+    expect(wellington[0].signups).toBe(1);
   });
 });

--- a/web/src/lib/shortage-analytics.ts
+++ b/web/src/lib/shortage-analytics.ts
@@ -35,6 +35,10 @@ export interface ShortageLogRow {
   success: boolean;
   /** JSON payload: an array of {@link LoggedShift}. */
   shifts: unknown;
+  /** Denormalized recipient name — only selected for the converters rollup. */
+  recipientName?: string;
+  /** Denormalized recipient email — only selected for the converters rollup. */
+  recipientEmail?: string;
 }
 
 /** Notification figures for a single restaurant (or "Unknown"). */
@@ -189,10 +193,32 @@ function withinConversionWindow(sentAt: Date, signedUpAt: Date): boolean {
 }
 
 /**
- * True if `recipientId` signed up for any of `shiftIds` within the crediting
- * window after `sentAt` — i.e. the alert plausibly drove the signup. Signups
+ * The earliest signup by `recipientId` for any of `shiftIds` that falls within
+ * the crediting window after `sentAt`, or `null` if none qualifies. Signups
  * before the alert (already-committed volunteers) or more than
  * {@link CONVERSION_WINDOW_DAYS} days later don't count.
+ */
+function qualifyingSignupTime(
+  recipientId: string,
+  shiftIds: string[],
+  sentAt: Date,
+  signups: SignupIndex
+): Date | null {
+  let earliest: Date | null = null;
+  for (const shiftId of shiftIds) {
+    const signedUpAt = signups.get(signupKey(recipientId, shiftId));
+    if (signedUpAt && withinConversionWindow(sentAt, signedUpAt)) {
+      if (!earliest || signedUpAt.getTime() < earliest.getTime()) {
+        earliest = signedUpAt;
+      }
+    }
+  }
+  return earliest;
+}
+
+/**
+ * True if `recipientId` signed up for any of `shiftIds` within the crediting
+ * window after `sentAt` — i.e. the alert plausibly drove the signup.
  */
 function convertedForShifts(
   recipientId: string,
@@ -200,11 +226,7 @@ function convertedForShifts(
   sentAt: Date,
   signups: SignupIndex
 ): boolean {
-  for (const shiftId of shiftIds) {
-    const signedUpAt = signups.get(signupKey(recipientId, shiftId));
-    if (signedUpAt && withinConversionWindow(sentAt, signedUpAt)) return true;
-  }
-  return false;
+  return qualifyingSignupTime(recipientId, shiftIds, sentAt, signups) !== null;
 }
 
 interface SiteAccumulator {
@@ -635,5 +657,212 @@ export async function getShortageConversions(
     conversions: all.slice(0, CONVERSIONS_CAP),
     total: all.length,
     cap: CONVERSIONS_CAP,
+  };
+}
+
+/** Per-volunteer responsiveness to shortage alerts (before User enrichment). */
+export interface ShortageConverterCore {
+  userId: string;
+  name: string;
+  email: string;
+  /** Delivered alerts this volunteer received in the period. */
+  alertsReceived: number;
+  /** Of those, how many led to a signup within the crediting window. */
+  signups: number;
+  /** signups / alertsReceived as a 0–100 percentage. */
+  conversionRate: number;
+  /** ISO timestamp of their most recent qualifying signup, or null. */
+  lastSignupAt: string | null;
+}
+
+/** A converting volunteer, enriched with profile photo for display. */
+export interface ShortageConverter extends ShortageConverterCore {
+  profilePhotoUrl: string | null;
+}
+
+export interface ShortageConvertersResult {
+  converters: ShortageConverter[];
+  total: number;
+  /** Max rows returned; `total` may exceed this. */
+  cap: number;
+}
+
+const CONVERTERS_CAP = 500;
+
+interface ConverterAccumulator {
+  userId: string;
+  name: string;
+  email: string;
+  alertsReceived: number;
+  signups: number;
+  lastSignupAt: Date | null;
+}
+
+/**
+ * Roll delivered alerts up per volunteer: how many alerts each received and how
+ * many led to a signup within the crediting window. Only volunteers with at
+ * least one signup are returned (the "converters"). Pure and DB-free so it can
+ * be unit tested; the async wrapper adds profile photos.
+ *
+ * When `location` names a specific site, only alerts covering that site count,
+ * and conversions are credited only for that site's shifts.
+ */
+export function aggregateConverters(
+  logs: ShortageLogRow[],
+  location: string | null,
+  signups: SignupIndex
+): ShortageConverterCore[] {
+  const isSiteFiltered = !!location && location !== "all";
+  const byUser = new Map<string, ConverterAccumulator>();
+
+  for (const row of logs) {
+    if (!row.success) continue;
+    const byLoc = shiftsByLocationForLog(row);
+    if (isSiteFiltered && !byLoc.has(location as string)) continue;
+
+    let acc = byUser.get(row.recipientId);
+    if (!acc) {
+      acc = {
+        userId: row.recipientId,
+        name: row.recipientName ?? "",
+        email: row.recipientEmail ?? "",
+        alertsReceived: 0,
+        signups: 0,
+        lastSignupAt: null,
+      };
+      byUser.set(row.recipientId, acc);
+    }
+    acc.alertsReceived += 1;
+
+    const shiftIds = isSiteFiltered
+      ? byLoc.get(location as string) ?? []
+      : [...byLoc.values()].flat();
+    const signedUpAt = qualifyingSignupTime(
+      row.recipientId,
+      shiftIds,
+      row.sentAt,
+      signups
+    );
+    if (signedUpAt) {
+      acc.signups += 1;
+      if (
+        !acc.lastSignupAt ||
+        signedUpAt.getTime() > acc.lastSignupAt.getTime()
+      ) {
+        acc.lastSignupAt = signedUpAt;
+      }
+    }
+  }
+
+  return [...byUser.values()]
+    .filter((acc) => acc.signups > 0)
+    .map((acc) => ({
+      userId: acc.userId,
+      name: acc.name,
+      email: acc.email,
+      alertsReceived: acc.alertsReceived,
+      signups: acc.signups,
+      conversionRate: percentage(acc.signups, acc.alertsReceived),
+      lastSignupAt: acc.lastSignupAt ? acc.lastSignupAt.toISOString() : null,
+    }))
+    .sort(
+      (a, b) =>
+        b.signups - a.signups ||
+        b.conversionRate - a.conversionRate ||
+        a.name.localeCompare(b.name)
+    );
+}
+
+/**
+ * The volunteers who respond to shortage alerts — one row each, ordered by
+ * signups then conversion rate — for the "who converts" table and for building
+ * a notification group of reliable responders.
+ *
+ * @param months Length of the trailing window; `0` means all time.
+ * @param location A specific restaurant, or `null`/`"all"` for the whole org.
+ */
+export async function getShortageConverters(
+  months: number,
+  location: string | null = null
+): Promise<ShortageConvertersResult> {
+  const now = new Date();
+  const where: { success: boolean; sentAt?: { gte: Date; lte: Date } } = {
+    success: true,
+  };
+  if (months > 0) {
+    const periodStart = new Date(now);
+    periodStart.setMonth(periodStart.getMonth() - months);
+    where.sentAt = { gte: periodStart, lte: now };
+  }
+
+  const logs = (await prisma.shortageNotificationLog.findMany({
+    where,
+    select: {
+      sentAt: true,
+      sentBy: true,
+      recipientId: true,
+      recipientName: true,
+      recipientEmail: true,
+      success: true,
+      shifts: true,
+    },
+  })) as ShortageLogRow[];
+
+  const recipientIds = new Set<string>();
+  const shiftIds = new Set<string>();
+  for (const log of logs) {
+    recipientIds.add(log.recipientId);
+    for (const ids of shiftsByLocationForLog(log).values()) {
+      for (const id of ids) shiftIds.add(id);
+    }
+  }
+  if (recipientIds.size === 0 || shiftIds.size === 0) {
+    return { converters: [], total: 0, cap: CONVERTERS_CAP };
+  }
+
+  const signupRows = await prisma.signup.findMany({
+    where: {
+      userId: { in: [...recipientIds] },
+      shiftId: { in: [...shiftIds] },
+    },
+    select: { userId: true, shiftId: true, createdAt: true },
+  });
+  const signups: SignupIndex = new Map(
+    signupRows.map((row) => [signupKey(row.userId, row.shiftId), row.createdAt])
+  );
+
+  const core = aggregateConverters(logs, location, signups);
+
+  // Enrich with current name + photo from the User table.
+  const users = await prisma.user.findMany({
+    where: { id: { in: core.map((c) => c.userId) } },
+    select: {
+      id: true,
+      name: true,
+      firstName: true,
+      lastName: true,
+      profilePhotoUrl: true,
+    },
+  });
+  const userById = new Map(users.map((u) => [u.id, u]));
+
+  const converters: ShortageConverter[] = core.map((c) => {
+    const u = userById.get(c.userId);
+    const currentName =
+      u?.name ||
+      [u?.firstName, u?.lastName].filter(Boolean).join(" ").trim() ||
+      c.name ||
+      c.email;
+    return {
+      ...c,
+      name: currentName,
+      profilePhotoUrl: u?.profilePhotoUrl ?? null,
+    };
+  });
+
+  return {
+    converters: converters.slice(0, CONVERTERS_CAP),
+    total: converters.length,
+    cap: CONVERTERS_CAP,
   };
 }

--- a/web/src/lib/shortage-analytics.ts
+++ b/web/src/lib/shortage-analytics.ts
@@ -675,9 +675,11 @@ export interface ShortageConverterCore {
   lastSignupAt: string | null;
 }
 
-/** A converting volunteer, enriched with profile photo for display. */
+/** A converting volunteer, enriched with profile photo + home site. */
 export interface ShortageConverter extends ShortageConverterCore {
   profilePhotoUrl: string | null;
+  /** The volunteer's default/home restaurant, if set. */
+  defaultLocation: string | null;
 }
 
 export interface ShortageConvertersResult {
@@ -833,7 +835,7 @@ export async function getShortageConverters(
 
   const core = aggregateConverters(logs, location, signups);
 
-  // Enrich with current name + photo from the User table.
+  // Enrich with current name, photo, and home site from the User table.
   const users = await prisma.user.findMany({
     where: { id: { in: core.map((c) => c.userId) } },
     select: {
@@ -842,6 +844,7 @@ export async function getShortageConverters(
       firstName: true,
       lastName: true,
       profilePhotoUrl: true,
+      defaultLocation: true,
     },
   });
   const userById = new Map(users.map((u) => [u.id, u]));
@@ -857,6 +860,7 @@ export async function getShortageConverters(
       ...c,
       name: currentName,
       profilePhotoUrl: u?.profilePhotoUrl ?? null,
+      defaultLocation: u?.defaultLocation ?? null,
     };
   });
 


### PR DESCRIPTION
# Pull Request

## Description
Builds on the shortage-notifications report to add two connected things:

1. **A "Volunteers Who Convert" table** - one row per volunteer who signed up after a delivered alert (within the 3-day window), ranked by signups then conversion rate. Columns: alerts received, signups, personal conversion rate, last signup. Identifies your reliable responders.
2. **Create a notification group from them** - a checkbox column (select individual + select-all) and a "Create group" action that opens a name/description dialog and POSTs the selected volunteers to the **existing** `/api/admin/notification-groups`. The group is then immediately usable when sending shortage alerts (via the notifications page's "Load Group"), and stores the report filters as provenance.

No new group backend - it reuses the existing NotificationGroup system.

**Stacking:** this branch is stacked on `claude/shortage-3day-conversion-cap` (#1075) because the changes are intertwined in the same files. Base is set to that branch so this PR shows only the converters/groups diff; it will auto-retarget to `main` once #1075 merges.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Unit tests pass (26 total; +3 for the per-volunteer `aggregateConverters` rollup: stats/sort, window exclusion, per-site filtering)
- [x] Manual testing completed - verified live: the table lists the 33 converters (consistent with the report's "Signups from Alerts"), select-all + individual selection work, and creating a group produced an active NotificationGroup with 33 members that the send flow's members endpoint returns. Light + dark, no console errors.
- [x] New tests added

`typecheck` and `lint` clean.

## Additional Notes
- The converters rollup is fetched server-side in the report page (parallel with the existing analytics) and passed as a prop, so it re-computes on Apply Filters like the rest of the report.
- Group `filters` stores `{ source: "shortage-converters", months, location }` for provenance; the send page applies any recognised filter keys on load.
