### PR TITLE
feat: quick location switcher with New badges, hide locations until shifts are published

### DIFF
--- a/mobile/app/(tabs)/shifts.tsx
+++ b/mobile/app/(tabs)/shifts.tsx
@@ -43,6 +43,7 @@ import {
   getShiftPeriodKey,
   getShiftPeriodLabel,
 } from "@/lib/shift-eligibility";
+import { useVolunteerLocationFilter } from "@/lib/volunteer-location-filter";
 import { getShiftThemeByName, type Shift } from "@/lib/dummy-data";
 
 /* ── Types ── */
@@ -182,23 +183,26 @@ export default function ShiftsScreen() {
     loadMorePast,
     isLoadingMore,
     userDefaultLocation,
+    browsableLocations,
     shiftFriends,
   } = useShifts();
 
-  /* Silent location default — applies the user's explicit default location without surfacing a picker */
-  const [locationFilter, setLocationFilter] = useState<string | null>(null);
-  const lastAppliedDefault = useRef<string | null | undefined>(undefined);
+  /* Location filter - persisted so a switch survives app restarts. Until the
+     volunteer explicitly picks, the profile's default location applies. */
+  const {
+    selected: chosenLocation,
+    hasChosen: hasChosenLocation,
+    setSelected: setLocationFilter,
+    hydrate: hydrateLocationFilter,
+  } = useVolunteerLocationFilter();
 
   useEffect(() => {
-    // Apply the user's saved default location on first load and whenever it
-    // changes (e.g. after editing on the profile screen). Skip when unchanged
-    // so a manual filter choice isn't overwritten on refetch.
-    if (lastAppliedDefault.current === userDefaultLocation) return;
-    lastAppliedDefault.current = userDefaultLocation;
-    if (userDefaultLocation) {
-      setLocationFilter(userDefaultLocation);
-    }
-  }, [userDefaultLocation]);
+    void hydrateLocationFilter();
+  }, [hydrateLocationFilter]);
+
+  const locationFilter = hasChosenLocation
+    ? chosenLocation
+    : userDefaultLocation ?? null;
 
   // Refetch shifts when the tab regains focus so profile edits (e.g. a new
   // default location) propagate. Skip the initial focus — useShifts already
@@ -251,13 +255,34 @@ export default function ShiftsScreen() {
     return keys;
   }, [myShifts]);
 
-  /* Available locations across all shifts — used by the picker */
+  /* Locations for the picker: server-driven browsable list (carries "New"
+     launch flags) merged with any venue from the user's own loaded shifts so
+     past-only locations stay pickable. */
   const locations = useMemo(() => {
     const all = [...myShifts, ...available, ...past];
-    return [...new Set(all.map((s) => s.location))].sort();
-  }, [myShifts, available, past]);
+    return [
+      ...new Set([
+        ...browsableLocations.map((l) => l.name),
+        ...all.map((s) => s.location),
+      ]),
+    ].sort();
+  }, [browsableLocations, myShifts, available, past]);
+
+  const newLocationNames = useMemo(
+    () => browsableLocations.filter((l) => l.isNew).map((l) => l.name),
+    [browsableLocations]
+  );
+
+  /* Subtle nudge: green dot on the location pill while any restaurant is
+     within its "New" launch window. */
+  const hasNewLocation = newLocationNames.length > 0;
 
   const [pickerVisible, setPickerVisible] = useState(false);
+
+  const openLocationPicker = useCallback(() => {
+    Haptics.selectionAsync();
+    setPickerVisible(true);
+  }, []);
 
   /* Selected date — respects ?date=YYYY-MM-DD deep links (e.g. from the
      "volunteers needed" home card), falling back to today. */
