### PR TITLE
style: make the Change location pill less muted

### DIFF
--- a/web/src/components/location-switcher.tsx
+++ b/web/src/components/location-switcher.tsx
@@ -93,12 +93,12 @@ export function LocationSwitcher({
           data-testid="location-switcher-trigger"
         >
           <span>{showAll ? "All locations" : selectedLocation ?? "Shifts"}</span>
-          <span className="relative inline-flex translate-y-[-0.2em] items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5 font-sans text-xs font-medium tracking-normal text-muted-foreground transition-colors group-hover:border-primary/40 group-hover:text-foreground sm:text-sm">
+          <span className="relative inline-flex translate-y-[-0.2em] items-center gap-1.5 rounded-full border border-[var(--ee-primary-text)]/30 bg-[var(--ee-primary-light)] px-3 py-1.5 font-sans text-xs font-semibold tracking-normal text-[var(--ee-primary-text)] transition-colors group-hover:border-[var(--ee-primary-text)]/60 group-hover:bg-[var(--ee-primary-light)]/70 sm:text-sm">
             <ChevronDown className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180" />
             Change location
             {hasNewLocation && (
               <span
-                className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-primary ring-2 ring-background"
+                className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-[var(--ee-primary-text)] ring-2 ring-background"
                 data-testid="location-switcher-new-dot"
                 aria-hidden
               />


### PR DESCRIPTION
## Description
The "Change location" pill next to the shifts page heading used `text-muted-foreground` on a plain `bg-background` chip, so it read as muted decoration rather than a control. This restyles it with the brand forest-green chip pattern already used elsewhere in the codebase (`bg-[var(--ee-primary-light)]` + `text-[var(--ee-primary-text)]` with a matching border), bumps the label to semibold, and deepens the tint/border on hover.

Also moves the "New" launch dot from `bg-primary` (#1d5337 in both themes) to the theme-aware `--ee-primary-text` token - on the new dark-mode chip background (#1a2f1a) the old dot would have been nearly invisible.

## Type of Change
- [x] 🧹 Code refactoring (no functional changes)

## Version Bump Required
`version:patch`

## Testing
- [x] Manual testing completed - verified in the running app in both light and dark mode: light mode renders #1d5337 on #eef4ef, dark mode #86d99b on #1a2f1a (both well above 4.5:1 contrast). Dropdown still opens and lists all locations. No console errors; ESLint clean.

## Additional Notes
Styling-only change to `web/src/components/location-switcher.tsx`; no behavior or test-id changes, so existing e2e selectors are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)