### PR TITLE
feat: redesign friend profile pages with achievements on web and mobile

### DIFF
--- a/mobile/app/user/[id].tsx
+++ b/mobile/app/user/[id].tsx
@@ -777,8 +777,8 @@ function FullProfile({
         </View>
       </View>
 
-      {/* ── Trophy shelf ───────────────────────────────── */}
-      <SectionHeading title="Trophy shelf" colors={colors} />
+      {/* ── Achievements ───────────────────────────────── */}
+      <SectionHeading title="Achievements" colors={colors} />
       <View style={styles.section}>
         <TrophyShelf
           achievements={connection.achievements}
@@ -1279,9 +1279,11 @@ function TrophyShelf({
                   styles.plate,
                   {
                     backgroundColor: isDark
-                      ? "rgba(255,255,255,0.06)"
+                      ? "rgba(248,251,105,0.10)"
                       : Palette.cream100,
-                    borderColor: colors.border,
+                    borderColor: isDark
+                      ? "rgba(248,251,105,0.16)"
+                      : colors.border,
                   },
                 ]}
               >

--- a/mobile/app/user/[id].tsx
+++ b/mobile/app/user/[id].tsx
@@ -861,8 +861,8 @@ function FullProfile({
         </View>
       </View>
 
-      {/* ── Shared moments ─────────────────────────────── */}
-      <SectionHeading title="Shared moments" colors={colors} />
+      {/* ── Shared shifts ──────────────────────────────── */}
+      <SectionHeading title="Shared shifts" colors={colors} />
       <View style={styles.section}>
         {connection.sharedShifts.length > 0 ? (
           <View>

--- a/mobile/app/user/[id].tsx
+++ b/mobile/app/user/[id].tsx
@@ -768,13 +768,24 @@ function FullProfile({
             ]}
           >
             <Text style={[styles.bentoLabel, { color: colors.textSecondary }]}>
-              TOTAL SHIFTS
+              MUTUAL FRIENDS
             </Text>
             <Text style={[styles.bentoMiniValue, { color: colors.text }]}>
-              {profile.totalShifts}
+              {connection.mutualFriends}
             </Text>
           </View>
         </View>
+      </View>
+
+      {/* ── Trophy shelf ───────────────────────────────── */}
+      <SectionHeading title="Trophy shelf" colors={colors} />
+      <View style={styles.section}>
+        <TrophyShelf
+          achievements={connection.achievements}
+          firstName={firstName}
+          colors={colors}
+          isDark={isDark}
+        />
       </View>
 
       {/* ── Their Mahi ─────────────────────────────────── */}
@@ -1152,6 +1163,168 @@ function Badge({
     <View style={[styles.badge, { backgroundColor: bg }]}>
       <Text style={{ fontSize: 12 }}>{emoji}</Text>
       <Text style={[styles.badgeText, { color: fg }]}>{label}</Text>
+    </View>
+  );
+}
+
+/**
+ * The friend's achievements rendered as "plates on a shelf" — a featured
+ * latest unlock, then the rest as a horizontally scrolling row of plates.
+ * Tolerates an undefined payload (older cached profiles) by showing the
+ * empty state.
+ */
+function TrophyShelf({
+  achievements,
+  firstName,
+  colors,
+  isDark,
+}: {
+  achievements: UserConnection["achievements"] | undefined;
+  firstName: string;
+  colors: (typeof Colors)["light"];
+  isDark: boolean;
+}) {
+  if (!achievements || achievements.unlockedCount === 0) {
+    return (
+      <EmptyCanvas
+        title="The shelf is waiting"
+        subtitle={`${firstName} hasn't unlocked any achievements yet — their first shift will start the collection.`}
+        colors={colors}
+        isDark={isDark}
+      />
+    );
+  }
+
+  const [latest, ...rest] = achievements.items;
+  const overflow = achievements.unlockedCount - achievements.items.length;
+
+  return (
+    <View style={{ gap: 12 }}>
+      <Text style={[styles.shelfSummary, { color: colors.textSecondary }]}>
+        {achievements.unlockedCount} of {achievements.totalCount} unlocked ·{" "}
+        {achievements.totalPoints} points
+      </Text>
+
+      {/* Featured latest unlock */}
+      <View
+        style={[
+          styles.featuredUnlock,
+          {
+            backgroundColor: colors.card,
+            borderColor: isDark ? "rgba(248,251,105,0.25)" : Palette.sun300,
+          },
+        ]}
+      >
+        <View
+          style={[
+            styles.plate,
+            styles.plateLarge,
+            {
+              backgroundColor: isDark
+                ? "rgba(248,251,105,0.12)"
+                : Palette.sun100,
+              borderColor: isDark ? "rgba(248,251,105,0.3)" : Palette.sun300,
+            },
+          ]}
+        >
+          <Text style={{ fontSize: 30 }}>{latest.icon}</Text>
+        </View>
+        <View style={{ flex: 1, gap: 3 }}>
+          <Text
+            style={[styles.featureEyebrow, { color: colors.textSecondary }]}
+          >
+            LATEST UNLOCK
+          </Text>
+          <Text
+            style={[styles.featuredUnlockName, { color: colors.text }]}
+            numberOfLines={1}
+          >
+            {latest.name}
+          </Text>
+          <Text
+            style={[styles.featuredUnlockMeta, { color: colors.textSecondary }]}
+            numberOfLines={2}
+          >
+            {latest.description}
+          </Text>
+          <Text
+            style={[
+              styles.featuredUnlockDate,
+              { color: isDark ? Brand.accentSubtle : Brand.greenHover },
+            ]}
+          >
+            +{latest.points} pts · {formatNZT(new Date(latest.unlockedAt), "MMM yyyy")}
+          </Text>
+        </View>
+      </View>
+
+      {/* The shelf */}
+      {rest.length > 0 && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.shelfScroll}
+        >
+          {rest.map((achievement) => (
+            <View
+              key={achievement.id}
+              style={[
+                styles.shelfItem,
+                { backgroundColor: colors.card, borderColor: colors.border },
+              ]}
+              accessibilityLabel={`${achievement.name}: ${achievement.description}`}
+            >
+              <View
+                style={[
+                  styles.plate,
+                  {
+                    backgroundColor: isDark
+                      ? "rgba(255,255,255,0.06)"
+                      : Palette.cream100,
+                    borderColor: colors.border,
+                  },
+                ]}
+              >
+                <Text style={{ fontSize: 22 }}>{achievement.icon}</Text>
+              </View>
+              <Text
+                style={[styles.shelfItemName, { color: colors.text }]}
+                numberOfLines={2}
+              >
+                {achievement.name}
+              </Text>
+              <Text
+                style={[styles.shelfItemPoints, { color: colors.textSecondary }]}
+              >
+                {achievement.points} pts
+              </Text>
+            </View>
+          ))}
+          {overflow > 0 && (
+            <View
+              style={[
+                styles.shelfItem,
+                styles.shelfOverflow,
+                { borderColor: colors.border },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.shelfOverflowCount,
+                  { color: isDark ? Palette.forest200 : Brand.green },
+                ]}
+              >
+                +{overflow}
+              </Text>
+              <Text
+                style={[styles.shelfItemPoints, { color: colors.textSecondary }]}
+              >
+                more
+              </Text>
+            </View>
+          )}
+        </ScrollView>
+      )}
     </View>
   );
 }
@@ -1862,6 +2035,84 @@ const styles = StyleSheet.create({
     fontFamily: FontFamily.regular,
     marginBottom: 4,
     marginTop: -4,
+  },
+
+  /* Trophy shelf */
+  shelfSummary: {
+    fontSize: 12,
+    fontFamily: FontFamily.medium,
+    letterSpacing: 0.2,
+    marginTop: -4,
+  },
+  featuredUnlock: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    padding: 16,
+    borderRadius: 18,
+    borderWidth: 1,
+  },
+  featuredUnlockName: {
+    fontSize: 17,
+    fontFamily: FontFamily.heading,
+    letterSpacing: -0.2,
+  },
+  featuredUnlockMeta: {
+    fontSize: 12,
+    fontFamily: FontFamily.regular,
+    lineHeight: 17,
+  },
+  featuredUnlockDate: {
+    fontSize: 12,
+    fontFamily: FontFamily.semiBold,
+    marginTop: 2,
+  },
+  plate: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+  },
+  plateLarge: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+  },
+  shelfScroll: {
+    gap: 10,
+    paddingRight: HORIZONTAL,
+  },
+  shelfItem: {
+    width: 104,
+    alignItems: "center",
+    gap: 8,
+    paddingVertical: 14,
+    paddingHorizontal: 10,
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  shelfItemName: {
+    fontSize: 12,
+    fontFamily: FontFamily.semiBold,
+    textAlign: "center",
+    lineHeight: 16,
+  },
+  shelfItemPoints: {
+    fontSize: 10,
+    fontFamily: FontFamily.medium,
+    letterSpacing: 0.3,
+  },
+  shelfOverflow: {
+    justifyContent: "center",
+    borderStyle: "dashed",
+    borderWidth: 1,
+  },
+  shelfOverflowCount: {
+    fontSize: 22,
+    fontFamily: FontFamily.headingBold,
+    letterSpacing: -0.5,
   },
 
   /* Empty canvas */

--- a/mobile/app/user/[id].tsx
+++ b/mobile/app/user/[id].tsx
@@ -103,8 +103,17 @@ export default function UserProfileScreen() {
       );
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       // Pull the freshly-friends payload (now includes the connection block)
-      // so the screen flips to the rich layout without a manual reload.
-      await refresh();
+      // so the screen flips to the rich layout without a manual reload. The
+      // request itself succeeded at this point, so a refresh failure only
+      // delays the rich view — tell the user they're connected either way.
+      try {
+        await refresh();
+      } catch {
+        Alert.alert(
+          "You're connected!",
+          `You're now friends with ${firstName}. Pull to refresh to see their full profile.`
+        );
+      }
     } catch {
       Alert.alert("Couldn't accept request", "Please try again in a moment.");
     } finally {

--- a/mobile/hooks/use-user-profile.ts
+++ b/mobile/hooks/use-user-profile.ts
@@ -38,6 +38,20 @@ export type UserConnection = {
     time: string;
     location: string;
   }>;
+  achievements: {
+    unlockedCount: number;
+    totalCount: number;
+    totalPoints: number;
+    items: Array<{
+      id: string;
+      name: string;
+      description: string;
+      icon: string;
+      category: string;
+      points: number;
+      unlockedAt: string;
+    }>;
+  };
 };
 
 export type UserProfile = {

--- a/web/src/app/api/mobile/users/[id]/route.ts
+++ b/web/src/app/api/mobile/users/[id]/route.ts
@@ -357,6 +357,9 @@ export async function GET(
         ORDER BY sh.start ASC
         LIMIT 5
       `,
+      // Intentionally un-capped: unlockedCount and totalPoints are computed
+      // from the full set below; only `items` is sliced to 12 for the shelf.
+      // The achievement catalogue is small (<20 active), so this stays cheap.
       prisma.userAchievement.findMany({
         where: { userId: targetId },
         orderBy: { unlockedAt: "desc" },

--- a/web/src/app/api/mobile/users/[id]/route.ts
+++ b/web/src/app/api/mobile/users/[id]/route.ts
@@ -215,6 +215,20 @@ export async function GET(
       time: string;
       location: string;
     }>;
+    achievements: {
+      unlockedCount: number;
+      totalCount: number;
+      totalPoints: number;
+      items: Array<{
+        id: string;
+        name: string;
+        description: string;
+        icon: string;
+        category: string;
+        points: number;
+        unlockedAt: string;
+      }>;
+    };
   } | null = null;
 
   if (friendshipStatus === "FRIENDS" && acceptedFriendship) {
@@ -225,6 +239,8 @@ export async function GET(
       mutualResult,
       favoriteRoleResult,
       upcomingShiftsRaw,
+      unlockedAchievements,
+      activeAchievementCount,
     ] = await Promise.all([
       prisma.$queryRaw<[{ count: bigint }]>`
         SELECT COUNT(*)::bigint as count
@@ -341,6 +357,24 @@ export async function GET(
         ORDER BY sh.start ASC
         LIMIT 5
       `,
+      prisma.userAchievement.findMany({
+        where: { userId: targetId },
+        orderBy: { unlockedAt: "desc" },
+        select: {
+          unlockedAt: true,
+          achievement: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              icon: true,
+              category: true,
+              points: true,
+            },
+          },
+        },
+      }),
+      prisma.achievement.count({ where: { isActive: true } }),
     ]);
 
     const shiftsThisMonth = Number(shiftsThisMonthResult[0].count);
@@ -376,6 +410,23 @@ export async function GET(
       favoriteRoleCount: Number(favoriteRoleResult[0]?.count ?? 0),
       sharedShifts,
       upcomingShifts,
+      achievements: {
+        unlockedCount: unlockedAchievements.length,
+        totalCount: activeAchievementCount,
+        totalPoints: unlockedAchievements.reduce(
+          (sum, ua) => sum + ua.achievement.points,
+          0
+        ),
+        items: unlockedAchievements.slice(0, 12).map((ua) => ({
+          id: ua.achievement.id,
+          name: ua.achievement.name,
+          description: ua.achievement.description,
+          icon: ua.achievement.icon,
+          category: ua.achievement.category,
+          points: ua.achievement.points,
+          unlockedAt: ua.unlockedAt.toISOString(),
+        })),
+      },
     };
   }
 

--- a/web/src/app/friends/[friendId]/friend-profile-content.tsx
+++ b/web/src/app/friends/[friendId]/friend-profile-content.tsx
@@ -217,7 +217,10 @@ export async function FriendProfileContent({
     .filter((id) => id !== user.id && id !== friendId && userFriendIds.has(id))
     .length;
 
-  // Match shared shifts based on day, AM/PM, and location
+  // Match shared shifts based on day, AM/PM, and location — deliberately
+  // coarser than exact shift-ID matching so different roles worked during the
+  // same service (e.g. kitchen vs front of house) still count as volunteering
+  // together. One shared "moment" per day/period/location.
   interface SharedShiftMatch {
     id: string;
     start: Date;

--- a/web/src/app/friends/[friendId]/friend-profile-content.tsx
+++ b/web/src/app/friends/[friendId]/friend-profile-content.tsx
@@ -6,32 +6,20 @@ import Link from "next/link";
 import { differenceInDays, differenceInHours, subMonths } from "date-fns";
 import { formatInNZT } from "@/lib/timezone";
 import { isAMShift, getShiftDate, getShiftPeriodLabel } from "@/lib/concurrent-shifts";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { AnimatedStatsGrid } from "@/components/animated-stats-grid";
-import {
-  Users,
-  Calendar,
-  Clock,
-  TrendingUp,
-  Heart,
-  UserCheck,
-  Handshake,
-  Sparkles,
-} from "lucide-react";
-import {
-  MotionCard,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/motion-card";
+import { Button } from "@/components/ui/button";
+import { Calendar, ChevronRight, Sparkles } from "lucide-react";
 import { MotionFriendStats } from "@/components/motion-friends";
 
 interface FriendProfileContentProps {
   friendId: string;
 }
 
+/**
+ * Friend profile — reads top to bottom as a story:
+ * identity → the friendship (together bento) → their trophy shelf →
+ * their mahi → shared moments → join them on an upcoming shift.
+ */
 export async function FriendProfileContent({
   friendId,
 }: FriendProfileContentProps) {
@@ -92,78 +80,56 @@ export async function FriendProfileContent({
     notFound();
   }
 
-  // Get comprehensive friendship stats
+  const now = new Date();
+
   const [
     userShifts,
     friendShifts,
     friendUpcomingShifts,
     friendCompletedShifts,
-    friendTotalShifts,
     friendThisMonthShifts,
     friendLast6MonthsShifts,
+    unlockedAchievements,
+    activeAchievementCount,
+    userFriendships,
+    friendFriendships,
   ] = await Promise.all([
-    // Get all user's shifts (confirmed or pending)
+    // All user's shifts (confirmed or pending) — for shared-shift matching
     prisma.signup.findMany({
       where: {
         userId: user.id,
         status: { in: ["CONFIRMED", "PENDING", "REGULAR_PENDING"] },
       },
       include: {
-        shift: {
-          include: {
-            shiftType: true,
-          },
-        },
-        user: {
-          select: {
-            id: true,
-            name: true,
-            firstName: true,
-            lastName: true,
-          },
-        },
+        shift: { include: { shiftType: true } },
       },
       orderBy: { shift: { start: "desc" } },
     }),
 
-    // Get all friend's shifts (confirmed or pending)
+    // All friend's shifts (confirmed or pending)
     prisma.signup.findMany({
       where: {
         userId: friendId,
         status: { in: ["CONFIRMED", "PENDING", "REGULAR_PENDING"] },
       },
       include: {
-        shift: {
-          include: {
-            shiftType: true,
-          },
-        },
-        user: {
-          select: {
-            id: true,
-            name: true,
-            firstName: true,
-            lastName: true,
-          },
-        },
+        shift: { include: { shiftType: true } },
       },
       orderBy: { shift: { start: "desc" } },
     }),
 
-    // Friend's upcoming shifts (if visibility allows)
+    // Friend's upcoming shifts
     prisma.signup.findMany({
       where: {
         userId: friendId,
         status: "CONFIRMED",
-        shift: { start: { gte: new Date() } },
+        shift: { start: { gte: now } },
       },
       include: {
-        shift: {
-          include: { shiftType: true },
-        },
+        shift: { include: { shiftType: true } },
       },
       orderBy: { shift: { start: "asc" } },
-      take: 10,
+      take: 5,
     }),
 
     // Friend's completed shifts
@@ -171,22 +137,12 @@ export async function FriendProfileContent({
       where: {
         userId: friendId,
         status: "CONFIRMED",
-        shift: { end: { lt: new Date() } },
+        shift: { end: { lt: now } },
       },
       include: {
-        shift: {
-          include: { shiftType: true },
-        },
+        shift: { include: { shiftType: true } },
       },
       orderBy: { shift: { start: "desc" } },
-    }),
-
-    // Friend's total shifts
-    prisma.signup.count({
-      where: {
-        userId: friendId,
-        status: "CONFIRMED",
-      },
     }),
 
     // Friend's shifts this month
@@ -196,12 +152,8 @@ export async function FriendProfileContent({
         status: "CONFIRMED",
         shift: {
           start: {
-            gte: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
-            lt: new Date(
-              new Date().getFullYear(),
-              new Date().getMonth() + 1,
-              1
-            ),
+            gte: new Date(now.getFullYear(), now.getMonth(), 1),
+            lt: new Date(now.getFullYear(), now.getMonth() + 1, 1),
           },
         },
       },
@@ -213,110 +165,111 @@ export async function FriendProfileContent({
         userId: friendId,
         status: "CONFIRMED",
         shift: {
-          end: {
-            gte: subMonths(new Date(), 6),
-            lt: new Date(),
+          end: { gte: subMonths(now, 6), lt: now },
+        },
+      },
+    }),
+
+    // Friend's unlocked achievements, newest first
+    prisma.userAchievement.findMany({
+      where: { userId: friendId },
+      orderBy: { unlockedAt: "desc" },
+      select: {
+        unlockedAt: true,
+        achievement: {
+          select: {
+            id: true,
+            name: true,
+            description: true,
+            icon: true,
+            category: true,
+            points: true,
           },
         },
       },
     }),
+
+    prisma.achievement.count({ where: { isActive: true } }),
+
+    // Both friend lists — intersected below for the mutual-friends count
+    prisma.friendship.findMany({
+      where: {
+        status: "ACCEPTED",
+        OR: [{ userId: user.id }, { friendId: user.id }],
+      },
+      select: { userId: true, friendId: true },
+    }),
+    prisma.friendship.findMany({
+      where: {
+        status: "ACCEPTED",
+        OR: [{ userId: friendId }, { friendId: friendId }],
+      },
+      select: { userId: true, friendId: true },
+    }),
   ]);
+
+  // Mutual friends — intersect the two friend lists, excluding the pair
+  const userFriendIds = new Set(
+    userFriendships.map((f) => (f.userId === user.id ? f.friendId : f.userId))
+  );
+  const mutualFriendsCount = friendFriendships
+    .map((f) => (f.userId === friendId ? f.friendId : f.userId))
+    .filter((id) => id !== user.id && id !== friendId && userFriendIds.has(id))
+    .length;
 
   // Match shared shifts based on day, AM/PM, and location
   interface SharedShiftMatch {
-    id: string; // Use the shift ID for uniqueness
+    id: string;
     start: Date;
     location: string | null;
-    shiftType: {
-      id: string;
-      name: string;
-    };
-    signups: Array<{
-      id: string;
-      user: {
-        id: string;
-        name: string | null;
-        firstName: string | null;
-        lastName: string | null;
-      };
-    }>;
+    shiftType: { id: string; name: string };
   }
 
   const sharedShiftsMap = new Map<string, SharedShiftMatch>();
 
-  // For each user shift, find matching friend shifts
   userShifts.forEach((userSignup) => {
     const userShift = userSignup.shift;
     const userDate = getShiftDate(userShift.start);
     const userIsAM = isAMShift(userShift.start);
     const userLocation = userShift.location || "";
 
-    // Find friend shifts that match
     friendShifts.forEach((friendSignup) => {
       const friendShift = friendSignup.shift;
-      const friendDate = getShiftDate(friendShift.start);
-      const friendIsAM = isAMShift(friendShift.start);
-      const friendLocation = friendShift.location || "";
-
-      // Check if they match: same day, same AM/PM, same location
       if (
-        userDate === friendDate &&
-        userIsAM === friendIsAM &&
-        userLocation === friendLocation
+        userDate === getShiftDate(friendShift.start) &&
+        userIsAM === isAMShift(friendShift.start) &&
+        userLocation === (friendShift.location || "")
       ) {
-        // Create a unique key for this day/time/location combination
         const key = `${userDate}-${userIsAM ? "AM" : "PM"}-${userLocation}`;
-
-        // If we haven't added this combination yet, add it
         if (!sharedShiftsMap.has(key)) {
-          // Use the user's shift as the base, but include both signups
           sharedShiftsMap.set(key, {
             id: userShift.id,
             start: userShift.start,
             location: userShift.location,
             shiftType: userShift.shiftType,
-            signups: [
-              {
-                id: userSignup.id,
-                user: userSignup.user,
-              },
-              {
-                id: friendSignup.id,
-                user: friendSignup.user,
-              },
-            ],
           });
         }
       }
     });
   });
 
-  // Convert map to array and sort by date (most recent first)
   const sharedShifts = Array.from(sharedShiftsMap.values()).sort(
     (a, b) => b.start.getTime() - a.start.getTime()
   );
 
-  // Calculate friendship stats
-  const daysSinceFriendship = differenceInDays(
-    new Date(),
-    friendship.createdAt
-  );
+  // Friendship + activity stats
+  const daysSinceFriendship = differenceInDays(now, friendship.createdAt);
+  const friendTotalShifts = friendCompletedShifts.length;
 
-  // Average shifts per month over a fixed 6-month window — matches the admin
-  // milestone analytics monthly-rate calculation so the number reflects the
-  // volunteer's actual recent rhythm, independent of friendship duration.
+  // Fixed 6-month window — matches the admin milestone analytics monthly rate
   const avgPerMonth = Math.round(friendLast6MonthsShifts / 6);
 
-  // Calculate friend's total hours
   const friendTotalHours = friendCompletedShifts.reduce((total, signup) => {
-    const hours = differenceInHours(signup.shift.end, signup.shift.start);
-    return total + hours;
+    return total + differenceInHours(signup.shift.end, signup.shift.start);
   }, 0);
 
-  // Calculate shared stats
   const sharedShiftsCount = sharedShifts.length;
 
-  // Get friend's favorite shift type
   const shiftTypeCounts = friendCompletedShifts.reduce((acc, signup) => {
     const typeName = signup.shift.shiftType.name;
     acc[typeName] = (acc[typeName] || 0) + 1;
@@ -327,316 +280,464 @@ export async function FriendProfileContent({
     ([, a], [, b]) => (b as number) - (a as number)
   )[0]?.[0];
 
+  // Achievements
+  const totalPoints = unlockedAchievements.reduce(
+    (sum, ua) => sum + ua.achievement.points,
+    0
+  );
+  const [latestUnlock, ...otherUnlocks] = unlockedAchievements;
+  const shelfLimit = 11;
+  const shelfItems = otherUnlocks.slice(0, shelfLimit);
+  const shelfOverflow = otherUnlocks.length - shelfItems.length;
+
   const displayName =
     friend.name ||
     `${friend.firstName || ""} ${friend.lastName || ""}`.trim() ||
     friend.email;
+  const firstName = friend.firstName || displayName.split(" ")[0];
   const initials = (
     friend.firstName?.[0] ||
     friend.name?.[0] ||
     friend.email[0]
   ).toUpperCase();
 
+  const isNewFriend = daysSinceFriendship <= 30;
+  const isCloseBuddy = sharedShiftsCount > 10;
+
   return (
-    <div className="space-y-8">
-      {/* Enhanced Friend Profile Header */}
-      <MotionFriendStats delay={0.1}>
-        <div className="relative overflow-hidden rounded-2xl border border-border/50 bg-gradient-to-br from-primary/5 via-background to-background shadow-md">
-          <div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-primary/10 to-transparent"></div>
-          <div className="absolute top-0 right-0 w-64 h-64 bg-primary/5 rounded-full blur-3xl"></div>
-          <div className="relative p-6 sm:p-8 flex flex-col sm:flex-row items-start sm:items-center gap-6">
-            <div className="relative">
-              <Avatar className="h-24 w-24 sm:h-28 sm:w-28 ring-4 ring-primary/20 ring-offset-4 ring-offset-background shadow-lg">
-                <AvatarImage
-                  src={friend.profilePhotoUrl || undefined}
-                  alt={displayName}
-                />
-                <AvatarFallback className="bg-gradient-to-br from-primary/40 to-primary/20 text-primary text-3xl sm:text-4xl font-bold">
-                  {initials}
-                </AvatarFallback>
-              </Avatar>
-              <div className="absolute -bottom-2 -right-2 w-10 h-10 bg-gradient-to-br from-green-500 to-green-600 rounded-full border-4 border-background flex items-center justify-center shadow-lg">
-                <Heart className="w-5 h-5 text-white fill-white" />
-              </div>
-            </div>
-            <div className="flex-1 space-y-3">
-              <div>
-                <h1 className="text-3xl sm:text-4xl font-bold text-foreground mb-2">
-                  {displayName}
-                </h1>
-                <div className="flex flex-wrap items-center gap-3 sm:gap-4 text-sm text-muted-foreground">
-                  <div className="flex items-center gap-2">
-                    <Clock className="h-4 w-4 text-primary" />
-                    <span>Friends for {daysSinceFriendship} days</span>
-                  </div>
-                  <div className="hidden sm:flex items-center gap-2">
-                    <Handshake className="h-4 w-4 text-primary" />
-                    <span>Volunteer friend</span>
-                  </div>
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {daysSinceFriendship <= 30 && (
-                  <Badge
-                    variant="secondary"
-                    className="bg-gradient-to-r from-green-100 to-emerald-100 dark:from-green-900/50 dark:to-emerald-900/50 text-green-700 dark:text-green-300 border-green-200 dark:border-green-800"
-                  >
-                    <Sparkles className="h-3 w-3 mr-1" />
-                    New Friend
-                  </Badge>
-                )}
-                {sharedShiftsCount > 10 && (
-                  <Badge
-                    variant="secondary"
-                    className="bg-gradient-to-r from-blue-100 to-indigo-100 dark:from-blue-900/50 dark:to-indigo-900/50 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-800"
-                  >
-                    <Handshake className="h-3 w-3 mr-1" />
-                    Close Volunteer Buddy
-                  </Badge>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-      </MotionFriendStats>
-
-      {/* Enhanced Friendship & Activity Stats */}
-      <AnimatedStatsGrid
-        data-testid="friend-stats-grid"
-        stats={[
-          {
-            title: "Days Connected",
-            value: daysSinceFriendship,
-            iconType: "heart",
-            variant: "red",
-            testId: "days-connected",
-          },
-          {
-            title: "Shared Shifts",
-            value: sharedShiftsCount,
-            iconType: "handshake",
-            variant: "green",
-            testId: "shared-shifts",
-          },
-          {
-            title: "Total Shifts",
-            value: friendTotalShifts,
-            iconType: "trendingUp",
-            variant: "blue",
-            testId: "total-shifts",
-          },
-          {
-            title: "Hours Volunteered",
-            value: friendTotalHours,
-            iconType: "clock",
-            variant: "purple",
-            testId: "hours-volunteered",
-          },
-        ]}
-      />
-
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8">
-        {/* Enhanced Friend's Activity Summary */}
-        <MotionFriendStats delay={0.2}>
-          <MotionCard className="overflow-hidden">
-            <CardHeader className="pb-4">
-              <CardTitle className="flex items-center gap-3">
-                <div className="w-10 h-10 bg-gradient-to-br from-primary/20 to-primary/10 rounded-xl flex items-center justify-center shadow-sm">
-                  <Users className="h-5 w-5 text-primary" />
-                </div>
-                <span className="text-xl">{displayName}&apos;s Activity</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="group p-5 bg-gradient-to-br from-primary/10 via-primary/5 to-background rounded-xl border border-primary/20 hover:border-primary/40 transition-all duration-300 hover:shadow-md">
-                  <p className="text-4xl font-bold text-primary mb-2 group-hover:scale-110 transition-transform">
-                    {friendThisMonthShifts}
-                  </p>
-                  <p className="text-xs text-muted-foreground font-semibold uppercase tracking-wide">
-                    This Month
-                  </p>
-                </div>
-                <div className="group p-5 bg-gradient-to-br from-blue-500/10 via-blue-500/5 to-background rounded-xl border border-blue-500/20 hover:border-blue-500/40 transition-all duration-300 hover:shadow-md">
-                  <p className="text-4xl font-bold text-blue-600 dark:text-blue-400 mb-2 group-hover:scale-110 transition-transform">
-                    {avgPerMonth}
-                  </p>
-                  <p className="text-xs text-muted-foreground font-semibold uppercase tracking-wide">
-                    Avg/Month (Last 6 Months)
-                  </p>
-                </div>
-              </div>
-              {favoriteShiftType && (
-                <div className="text-center p-5 bg-gradient-to-br from-muted/50 to-background rounded-xl border border-border hover:border-primary/30 transition-all duration-300">
-                  <Badge variant="outline" className="mb-3 bg-background shadow-sm">
-                    <TrendingUp className="h-3 w-3 mr-1" />
-                    Favorite Role
-                  </Badge>
-                  <p className="font-bold text-xl mb-1 text-foreground">
-                    {favoriteShiftType}
-                  </p>
-                  <p className="text-sm text-muted-foreground">
-                    Completed {shiftTypeCounts[favoriteShiftType]} times
-                  </p>
-                </div>
-              )}
-            </CardContent>
-          </MotionCard>
-        </MotionFriendStats>
-
-        {/* Enhanced Shared Volunteering History */}
-        <MotionFriendStats delay={0.3}>
-          <MotionCard className="overflow-hidden">
-            <CardHeader className="pb-4">
-              <CardTitle className="flex items-center gap-3">
-                <div className="w-10 h-10 bg-gradient-to-br from-green-500/20 to-green-500/10 rounded-xl flex items-center justify-center shadow-sm">
-                  <UserCheck className="h-5 w-5 text-green-600 dark:text-green-400" />
-                </div>
-                <span className="text-xl">Shared Volunteering</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {sharedShifts.length > 0 ? (
-                <div className="space-y-3">
-                  {sharedShifts.slice(0, 5).map((shift) => (
-                    <div
-                      key={shift.id}
-                      className="group flex items-center gap-4 p-4 rounded-xl hover:bg-muted/50 transition-all duration-200 border border-transparent hover:border-border hover:shadow-sm"
-                    >
-                      <div className="w-3 h-3 bg-gradient-to-br from-green-500 to-emerald-500 rounded-full flex-shrink-0 group-hover:scale-125 group-hover:shadow-lg transition-all" />
-                      <div className="flex-1 min-w-0">
-                        <p className="font-semibold text-sm truncate mb-1">
-                          {getShiftPeriodLabel(shift.start)} · {shift.location}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {formatInNZT(shift.start, "MMM d, yyyy")}
-                        </p>
-                      </div>
-                      <Badge
-                        variant={
-                          shift.start >= new Date() ? "default" : "secondary"
-                        }
-                        className="text-xs shadow-sm"
-                      >
-                        {shift.start >= new Date() ? "Upcoming" : "Completed"}
-                      </Badge>
-                    </div>
-                  ))}
-                  {sharedShifts.length > 5 && (
-                    <div className="text-center pt-4 border-t border-border/50">
-                      <p className="text-sm font-medium text-muted-foreground">
-                        +{sharedShifts.length - 5} more shared shifts
-                      </p>
-                    </div>
+    <div className="space-y-12" data-testid="friend-profile-content">
+      {/* ── Identity: forest hero band ─────────────────────────── */}
+      <MotionFriendStats delay={0.05}>
+        <section
+          data-testid="friend-profile-hero"
+          className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-forest-500 to-forest-700 dark:from-forest-600 dark:to-forest-800"
+        >
+          {/* Sun disc rising over the table — brand accent, kept decorative.
+              Soft on small screens where it sits behind the text column. */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-20 -bottom-28 h-72 w-72 rounded-full bg-sun-200 opacity-15 sm:opacity-90 dark:opacity-10 dark:sm:opacity-25"
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -right-10 -top-24 h-56 w-56 rounded-full border-2 border-cream-50/10"
+          />
+          <div className="relative flex flex-col items-start gap-6 p-8 sm:flex-row sm:items-center sm:gap-8 sm:p-10">
+            <Avatar className="h-24 w-24 shrink-0 ring-4 ring-cream-50/90 sm:h-28 sm:w-28">
+              <AvatarImage
+                src={friend.profilePhotoUrl || undefined}
+                alt={displayName}
+              />
+              <AvatarFallback className="bg-forest-100 font-accent text-4xl font-semibold text-forest-600">
+                {initials}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 space-y-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-cream-50/70">
+                Your whānau
+              </p>
+              <h1 className="text-4xl leading-tight text-cream-50 sm:text-5xl">
+                {displayName}
+              </h1>
+              <p className="text-sm text-cream-50/80">
+                Connected since {formatInNZT(friendship.createdAt, "MMMM yyyy")}
+                <span className="text-sun-200"> · {daysSinceFriendship} days</span>
+              </p>
+              {(isNewFriend || isCloseBuddy) && (
+                <div className="flex flex-wrap gap-2 pt-1">
+                  {isNewFriend && (
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-sun-200 px-3 py-1 text-xs font-semibold text-forest-700">
+                      <Sparkles className="h-3 w-3" />
+                      New friend
+                    </span>
+                  )}
+                  {isCloseBuddy && (
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-cream-50/15 px-3 py-1 text-xs font-semibold text-cream-50">
+                      🤝 Close buddy
+                    </span>
                   )}
                 </div>
-              ) : (
-                <div className="text-center py-16">
-                  <div className="relative w-20 h-20 mx-auto mb-5">
-                    <div className="absolute inset-0 bg-gradient-to-br from-green-500/20 to-emerald-500/20 rounded-full blur-xl"></div>
-                    <div className="relative w-full h-full bg-gradient-to-br from-muted/80 to-muted/40 rounded-full flex items-center justify-center">
-                      <UserCheck className="h-10 w-10 text-muted-foreground/50" />
-                    </div>
-                  </div>
-                  <h3 className="font-bold text-lg mb-2">
-                    No shared shifts yet
-                  </h3>
-                  <p className="text-sm text-muted-foreground mb-6 max-w-xs mx-auto">
-                    Sign up for the same shifts to volunteer together and build
-                    memories!
+              )}
+            </div>
+          </div>
+        </section>
+      </MotionFriendStats>
+
+      {/* ── Together: asymmetric bento ─────────────────────────── */}
+      <MotionFriendStats delay={0.12}>
+        <section
+          aria-label="Your friendship in numbers"
+          className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4 lg:grid-rows-2"
+          data-testid="friend-stats-grid"
+        >
+          <div
+            data-testid="shared-shifts"
+            className="relative col-span-2 row-span-2 flex min-h-[200px] flex-col justify-between overflow-hidden rounded-3xl bg-forest-700 p-7 dark:bg-forest-800"
+          >
+            <div
+              aria-hidden
+              className="pointer-events-none absolute -left-10 -top-16 h-44 w-44 rounded-full bg-sun-200/10"
+            />
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-cream-50/60">
+              Shifts together
+            </p>
+            <div>
+              <p className="font-accent text-7xl font-semibold leading-none tracking-tight text-sun-200 tabular-nums sm:text-8xl">
+                {sharedShiftsCount}
+              </p>
+              <p className="mt-2 text-sm italic text-cream-50/70">
+                mahi done side by side
+              </p>
+            </div>
+          </div>
+
+          <BentoStat
+            label="Days connected"
+            value={daysSinceFriendship}
+            testId="days-connected"
+          />
+          <BentoStat
+            label="Mutual friends"
+            value={mutualFriendsCount}
+            testId="mutual-friends"
+          />
+          <BentoStat
+            label="Their hours"
+            value={friendTotalHours}
+            testId="hours-volunteered"
+          />
+          <BentoStat
+            label="Their shifts"
+            value={friendTotalShifts}
+            testId="total-shifts"
+          />
+        </section>
+      </MotionFriendStats>
+
+      {/* ── Trophy shelf: achievements ─────────────────────────── */}
+      <MotionFriendStats delay={0.18}>
+        <section data-testid="friend-achievements">
+          <SectionHeading
+            title="Trophy shelf"
+            meta={
+              unlockedAchievements.length > 0
+                ? `${unlockedAchievements.length} of ${activeAchievementCount} unlocked · ${totalPoints} points`
+                : undefined
+            }
+          />
+          {latestUnlock ? (
+            <div className="space-y-4">
+              {/* Featured latest unlock */}
+              <div className="flex items-center gap-5 rounded-3xl border border-forest-500/15 bg-gradient-to-r from-sun-100/60 via-card to-card p-5 dark:border-border dark:from-sun-200/10 sm:p-6">
+                <AchievementPlate icon={latestUnlock.achievement.icon} size="lg" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-forest-500 dark:text-forest-200">
+                    Latest unlock
                   </p>
-                  <Button
-                    asChild
-                    size="default"
-                    className="shadow-md hover:shadow-lg transition-all"
-                  >
-                    <Link href="/shifts">
-                      <Calendar className="h-4 w-4 mr-2" />
-                      Browse Shifts
-                    </Link>
-                  </Button>
+                  <p className="mt-1 truncate font-accent text-xl font-semibold text-foreground">
+                    {latestUnlock.achievement.name}
+                  </p>
+                  <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground">
+                    {latestUnlock.achievement.description}
+                  </p>
+                </div>
+                <div className="hidden shrink-0 text-right sm:block">
+                  <p className="text-sm font-semibold text-foreground">
+                    +{latestUnlock.achievement.points} pts
+                  </p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {formatInNZT(latestUnlock.unlockedAt, "MMM d, yyyy")}
+                  </p>
+                </div>
+              </div>
+
+              {/* The shelf */}
+              {shelfItems.length > 0 && (
+                <ul className="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-6">
+                  {shelfItems.map((ua) => (
+                    <li
+                      key={ua.achievement.id}
+                      title={`${ua.achievement.description} · unlocked ${formatInNZT(ua.unlockedAt, "MMM d, yyyy")}`}
+                      className="flex flex-col items-center gap-2 rounded-2xl border border-border bg-card p-4 text-center transition-colors hover:border-forest-500/30"
+                    >
+                      <AchievementPlate icon={ua.achievement.icon} />
+                      <p className="line-clamp-2 text-xs font-semibold leading-snug text-foreground">
+                        {ua.achievement.name}
+                      </p>
+                      <p className="text-[11px] text-muted-foreground">
+                        {ua.achievement.points} pts
+                      </p>
+                    </li>
+                  ))}
+                  {shelfOverflow > 0 && (
+                    <li className="flex flex-col items-center justify-center gap-1 rounded-2xl border border-dashed border-border p-4 text-center">
+                      <p className="font-accent text-2xl font-semibold text-forest-500 dark:text-forest-200">
+                        +{shelfOverflow}
+                      </p>
+                      <p className="text-xs text-muted-foreground">more</p>
+                    </li>
+                  )}
+                </ul>
+              )}
+            </div>
+          ) : (
+            <EmptyCanvas
+              title="The shelf is waiting"
+              subtitle={`${firstName} hasn't unlocked any achievements yet — their first shift will start the collection.`}
+            />
+          )}
+        </section>
+      </MotionFriendStats>
+
+      <div className="grid grid-cols-1 items-start gap-10 lg:grid-cols-2 lg:gap-8">
+        {/* ── Their mahi ─────────────────────────────────────── */}
+        <MotionFriendStats delay={0.24}>
+          <section data-testid="friend-activity">
+            <SectionHeading title="Their mahi" />
+            <div className="space-y-4">
+              <div className="flex divide-x divide-border rounded-2xl border border-border bg-card py-5">
+                <RhythmStat value={friendThisMonthShifts} label="This month" />
+                <RhythmStat value={avgPerMonth} label="Avg / month" />
+                <RhythmStat value={friendTotalShifts} label="All-time" />
+              </div>
+              {favoriteShiftType && (
+                <div className="flex overflow-hidden rounded-2xl border border-border bg-card">
+                  <div className="w-1 shrink-0 bg-forest-500 dark:bg-sun-200" />
+                  <div className="flex-1 p-5">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      Favourite role
+                    </p>
+                    <p className="mt-1.5 font-accent text-xl font-semibold text-foreground">
+                      {favoriteShiftType}
+                    </p>
+                    <p className="mt-0.5 text-sm text-muted-foreground">
+                      Completed {shiftTypeCounts[favoriteShiftType]}{" "}
+                      {shiftTypeCounts[favoriteShiftType] === 1 ? "time" : "times"}
+                    </p>
+                  </div>
                 </div>
               )}
-            </CardContent>
-          </MotionCard>
+            </div>
+          </section>
+        </MotionFriendStats>
+
+        {/* ── Shared moments ─────────────────────────────────── */}
+        <MotionFriendStats delay={0.3}>
+          <section data-testid="shared-moments">
+            <SectionHeading title="Shared moments" />
+            {sharedShifts.length > 0 ? (
+              <ol>
+                {sharedShifts.slice(0, 5).map((shift, idx) => {
+                  const isLast =
+                    idx === Math.min(sharedShifts.length, 5) - 1;
+                  const isUpcoming = shift.start >= now;
+                  return (
+                    <li key={shift.id} className="flex gap-4">
+                      <div className="w-11 shrink-0 text-right">
+                        <p className="font-accent text-2xl font-semibold leading-7 text-foreground tabular-nums">
+                          {formatInNZT(shift.start, "d")}
+                        </p>
+                        <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                          {formatInNZT(shift.start, "MMM")}
+                        </p>
+                      </div>
+                      <div className="flex w-3 flex-col items-center pt-2">
+                        <span
+                          className={`h-2.5 w-2.5 rounded-full ${
+                            isUpcoming
+                              ? "bg-forest-500 dark:bg-sun-200"
+                              : "bg-border"
+                          }`}
+                        />
+                        {!isLast && <span className="mt-1 w-px flex-1 bg-border" />}
+                      </div>
+                      <div className="flex-1 pb-6 pt-0.5">
+                        <p className="text-sm font-semibold text-foreground">
+                          {getShiftPeriodLabel(shift.start)}
+                          {shift.location ? ` · ${shift.location}` : ""}
+                        </p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                          {formatInNZT(shift.start, "EEEE, MMM d yyyy")}
+                        </p>
+                        {isUpcoming && (
+                          <span className="mt-1.5 inline-flex items-center gap-1.5 rounded-md bg-sun-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-forest-600 dark:bg-sun-200/15 dark:text-sun-200">
+                            <span className="h-1 w-1 rounded-full bg-forest-500 dark:bg-sun-200" />
+                            Coming up
+                          </span>
+                        )}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ol>
+            ) : (
+              <EmptyCanvas
+                title="No shared shifts yet"
+                subtitle={`Sign up for the same shifts to create moments with ${firstName}.`}
+                action={
+                  <Button asChild size="sm" className="mt-4">
+                    <Link href="/shifts">
+                      <Calendar className="mr-2 h-4 w-4" />
+                      Browse shifts
+                    </Link>
+                  </Button>
+                }
+              />
+            )}
+            {sharedShifts.length > 5 && (
+              <p className="mt-1 text-center text-sm italic text-muted-foreground">
+                + {sharedShifts.length - 5} more shifts together
+              </p>
+            )}
+          </section>
         </MotionFriendStats>
       </div>
 
-      {/* Friend's Upcoming Shifts */}
-      {(friend.friendVisibility === "PUBLIC" ||
-        friend.friendVisibility === "FRIENDS_ONLY") && (
-        <MotionFriendStats delay={0.4}>
-          <MotionCard>
-            <CardHeader>
-              <CardTitle className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 bg-gradient-to-br from-blue-500/20 to-blue-500/10 rounded-xl flex items-center justify-center shadow-sm">
-                    <Calendar className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                  </div>
-                  <span className="text-xl">
-                    {displayName}&apos;s Upcoming Shifts
-                  </span>
-                </div>
-                <Button
-                  asChild
-                  variant="outline"
-                  size="sm"
-                  className="shadow-sm hover:shadow-md transition-all"
-                >
-                  <Link href="/shifts">View All Shifts</Link>
-                </Button>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              {friendUpcomingShifts.length > 0 ? (
-                <div className="space-y-3">
-                  {friendUpcomingShifts.map((signup) => (
-                    <div
-                      key={signup.id}
-                      className="group flex items-center gap-4 p-4 border border-border rounded-xl hover:bg-accent/50 hover:border-primary/30 transition-all duration-200 hover:shadow-sm"
-                    >
-                      <div className="w-14 h-14 bg-gradient-to-br from-primary/20 to-primary/10 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform shadow-sm">
-                        <Calendar className="w-6 h-6 text-primary" />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="font-semibold mb-1">
-                          {signup.shift.shiftType.name}
-                        </p>
-                        <p className="text-sm text-muted-foreground truncate">
-                          {signup.shift.location}
-                        </p>
-                      </div>
-                      <div className="text-right flex-shrink-0">
-                        <p className="text-sm font-bold text-foreground">
-                          {formatInNZT(signup.shift.start, "MMM d")}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {formatInNZT(signup.shift.start, "h:mm a")}
-                        </p>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-16">
-                  <div className="relative w-20 h-20 mx-auto mb-5">
-                    <div className="absolute inset-0 bg-gradient-to-br from-blue-500/20 to-primary/20 rounded-full blur-xl"></div>
-                    <div className="relative w-full h-full bg-gradient-to-br from-muted/80 to-muted/40 rounded-full flex items-center justify-center">
-                      <Calendar className="h-10 w-10 text-muted-foreground/50" />
-                    </div>
-                  </div>
-                  <h3 className="font-bold text-lg mb-2">
-                    No upcoming shifts
-                  </h3>
-                  <p className="text-sm text-muted-foreground max-w-xs mx-auto">
-                    Check back later to see {displayName}&apos;s schedule
-                  </p>
-                </div>
-              )}
-            </CardContent>
-          </MotionCard>
-        </MotionFriendStats>
+      {/* ── Join them ──────────────────────────────────────────── */}
+      <MotionFriendStats delay={0.36}>
+        <section data-testid="upcoming-shifts">
+          <SectionHeading title={`Join ${firstName}`} />
+          {friendUpcomingShifts.length > 0 ? (
+            <>
+              <p className="-mt-2 mb-4 text-sm text-muted-foreground">
+                Pick a shift to sign up alongside {firstName}.
+              </p>
+              <ul className="space-y-3">
+                {friendUpcomingShifts.map((signup) => {
+                  const href = signup.shift.location
+                    ? `/shifts/details?date=${formatInNZT(signup.shift.start, "yyyy-MM-dd")}&location=${encodeURIComponent(signup.shift.location)}`
+                    : "/shifts";
+                  return (
+                    <li key={signup.id}>
+                      <Link
+                        href={href}
+                        className="group flex items-center gap-4 rounded-2xl border border-border bg-card p-4 transition-all hover:border-forest-500/40 hover:shadow-sm"
+                      >
+                        <div className="flex h-14 w-14 shrink-0 flex-col items-center justify-center rounded-xl bg-forest-500/10 dark:bg-forest-100/10">
+                          <span className="font-accent text-xl font-semibold leading-6 text-forest-600 tabular-nums dark:text-forest-200">
+                            {formatInNZT(signup.shift.start, "d")}
+                          </span>
+                          <span className="text-[10px] font-semibold uppercase tracking-wide text-forest-500/80 dark:text-forest-200/80">
+                            {formatInNZT(signup.shift.start, "MMM")}
+                          </span>
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm font-semibold text-foreground">
+                            {signup.shift.shiftType.name}
+                          </p>
+                          <p className="mt-0.5 truncate text-sm text-muted-foreground">
+                            {signup.shift.location ?? "Location TBC"} ·{" "}
+                            {formatInNZT(signup.shift.start, "h:mm a")}
+                          </p>
+                        </div>
+                        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </>
+          ) : (
+            <EmptyCanvas
+              title="Quiet for now"
+              subtitle={`Check back later — ${firstName}'s upcoming shifts will appear here.`}
+            />
+          )}
+        </section>
+      </MotionFriendStats>
+    </div>
+  );
+}
+
+/* ─── Building blocks ───────────────────────────────────────────── */
+
+function SectionHeading({ title, meta }: { title: string; meta?: string }) {
+  return (
+    <div className="mb-5 flex items-baseline gap-4">
+      <h2 className="shrink-0 text-2xl text-foreground">{title}</h2>
+      <div className="h-px flex-1 self-center bg-border" />
+      {meta && (
+        <p className="shrink-0 text-xs font-medium text-muted-foreground">
+          {meta}
+        </p>
       )}
+    </div>
+  );
+}
+
+function BentoStat({
+  label,
+  value,
+  testId,
+}: {
+  label: string;
+  value: number;
+  testId: string;
+}) {
+  return (
+    <div
+      data-testid={testId}
+      className="flex flex-col justify-between gap-3 rounded-2xl border border-border bg-card p-5"
+    >
+      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="font-accent text-4xl font-semibold leading-none tracking-tight text-foreground tabular-nums">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+/** Round "plate" tile for an achievement emoji — the restaurant's trophy. */
+function AchievementPlate({
+  icon,
+  size = "md",
+}: {
+  icon: string;
+  size?: "md" | "lg";
+}) {
+  return (
+    <div
+      aria-hidden
+      className={`flex shrink-0 items-center justify-center rounded-full border border-forest-500/15 bg-cream-100 shadow-[inset_0_0_0_5px_rgba(253,248,239,0.9)] dark:border-border dark:bg-white/[0.06] dark:shadow-[inset_0_0_0_5px_rgba(255,255,255,0.04)] ${
+        size === "lg" ? "h-20 w-20 text-4xl" : "h-14 w-14 text-2xl"
+      }`}
+    >
+      <span>{icon}</span>
+    </div>
+  );
+}
+
+function EmptyCanvas({
+  title,
+  subtitle,
+  action,
+}: {
+  title: string;
+  subtitle: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center rounded-2xl border border-dashed border-border bg-forest-500/[0.03] px-6 py-10 text-center dark:bg-white/[0.02]">
+      <p className="font-accent text-lg font-semibold text-foreground">
+        {title}
+      </p>
+      <p className="mt-1 max-w-xs text-sm text-muted-foreground">{subtitle}</p>
+      {action}
+    </div>
+  );
+}
+
+function RhythmStat({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="flex flex-1 flex-col items-center gap-1">
+      <p className="font-accent text-2xl font-semibold text-foreground tabular-nums">
+        {value}
+      </p>
+      <p className="text-[11px] font-medium tracking-wide text-muted-foreground">
+        {label}
+      </p>
     </div>
   );
 }

--- a/web/src/app/friends/[friendId]/friend-profile-content.tsx
+++ b/web/src/app/friends/[friendId]/friend-profile-content.tsx
@@ -523,8 +523,8 @@ export async function FriendProfileContent({
 
         {/* ── Shared moments ─────────────────────────────────── */}
         <MotionFriendStats delay={0.3}>
-          <section data-testid="shared-moments">
-            <SectionHeading title="Shared moments" />
+          <section data-testid="shared-shifts">
+            <SectionHeading title="Shared shifts" />
             {sharedShifts.length > 0 ? (
               <ol>
                 {sharedShifts.slice(0, 5).map((shift, idx) => {

--- a/web/src/app/friends/[friendId]/friend-profile-content.tsx
+++ b/web/src/app/friends/[friendId]/friend-profile-content.tsx
@@ -418,7 +418,7 @@ export async function FriendProfileContent({
       <MotionFriendStats delay={0.18}>
         <section data-testid="friend-achievements">
           <SectionHeading
-            title="Trophy shelf"
+            title="Achievements"
             meta={
               unlockedAchievements.length > 0
                 ? `${unlockedAchievements.length} of ${activeAchievementCount} unlocked · ${totalPoints} points`
@@ -428,10 +428,18 @@ export async function FriendProfileContent({
           {latestUnlock ? (
             <div className="space-y-4">
               {/* Featured latest unlock */}
-              <div className="flex items-center gap-5 rounded-3xl border border-forest-500/15 bg-gradient-to-r from-sun-100/60 via-card to-card p-5 dark:border-border dark:from-sun-200/10 sm:p-6">
-                <AchievementPlate icon={latestUnlock.achievement.icon} size="lg" />
-                <div className="min-w-0 flex-1">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-forest-500 dark:text-forest-200">
+              <div className="relative flex items-center gap-5 overflow-hidden rounded-3xl border border-sun-300/50 bg-gradient-to-r from-sun-100/80 via-card to-card p-5 dark:border-sun-200/25 dark:from-sun-200/15 dark:via-sun-200/[0.04] dark:to-transparent sm:p-6">
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute -left-12 -top-14 h-40 w-40 rounded-full bg-sun-200/40 blur-2xl dark:bg-sun-200/15"
+                />
+                <AchievementPlate
+                  icon={latestUnlock.achievement.icon}
+                  size="lg"
+                  featured
+                />
+                <div className="relative min-w-0 flex-1">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-forest-500 dark:text-sun-200">
                     Latest unlock
                   </p>
                   <p className="mt-1 truncate font-accent text-xl font-semibold text-foreground">
@@ -440,12 +448,16 @@ export async function FriendProfileContent({
                   <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground">
                     {latestUnlock.achievement.description}
                   </p>
-                </div>
-                <div className="hidden shrink-0 text-right sm:block">
-                  <p className="text-sm font-semibold text-foreground">
-                    +{latestUnlock.achievement.points} pts
+                  <p className="mt-2 text-xs font-medium text-muted-foreground sm:hidden">
+                    +{latestUnlock.achievement.points} pts ·{" "}
+                    {formatInNZT(latestUnlock.unlockedAt, "MMM d, yyyy")}
                   </p>
-                  <p className="mt-0.5 text-xs text-muted-foreground">
+                </div>
+                <div className="relative hidden shrink-0 flex-col items-end gap-1.5 sm:flex">
+                  <span className="inline-flex items-center rounded-full bg-forest-500/10 px-3 py-1 text-xs font-bold text-forest-600 dark:bg-sun-200/15 dark:text-sun-200">
+                    +{latestUnlock.achievement.points} pts
+                  </span>
+                  <p className="text-xs text-muted-foreground">
                     {formatInNZT(latestUnlock.unlockedAt, "MMM d, yyyy")}
                   </p>
                 </div>
@@ -458,13 +470,15 @@ export async function FriendProfileContent({
                     <li
                       key={ua.achievement.id}
                       title={`${ua.achievement.description} · unlocked ${formatInNZT(ua.unlockedAt, "MMM d, yyyy")}`}
-                      className="flex flex-col items-center gap-2 rounded-2xl border border-border bg-card p-4 text-center transition-colors hover:border-forest-500/30"
+                      className="group flex flex-col items-center gap-2.5 rounded-2xl border border-border/70 bg-card p-4 pt-5 text-center transition-all duration-200 hover:-translate-y-0.5 hover:border-forest-500/30 hover:shadow-md dark:hover:border-sun-200/30"
                     >
-                      <AchievementPlate icon={ua.achievement.icon} />
+                      <div className="transition-transform duration-200 group-hover:scale-110">
+                        <AchievementPlate icon={ua.achievement.icon} />
+                      </div>
                       <p className="line-clamp-2 text-xs font-semibold leading-snug text-foreground">
                         {ua.achievement.name}
                       </p>
-                      <p className="text-[11px] text-muted-foreground">
+                      <p className="-mt-1 text-[11px] font-medium text-forest-500/80 dark:text-sun-200/70">
                         {ua.achievement.points} pts
                       </p>
                     </li>
@@ -693,18 +707,28 @@ function BentoStat({
 function AchievementPlate({
   icon,
   size = "md",
+  featured = false,
 }: {
   icon: string;
   size?: "md" | "lg";
+  featured?: boolean;
 }) {
   return (
     <div
       aria-hidden
-      className={`flex shrink-0 items-center justify-center rounded-full border border-forest-500/15 bg-cream-100 shadow-[inset_0_0_0_5px_rgba(253,248,239,0.9)] dark:border-border dark:bg-white/[0.06] dark:shadow-[inset_0_0_0_5px_rgba(255,255,255,0.04)] ${
-        size === "lg" ? "h-20 w-20 text-4xl" : "h-14 w-14 text-2xl"
-      }`}
+      className={`relative flex shrink-0 items-center justify-center rounded-full bg-gradient-to-b shadow-sm ${
+        featured
+          ? "from-sun-100 to-cream-200 ring-2 ring-sun-300/70 dark:from-sun-200/25 dark:to-sun-200/[0.06] dark:ring-sun-200/40"
+          : "from-cream-100 to-cream-200 ring-1 ring-forest-500/15 dark:from-sun-200/[0.14] dark:to-white/[0.02] dark:ring-sun-200/20"
+      } ${size === "lg" ? "h-20 w-20 text-4xl" : "h-14 w-14 text-2xl"}`}
     >
-      <span>{icon}</span>
+      {/* Inner rim — reads as the lip of a plate */}
+      <div
+        className={`pointer-events-none absolute rounded-full border border-forest-500/10 dark:border-cream-50/10 ${
+          size === "lg" ? "inset-2" : "inset-1.5"
+        }`}
+      />
+      <span className="drop-shadow-sm">{icon}</span>
     </div>
   );
 }

--- a/web/src/app/friends/[friendId]/page.tsx
+++ b/web/src/app/friends/[friendId]/page.tsx
@@ -47,121 +47,64 @@ export default async function FriendProfilePage({
         {/* Friend profile content streams in */}
         <Suspense
           fallback={
-            <div className="space-y-8">
-              {/* Profile header skeleton */}
-              <div className="relative overflow-hidden rounded-2xl border border-border/50 bg-muted/10 shadow-md">
-                <div className="p-6 sm:p-8 flex flex-col sm:flex-row items-start sm:items-center gap-6">
-                  <Skeleton className="h-24 w-24 sm:h-28 sm:w-28 rounded-full" />
-                  <div className="flex-1 space-y-3">
-                    <div>
-                      <Skeleton className="h-10 w-56 mb-2" />
-                      <div className="flex items-center gap-4">
-                        <Skeleton className="h-4 w-36" />
-                        <Skeleton className="h-4 w-28 hidden sm:block" />
-                      </div>
-                    </div>
-                    <div className="flex gap-2">
-                      <Skeleton className="h-6 w-24 rounded-full" />
-                    </div>
+            <div className="space-y-12">
+              {/* Hero band skeleton */}
+              <div className="overflow-hidden rounded-3xl border border-border">
+                <div className="flex flex-col items-start gap-6 p-8 sm:flex-row sm:items-center sm:gap-8 sm:p-10">
+                  <Skeleton className="h-24 w-24 shrink-0 rounded-full sm:h-28 sm:w-28" />
+                  <div className="space-y-3">
+                    <Skeleton className="h-3 w-24" />
+                    <Skeleton className="h-11 w-64" />
+                    <Skeleton className="h-4 w-48" />
                   </div>
                 </div>
               </div>
 
-              {/* Stats grid skeleton */}
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {/* Together bento skeleton */}
+              <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4 lg:grid-rows-2">
+                <Skeleton className="col-span-2 row-span-2 min-h-[200px] rounded-3xl" />
                 {[1, 2, 3, 4].map((i) => (
-                  <div
-                    key={i}
-                    className="bg-card border rounded-xl p-5 space-y-3"
-                  >
-                    <Skeleton className="h-4 w-24" />
-                    <Skeleton className="h-8 w-16" />
+                  <Skeleton key={i} className="h-[92px] rounded-2xl" />
+                ))}
+              </div>
+
+              {/* Trophy shelf skeleton */}
+              <div>
+                <div className="mb-5 flex items-center gap-4">
+                  <Skeleton className="h-7 w-36" />
+                  <Skeleton className="h-px flex-1" />
+                </div>
+                <Skeleton className="mb-4 h-28 rounded-3xl" />
+                <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-6">
+                  {[1, 2, 3, 4, 5, 6].map((i) => (
+                    <Skeleton key={i} className="h-32 rounded-2xl" />
+                  ))}
+                </div>
+              </div>
+
+              {/* Their mahi + shared moments skeleton */}
+              <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:gap-8">
+                {[1, 2].map((col) => (
+                  <div key={col}>
+                    <div className="mb-5 flex items-center gap-4">
+                      <Skeleton className="h-7 w-36" />
+                      <Skeleton className="h-px flex-1" />
+                    </div>
+                    <Skeleton className="h-24 rounded-2xl" />
+                    <Skeleton className="mt-4 h-24 rounded-2xl" />
                   </div>
                 ))}
               </div>
 
-              {/* Two-column card layout skeleton */}
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8">
-                {/* Activity card skeleton */}
-                <div className="bg-card border rounded-xl overflow-hidden">
-                  <div className="p-6 pb-4">
-                    <div className="flex items-center gap-3">
-                      <Skeleton className="h-10 w-10 rounded-xl" />
-                      <Skeleton className="h-6 w-44" />
-                    </div>
-                  </div>
-                  <div className="px-6 pb-6 space-y-6">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="p-5 bg-muted/20 rounded-xl border">
-                        <Skeleton className="h-10 w-12 mb-2" />
-                        <Skeleton className="h-3 w-20" />
-                      </div>
-                      <div className="p-5 bg-muted/20 rounded-xl border">
-                        <Skeleton className="h-10 w-12 mb-2" />
-                        <Skeleton className="h-3 w-20" />
-                      </div>
-                    </div>
-                    <div className="p-5 bg-muted/20 rounded-xl border text-center">
-                      <Skeleton className="h-6 w-28 mx-auto mb-3" />
-                      <Skeleton className="h-6 w-36 mx-auto mb-1" />
-                      <Skeleton className="h-4 w-28 mx-auto" />
-                    </div>
-                  </div>
+              {/* Join them skeleton */}
+              <div>
+                <div className="mb-5 flex items-center gap-4">
+                  <Skeleton className="h-7 w-36" />
+                  <Skeleton className="h-px flex-1" />
                 </div>
-
-                {/* Shared volunteering card skeleton */}
-                <div className="bg-card border rounded-xl overflow-hidden">
-                  <div className="p-6 pb-4">
-                    <div className="flex items-center gap-3">
-                      <Skeleton className="h-10 w-10 rounded-xl" />
-                      <Skeleton className="h-6 w-44" />
-                    </div>
-                  </div>
-                  <div className="px-6 pb-6 space-y-3">
-                    {[1, 2, 3, 4, 5].map((i) => (
-                      <div
-                        key={i}
-                        className="flex items-center gap-4 p-4 rounded-xl"
-                      >
-                        <Skeleton className="w-3 h-3 rounded-full" />
-                        <div className="flex-1 min-w-0">
-                          <Skeleton className="h-4 w-32 mb-1" />
-                          <Skeleton className="h-3 w-40" />
-                        </div>
-                        <Skeleton className="h-5 w-20 rounded-full" />
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-
-              {/* Upcoming shifts skeleton */}
-              <div className="bg-card border rounded-xl">
-                <div className="p-6">
-                  <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-                    <div className="flex items-center gap-3">
-                      <Skeleton className="h-10 w-10 rounded-xl" />
-                      <Skeleton className="h-6 w-52" />
-                    </div>
-                    <Skeleton className="h-9 w-28" />
-                  </div>
-                </div>
-                <div className="px-6 pb-6 space-y-3">
+                <div className="space-y-3">
                   {[1, 2, 3].map((i) => (
-                    <div
-                      key={i}
-                      className="flex items-center gap-4 p-4 border border-border rounded-xl"
-                    >
-                      <Skeleton className="w-14 h-14 rounded-xl" />
-                      <div className="flex-1 min-w-0">
-                        <Skeleton className="h-5 w-36 mb-1" />
-                        <Skeleton className="h-4 w-28" />
-                      </div>
-                      <div className="text-right">
-                        <Skeleton className="h-4 w-16 mb-1" />
-                        <Skeleton className="h-3 w-14" />
-                      </div>
-                    </div>
+                    <Skeleton key={i} className="h-[88px] rounded-2xl" />
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
## What changed

Complete visual overhaul of the friend profile pages on **web** and **mobile**, rebuilt around one shared information architecture that reads top to bottom as a story:

1. **Identity** — forest hero band, Fraunces display name, connected-since meta, relationship badges
2. **Together** — asymmetric bento with *shifts together* as the hero stat (dark forest panel, sun numeral), plus days connected, **mutual friends**, their hours and shifts
3. **Trophy shelf** *(new)* — the friend's achievements as round "plates": a featured latest-unlock card, a shelf of emoji plates with points, and an "X of Y unlocked · Z points" summary
4. **Their mahi** — rhythm strip (this month / avg / all-time) + favourite role
5. **Shared moments** — date-rail timeline with *Coming up* tags
6. **Join {name}** — their upcoming shifts; on web these now deep-link to `/shifts/details?date=…&location=…` instead of the generic shifts page

### Web
- `friends/[friendId]/friend-profile-content.tsx` fully rebuilt in the brand system (cream/forest/sun + Fraunces), replacing the old blue/purple/red gradient cards; matching Suspense skeleton in `page.tsx`
- Adds achievements and mutual-friends queries (mutual friends wasn't computed on web at all before)
- Hero sun disc softens to a glow below `sm` so it never sits behind the name

### Mobile
- `app/user/[id].tsx` friend view gains the Trophy shelf (featured unlock + horizontal plate shelf)
- Bento now shows the previously unused mutual-friends stat instead of duplicating total shifts (already shown as *All-time* in the rhythm strip)

### API
- `/api/mobile/users/[id]` friends-only payload now includes `achievements` (unlocked/total counts, points, 12 most recent items); types updated in `use-user-profile.ts`

## Why

The web page predated the brand refresh and was visually off-brand; achievements — a core part of the volunteer experience — were missing entirely from friend profiles on both platforms.

## Reviewer notes

- Achievements are only exposed in the accepted-friends payload/page, matching the existing visibility gating
- No e2e specs cover the friend profile page, so no test updates were needed; `friends.spec.ts` (list page) is untouched
- Verified in browser at desktop/375px/dark mode with seeded data; mobile API payload verified end-to-end with a real JWT; web lint + typecheck and mobile tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)