@@ -421,10 +446,8 @@ export default function ShiftsScreen() {
           {locations.length > 1 && (
             <LocationPill
               label={locationFilter ?? "All locations"}
-              onPress={() => {
-                Haptics.selectionAsync();
-                setPickerVisible(true);
-              }}
+              showNewDot={hasNewLocation}
+              onPress={openLocationPicker}
               isDark={isDark}
               colors={colors}
             />
@@ -436,6 +459,7 @@ export default function ShiftsScreen() {
       <LocationPickerSheet
         visible={pickerVisible}
         locations={locations}
+        newLocationNames={newLocationNames}
         selected={locationFilter}
         onSelect={(value) => {
           Haptics.selectionAsync();
@@ -619,11 +643,14 @@ export default function ShiftsScreen() {
 
 function LocationPill({
   label,
+  showNewDot,
   onPress,
   isDark,
   colors,
 }: {
   label: string;
+  /** A newly launched restaurant hasn't been seen in the picker yet. */
+  showNewDot: boolean;
   onPress: () => void;
   isDark: boolean;
   colors: (typeof Colors)["light"];
@@ -641,7 +668,11 @@ function LocationPill({
         },
       ]}
       accessibilityRole="button"
-      accessibilityLabel={`Location: ${label}. Tap to change.`}
+      accessibilityLabel={
+        showNewDot
+          ? `Location: ${label}. New location available. Tap to change.`
+          : `Location: ${label}. Tap to change.`
+      }
     >
       <Ionicons name="location" size={13} color={colors.textSecondary} />
       <Text
@@ -651,6 +682,17 @@ function LocationPill({
         {label}
       </Text>
       <Ionicons name="chevron-down" size={13} color={colors.textSecondary} />
+      {showNewDot && (
+        <View
+          style={[
+            styles.locationPillDot,
+            {
+              backgroundColor: isDark ? colors.tint : Brand.green,
+              borderColor: colors.background,
+            },
+          ]}
+        />
+      )}
     </Pressable>
   );
 }
@@ -660,6 +702,7 @@ function LocationPill({
 function LocationPickerSheet({
   visible,
   locations,
+  newLocationNames,
   selected,
   onSelect,
   onClose,
@@ -668,6 +711,8 @@ function LocationPickerSheet({
 }: {
   visible: boolean;
   locations: string[];
+  /** Recently launched restaurants - flagged with a "New" chip. */
+  newLocationNames: string[];
   selected: string | null;
   onSelect: (value: string | null) => void;
   onClose: () => void;
@@ -680,13 +725,21 @@ function LocationPickerSheet({
     label: string;
     value: string | null;
     icon: keyof typeof Ionicons.glyphMap;
+    isNew: boolean;
   }[] = [
-    { key: "all", label: "All locations", value: null, icon: "globe-outline" },
+    {
+      key: "all",
+      label: "All locations",
+      value: null,
+      icon: "globe-outline",
+      isNew: false,
+    },
     ...locations.map((loc) => ({
       key: loc,
       label: loc,
       value: loc,
       icon: "location" as const,
+      isNew: newLocationNames.includes(loc),
     })),
   ];
 
@@ -788,23 +841,47 @@ function LocationPickerSheet({
                       : colors.textSecondary
                   }
                 />
-                <Text
-                  style={[
-                    styles.sheetItemText,
-                    {
-                      color: active
-                        ? isDark
-                          ? colors.tint
-                          : Brand.green
-                        : colors.text,
-                      fontFamily: active
-                        ? FontFamily.semiBold
-                        : FontFamily.regular,
-                    },
-                  ]}
-                >
-                  {item.label}
-                </Text>
+                <View style={styles.sheetItemLabelRow}>
+                  <Text
+                    style={[
+                      styles.sheetItemText,
+                      {
+                        color: active
+                          ? isDark
+                            ? colors.tint
+                            : Brand.green
+                          : colors.text,
+                        fontFamily: active
+                          ? FontFamily.semiBold
+                          : FontFamily.regular,
+                      },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {item.label}
+                  </Text>
+                  {item.isNew && (
+                    <View
+                      style={[
+                        styles.newChip,
+                        {
+                          backgroundColor: isDark
+                            ? "rgba(29, 83, 55, 0.35)"
+                            : Brand.greenLight,
+                        },
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          styles.newChipText,
+                          { color: isDark ? colors.tint : Brand.green },
+                        ]}
+                      >
+                        NEW
+                      </Text>
+                    </View>
+                  )}
+                </View>
                 {active && (
                   <Ionicons
                     name="checkmark"
@@ -1541,6 +1618,25 @@ const styles = StyleSheet.create({
     fontFamily: FontFamily.semiBold,
     maxWidth: 120,
   },
+  locationPillDot: {
+    position: "absolute",
+    top: -2,
+    right: -2,
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    borderWidth: 2,
+  },
+  newChip: {
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    borderRadius: 8,
+  },
+  newChipText: {
+    fontSize: 10,
+    fontFamily: FontFamily.semiBold,
+    letterSpacing: 0.6,
+  },
 
   // Location picker sheet (pageSheet)
   sheetPage: { flex: 1 },
@@ -1594,8 +1690,14 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     minHeight: 48,
   },
-  sheetItemText: {
+  sheetItemLabelRow: {
     flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  sheetItemText: {
+    flexShrink: 1,
     fontSize: 15,
     lineHeight: 20,
   },

--- a/mobile/hooks/use-shifts.ts
+++ b/mobile/hooks/use-shifts.ts
@@ -14,12 +14,20 @@ export type PeriodFriend = {
   isFriend: boolean;
 };
 
+export type BrowsableLocation = {
+  name: string;
+  /** Recently launched restaurant - shows a subtle "New" badge in the picker. */
+  isNew: boolean;
+};
+
 type ShiftsResponse = {
   myShifts: Shift[];
   available: Shift[];
   past: Shift[];
   pastNextCursor: string | null;
   userDefaultLocation: string | null;
+  /** Locations with upcoming shifts (server-driven, includes "New" flags). */
+  locations?: BrowsableLocation[];
   periodFriends: Record<string, PeriodFriend[]>;
   shiftFriends?: Record<string, PeriodFriend[]>;
 };
@@ -35,6 +43,8 @@ type UseShiftsReturn = {
   hasMorePast: boolean;
   isLoadingMore: boolean;
   userDefaultLocation: string | null;
+  /** Locations volunteers can browse right now, with "New" launch flags. */
+  browsableLocations: BrowsableLocation[];
   /** Friends keyed by "YYYY-MM-DD-DAY" or "YYYY-MM-DD-EVE" */
   periodFriends: Record<string, PeriodFriend[]>;
   /** Friends keyed by shift ID — friends signed up for that specific role */
@@ -95,6 +105,7 @@ export function useShifts(): UseShiftsReturn {
     hasMorePast: query.hasNextPage,
     isLoadingMore: query.isFetchingNextPage,
     userDefaultLocation: firstPage?.userDefaultLocation ?? null,
+    browsableLocations: firstPage?.locations ?? [],
     periodFriends: firstPage?.periodFriends ?? {},
     shiftFriends: firstPage?.shiftFriends ?? {},
   };

--- a/mobile/lib/volunteer-location-filter.test.ts
+++ b/mobile/lib/volunteer-location-filter.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getItemMock = vi.fn();
+const setItemMock = vi.fn();
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: (...args: unknown[]) => getItemMock(...args),
+    setItem: (...args: unknown[]) => setItemMock(...args),
+  },
+}));
+
+import { useVolunteerLocationFilter } from "@/lib/volunteer-location-filter";
+
+describe("useVolunteerLocationFilter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The store is a module-level singleton; reset it between tests.
+    useVolunteerLocationFilter.setState({
+      selected: null,
+      hasChosen: false,
+      hydrated: false,
+    });
+    getItemMock.mockResolvedValue(null);
+    setItemMock.mockResolvedValue(undefined);
+  });
+
+  it("persists an explicit pick, including 'All locations' (null)", () => {
+    const { setSelected } = useVolunteerLocationFilter.getState();
+
+    setSelected("Wellington");
+    expect(useVolunteerLocationFilter.getState()).toMatchObject({
+      selected: "Wellington",
+      hasChosen: true,
+    });
+    expect(setItemMock).toHaveBeenCalledWith(
+      "@ee/volunteer_location_filter_v1",
+      JSON.stringify({ selected: "Wellington" })
+    );
+
+    setSelected(null);
+    expect(useVolunteerLocationFilter.getState()).toMatchObject({
+      selected: null,
+      hasChosen: true,
+    });
+    expect(setItemMock).toHaveBeenLastCalledWith(
+      "@ee/volunteer_location_filter_v1",
+      JSON.stringify({ selected: null })
+    );
+  });
+
+  it("hydrates a saved pick from storage", async () => {
+    getItemMock.mockResolvedValue(JSON.stringify({ selected: "Onehunga" }));
+
+    await useVolunteerLocationFilter.getState().hydrate();
+
+    expect(useVolunteerLocationFilter.getState()).toMatchObject({
+      selected: "Onehunga",
+      hasChosen: true,
+      hydrated: true,
+    });
+  });
+
+  it("leaves hasChosen false when nothing was saved, so the profile default applies", async () => {
+    await useVolunteerLocationFilter.getState().hydrate();
+
+    expect(useVolunteerLocationFilter.getState()).toMatchObject({
+      selected: null,
+      hasChosen: false,
+      hydrated: true,
+    });
+  });
+
+  it("does not clobber a pick made before hydration resolves", async () => {
+    let resolveRead!: (value: string) => void;
+    getItemMock.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveRead = resolve;
+      })
+    );
+
+    const hydration = useVolunteerLocationFilter.getState().hydrate();
+    useVolunteerLocationFilter.getState().setSelected("Glen Innes");
+    resolveRead(JSON.stringify({ selected: "Wellington" }));
+    await hydration;
+
+    expect(useVolunteerLocationFilter.getState()).toMatchObject({
+      selected: "Glen Innes",
+      hasChosen: true,
+      hydrated: true,
+    });
+  });
+
+  it("survives corrupted storage", async () => {
+    getItemMock.mockResolvedValue("not-json{");
+
+    await useVolunteerLocationFilter.getState().hydrate();
+
+    expect(useVolunteerLocationFilter.getState()).toMatchObject({
+      selected: null,
+      hasChosen: false,
+      hydrated: true,
+    });
+  });
+});

--- a/mobile/lib/volunteer-location-filter.ts
+++ b/mobile/lib/volunteer-location-filter.ts
@@ -1,0 +1,58 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+
+const FILTER_KEY = "@ee/volunteer_location_filter_v1";
+
+/**
+ * The location the volunteer shifts tab is filtered to. `null` means
+ * "All locations". Until the volunteer explicitly picks (hasChosen), the
+ * profile's default location applies instead.
+ *
+ * Persisted to AsyncStorage so a switch survives app restarts - previously the
+ * filter reset to the profile default on every launch, which made hopping
+ * between restaurants tedious for anyone volunteering at more than one.
+ */
+interface VolunteerLocationFilterState {
+  selected: string | null;
+  /** True once the volunteer explicitly picked (including "All locations"). */
+  hasChosen: boolean;
+  hydrated: boolean;
+  setSelected: (location: string | null) => void;
+  hydrate: () => Promise<void>;
+}
+
+export const useVolunteerLocationFilter = create<VolunteerLocationFilterState>(
+  (set, get) => ({
+    selected: null,
+    hasChosen: false,
+    hydrated: false,
+
+    setSelected: (selected) => {
+      set({ selected, hasChosen: true });
+      // Best-effort persistence; JSON wrapper keeps "All locations" (null)
+      // distinguishable from "never chosen" (missing key).
+      void AsyncStorage.setItem(FILTER_KEY, JSON.stringify({ selected })).catch(
+        () => {}
+      );
+    },
+
+    hydrate: async () => {
+      if (get().hydrated) return;
+      try {
+        const saved = await AsyncStorage.getItem(FILTER_KEY);
+        const parsed = saved
+          ? (JSON.parse(saved) as { selected?: string | null })
+          : null;
+        // Don't clobber a choice made before hydration resolved.
+        set((state) => ({
+          hydrated: true,
+          ...(!state.hasChosen && parsed
+            ? { selected: parsed.selected ?? null, hasChosen: true }
+            : {}),
+        }));
+      } catch {
+        set({ hydrated: true });
+      }
+    },
+  })
+);

--- a/web/prisma/migrations/20260702000001_add_location_launched_at/migration.sql
+++ b/web/prisma/migrations/20260702000001_add_location_launched_at/migration.sql
@@ -1,0 +1,12 @@
+-- Add Location.launchedAt: the first time a location had published shifts.
+-- Stays NULL for locations created ahead of their shifts, so they remain
+-- hidden from volunteer-facing location lists until shifts exist.
+ALTER TABLE "Location" ADD COLUMN "launchedAt" TIMESTAMP(3);
+
+-- Backfill: any location that already has shifts launched when it was created.
+-- Locations without shifts keep NULL and get stamped when their first shifts appear.
+UPDATE "Location" l
+SET "launchedAt" = l."createdAt"
+WHERE EXISTS (
+  SELECT 1 FROM "Shift" s WHERE s."location" = l."name"
+);

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -750,6 +750,7 @@ model Location {
   targetPerNight     Decimal? @db.Decimal(10, 2) // Koha banking target per service night ($)
   isActive           Boolean  @default(true)
   isPopup            Boolean  @default(false) // Pop-up / temporary venue: selectable as an available location, but never as a user's default location
+  launchedAt         DateTime? // First time this location had upcoming published shifts. Null until then - locations are created ahead of their shifts and stay hidden from volunteers until launch. Drives the "New" badge window.
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 

--- a/web/prisma/seed-demo.ts
+++ b/web/prisma/seed-demo.ts
@@ -1002,6 +1002,8 @@ async function main() {
       defaultMealsServed: 60,
       targetPerNight: 1500,
       isActive: true,
+      // Long-established restaurant - launched well outside the "New" badge window
+      launchedAt: new Date("2020-01-01T00:00:00Z"),
     },
   });
 
@@ -1014,6 +1016,7 @@ async function main() {
       defaultMealsServed: 60,
       targetPerNight: 1200,
       isActive: true,
+      launchedAt: new Date("2020-01-01T00:00:00Z"),
     },
   });
 
@@ -1026,6 +1029,7 @@ async function main() {
       defaultMealsServed: 60,
       targetPerNight: 1100,
       isActive: true,
+      launchedAt: new Date("2020-01-01T00:00:00Z"),
     },
   });
 

--- a/web/prisma/seed-locations.ts
+++ b/web/prisma/seed-locations.ts
@@ -17,6 +17,8 @@ async function main() {
       address: "60 Dixon Street, Te Aro, Wellington, New Zealand",
       defaultMealsServed: 60,
       isActive: true,
+      // Long-established restaurant - launched well outside the "New" badge window
+      launchedAt: new Date("2020-01-01T00:00:00Z"),
     },
   });
 
@@ -28,6 +30,7 @@ async function main() {
       address: "133 Line Road, Glen Innes, Auckland, New Zealand",
       defaultMealsServed: 60,
       isActive: true,
+      launchedAt: new Date("2020-01-01T00:00:00Z"),
     },
   });
 
@@ -39,6 +42,7 @@ async function main() {
       address: "306 Onehunga Mall, Auckland, New Zealand",
       defaultMealsServed: 60,
       isActive: true,
+      launchedAt: new Date("2020-01-01T00:00:00Z"),
     },
   });
 

--- a/web/prisma/seed-production.ts
+++ b/web/prisma/seed-production.ts
@@ -81,6 +81,8 @@ async function main() {
       address: "60 Dixon Street, Te Aro, Wellington, New Zealand",
       defaultMealsServed: 60,
       isActive: true,
+      // Long-established restaurant - launched well outside the "New" badge window
+      launchedAt: new Date("2020-01-01T00:00:00Z"),
     },
   });
 
