### PR TITLE
test(e2e): de-flake notification persist-after-refresh test

### DIFF
--- a/web/tests/e2e/notifications.spec.ts
+++ b/web/tests/e2e/notifications.spec.ts
@@ -1,5 +1,47 @@
 import { test, expect } from "./base";
+import type { Page } from "@playwright/test";
 import { loginAsVolunteer } from "./helpers/auth";
+
+/**
+ * Reads the number of notification items in an open dropdown, but only once the
+ * list has demonstrably settled.
+ *
+ * The dropdown becomes visible immediately when opened, while `NotificationList`
+ * is still in its `loading` state and fetches `/api/notifications` async. On top
+ * of that a live SSE stream can push a new item in at any moment. Reading the
+ * count the instant the dropdown is visible therefore races both the fetch and
+ * the stream. We first wait for the loading spinner to detach and the list (or
+ * empty state) to render, then poll until the item count stops changing so a
+ * late-arriving item can't produce a mismatched read.
+ */
+async function readSettledNotificationCount(page: Page): Promise<number> {
+  // Wait for the async list fetch to finish: spinner gone, list/empty rendered.
+  await expect(page.getByTestId("notification-loading")).toHaveCount(0);
+  await expect(
+    page
+      .getByTestId("notification-list")
+      .or(page.getByTestId("no-notifications"))
+  ).toBeVisible();
+
+  const items = page.locator('[data-testid*="notification-item-"]');
+
+  // Poll until the count is identical across two consecutive reads spaced apart,
+  // so anything still streaming/hydrating in has stopped before we commit.
+  let previous = -1;
+  await expect
+    .poll(
+      async () => {
+        const current = await items.count();
+        const stable = current === previous;
+        previous = current;
+        return stable;
+      },
+      { timeout: 5000, intervals: [250, 250, 250, 250] }
+    )
+    .toBe(true);
+
+  return items.count();
+}
 
 test.describe("Notification System", () => {
   test.beforeEach(async ({ page }) => {
@@ -348,9 +390,7 @@ test.describe("Notification System", () => {
     await bellButton.click();
     await expect(page.getByTestId("notification-dropdown")).toBeVisible();
 
-    const initialNotificationCount = await page
-      .locator('[data-testid*="notification-item-"]')
-      .count();
+    const initialNotificationCount = await readSettledNotificationCount(page);
 
     if (initialNotificationCount > 0) {
       // Mark first notification as read
@@ -364,7 +404,14 @@ test.describe("Notification System", () => {
       if (wasUnread) {
         await firstNotification.hover();
         await firstNotification.getByTestId("mark-read-button").click();
-        await page.waitForTimeout(500);
+        // Wait for the mark-read to actually land instead of a fixed timeout:
+        // the item only drops its unread badge once the PUT resolves 200 (see
+        // NotificationItem.onRead), so this guarantees the change persisted
+        // server-side before we reload. A fixed wait races a cold/slow API
+        // route, and reloading would abort the in-flight request.
+        await expect(
+          firstNotification.getByTestId("unread-badge")
+        ).not.toBeVisible();
       }
 
       // Close dropdown
@@ -379,9 +426,7 @@ test.describe("Notification System", () => {
       await expect(page.getByTestId("notification-dropdown")).toBeVisible();
 
       // Should have same number of notifications
-      const newNotificationCount = await page
-        .locator('[data-testid*="notification-item-"]')
-        .count();
+      const newNotificationCount = await readSettledNotificationCount(page);
       expect(newNotificationCount).toBe(initialNotificationCount);
 
       // Previously read notification should still be marked as read


### PR DESCRIPTION
# Pull Request

## Description
De-flakes the e2e test `notifications.spec.ts` › "Notification System › should persist notification state after page refresh", which was intermittently failing in CI (surfaced on PR #1077, a workflow-only change that cannot affect notification behavior — i.e. a pre-existing flaky test, not a regression).

Investigation found **two** timing races in the test:

1. **Count read races the fetch + SSE stream (the reported failure, `expect(newNotificationCount).toBe(initialNotificationCount)`).** Every time the dropdown opens, `NotificationList` remounts and re-fetches `/api/notifications` asynchronously. The dropdown becomes *visible* immediately while the list is still in its `loading` state, so reading the item count right after `toBeVisible()` races the fetch — and the live SSE notification stream can push a new item in between the pre- and post-refresh reads.

2. **Mark-read is aborted by the reload (a second race surfaced while verifying).** The test waited a fixed `500ms` after clicking mark-read, then called `page.reload()`. A cold/slow `PUT /api/notifications/[id]` takes **>500ms on first compile** (measured ~633ms cold vs ~26ms warm), so the reload aborts the in-flight request before it commits — the read never persists and the "still marked as read" assertion fails.

## Type of Change
- [x] 🧪 Tests (adding missing tests or correcting existing tests)

## What changed
- Added `readSettledNotificationCount()` helper: waits for the loading spinner to detach and the list (or empty state) to render, then **polls until the item count is stable** across consecutive reads before committing. Used for both the pre- and post-refresh reads.
- Replaced the fixed `waitForTimeout(500)` with a wait for the item's **unread badge to disappear** — which only happens after the mark-read PUT resolves `200` (`NotificationItem.onRead`), guaranteeing the change persisted server-side before reload.

Nothing the test verifies was weakened: it still asserts the item count is unchanged across the refresh and that the marked notification remains read.

## Testing
- [x] E2E tests pass
- Target test run with `--repeat-each=5 --workers=1` against a local dev server, both **cold** and **warm**: 5/5 pass each.
- `eslint` clean on the modified file.

## Additional Notes
While verifying I noticed (out of scope for this PR, noted for future work): all tests in `notifications.spec.ts` share the single `volunteer@example.com` account, so running the file **alone** with parallel workers causes heavy self-interference (they mark the same notifications read concurrently). This is not representative of CI, where the file's tests are spread across 2 workers among hundreds of tests. Validate these tests serially (`--workers=1`). Separately, `restaurant-manager-notifications.spec.ts` has its own pre-existing delete/unique-constraint data race — also untouched here.
