### PR TITLE
fix(flaky): should successfully login with demo credentials

### DIFF
--- a/web/tests/e2e/login.spec.ts
+++ b/web/tests/e2e/login.spec.ts
@@ -216,12 +216,16 @@ test.describe("Login Page", () => {
       const submitButton = page.getByTestId("login-submit-button");
       await submitButton.click();
 
-      // Wait for navigation away from login page
+      // Wait for navigation away from login page. The credentials sign-in
+      // redirect lands on /dashboard, which the CI webServer runs in dev
+      // mode (on-demand route compilation) — under sharded CI load the
+      // first compile of that route can take well over 10s, so this needs
+      // more headroom than a warm/production navigation would.
       await page.waitForURL(
         (url) => {
           return url.pathname !== "/login";
         },
-        { timeout: 10000 }
+        { timeout: 20000 }
       );
 
       // Verify we're no longer on login page


### PR DESCRIPTION
## Description
Fixes the flakiest e2e test found in a scan of the last 7 days of CI runs on `main`: `tests/e2e/login.spec.ts:212` — `Login Page › Successful Login Flows › should successfully login with demo credentials`. It failed-then-passed-on-retry in 3 of 3 observed occurrences this week, always with the same error:

```
TimeoutError: page.waitForURL: Timeout 10000ms exceeded
```

**Root cause**: the e2e `webServer` runs `next dev` (on-demand route compilation), not a production build. After submitting the credentials form, the browser navigates to `/dashboard`. If that shard is the first to hit the `/dashboard` route in a given CI job, Next.js has to compile it on demand, which can take well over 10s under CI resource contention (20 parallel shards × 2 workers sharing one runner) — even though the login itself succeeded. The test's `page.waitForURL(..., { timeout: 10000 })` was too tight for that on-demand compile, so it timed out despite nothing being functionally broken.

**Verification**: reproduced the exact failure mode locally against a cold dev server (`page.waitForURL` timed out while `navigated to "http://localhost:3000/dashboard"` had already happened but the `load` event hadn't fired yet — matching the CI error precisely). With the timeout raised to 20s, ran the test 8 times under CI-like settings (`CI=true`, 2 workers, 30s overall test timeout) with 0 failures.

## Fix
Bumped `page.waitForURL`'s timeout from 10s → 20s in this test, which still comfortably fits inside the workflow's 30s per-test timeout (`playwright.config.ts` sets `timeout: 30000` in CI).

## Type of Change
- [x] 🧪 Tests (adding missing tests or correcting existing tests)

## Testing
- [x] E2E tests pass (verified locally: 8/8 repeated runs of the fixed test under CI-like settings)
- [ ] Manual testing completed (not applicable — test-only change)
- [ ] New tests added (not applicable — existing test's timeout adjusted)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
This was surfaced by a scheduled flaky-test scan of the last 7 days of CI runs on `main`. Other flaky/consistently-failing tests were found but out of scope for this PR (see the accompanying report for the full ranked list, including `tests/e2e/my-shifts.spec.ts:361` which looks like a genuine product/test-isolation bug worth separate investigation — a recurring `[SSE] Connection error` triggers the Next.js dev error overlay, which then collides with the test's `[role='dialog']` locator).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgWxCPmFejQAj9MvzM7iZT)_