### PR TITLE
test: add e2e coverage for the redesigned friend profile page

### DIFF
--- a/web/tests/e2e/friend-profile.spec.ts
+++ b/web/tests/e2e/friend-profile.spec.ts
@@ -1,0 +1,267 @@
+import { test, expect } from "./base";
+import type { Browser, Page } from "@playwright/test";
+import { loginAsAdmin, loginAsVolunteer } from "./helpers/auth";
+import {
+  createTestUser,
+  createShift,
+  deleteTestShifts,
+  deleteTestUsers,
+  getUserByEmail,
+} from "./helpers/test-helpers";
+
+/**
+ * E2E coverage for the redesigned friend profile page
+ * (web/src/app/friends/[friendId]/).
+ *
+ * The page requires an authenticated volunteer viewing an ACCEPTED friend,
+ * so beforeAll seeds a pair of users, an accepted friendship, a shared past
+ * shift (which also unlocks achievements for the friend) and an upcoming
+ * shift for the friend — all via the test/admin APIs.
+ *
+ * Serial mode keeps the whole file in one worker so this setup runs exactly
+ * once; parallel workers each re-running beforeAll race each other on the
+ * admin shift API.
+ */
+test.describe.configure({ mode: "serial" });
+
+const FRIEND_FIRST_NAME = "Aroha";
+const FRIEND_LAST_NAME = "Ngata";
+const FRIEND_DISPLAY_NAME = `${FRIEND_FIRST_NAME} ${FRIEND_LAST_NAME}`;
+const SHIFT_LOCATION = "Wellington";
+
+// Seeded once in beforeAll; unique per run so leftover data from an
+// interrupted run can never collide.
+let viewerEmail: string;
+let friendEmail: string;
+let friendId: string;
+let achievementId: string | undefined;
+let achievementName: string;
+let shiftIds: string[] = [];
+let upcomingShiftDate: string; // yyyy-MM-dd, NZT
+
+/** Shift starting at 00:30 UTC is 12:30/13:30 NZT — same calendar date in
+ * both zones, so the NZT date the page renders equals the UTC date. */
+function shiftStartDaysFromNow(days: number): Date {
+  const start = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+  start.setUTCHours(0, 30, 0, 0);
+  return start;
+}
+
+/**
+ * Next.js streaming can briefly render two copies of the page content
+ * (loading + streamed tree), which trips Playwright's strict mode on
+ * page-level testids. Scope to the visible instance.
+ */
+function visibleTestId(page: Page, testId: string) {
+  return page.locator(`[data-testid="${testId}"]:visible`);
+}
+
+async function withPage<T>(
+  browser: Browser,
+  fn: (page: Page) => Promise<T>
+): Promise<T> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  try {
+    return await fn(page);
+  } finally {
+    await context.close();
+  }
+}
+
+test.beforeAll(async ({ browser }, testInfo) => {
+  const runId = `w${testInfo.workerIndex}-${Date.now()}`;
+  viewerEmail = `friend-profile-viewer-${runId}@example.com`;
+  friendEmail = `friend-profile-friend-${runId}@example.com`;
+  achievementName = `E2E Friend Profile Star ${runId}`;
+
+  await withPage(browser, async (page) => {
+    await createTestUser(page, viewerEmail, "VOLUNTEER", {
+      firstName: "Manaia",
+      lastName: "Viewer",
+    });
+    await createTestUser(page, friendEmail, "VOLUNTEER", {
+      firstName: FRIEND_FIRST_NAME,
+      lastName: FRIEND_LAST_NAME,
+    });
+
+    const friend = await getUserByEmail(page, friendEmail);
+    const viewer = await getUserByEmail(page, viewerEmail);
+    if (!friend || !viewer) {
+      throw new Error("Failed to look up seeded test users");
+    }
+    friendId = friend.id;
+
+    // Shifts need an admin session; signups go through the test API.
+    await loginAsAdmin(page);
+
+    const pastStart = shiftStartDaysFromNow(-7);
+    const upcomingStart = shiftStartDaysFromNow(7);
+    upcomingShiftDate = upcomingStart.toISOString().slice(0, 10);
+
+    const pastShift = await createShift(page, {
+      location: SHIFT_LOCATION,
+      start: pastStart,
+      capacity: 4,
+    });
+    const upcomingShift = await createShift(page, {
+      location: SHIFT_LOCATION,
+      start: upcomingStart,
+      capacity: 4,
+    });
+    shiftIds = [pastShift.id, upcomingShift.id];
+
+    // Shared past shift (both volunteers) + an upcoming shift for the friend.
+    for (const signup of [
+      { userId: viewer.id, shiftId: pastShift.id },
+      { userId: friend.id, shiftId: pastShift.id },
+      { userId: friend.id, shiftId: upcomingShift.id },
+    ]) {
+      const response = await page.request.post("/api/test/signups", {
+        data: { ...signup, status: "CONFIRMED" },
+      });
+      if (!response.ok()) {
+        throw new Error(`Failed to create signup: ${await response.text()}`);
+      }
+    }
+
+    // A dedicated achievement the friend is guaranteed to unlock (one
+    // completed shift), so the test doesn't depend on seeded definitions.
+    const achievementResponse = await page.request.post(
+      "/api/admin/achievements",
+      {
+        data: {
+          name: achievementName,
+          description: "Complete a volunteer shift (e2e seed)",
+          category: "MILESTONE",
+          icon: "🌟",
+          criteria: JSON.stringify({ type: "shifts_completed", value: 1 }),
+          points: 15,
+          isActive: true,
+        },
+      }
+    );
+    if (!achievementResponse.ok()) {
+      throw new Error(
+        `Failed to create achievement: ${await achievementResponse.text()}`
+      );
+    }
+    achievementId = (await achievementResponse.json()).id;
+
+    // Establish the ACCEPTED friendship through the real friends API.
+    await loginAsVolunteer(page, viewerEmail);
+    const requestResponse = await page.request.post("/api/friends", {
+      data: { email: friendEmail, message: "Kia ora, let's volunteer!" },
+    });
+    if (!requestResponse.ok()) {
+      throw new Error(
+        `Failed to send friend request: ${await requestResponse.text()}`
+      );
+    }
+
+    await loginAsVolunteer(page, friendEmail);
+    const friendsResponse = await page.request.get("/api/friends");
+    const { pendingRequests } = await friendsResponse.json();
+    const pendingRequest = pendingRequests.find(
+      (request: { id: string; fromUser: { email: string } }) =>
+        request.fromUser.email === viewerEmail
+    );
+    if (!pendingRequest) {
+      throw new Error("Friend request from viewer not found");
+    }
+    const acceptResponse = await page.request.post(
+      `/api/friends/requests/${pendingRequest.id}/accept`
+    );
+    if (!acceptResponse.ok()) {
+      throw new Error(
+        `Failed to accept friend request: ${await acceptResponse.text()}`
+      );
+    }
+
+    // Unlock the friend's achievements based on their completed shift.
+    const unlockResponse = await page.request.post("/api/achievements");
+    if (!unlockResponse.ok()) {
+      throw new Error(
+        `Failed to unlock achievements: ${await unlockResponse.text()}`
+      );
+    }
+  });
+});
+
+test.afterAll(async ({ browser }) => {
+  await withPage(browser, async (page) => {
+    await loginAsAdmin(page);
+    await deleteTestUsers(page, [viewerEmail, friendEmail]);
+    await deleteTestShifts(page, shiftIds);
+    if (achievementId) {
+      await page.request.delete(`/api/admin/achievements/${achievementId}`);
+    }
+  });
+});
+
+test.describe("Friend Profile Page", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsVolunteer(page, viewerEmail);
+    await page.goto(`/friends/${friendId}`);
+  });
+
+  test("renders the hero with the friend's name", async ({ page }) => {
+    const hero = visibleTestId(page, "friend-profile-hero");
+    await expect(hero).toBeVisible({ timeout: 15000 });
+    await expect(hero).toContainText(FRIEND_DISPLAY_NAME);
+    // Friendship context is part of the hero band
+    await expect(hero).toContainText("Connected since");
+  });
+
+  test("renders the together bento stats", async ({ page }) => {
+    const statsGrid = visibleTestId(page, "friend-stats-grid");
+    await expect(statsGrid).toBeVisible({ timeout: 15000 });
+
+    // Scope to the grid: a "shared-shifts" testid also exists on the
+    // shared-shifts timeline section further down the page.
+    const sharedShifts = statsGrid.getByTestId("shared-shifts");
+    await expect(sharedShifts).toContainText("Shifts together");
+    // Both volunteers were signed up for the same past shift
+    await expect(sharedShifts).toContainText("1");
+
+    const mutualFriends = statsGrid.getByTestId("mutual-friends");
+    await expect(mutualFriends).toContainText("Mutual friends");
+    // Fresh users share no other friends
+    await expect(mutualFriends).toContainText("0");
+  });
+
+  test("renders achievements with the latest unlock featured", async ({
+    page,
+  }) => {
+    const achievements = visibleTestId(page, "friend-achievements");
+    await expect(achievements).toBeVisible({ timeout: 15000 });
+
+    // The friend has UserAchievement rows, so the featured card renders
+    // instead of the empty state.
+    await expect(achievements).toContainText("Latest unlock");
+    // The dedicated e2e achievement was unlocked by the friend's completed
+    // shift — it appears either as the featured card or on the shelf.
+    await expect(achievements).toContainText(achievementName);
+  });
+
+  test("links an upcoming shift row to the shift details page", async ({
+    page,
+  }) => {
+    const upcomingShifts = visibleTestId(page, "upcoming-shifts");
+    await expect(upcomingShifts).toBeVisible({ timeout: 15000 });
+
+    const expectedHref = `/shifts/details?date=${upcomingShiftDate}&location=${encodeURIComponent(
+      SHIFT_LOCATION
+    )}`;
+    const shiftLink = upcomingShifts.locator(
+      `a[href="${expectedHref}"]`
+    );
+    await expect(shiftLink).toBeVisible();
+    await expect(shiftLink).toContainText(SHIFT_LOCATION);
+
+    await shiftLink.click();
+    await page.waitForURL(`**/shifts/details?*`);
+    expect(page.url()).toContain(`date=${upcomingShiftDate}`);
+    expect(page.url()).toContain(`location=${SHIFT_LOCATION}`);
+  });
+});