@@ -92,6 +94,7 @@ async function main() {
       address: "133 Line Road, Glen Innes, Auckland, New Zealand",
       defaultMealsServed: 60,
       isActive: true,
+      launchedAt: new Date("2020-01-01T00:00:00Z"),
     },
   });
 
@@ -103,6 +106,7 @@ async function main() {
       address: "306 Onehunga Mall, Auckland, New Zealand",
       defaultMealsServed: 60,
       isActive: true,
+      launchedAt: new Date("2020-01-01T00:00:00Z"),
     },
   });
 

--- a/web/src/app/admin/locations/page.tsx
+++ b/web/src/app/admin/locations/page.tsx
@@ -14,15 +14,29 @@ export default async function LocationsPage() {
   }
 
   // Fetch all locations (both active and inactive)
-  const allLocations = await prisma.location.findMany({
-    orderBy: { name: "asc" },
-  });
+  const [allLocations, upcomingShiftGroups] = await Promise.all([
+    prisma.location.findMany({
+      orderBy: { name: "asc" },
+    }),
+    prisma.shift.groupBy({
+      by: ["location"],
+      where: { start: { gte: new Date() }, location: { not: null } },
+      _count: { _all: true },
+    }),
+  ]);
+
+  const upcomingCountByLocation = new Map(
+    upcomingShiftGroups.map((group) => [group.location, group._count._all])
+  );
 
   // Serialize Decimal targetPerNight to a plain number for the client component
   const serialized = allLocations.map((loc) => ({
     ...loc,
     targetPerNight:
       loc.targetPerNight === null ? null : Number(loc.targetPerNight),
+    // Locations without upcoming shifts are hidden from volunteer-facing
+    // location lists - surface that so admins know why after creating one.
+    hasUpcomingShifts: (upcomingCountByLocation.get(loc.name) ?? 0) > 0,
   }));
 
   const activeLocations = serialized.filter((loc) => loc.isActive);

