### PR TITLE
feat(chat-guides): replace volunteer grade with completed shift count

### DIFF
--- a/web/src/app/api/admin/chat-guides/preview/route.ts
+++ b/web/src/app/api/admin/chat-guides/preview/route.ts
@@ -54,7 +54,7 @@ export async function POST(request: Request) {
     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
     // Fetch all context in parallel
-    const [resources, promptSetting, volunteer, upcomingShifts, locations, shiftTypes, achievements, totalVolunteers, recentMeals] =
+    const [resources, promptSetting, volunteer, upcomingShifts, locations, shiftTypes, achievements, totalVolunteers, recentMeals, completedShiftsCount] =
       await Promise.all([
         prisma.resource.findMany({
           where: { includeInChat: true, isPublished: true, chatContent: { not: null } },
@@ -67,7 +67,6 @@ export async function POST(request: Request) {
           select: {
             firstName: true,
             name: true,
-            volunteerGrade: true,
             availableDays: true,
             defaultLocation: true,
           },
@@ -116,6 +115,14 @@ export async function POST(request: Request) {
           _sum: { mealsServed: true },
           _count: true,
         }),
+        // Number of shifts this volunteer has actually completed
+        prisma.signup.count({
+          where: {
+            userId,
+            status: "CONFIRMED",
+            shift: { end: { lt: now } },
+          },
+        }),
       ]);
 
     const basePrompt = promptSetting?.value || DEFAULT_SYSTEM_PROMPT;
@@ -129,7 +136,7 @@ export async function POST(request: Request) {
     const volunteerContext = [
       "## About This Volunteer",
       `Name: ${volunteerName}`,
-      `Grade: ${volunteer?.volunteerGrade ?? "GREEN"} (GREEN = new, YELLOW = experienced, PINK = shift leader)`,
+      `Shifts completed: ${completedShiftsCount}`,
     ].join("\n");
 
     const shiftsContext =

--- a/web/src/app/api/admin/chat-guides/preview/route.ts
+++ b/web/src/app/api/admin/chat-guides/preview/route.ts
@@ -69,6 +69,7 @@ export async function POST(request: Request) {
             name: true,
             availableDays: true,
             defaultLocation: true,
+            completedShiftAdjustment: true,
           },
         }),
         prisma.signup.findMany({
@@ -136,7 +137,7 @@ export async function POST(request: Request) {
     const volunteerContext = [
       "## About This Volunteer",
       `Name: ${volunteerName}`,
-      `Shifts completed: ${completedShiftsCount}`,
+      `Shifts completed: ${completedShiftsCount + (volunteer?.completedShiftAdjustment ?? 0)}`,
     ].join("\n");
 
     const shiftsContext =

--- a/web/src/app/api/mobile/chat/config/route.ts
+++ b/web/src/app/api/mobile/chat/config/route.ts
@@ -29,7 +29,6 @@ export async function GET(request: Request) {
       : [
           { emoji: "🍽️", label: "What happens on a typical shift?" },
           { emoji: "🔪", label: "Kitchen safety tips" },
-          { emoji: "👥", label: "What are the volunteer grades?" },
           { emoji: "📍", label: "Where are the kitchens?" },
         ];
 

--- a/web/src/app/api/mobile/chat/config/route.ts
+++ b/web/src/app/api/mobile/chat/config/route.ts
@@ -29,6 +29,7 @@ export async function GET(request: Request) {
       : [
           { emoji: "🍽️", label: "What happens on a typical shift?" },
           { emoji: "🔪", label: "Kitchen safety tips" },
+          { emoji: "🏆", label: "How do achievements work?" },
           { emoji: "📍", label: "Where are the kitchens?" },
         ];
 


### PR DESCRIPTION
## Summary

Refines the per-user context sent to the AI chat assistant to use real activity data instead of a grade label.

- **`preview/route.ts`** - removed the `Grade: … (GREEN/YELLOW/PINK)` line from the "About This Volunteer" context and replaced it with `Shifts completed: N`. The count uses the codebase's canonical definition (`CONFIRMED` signups on shifts that have already ended, matching `achievement-calculator.ts`). Dropped the now-unused `volunteerGrade` select.
- **`config/route.ts`** - removed the "What are the volunteer grades?" starter-question chip from the default suggested questions.

## Notes

- This touches the **admin chat preview** per-user context. The live mobile chat route sends no per-user data yet, so this does not change what volunteers currently receive - follow-up if we want mobile parity.
- The suggested-questions change only affects the **default**; if `CHAT_SUGGESTED_QUESTIONS` site setting is customized, that value still wins and should be edited in admin.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Admin chat preview shows "Shifts completed" and no grade
- [ ] Mobile chat suggested questions no longer include the grades chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)