--- a/web/tests/e2e/friend-profile.spec.ts
+++ b/web/tests/e2e/friend-profile.spec.ts
@@ -7,6 +7,7 @@ import {
   deleteTestShifts,
   deleteTestUsers,
   getUserByEmail,
+  visibleTestId,
 } from "./helpers/test-helpers";
 
 /**
@@ -23,6 +24,9 @@ import {
  * admin shift API.
  */
 test.describe.configure({ mode: "serial" });
+
+// The page streams its content in via Suspense after several DB queries
+const PAGE_LOAD_TIMEOUT = 15000;
 
 const FRIEND_FIRST_NAME = "Aroha";
 const FRIEND_LAST_NAME = "Ngata";
@@ -45,15 +49,6 @@ function shiftStartDaysFromNow(days: number): Date {
   const start = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
   start.setUTCHours(0, 30, 0, 0);
   return start;
-}
-
-/**
- * Next.js streaming can briefly render two copies of the page content
- * (loading + streamed tree), which trips Playwright's strict mode on
- * page-level testids. Scope to the visible instance.
- */
-function visibleTestId(page: Page, testId: string) {
-  return page.locator(`[data-testid="${testId}"]:visible`);
 }
 
 async function withPage<T>(
@@ -194,7 +189,14 @@ test.afterAll(async ({ browser }) => {
     await deleteTestUsers(page, [viewerEmail, friendEmail]);
     await deleteTestShifts(page, shiftIds);
     if (achievementId) {
-      await page.request.delete(`/api/admin/achievements/${achievementId}`);
+      const deleteResponse = await page.request.delete(
+        `/api/admin/achievements/${achievementId}`
+      );
+      if (!deleteResponse.ok()) {
+        console.warn(
+          `Failed to delete achievement ${achievementId}: ${await deleteResponse.text()}`
+        );
+      }
     }
   });
 });