--- a/web/src/app/api/mobile/shifts/route.ts
+++ b/web/src/app/api/mobile/shifts/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireMobileUser } from "@/lib/mobile-auth";
+import { getLiveLocations } from "@/lib/live-locations";
 import { getShiftDate, isAMShift } from "@/lib/concurrent-shifts";
 import {
   getShiftEffectiveCount,
@@ -256,10 +257,15 @@ export async function GET(request: Request) {
     );
   }
 
+  // Locations volunteers can browse (live = has upcoming shifts, not
+  // disabled), with the "New" flag for recently launched restaurants.
+  const liveLocations = await getLiveLocations();
+
   return NextResponse.json({
     myShifts: mySignups.map((signup) =>
       toMobileShift(signup.shift, signup.status)
     ),
+    locations: liveLocations.map(({ name, isNew }) => ({ name, isNew })),
     available: availableShifts.map((s) => toMobileShift(s)),
     past: pastSignups.map((signup) =>
       toMobileShift(signup.shift, signup.status)

--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -5,13 +5,10 @@ import { MapPin } from "lucide-react";
 import { PageContainer } from "@/components/page-container";
 import { safeParseAvailability } from "@/lib/parse-availability";
 import { ShiftsCalendar } from "@/components/shifts-calendar";
-import {
-  LocationOption,
-  LOCATION_ADDRESSES,
-  Location,
-  getLocationMapsUrl,
-  LOCATIONS,
-} from "@/lib/locations";
+import { getGoogleMapsUrl } from "@/lib/locations";
+import { getLiveLocations } from "@/lib/live-locations";
+import { LocationSwitcher } from "@/components/location-switcher";
+import { Badge } from "@/components/ui/badge";
 import { ShiftsProfileCompletionBanner } from "@/components/shifts-profile-completion-banner";
 import { Suspense } from "react";
 import { getAuthInfo } from "@/lib/auth-utils";
@@ -41,7 +38,8 @@ export async function generateMetadata({
     "Explore available volunteer opportunities at Everybody Eats. From prep work to service, find shifts that fit your schedule.";
   let path = "/shifts";
 
-  if (location && LOCATIONS.includes(location as LocationOption)) {
+  const liveLocations = await getLiveLocations();
+  if (location && liveLocations.some((l) => l.name === location)) {
     title = `Volunteer Shifts in ${location}`;
     description = `Browse upcoming volunteer shifts at Everybody Eats ${location}. From prep work to service, find opportunities that fit your schedule.`;
     path = `/shifts?location=${encodeURIComponent(location)}`;
@@ -141,22 +139,28 @@ export default async function ShiftsCalendarPage({
   // Explicit default location set by the user in their profile
   const userDefaultLocation = currentUser?.defaultLocation ?? null;
 
+  // Locations volunteers can browse right now: live (has upcoming shifts) and
+  // not disabled. Locations created ahead of their shifts stay hidden here.
+  const liveLocations = await getLiveLocations();
+  const liveLocationNames = liveLocations.map((l) => l.name);
+  const addressByName = new Map(
+    liveLocations.map((l) => [l.name, l.address] as const)
+  );
+
   // Handle location filtering
   const rawLocation = Array.isArray(params.location)
     ? params.location[0]
     : params.location;
-  let selectedLocation: LocationOption | undefined = LOCATIONS.includes(
-    (rawLocation as LocationOption) ?? ("" as LocationOption)
-  )
-    ? (rawLocation as LocationOption)
-    : undefined;
+  let selectedLocation: string | undefined =
+    rawLocation && liveLocationNames.includes(rawLocation)
+      ? rawLocation
+      : undefined;
 
   const showAll = params.showAll === "true";
   const chooseLocation = params.chooseLocation === "true";
 
   // Determine filter locations
   let filterLocations: string[] = [];
-  let isUsingProfileFilter = false;
   let hasExplicitLocationChoice = false;
 
   if (selectedLocation) {
@@ -167,14 +171,13 @@ export default async function ShiftsCalendarPage({
     hasExplicitLocationChoice = true;
   } else if (
     userDefaultLocation &&
-    LOCATIONS.includes(userDefaultLocation as LocationOption) &&
+    liveLocationNames.includes(userDefaultLocation) &&
     !chooseLocation
   ) {
     // Auto-filter to the user's explicit default location unless they've
     // requested to choose one manually.
     filterLocations = [userDefaultLocation];
-    selectedLocation = userDefaultLocation as LocationOption;
-    isUsingProfileFilter = true;
+    selectedLocation = userDefaultLocation;
     hasExplicitLocationChoice = true;
   }
 
@@ -333,7 +336,7 @@ export default async function ShiftsCalendarPage({
                 <div className="grid gap-3">
                   {userPreferredLocations.map(
                     (loc) =>
-                      LOCATIONS.includes(loc as LocationOption) && (
+                      liveLocationNames.includes(loc) && (
                         <Link
                           key={loc}
                           href={`/shifts?location=${loc}`}
@@ -346,9 +349,9 @@ export default async function ShiftsCalendarPage({
                             <div className="w-3 h-3 bg-primary rounded-full"></div>
                             <div>
                               <span className="font-medium">{loc}</span>
-                              {LOCATION_ADDRESSES[loc as Location] && (
+                              {addressByName.get(loc) && (
                                 <LocationAddress
-                                  address={LOCATION_ADDRESSES[loc as Location]}
+                                  address={addressByName.get(loc)!}
                                 />
                               )}
                             </div>
@@ -371,35 +374,47 @@ export default async function ShiftsCalendarPage({
                 </p>
               )}
               <div className="grid gap-3">
-                {LOCATIONS.filter((loc) =>
-                  userPreferredLocations.length > 1
-                    ? !userPreferredLocations.includes(loc)
-                    : true
-                ).map((loc) => (
-                  <Link
-                    key={loc}
-                    href={`/shifts?location=${loc}`}
-                    className="flex items-center justify-between p-4 bg-background hover:bg-muted border border-border hover:border-primary/30 rounded-lg transition-all duration-200 group text-left"
-                    data-testid={`location-option-${loc
-                      .toLowerCase()
-                      .replace(/\s+/g, "-")}`}
-                  >
-                    <div className="flex items-center gap-3">
-                      <div className="w-3 h-3 bg-muted-foreground rounded-full"></div>
-                      <div>
-                        <span className="font-medium">{loc}</span>
-                        {LOCATION_ADDRESSES[loc as Location] && (
-                          <LocationAddress
-                            address={LOCATION_ADDRESSES[loc as Location]}
-                          />
-                        )}
+                {liveLocations
+                  .filter((loc) =>
+                    userPreferredLocations.length > 1
+                      ? !userPreferredLocations.includes(loc.name)
+                      : true
+                  )
+                  .map((loc) => (
+                    <Link
+                      key={loc.name}
+                      href={`/shifts?location=${loc.name}`}
+                      className="flex items-center justify-between p-4 bg-background hover:bg-muted border border-border hover:border-primary/30 rounded-lg transition-all duration-200 group text-left"
+                      data-testid={`location-option-${loc.name
+                        .toLowerCase()
+                        .replace(/\s+/g, "-")}`}
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="w-3 h-3 bg-muted-foreground rounded-full"></div>
+                        <div>
+                          <span className="flex items-center gap-2 font-medium">
+                            {loc.name}
+                            {loc.isNew && (
+                              <Badge
+                                className="h-5 px-1.5 text-[10px] uppercase tracking-wide"
+                                data-testid={`location-new-badge-${loc.name
+                                  .toLowerCase()
+                                  .replace(/\s+/g, "-")}`}
+                              >
+                                New
+                              </Badge>
+                            )}
+                          </span>
+                          {loc.address && (
+                            <LocationAddress address={loc.address} />
+                          )}
+                        </div>
                       </div>
-                    </div>
-                    <div className="text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity">
-                      →
-                    </div>
-                  </Link>
-                ))}
+                      <div className="text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity">
+                        →
+                      </div>
+                    </Link>
+                  ))}
 
                 {/* Show all locations option */}
                 <Link
@@ -464,53 +479,42 @@ export default async function ShiftsCalendarPage({
         />
       ))}
       <PageContainer testid="shifts-browse-page">
-        <div className="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6">
-          <div className="flex-1">
-            <PageHeader
-            title={
-              selectedLocation ||
-              (showAll
-                ? "All Locations"
-                : isUsingProfileFilter && userDefaultLocation
-                ? userDefaultLocation
-                : "Shifts")
-            }
-            description={
-              (selectedLocation &&
-                LOCATION_ADDRESSES[selectedLocation as Location] && (
-                  <div
-                    className="flex items-start gap-2 text-sm text-muted-foreground"
-                    data-testid="restaurant-address-banner"
-                  >
-                    <MapPin className="h-4 w-4 flex-shrink-0 mt-0.5" />
-                    <a
-                      href={getLocationMapsUrl(selectedLocation as Location)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      data-testid="restaurant-address"
-                      className="text-left hover:text-primary hover:underline"
-                    >
-                      {LOCATION_ADDRESSES[selectedLocation as Location]}
-                    </a>
-                  </div>
-                )) ||
-              undefined
-            }
-            data-testid="shifts-page-header"
-          />
-        </div>
-
-        <div className="flex flex-col lg:flex-row gap-4 lg:items-end">
-          {/* Back to locations button */}
-          <Link
-            href="/shifts?chooseLocation=true"
-            className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground border border-border hover:border-primary/30 rounded-lg transition-colors"
-            data-testid="back-to-locations-button"
-          >
-            ← Choose Different Location
-          </Link>
-        </div>
-      </div>
+        {/* The page title doubles as the location switcher */}
+        <PageHeader
+          title={
+            <LocationSwitcher
+              locations={liveLocations.map(({ name, isNew }) => ({
+                name,
+                isNew,
+              }))}
+              selectedLocation={selectedLocation}
+              showAll={showAll}
+              isLoggedIn={isLoggedIn}
+              userDefaultLocation={userDefaultLocation}
+            />
+          }
+          description={
+            (selectedLocation && addressByName.get(selectedLocation) && (
+              <div
+                className="flex items-start gap-2 text-sm text-muted-foreground"
+                data-testid="restaurant-address-banner"
+              >
+                <MapPin className="h-4 w-4 flex-shrink-0 mt-0.5" />
+                <a
+                  href={getGoogleMapsUrl(addressByName.get(selectedLocation)!)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  data-testid="restaurant-address"
+                  className="text-left hover:text-primary hover:underline"
+                >
+                  {addressByName.get(selectedLocation)}
+                </a>
+              </div>
+            )) ||
+            undefined
+          }
+          data-testid="shifts-page-header"
+        />
 
       {/* Profile completion banner - shows if profile incomplete */}
       <Suspense fallback={null}>

--- a/web/src/components/location-settings-form.tsx
+++ b/web/src/components/location-settings-form.tsx
@@ -29,6 +29,8 @@ interface Location {
   targetPerNight: number | null;
   isActive: boolean;
   isPopup: boolean;
+  /** False while a location has no upcoming shifts - volunteers can't see it yet. */
+  hasUpcomingShifts?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -358,6 +360,18 @@ export function LocationSettingsForm({
               {location.isPopup && (
                 <Badge variant="secondary" className="font-normal">
                   Pop-up
+                </Badge>
+              )}
+              {isActive && location.hasUpcomingShifts === false && (
+                <Badge
+                  variant="outline"
+                  className="font-normal text-muted-foreground"
+                  title="Volunteers won't see this location in shift browsing until it has upcoming shifts"
+                  data-testid={`location-not-launched-${location.name
+                    .toLowerCase()
+                    .replace(/\s+/g, "-")}`}
+                >
+                  Hidden until shifts are published
                 </Badge>
               )}
             </CardTitle>

--- a/web/src/components/location-switcher.tsx
+++ b/web/src/components/location-switcher.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Check, ChevronDown, Globe, MapPin, Star } from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+/** Serializable subset of LiveLocation passed down from server components. */
+export interface SwitcherLocation {
+  name: string;
+  isNew: boolean;
+}
+
+const slugify = (name: string) => name.toLowerCase().replace(/\s+/g, "-");
+
+/**
+ * The shifts page title doubled as a location switcher: the heading itself
+ * opens a dropdown of live locations, with an explicit "Change location"
+ * pill so it's obvious the title is interactive.
+ *
+ * Rendered inside PageHeader's h1, so the trigger inherits the heading type
+ * (via [font:inherit]) and keeps heading semantics; the menu itself portals
+ * out to <body>.
+ *
+ * Newly launched locations carry a "New" badge, and the pill shows a green
+ * dot for as long as any location is within its launch window - quiet by
+ * design, no notifications.
+ */
+export function LocationSwitcher({
+  locations,
+  selectedLocation,
+  showAll,
+  isLoggedIn,
+  userDefaultLocation,
+}: {
+  locations: SwitcherLocation[];
+  selectedLocation?: string;
+  showAll: boolean;
+  isLoggedIn: boolean;
+  userDefaultLocation: string | null;
+}) {
+  const router = useRouter();
+  const [isSavingDefault, setIsSavingDefault] = useState(false);
+
+  const hasNewLocation = locations.some((l) => l.isNew);
+
+  const switchTo = (location: string | null) => {
+    router.push(
+      location === null
+        ? "/shifts?showAll=true"
+        : `/shifts?location=${encodeURIComponent(location)}`
+    );
+  };
+
+  const canSetDefault =
+    isLoggedIn && !!selectedLocation && selectedLocation !== userDefaultLocation;
+
+  const setAsDefault = async () => {
+    if (!selectedLocation || isSavingDefault) return;
+    setIsSavingDefault(true);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ defaultLocation: selectedLocation }),
+      });
+      if (!res.ok) throw new Error();
+      toast.success(`${selectedLocation} is now your default location`);
+      router.refresh();
+    } catch {
+      toast.error("Couldn't save your default location. Please try again.");
+    } finally {
+      setIsSavingDefault(false);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="group inline-flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded-lg text-left [font:inherit] tracking-[inherit] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          data-testid="location-switcher-trigger"
+        >
+          <span>{showAll ? "All locations" : selectedLocation ?? "Shifts"}</span>
+          <span className="relative inline-flex translate-y-[-0.2em] items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5 font-sans text-xs font-medium tracking-normal text-muted-foreground transition-colors group-hover:border-primary/40 group-hover:text-foreground sm:text-sm">
+            <ChevronDown className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180" />
+            Change location
+            {hasNewLocation && (
+              <span
+                className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-primary ring-2 ring-background"
+                data-testid="location-switcher-new-dot"
+                aria-hidden
+              />
+            )}
+          </span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        {locations.map((location) => {
+          const isSelected = !showAll && location.name === selectedLocation;
+          return (
+            <DropdownMenuItem
+              key={location.name}
+              onSelect={() => switchTo(location.name)}
+              className="gap-3 py-2.5"
+              data-testid={`location-switcher-option-${slugify(location.name)}`}
+            >
+              <MapPin className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="flex min-w-0 flex-1 items-center gap-2">
+                <span className="truncate font-medium">{location.name}</span>
+                {location.isNew && (
+                  <Badge
+                    className="h-5 px-1.5 text-[10px] uppercase tracking-wide"
+                    data-testid={`location-new-badge-${slugify(location.name)}`}
+                  >
+                    New
+                  </Badge>
+                )}
+                {location.name === userDefaultLocation && (
+                  <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    Default
+                  </span>
+                )}
+              </span>
+              {isSelected && <Check className="h-4 w-4 shrink-0 text-primary" />}
+            </DropdownMenuItem>
+          );
+        })}
+        <DropdownMenuItem
+          onSelect={() => switchTo(null)}
+          className="gap-3 py-2.5"
+          data-testid="location-switcher-all"
+        >
+          <Globe className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="flex-1 font-medium">All locations</span>
+          {showAll && <Check className="h-4 w-4 shrink-0 text-primary" />}
+        </DropdownMenuItem>
+        {canSetDefault && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault();
+                void setAsDefault();
+              }}
+              disabled={isSavingDefault}
+              className="gap-3 py-2.5 text-muted-foreground"
+              data-testid="location-switcher-set-default"
+            >
+              <Star className="h-4 w-4 shrink-0" />
+              <span>Make {selectedLocation} my default</span>
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web/src/components/location-switcher.tsx
+++ b/web/src/components/location-switcher.tsx
@@ -76,7 +76,8 @@ export function LocationSwitcher({
       if (!res.ok) throw new Error();
       toast.success(`${selectedLocation} is now your default location`);
       router.refresh();
-    } catch {
+    } catch (error) {
+      console.error("Failed to set default location:", error);
       toast.error("Couldn't save your default location. Please try again.");
     } finally {
       setIsSavingDefault(false);

--- a/web/src/lib/live-locations.test.ts
+++ b/web/src/lib/live-locations.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getLiveLocationsUncached } from "./live-locations";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    shift: { findMany: vi.fn() },
+    location: { findMany: vi.fn(), updateMany: vi.fn() },
+  },
+}));
+
+const shiftFindMany = vi.mocked(prisma.shift.findMany);
+const locationFindMany = vi.mocked(prisma.location.findMany);
+const locationUpdateMany = vi.mocked(prisma.location.updateMany);
+
+const daysAgo = (days: number) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+function locationRow(overrides: {
+  id: string;
+  name: string;
+  launchedAt?: Date | null;
+  isActive?: boolean;
+  isPopup?: boolean;
+  address?: string;
+}) {
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    address: overrides.address ?? `${overrides.name} address`,
+    isActive: overrides.isActive ?? true,
+    isPopup: overrides.isPopup ?? false,
+    launchedAt: overrides.launchedAt ?? null,
+  };
+}
+
+describe("getLiveLocationsUncached", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    locationUpdateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it("hides locations that have no upcoming shifts yet", async () => {
+    shiftFindMany.mockResolvedValue([{ location: "Wellington" }] as never);
+    locationFindMany.mockResolvedValue([
+      locationRow({ id: "1", name: "Wellington", launchedAt: daysAgo(400) }),
+      locationRow({ id: "2", name: "Hamilton" }), // created ahead of its shifts
+    ] as never);
+
+    const result = await getLiveLocationsUncached();
+
+    expect(result.map((l) => l.name)).toEqual(["Wellington"]);
+    // Hamilton has no upcoming shifts, so it must not be stamped as launched.
+    expect(locationUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("stamps launchedAt and flags isNew when shifts first appear", async () => {
+    shiftFindMany.mockResolvedValue([
+      { location: "Wellington" },
+      { location: "Hamilton" },
+    ] as never);
+    locationFindMany.mockResolvedValue([
+      locationRow({ id: "1", name: "Wellington", launchedAt: daysAgo(400) }),
+      locationRow({ id: "2", name: "Hamilton" }),
+    ] as never);
+
+    const result = await getLiveLocationsUncached();
+
+    expect(locationUpdateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["2"] } },
+      data: { launchedAt: expect.any(Date) },
+    });
+    expect(result).toEqual([
+      expect.objectContaining({ name: "Hamilton", isNew: true }),
+      expect.objectContaining({ name: "Wellington", isNew: false }),
+    ]);
+  });
+
+  it("drops the New flag once the launch window has passed", async () => {
+    shiftFindMany.mockResolvedValue([
+      { location: "Recent" },
+      { location: "Older" },
+    ] as never);
+    locationFindMany.mockResolvedValue([
+      locationRow({ id: "1", name: "Recent", launchedAt: daysAgo(5) }),
+      locationRow({ id: "2", name: "Older", launchedAt: daysAgo(45) }),
+    ] as never);
+
+    const result = await getLiveLocationsUncached();
+
+    expect(result).toEqual([
+      expect.objectContaining({ name: "Older", isNew: false }),
+      expect.objectContaining({ name: "Recent", isNew: true }),
+    ]);
+    expect(locationUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("excludes disabled locations even when they still have upcoming shifts", async () => {
+    shiftFindMany.mockResolvedValue([
+      { location: "Wellington" },
+      { location: "Closed Venue" },
+    ] as never);
+    locationFindMany.mockResolvedValue([
+      locationRow({ id: "1", name: "Wellington", launchedAt: daysAgo(400) }),
+      locationRow({
+        id: "2",
+        name: "Closed Venue",
+        isActive: false,
+        launchedAt: daysAgo(400),
+      }),
+    ] as never);
+
+    const result = await getLiveLocationsUncached();
+
+    expect(result.map((l) => l.name)).toEqual(["Wellington"]);
+  });
+
+  it("keeps ad-hoc shift venues without a Location row, never flagged new", async () => {
+    shiftFindMany.mockResolvedValue([
+      { location: "  Pop-up   Night " }, // whitespace normalized
+    ] as never);
+    locationFindMany.mockResolvedValue([] as never);
+
+    const result = await getLiveLocationsUncached();
+
+    expect(result).toEqual([
+      { name: "Pop-up Night", address: null, isPopup: false, isNew: false },
+    ]);
+    expect(locationUpdateMany).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/live-locations.test.ts
+++ b/web/src/lib/live-locations.test.ts
@@ -68,7 +68,7 @@ describe("getLiveLocationsUncached", () => {
     const result = await getLiveLocationsUncached();
 
     expect(locationUpdateMany).toHaveBeenCalledWith({
-      where: { id: { in: ["2"] } },
+      where: { id: { in: ["2"] }, launchedAt: null },
       data: { launchedAt: expect.any(Date) },
     });
     expect(result).toEqual([
@@ -114,6 +114,24 @@ describe("getLiveLocationsUncached", () => {
     const result = await getLiveLocationsUncached();
 
     expect(result.map((l) => l.name)).toEqual(["Wellington"]);
+  });
+
+  it("matches Location rows to shift venues despite stray whitespace", async () => {
+    shiftFindMany.mockResolvedValue([{ location: "Glen  Innes" }] as never);
+    locationFindMany.mockResolvedValue([
+      locationRow({ id: "1", name: " Glen Innes ", launchedAt: daysAgo(5) }),
+    ] as never);
+
+    const result = await getLiveLocationsUncached();
+
+    // The row still matches, so its address and New flag come through.
+    expect(result).toEqual([
+      expect.objectContaining({
+        name: "Glen Innes",
+        address: " Glen Innes  address",
+        isNew: true,
+      }),
+    ]);
   });
 
   it("keeps ad-hoc shift venues without a Location row, never flagged new", async () => {

--- a/web/src/lib/live-locations.ts
+++ b/web/src/lib/live-locations.ts
@@ -1,0 +1,95 @@
+import { cache } from "react";
+
+import { prisma } from "@/lib/prisma";
+
+/** How long a freshly launched location keeps its "New" badge. */
+export const NEW_LOCATION_WINDOW_DAYS = 30;
+
+export interface LiveLocation {
+  name: string;
+  address: string | null;
+  isPopup: boolean;
+  /** Launched within the last NEW_LOCATION_WINDOW_DAYS - show a "New" badge. */
+  isNew: boolean;
+}
+
+/**
+ * Locations volunteers can actually browse: active (or ad-hoc shift venues)
+ * with at least one upcoming shift.
+ *
+ * Admins usually create a Location row well before its shifts exist. Those
+ * rows stay out of this list until the first upcoming shifts appear, at which
+ * point `launchedAt` is stamped and the location is flagged `isNew` for
+ * NEW_LOCATION_WINDOW_DAYS - that flag drives the subtle "New" badges in the
+ * web and mobile location switchers.
+ *
+ * Exported uncached for unit tests; use getLiveLocations everywhere else.
+ */
+export async function getLiveLocationsUncached(): Promise<LiveLocation[]> {
+  const now = new Date();
+
+  const [shiftLocations, locationRows] = await Promise.all([
+    prisma.shift.findMany({
+      where: { start: { gte: now }, location: { not: null } },
+      select: { location: true },
+      distinct: ["location"],
+    }),
+    prisma.location.findMany({
+      select: {
+        id: true,
+        name: true,
+        address: true,
+        isActive: true,
+        isPopup: true,
+        launchedAt: true,
+      },
+    }),
+  ]);
+
+  const liveNames = new Set(
+    shiftLocations
+      .map((s) => (s.location ?? "").replace(/\s+/g, " ").trim())
+      .filter((name) => name.length > 0)
+  );
+  const rowByName = new Map(locationRows.map((row) => [row.name, row]));
+
+  // Stamp launchedAt the first time a location shows up with upcoming shifts.
+  const justLaunched = locationRows.filter(
+    (row) => row.isActive && !row.launchedAt && liveNames.has(row.name)
+  );
+  if (justLaunched.length > 0) {
+    await prisma.location.updateMany({
+      where: { id: { in: justLaunched.map((row) => row.id) } },
+      data: { launchedAt: now },
+    });
+  }
+  const justLaunchedIds = new Set(justLaunched.map((row) => row.id));
+
+  const newCutoff = new Date(
+    now.getTime() - NEW_LOCATION_WINDOW_DAYS * 24 * 60 * 60 * 1000
+  );
+
+  return [...liveNames]
+    .filter((name) => rowByName.get(name)?.isActive !== false)
+    .sort()
+    .map((name) => {
+      const row = rowByName.get(name);
+      const launchedAt = row
+        ? justLaunchedIds.has(row.id)
+          ? now
+          : row.launchedAt
+        : null;
+      return {
+        name,
+        address: row?.address ?? null,
+        isPopup: row?.isPopup ?? false,
+        isNew: launchedAt !== null && launchedAt > newCutoff,
+      };
+    });
+}
+
+/**
+ * Wrapped in React cache() so generateMetadata and the page render share one
+ * query per request.
+ */
+export const getLiveLocations = cache(getLiveLocationsUncached);

--- a/web/src/lib/live-locations.ts
+++ b/web/src/lib/live-locations.ts
@@ -46,20 +46,29 @@ export async function getLiveLocationsUncached(): Promise<LiveLocation[]> {
     }),
   ]);
 
+  const normalizeName = (name: string) => name.replace(/\s+/g, " ").trim();
+
   const liveNames = new Set(
     shiftLocations
-      .map((s) => (s.location ?? "").replace(/\s+/g, " ").trim())
+      .map((s) => normalizeName(s.location ?? ""))
       .filter((name) => name.length > 0)
   );
-  const rowByName = new Map(locationRows.map((row) => [row.name, row]));
+  // Keyed by normalized name so a Location row with stray whitespace still
+  // matches the (normalized) shift venue strings.
+  const rowByName = new Map(
+    locationRows.map((row) => [normalizeName(row.name), row])
+  );
 
   // Stamp launchedAt the first time a location shows up with upcoming shifts.
   const justLaunched = locationRows.filter(
-    (row) => row.isActive && !row.launchedAt && liveNames.has(row.name)
+    (row) =>
+      row.isActive && !row.launchedAt && liveNames.has(normalizeName(row.name))
   );
   if (justLaunched.length > 0) {
+    // launchedAt: null in the WHERE keeps concurrent requests from
+    // re-stamping a location one of them already launched.
     await prisma.location.updateMany({
-      where: { id: { in: justLaunched.map((row) => row.id) } },
+      where: { id: { in: justLaunched.map((row) => row.id) }, launchedAt: null },
       data: { launchedAt: now },
     });
   }

--- a/web/tests/e2e/shifts-browse.spec.ts
+++ b/web/tests/e2e/shifts-browse.spec.ts
@@ -107,11 +107,9 @@ test.describe("Shifts Browse Page", () => {
       });
       await expect(pageTitle).toBeVisible();
 
-      // Should show back to locations button now
-      const backToLocationsButton = page.getByTestId(
-        "back-to-locations-button"
-      );
-      await expect(backToLocationsButton).toBeVisible();
+      // Should show the quick location switcher now
+      const switcherTrigger = page.getByTestId("location-switcher-trigger");
+      await expect(switcherTrigger).toBeVisible();
     });
   });
 
@@ -372,35 +370,51 @@ test.describe("Shifts Browse Page", () => {
   });
 
   test.describe("Location Navigation", () => {
-    test("should show back to locations button after selecting a location", async ({
+    test("should show location switcher after selecting a location", async ({
       page,
     }) => {
       // Go to a specific location
       await page.goto("/shifts?location=Wellington");
       await page.waitForLoadState("load");
 
-      // Should show back to locations button
-      const backButton = page.getByTestId("back-to-locations-button");
-      await expect(backButton).toBeVisible();
-      await expect(backButton).toHaveText("← Choose Different Location");
+      // Should show the quick location switcher with the current location
+      const switcherTrigger = page.getByTestId("location-switcher-trigger");
+      await expect(switcherTrigger).toBeVisible();
+      await expect(switcherTrigger).toContainText("Wellington");
     });
 
-    test("should return to location selection when clicking back button", async ({
+    test("should switch location from the switcher menu", async ({ page }) => {
+      // Go to a specific location
+      await page.goto("/shifts?location=Wellington");
+      await page.waitForLoadState("load");
+
+      // Open the switcher and pick a different location
+      await page.getByTestId("location-switcher-trigger").click();
+      await page.getByTestId("location-switcher-option-glen-innes").click();
+      await page.waitForLoadState("load");
+
+      // Should navigate to the newly selected location
+      await expect(page).toHaveURL("/shifts?location=Glen%20Innes");
+      const switcherTrigger = page.getByTestId("location-switcher-trigger");
+      await expect(switcherTrigger).toContainText("Glen Innes");
+    });
+
+    test("should switch to all locations from the switcher menu", async ({
       page,
     }) => {
       // Go to a specific location
       await page.goto("/shifts?location=Wellington");
       await page.waitForLoadState("load");
 
-      // Click back to locations button
-      const backButton = page.getByTestId("back-to-locations-button");
-      await backButton.click();
+      // Open the switcher and pick "All locations"
+      await page.getByTestId("location-switcher-trigger").click();
+      await page.getByTestId("location-switcher-all").click();
       await page.waitForLoadState("load");
 
-      // Should return to location selection screen (with chooseLocation parameter)
-      await expect(page).toHaveURL("/shifts?chooseLocation=true");
-      const selectionTitle = page.getByTestId("location-selection-title");
-      await expect(selectionTitle).toBeVisible();
+      // Should show all locations
+      await expect(page).toHaveURL("/shifts?showAll=true");
+      const switcherTrigger = page.getByTestId("location-switcher-trigger");
+      await expect(switcherTrigger).toContainText("All locations");
     });
   });
 
@@ -600,9 +614,9 @@ test.describe("Shifts Browse Page", () => {
       });
       await expect(pageTitle).toBeVisible();
 
-      // Check back button is accessible on mobile
-      const backButton = page.getByTestId("back-to-locations-button");
-      await expect(backButton).toBeVisible();
+      // Check location switcher is accessible on mobile
+      const switcherTrigger = page.getByTestId("location-switcher-trigger");
+      await expect(switcherTrigger).toBeVisible();
 
       // Check shift cards adapt to mobile layout
       const shiftCards = page.locator('[data-testid^="shift-card-"]');
@@ -668,20 +682,21 @@ test.describe("Shifts Browse Page", () => {
 
       await expect(page).toHaveURL("/shifts?location=Wellington");
 
-      // Should show shifts page with back button
+      // Should show shifts page with the location switcher
       const pageTitle = page.getByRole("heading", {
         name: /wellington/i,
       });
       await expect(pageTitle).toBeVisible();
 
-      // Click back button
-      const backButton = page.getByTestId("back-to-locations-button");
-      await backButton.click();
+      // Switch to another location via the switcher
+      await page.getByTestId("location-switcher-trigger").click();
+      await page.getByTestId("location-switcher-option-onehunga").click();
       await page.waitForLoadState("load");
 
-      // Should return to location selection (with chooseLocation parameter)
-      await expect(page).toHaveURL("/shifts?chooseLocation=true");
-      await expect(selectionTitle).toBeVisible();
+      // Should land on the newly selected location
+      await expect(page).toHaveURL("/shifts?location=Onehunga");
+      const onehungaTitle = page.getByRole("heading", { name: /onehunga/i });
+      await expect(onehungaTitle).toBeVisible();
     });
   });
 
@@ -1044,9 +1059,9 @@ test.describe("Shifts Browse Page", () => {
       const pageHeader = page.getByTestId("shifts-page-header");
       await expect(pageHeader).toBeVisible();
 
-      // Check back button is accessible
-      const backButton = page.getByTestId("back-to-locations-button");
-      await expect(backButton).toBeVisible();
+      // Check location switcher is accessible
+      const switcherTrigger = page.getByTestId("location-switcher-trigger");
+      await expect(switcherTrigger).toBeVisible();
 
       // Check that buttons have accessible names
       const signupButton = page
@@ -1072,10 +1087,10 @@ test.describe("Shifts Browse Page", () => {
       await wellingtonOption.click();
       await page.waitForLoadState("load");
 
-      // Check back button is keyboard accessible
-      const backButton = page.getByTestId("back-to-locations-button");
-      await backButton.focus();
-      await expect(backButton).toBeFocused();
+      // Check location switcher is keyboard accessible
+      const switcherTrigger = page.getByTestId("location-switcher-trigger");
+      await switcherTrigger.focus();
+      await expect(switcherTrigger).toBeFocused();
     });
   });
 });


### PR DESCRIPTION
# Pull Request

## Description

Makes switching locations much easier on both the web and mobile apps, adds a subtle nudge when a new restaurant launches, and solves the "location created before its shifts exist" problem.

**The core concept:** a location doesn't exist for volunteers until it has upcoming shifts. New `Location.launchedAt` column (migration included, backfilled from `createdAt` for locations that already have shifts):

- A location created ahead of time stays **hidden** from all volunteer-facing pickers while it has no upcoming shifts. The admin locations page shows a "Hidden until shifts are published" badge so admins know why.
- When its first shifts are published, it appears automatically, `launchedAt` is stamped, and it's flagged **New** for 30 days.

**Web (`/shifts`)**
- The page title now doubles as the location switcher: the heading opens a dropdown of live locations, with an explicit "Change location" pill beside it (replaces the "← Choose Different Location" full-page round-trip).
- Menu shows a "New" badge next to recently launched locations, and the pill carries a green dot while any location is in its launch window.
- Logged-in users get a "Make X my default" action that saves to their profile.
- Fixes a latent bug: the page validated locations against a list loaded once at server start (top-level await in `lib/locations.ts`), so a newly created location wouldn't filter until a redeploy. The switcher list is now queried fresh per request via `getLiveLocations()` (React `cache()`-deduped).

**Mobile**
- The shifts-tab location filter is now persisted (Zustand + AsyncStorage, same pattern as the admin filter) so a switch survives app restarts instead of resetting to the profile default.
- `/api/mobile/shifts` now returns a server-driven `locations` list with `isNew` flags; the picker sheet shows NEW chips next to names and the location pill gets the green dot while a new location exists.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor` label added.

## Testing
- [x] Unit tests pass (423, incl. 5 new tests for `getLiveLocations`: hiding, launch-stamping, 30-day window, disabled locations, ad-hoc venues)
- [x] E2E tests updated (`shifts-browse.spec.ts` rewritten from the back-button flow to the switcher, incl. two new switching tests) — will run in CI
- [x] Manual testing completed (preview walkthrough: switching, badges, dot, chooser screen, mobile viewport; simulated a shift-less location staying hidden then launching with a New badge)
- [x] New tests added (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
- Typecheck clean on web and mobile; lint has no findings in changed files.
- Seeds set `launchedAt` for the three established restaurants so fresh dev/CI databases don't badge them as New.
- The subtle-nudge approach is deliberate: no notifications. For a louder push admins can still use Announcements with location targeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)