@@ -207,7 +209,7 @@ test.describe("Friend Profile Page", () => {
 
   test("renders the hero with the friend's name", async ({ page }) => {
     const hero = visibleTestId(page, "friend-profile-hero");
-    await expect(hero).toBeVisible({ timeout: 15000 });
+    await expect(hero).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
     await expect(hero).toContainText(FRIEND_DISPLAY_NAME);
     // Friendship context is part of the hero band
     await expect(hero).toContainText("Connected since");
@@ -215,7 +217,7 @@ test.describe("Friend Profile Page", () => {
 
   test("renders the together bento stats", async ({ page }) => {
     const statsGrid = visibleTestId(page, "friend-stats-grid");
-    await expect(statsGrid).toBeVisible({ timeout: 15000 });
+    await expect(statsGrid).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     // Scope to the grid: a "shared-shifts" testid also exists on the
     // shared-shifts timeline section further down the page.
@@ -234,7 +236,7 @@ test.describe("Friend Profile Page", () => {
     page,
   }) => {
     const achievements = visibleTestId(page, "friend-achievements");
-    await expect(achievements).toBeVisible({ timeout: 15000 });
+    await expect(achievements).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     // The friend has UserAchievement rows, so the featured card renders
     // instead of the empty state.
@@ -248,7 +250,7 @@ test.describe("Friend Profile Page", () => {
     page,
   }) => {
     const upcomingShifts = visibleTestId(page, "upcoming-shifts");
-    await expect(upcomingShifts).toBeVisible({ timeout: 15000 });
+    await expect(upcomingShifts).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
 
     const expectedHref = `/shifts/details?date=${upcomingShiftDate}&location=${encodeURIComponent(
       SHIFT_LOCATION

--- a/web/tests/e2e/helpers/test-helpers.ts
+++ b/web/tests/e2e/helpers/test-helpers.ts
@@ -1,6 +1,17 @@
 import { Page, expect } from "@playwright/test";
 
 /**
+ * Locate a testid scoped to its visible instance.
+ *
+ * Next.js streaming can briefly render two copies of the page content
+ * (loading + streamed tree), which trips Playwright's strict mode on
+ * page-level testids — one copy is hidden, so scope to the visible one.
+ */
+export function visibleTestId(page: Page, testId: string) {
+  return page.locator(`[data-testid="${testId}"]:visible`);
+}
+
+/**
  * Create a test user via test API endpoint
  * Uses /api/test/users which is only available in non-production
  */


### PR DESCRIPTION
# Pull Request

## Description
Adds `web/tests/e2e/friend-profile.spec.ts`, the follow-up e2e coverage suggested in the review of #1082 for the redesigned friend profile page (`web/src/app/friends/[friendId]/`). Four tests cover:

1. The hero (`data-testid="friend-profile-hero"`) renders with the friend's name and the "Connected since" line.
2. The together bento stats (`friend-stats-grid`) render, asserting deterministic values for `shared-shifts` (1, from a shared past shift) and `mutual-friends` (0). The `shared-shifts` locator is scoped inside the grid because the redesign reuses that testid on the shared-shifts timeline section.
3. The achievements section (`friend-achievements`) renders the "Latest unlock" featured card and the seeded achievement's name.
4. An upcoming-shift row in `upcoming-shifts` links to `/shifts/details?date=...&location=...` — asserts the exact href, clicks through, and verifies navigation.

**Test setup** (all via existing test/admin APIs, no app code changes): `beforeAll` creates two fresh volunteers with run-unique emails, an admin-created past + upcoming shift, confirmed signups, a friend request sent and accepted through the real friends API, and a dedicated `shifts_completed >= 1` achievement created via `/api/admin/achievements` then unlocked via `POST /api/achievements` — so the suite never depends on seed-demo achievement definitions. `afterAll` cleans everything up.

**Robustness notes for reviewers:**
- Shifts start at 00:30 UTC (midday NZT), so the NZT date in the details link equals the UTC date — no timezone-boundary flakiness.
- Page-level testids are scoped to `:visible` because Next.js streaming briefly renders two copies of the content tree (known strict-mode flake pattern in this repo).
- The file uses `test.describe.configure({ mode: "serial" })` (same pattern as `admin-assign-past-shifts.spec.ts`): with multiple workers each re-running the heavy `beforeAll`, `/api/admin/shifts` intermittently 500s.

## Type of Change
- [x] 🧪 Tests (adding missing tests or correcting existing tests)

## Version Bump Required
`version:skip` — tests only.

## Testing
- [x] E2E tests pass (`npx playwright test friend-profile.spec.ts --project=chromium`: 4 passed in ~22s against the #1082 page code)
- [x] New tests added
- [x] `eslint` and `tsc --noEmit` clean

## Additional Notes
Suggested as a follow-up in the review of #1082 (now merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)