### PR TITLE
feat(chat-guides): AI model config, preview override & content refine

### DIFF
--- a/web/src/app/admin/chat-guides/chat-guides-content.tsx
+++ b/web/src/app/admin/chat-guides/chat-guides-content.tsx
@@ -7,7 +7,6 @@ import {
   Trash2,
   Pencil,
   FileText,
-  Check,
   X,
   Info,
   Send,
@@ -93,6 +92,7 @@ interface ChatGuidesContentProps {
   estimatedTokens: number;
   initialSystemPrompt: string;
   initialSuggestedQuestions: string; // JSON string
+  initialModel: string;
 }
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -132,12 +132,25 @@ const DEFAULT_QUESTIONS: SuggestedQuestion[] = [
   { emoji: "📍", label: "Where are the kitchens?" },
 ];
 
+// Fallback model used when no CHAT_MODEL setting is saved (must match the API routes).
+const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
+
+// Recommended models — capable enough to answer reliably from the knowledge base.
+// Avoid "nano"/"mini" tiers: they struggle to retrieve facts from long context.
+const RECOMMENDED_MODELS = [
+  "anthropic/claude-sonnet-4",
+  "anthropic/claude-3.7-sonnet",
+  "openai/gpt-5",
+  "google/gemini-2.5-flash",
+];
+
 export function ChatGuidesContent({
   initialChatResources,
   allResources,
   estimatedTokens: initialTokens,
   initialSystemPrompt,
   initialSuggestedQuestions,
+  initialModel,
 }: ChatGuidesContentProps) {
   const { toast } = useToast();
   const [chatResources, setChatResources] = useState(initialChatResources);
@@ -155,6 +168,7 @@ export function ChatGuidesContent({
       return DEFAULT_QUESTIONS;
     }
   });
+  const [model, setModel] = useState(initialModel);
   const [isSavingSettings, setIsSavingSettings] = useState(false);
 
   // Add resource dialog
@@ -222,6 +236,7 @@ export function ChatGuidesContent({
         body: JSON.stringify({
           systemPrompt,
           suggestedQuestions,
+          model: model.trim(),
         }),
       });
 
@@ -689,7 +704,7 @@ export function ChatGuidesContent({
       toast({ title: "Removed from chat context", description: removingResource.title });
       setRemoveDialogOpen(false);
       setRemovingResource(null);
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to remove resource from chat",
@@ -764,6 +779,42 @@ export function ChatGuidesContent({
           </p>
         </div>
       </div>
+
+      {/* AI Model */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">AI Model</CardTitle>
+          <CardDescription>
+            The OpenRouter model that powers the chat assistant. Leave blank to use the
+            default ({DEFAULT_MODEL}). Avoid &quot;nano&quot; / &quot;mini&quot; tiers — they
+            struggle to answer reliably from the knowledge base.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Input
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder={DEFAULT_MODEL}
+            className="font-mono text-sm"
+            aria-label="OpenRouter model ID"
+          />
+          <div className="flex flex-wrap gap-2">
+            <span className="text-xs text-muted-foreground self-center">Recommended:</span>
+            {RECOMMENDED_MODELS.map((m) => (
+              <Button
+                key={m}
+                type="button"
+                variant={model.trim() === m ? "default" : "outline"}
+                size="sm"
+                onClick={() => setModel(m)}
+                className="h-7 font-mono text-xs"
+              >
+                {m}
+              </Button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
 
       {/* System Prompt & Suggested Questions */}
       <div className="grid gap-6 lg:grid-cols-2">

--- a/web/src/app/admin/chat-guides/chat-guides-content.tsx
+++ b/web/src/app/admin/chat-guides/chat-guides-content.tsx
@@ -213,6 +213,8 @@ export function ChatGuidesContent({
   const [previewMessages, setPreviewMessages] = useState<PreviewMessage[]>([]);
   const [previewInput, setPreviewInput] = useState("");
   const [previewLoading, setPreviewLoading] = useState(false);
+  // Per-preview model override — lets admins A/B models without changing the saved setting.
+  const [previewModel, setPreviewModel] = useState(initialModel);
   const previewEndRef = useRef<HTMLDivElement>(null);
 
   const availableResources = allResources.filter(
@@ -564,6 +566,7 @@ export function ChatGuidesContent({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           messages: allMsgs.map((m) => ({ role: m.role, content: m.content })),
+          model: previewModel.trim() || undefined,
         }),
       });
 
@@ -600,7 +603,7 @@ export function ChatGuidesContent({
       setPreviewLoading(false);
       setTimeout(() => previewEndRef.current?.scrollIntoView({ behavior: "smooth" }), 100);
     }
-  }, [previewInput, previewLoading, previewMessages]);
+  }, [previewInput, previewLoading, previewMessages, previewModel]);
 
   const resetPreview = () => {
     setPreviewMessages([]);
@@ -1029,6 +1032,24 @@ export function ChatGuidesContent({
                 Reset
               </Button>
             )}
+          </div>
+          <div className="mt-3 flex items-center gap-2">
+            <Label htmlFor="preview-model" className="shrink-0 text-xs text-muted-foreground">
+              Model
+            </Label>
+            <Input
+              id="preview-model"
+              list="preview-model-presets"
+              value={previewModel}
+              onChange={(e) => setPreviewModel(e.target.value)}
+              placeholder={`${DEFAULT_MODEL} (saved default)`}
+              className="h-8 font-mono text-xs"
+            />
+            <datalist id="preview-model-presets">
+              {RECOMMENDED_MODELS.map((m) => (
+                <option key={m} value={m} />
+              ))}
+            </datalist>
           </div>
         </CardHeader>
         <CardContent>

--- a/web/src/app/admin/chat-guides/chat-guides-content.tsx
+++ b/web/src/app/admin/chat-guides/chat-guides-content.tsx
@@ -57,6 +57,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
+import { DEFAULT_CHAT_MODEL } from "@/lib/chat-model";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -132,9 +133,6 @@ const DEFAULT_QUESTIONS: SuggestedQuestion[] = [
   { emoji: "👥", label: "What are the volunteer grades?" },
   { emoji: "📍", label: "Where are the kitchens?" },
 ];
-
-// Fallback model used when no CHAT_MODEL setting is saved (must match the API routes).
-const DEFAULT_MODEL = "anthropic/claude-sonnet-4";
 
 // Recommended models — capable enough to answer reliably from the knowledge base.
 // Avoid "nano"/"mini" tiers: they struggle to retrieve facts from long context.
@@ -826,7 +824,7 @@ export function ChatGuidesContent({
           <CardTitle className="text-base">AI Model</CardTitle>
           <CardDescription>
             The OpenRouter model that powers the chat assistant. Leave blank to use the
-            default ({DEFAULT_MODEL}). Avoid &quot;nano&quot; / &quot;mini&quot; tiers — they
+            default ({DEFAULT_CHAT_MODEL}). Avoid &quot;nano&quot; / &quot;mini&quot; tiers — they
             struggle to answer reliably from the knowledge base.
           </CardDescription>
         </CardHeader>
@@ -834,7 +832,7 @@ export function ChatGuidesContent({
           <Input
             value={model}
             onChange={(e) => setModel(e.target.value)}
-            placeholder={DEFAULT_MODEL}
+            placeholder={DEFAULT_CHAT_MODEL}
             className="font-mono text-sm"
             aria-label="OpenRouter model ID"
           />
@@ -1079,7 +1077,7 @@ export function ChatGuidesContent({
               list="preview-model-presets"
               value={previewModel}
               onChange={(e) => setPreviewModel(e.target.value)}
-              placeholder={`${DEFAULT_MODEL} (saved default)`}
+              placeholder={`${DEFAULT_CHAT_MODEL} (saved default)`}
               className="h-8 font-mono text-xs"
             />
             <datalist id="preview-model-presets">

--- a/web/src/app/admin/chat-guides/chat-guides-content.tsx
+++ b/web/src/app/admin/chat-guides/chat-guides-content.tsx
@@ -16,6 +16,7 @@ import {
   Globe,
   RefreshCw,
   Link,
+  Sparkles,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -197,6 +198,9 @@ export function ChatGuidesContent({
   const [editContent, setEditContent] = useState("");
   const [isSaving, setIsSaving] = useState(false);
 
+  // AI refine (shared across edit / import / create dialogs; key identifies which is running)
+  const [refiningKey, setRefiningKey] = useState<null | "edit" | "import" | "create">(null);
+
   // Remove dialog
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
   const [removingResource, setRemovingResource] = useState<ChatResource | null>(null);
@@ -227,6 +231,39 @@ export function ChatGuidesContent({
       0,
     );
     setEstimatedTokens(Math.round(chars / 4));
+  };
+
+  // Send raw imported/linked text to the AI and replace it with a cleaned-up version.
+  const handleRefine = async (
+    key: "edit" | "import" | "create",
+    content: string,
+    title: string | undefined,
+    apply: (refined: string) => void,
+  ) => {
+    if (!content.trim() || refiningKey) return;
+    setRefiningKey(key);
+    try {
+      const response = await fetch("/api/admin/chat-guides/refine", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content, title }),
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err.error || "Failed to refine content");
+      }
+      const { refined } = await response.json();
+      apply(refined);
+      toast({ title: "Content refined", description: "Review the result before saving." });
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to refine",
+        variant: "destructive",
+      });
+    } finally {
+      setRefiningKey(null);
+    }
   };
 
   const handleSaveSettings = async () => {
@@ -1233,6 +1270,23 @@ export function ChatGuidesContent({
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
+            <div className="flex items-center justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  handleRefine("edit", editContent, editingResource?.title, setEditContent)
+                }
+                disabled={!editContent.trim() || refiningKey !== null}
+              >
+                {refiningKey === "edit" ? (
+                  <RefreshCw className="mr-1 h-3 w-3 animate-spin" />
+                ) : (
+                  <Sparkles className="mr-1 h-3 w-3" />
+                )}
+                {refiningKey === "edit" ? "Refining..." : "Refine with AI"}
+              </Button>
+            </div>
             <Textarea
               value={editContent}
               onChange={(e) => setEditContent(e.target.value)}
@@ -1240,7 +1294,8 @@ export function ChatGuidesContent({
               className="font-mono text-sm"
             />
             <p className="text-xs text-muted-foreground">
-              ~{Math.round(editContent.length / 4).toLocaleString()} tokens
+              ~{Math.round(editContent.length / 4).toLocaleString()} tokens · Refine cleans up
+              imported text — review before saving.
             </p>
           </div>
           <DialogFooter>
@@ -1340,7 +1395,24 @@ export function ChatGuidesContent({
               </div>
             </div>
             <div className="space-y-2">
-              <Label>Extracted Content</Label>
+              <div className="flex items-center justify-between">
+                <Label>Extracted Content</Label>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    handleRefine("import", importContent, importTitle, setImportContent)
+                  }
+                  disabled={!importContent.trim() || isExtractingImportUrl || refiningKey !== null}
+                >
+                  {refiningKey === "import" ? (
+                    <RefreshCw className="mr-1 h-3 w-3 animate-spin" />
+                  ) : (
+                    <Sparkles className="mr-1 h-3 w-3" />
+                  )}
+                  {refiningKey === "import" ? "Refining..." : "Refine with AI"}
+                </Button>
+              </div>
               <Textarea
                 value={importContent}
                 onChange={(e) => setImportContent(e.target.value)}
@@ -1409,7 +1481,24 @@ export function ChatGuidesContent({
               </Select>
             </div>
             <div className="space-y-2">
-              <Label>Content</Label>
+              <div className="flex items-center justify-between">
+                <Label>Content</Label>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    handleRefine("create", newContent, newTitle, setNewContent)
+                  }
+                  disabled={!newContent.trim() || refiningKey !== null}
+                >
+                  {refiningKey === "create" ? (
+                    <RefreshCw className="mr-1 h-3 w-3 animate-spin" />
+                  ) : (
+                    <Sparkles className="mr-1 h-3 w-3" />
+                  )}
+                  {refiningKey === "create" ? "Refining..." : "Refine with AI"}
+                </Button>
+              </div>
               <Textarea
                 value={newContent}
                 onChange={(e) => setNewContent(e.target.value)}

--- a/web/src/app/admin/chat-guides/page.tsx
+++ b/web/src/app/admin/chat-guides/page.tsx
@@ -54,12 +54,13 @@ export default async function ChatGuidesPage() {
     }),
     // Chat prompt settings
     prisma.siteSetting.findMany({
-      where: { key: { in: ["CHAT_SYSTEM_PROMPT", "CHAT_SUGGESTED_QUESTIONS"] } },
+      where: { key: { in: ["CHAT_SYSTEM_PROMPT", "CHAT_SUGGESTED_QUESTIONS", "CHAT_MODEL"] } },
     }),
   ]);
 
   const systemPrompt = chatSettings.find((s) => s.key === "CHAT_SYSTEM_PROMPT")?.value ?? "";
   const suggestedQuestions = chatSettings.find((s) => s.key === "CHAT_SUGGESTED_QUESTIONS")?.value ?? "[]";
+  const model = chatSettings.find((s) => s.key === "CHAT_MODEL")?.value ?? "";
 
   // Estimate total token count (rough: ~4 chars per token)
   const totalChars = chatResources.reduce(
@@ -87,6 +88,7 @@ export default async function ChatGuidesPage() {
         estimatedTokens={estimatedTokens}
         initialSystemPrompt={systemPrompt}
         initialSuggestedQuestions={suggestedQuestions}
+        initialModel={model}
       />
     </AdminPageWrapper>
   );

--- a/web/src/app/api/admin/chat-guides/preview/route.ts
+++ b/web/src/app/api/admin/chat-guides/preview/route.ts
@@ -54,7 +54,7 @@ export async function POST(request: Request) {
     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
     // Fetch all context in parallel
-    const [resources, promptSetting, volunteer, upcomingShifts, locations, shiftTypes, achievements, totalVolunteers, recentMeals] =
+    const [resources, promptSetting, modelSetting, volunteer, upcomingShifts, locations, shiftTypes, achievements, totalVolunteers, recentMeals] =
       await Promise.all([
         prisma.resource.findMany({
           where: { includeInChat: true, isPublished: true, chatContent: { not: null } },
@@ -62,6 +62,7 @@ export async function POST(request: Request) {
           orderBy: { category: "asc" },
         }),
         prisma.siteSetting.findUnique({ where: { key: "CHAT_SYSTEM_PROMPT" } }),
+        prisma.siteSetting.findUnique({ where: { key: "CHAT_MODEL" } }),
         prisma.user.findUnique({
           where: { id: userId },
           select: {
@@ -171,7 +172,10 @@ export async function POST(request: Request) {
 
     const systemPrompt = basePrompt + "\n\n" + dynamicContext + "\n\nHere is your knowledge base:\n---\n" + resourceContext + "\n---";
 
-    const modelId = process.env.OPENROUTER_MODEL ?? "anthropic/claude-sonnet-4";
+    const modelId =
+      modelSetting?.value?.trim() ||
+      process.env.OPENROUTER_MODEL ||
+      "anthropic/claude-sonnet-4";
     console.log("[chat-preview] Starting streamText", {
       modelId,
       hasApiKey: !!process.env.OPENROUTER_API_KEY,

--- a/web/src/app/api/admin/chat-guides/preview/route.ts
+++ b/web/src/app/api/admin/chat-guides/preview/route.ts
@@ -40,7 +40,10 @@ export async function POST(request: Request) {
 
   try {
     const body = await request.json();
-    const { messages } = body as { messages: ChatMessage[] };
+    const { messages, model: modelOverride } = body as {
+      messages: ChatMessage[];
+      model?: string;
+    };
 
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
       return NextResponse.json(
@@ -172,7 +175,10 @@ export async function POST(request: Request) {
 
     const systemPrompt = basePrompt + "\n\n" + dynamicContext + "\n\nHere is your knowledge base:\n---\n" + resourceContext + "\n---";
 
+    // A per-request override (from the preview model picker) wins, so admins can
+    // A/B models without changing the saved CHAT_MODEL setting.
     const modelId =
+      modelOverride?.trim() ||
       modelSetting?.value?.trim() ||
       process.env.OPENROUTER_MODEL ||
       "anthropic/claude-sonnet-4";

--- a/web/src/app/api/admin/chat-guides/preview/route.ts
+++ b/web/src/app/api/admin/chat-guides/preview/route.ts
@@ -4,6 +4,7 @@ import { openrouter } from "@openrouter/ai-sdk-provider";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import { resolveChatModel } from "@/lib/chat-model";
 
 const DEFAULT_SYSTEM_PROMPT = `You are a friendly and helpful volunteer assistant for Everybody Eats, a charitable restaurant in Aotearoa New Zealand that serves free meals to the community. Your name is EE Assistant.
 
@@ -185,11 +186,11 @@ export async function POST(request: Request) {
 
     // A per-request override (from the preview model picker) wins, so admins can
     // A/B models without changing the saved CHAT_MODEL setting.
-    const modelId =
-      modelOverride?.trim() ||
-      modelSetting?.value?.trim() ||
-      process.env.OPENROUTER_MODEL ||
-      "anthropic/claude-sonnet-4";
+    const modelId = resolveChatModel(
+      modelOverride,
+      modelSetting?.value,
+      process.env.OPENROUTER_MODEL,
+    );
     console.log("[chat-preview] Starting streamText", {
       modelId,
       hasApiKey: !!process.env.OPENROUTER_API_KEY,

--- a/web/src/app/api/admin/chat-guides/refine/route.ts
+++ b/web/src/app/api/admin/chat-guides/refine/route.ts
@@ -4,6 +4,7 @@ import { openrouter } from "@openrouter/ai-sdk-provider";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import { resolveChatModel } from "@/lib/chat-model";
 
 const REFINE_SYSTEM_PROMPT = `You clean up raw, imported web page or PDF text into concise knowledge-base content for an AI volunteer assistant.
 
@@ -35,10 +36,10 @@ export async function POST(request: Request) {
     const modelSetting = await prisma.siteSetting.findUnique({
       where: { key: "CHAT_MODEL" },
     });
-    const modelId =
-      modelSetting?.value?.trim() ||
-      process.env.OPENROUTER_MODEL ||
-      "anthropic/claude-sonnet-4";
+    const modelId = resolveChatModel(
+      modelSetting?.value,
+      process.env.OPENROUTER_MODEL,
+    );
 
     const { text } = await generateText({
       model: openrouter(modelId),

--- a/web/src/app/api/admin/chat-guides/refine/route.ts
+++ b/web/src/app/api/admin/chat-guides/refine/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { generateText } from "ai";
+import { openrouter } from "@openrouter/ai-sdk-provider";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import { prisma } from "@/lib/prisma";
+
+const REFINE_SYSTEM_PROMPT = `You clean up raw, imported web page or PDF text into concise knowledge-base content for an AI volunteer assistant.
+
+Rules:
+- Remove navigation menus, buttons, cookie/boilerplate text, repeated whitespace, stray quote/encoding artifacts, and broken mid-sentence line breaks.
+- PRESERVE every factual detail exactly as written: names, roles, addresses, phone numbers, email addresses, opening hours, dates, policies, and prices. Never drop or alter a fact.
+- Organise the result into clean, readable Markdown — short headings and bullet lists where they help.
+- Do NOT invent information, summarise away detail, or add any commentary.
+- Output ONLY the refined content, with no preamble or closing remarks.`;
+
+// POST /api/admin/chat-guides/refine — clean raw imported/scraped text via the AI model
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  try {
+    const body = await request.json();
+    const { content, title } = body as { content?: string; title?: string };
+
+    if (!content || !content.trim()) {
+      return NextResponse.json(
+        { error: "content is required" },
+        { status: 400 },
+      );
+    }
+
+    const modelSetting = await prisma.siteSetting.findUnique({
+      where: { key: "CHAT_MODEL" },
+    });
+    const modelId =
+      modelSetting?.value?.trim() ||
+      process.env.OPENROUTER_MODEL ||
+      "anthropic/claude-sonnet-4";
+
+    const { text } = await generateText({
+      model: openrouter(modelId),
+      system: REFINE_SYSTEM_PROMPT,
+      prompt: title
+        ? `Title: ${title}\n\nRaw content to refine:\n\n${content}`
+        : `Raw content to refine:\n\n${content}`,
+    });
+
+    const refined = text.trim();
+    if (!refined) {
+      return NextResponse.json(
+        { error: "The model returned an empty result — try again" },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ refined });
+  } catch (error) {
+    console.error("Chat guide refine error:", error);
+    return NextResponse.json(
+      { error: "Failed to refine content" },
+      { status: 500 },
+    );
+  }
+}

--- a/web/src/app/api/admin/chat-guides/settings/route.ts
+++ b/web/src/app/api/admin/chat-guides/settings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
+import { isValidChatModelId } from "@/lib/chat-model";
 import { z } from "zod";
 
 const suggestedQuestionSchema = z.object({
@@ -12,7 +13,15 @@ const suggestedQuestionSchema = z.object({
 const updateSchema = z.object({
   systemPrompt: z.string().optional(),
   suggestedQuestions: z.array(suggestedQuestionSchema).optional(),
-  model: z.string().optional(),
+  // Blank clears the setting (falls back to env/default); otherwise must look
+  // like an OpenRouter id. Trimmed so we never store surrounding whitespace.
+  model: z
+    .string()
+    .trim()
+    .refine((v) => v === "" || isValidChatModelId(v), {
+      message: "Model must be an OpenRouter id like provider/model",
+    })
+    .optional(),
 });
 
 // PATCH /api/admin/chat-guides/settings — update chat prompt settings

--- a/web/src/app/api/admin/chat-guides/settings/route.ts
+++ b/web/src/app/api/admin/chat-guides/settings/route.ts
@@ -12,6 +12,7 @@ const suggestedQuestionSchema = z.object({
 const updateSchema = z.object({
   systemPrompt: z.string().optional(),
   suggestedQuestions: z.array(suggestedQuestionSchema).optional(),
+  model: z.string().optional(),
 });
 
 // PATCH /api/admin/chat-guides/settings — update chat prompt settings
@@ -37,6 +38,22 @@ export async function PATCH(request: Request) {
             key: "CHAT_SYSTEM_PROMPT",
             value: parsed.systemPrompt,
             description: "System prompt for the mobile AI chat assistant",
+            category: "CHAT",
+            updatedBy: userId,
+          },
+        }),
+      );
+    }
+
+    if (parsed.model !== undefined) {
+      updates.push(
+        prisma.siteSetting.upsert({
+          where: { key: "CHAT_MODEL" },
+          update: { value: parsed.model, updatedBy: userId },
+          create: {
+            key: "CHAT_MODEL",
+            value: parsed.model,
+            description: "OpenRouter model ID for the AI chat assistant",
             category: "CHAT",
             updatedBy: userId,
           },

--- a/web/src/app/api/mobile/chat/route.ts
+++ b/web/src/app/api/mobile/chat/route.ts
@@ -4,6 +4,7 @@ import { openrouter } from "@openrouter/ai-sdk-provider";
 import { prisma } from "@/lib/prisma";
 import { requireMobileUser } from "@/lib/mobile-auth";
 import { isFeatureEnabled, FeatureFlag } from "@/lib/posthog-server";
+import { resolveChatModel } from "@/lib/chat-model";
 
 const DEFAULT_SYSTEM_PROMPT = `You are a friendly and helpful volunteer assistant for Everybody Eats, a charitable restaurant in Aotearoa New Zealand that serves free meals to the community. Your name is EE Assistant.
 
@@ -121,10 +122,7 @@ async function getStaticContext(): Promise<StaticContext> {
 
   staticCache = {
     systemPrompt: promptSetting?.value || DEFAULT_SYSTEM_PROMPT,
-    modelId:
-      modelSetting?.value?.trim() ||
-      process.env.OPENROUTER_MODEL ||
-      "anthropic/claude-sonnet-4",
+    modelId: resolveChatModel(modelSetting?.value, process.env.OPENROUTER_MODEL),
     resourceContext,
     locationsContext,
     shiftTypesContext,

--- a/web/src/app/api/mobile/chat/route.ts
+++ b/web/src/app/api/mobile/chat/route.ts
@@ -25,6 +25,7 @@ Social media & links:
 
 type StaticContext = {
   systemPrompt: string;
+  modelId: string;
   resourceContext: string;
   locationsContext: string;
   shiftTypesContext: string;
@@ -42,7 +43,7 @@ async function getStaticContext(): Promise<StaticContext> {
 
   const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
 
-  const [resources, promptSetting, locations, shiftTypes, totalVolunteers, recentMeals, totalMeals, recentShiftCount] =
+  const [resources, promptSetting, modelSetting, locations, shiftTypes, totalVolunteers, recentMeals, totalMeals, recentShiftCount] =
     await Promise.all([
       prisma.resource.findMany({
         where: { includeInChat: true, isPublished: true, chatContent: { not: null } },
@@ -50,6 +51,7 @@ async function getStaticContext(): Promise<StaticContext> {
         orderBy: { category: "asc" },
       }),
       prisma.siteSetting.findUnique({ where: { key: "CHAT_SYSTEM_PROMPT" } }),
+      prisma.siteSetting.findUnique({ where: { key: "CHAT_MODEL" } }),
       prisma.location.findMany({
         where: { isActive: true },
         select: { name: true, address: true, defaultMealsServed: true },
@@ -119,6 +121,10 @@ async function getStaticContext(): Promise<StaticContext> {
 
   staticCache = {
     systemPrompt: promptSetting?.value || DEFAULT_SYSTEM_PROMPT,
+    modelId:
+      modelSetting?.value?.trim() ||
+      process.env.OPENROUTER_MODEL ||
+      "anthropic/claude-sonnet-4",
     resourceContext,
     locationsContext,
     shiftTypesContext,
@@ -184,8 +190,8 @@ export async function POST(request: Request) {
       staticCtx.resourceContext +
       "\n---";
 
-    // Stream response from OpenRouter
-    const modelId = process.env.OPENROUTER_MODEL ?? "anthropic/claude-sonnet-4";
+    // Stream response from OpenRouter (model configurable via CHAT_MODEL setting)
+    const modelId = staticCtx.modelId;
     console.log("[mobile-chat] Starting streamText", {
       modelId,
       hasApiKey: !!process.env.OPENROUTER_API_KEY,

--- a/web/src/lib/chat-model.test.ts
+++ b/web/src/lib/chat-model.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_CHAT_MODEL,
+  resolveChatModel,
+  isValidChatModelId,
+} from "./chat-model";
+
+describe("resolveChatModel", () => {
+  it("returns the first non-blank source", () => {
+    expect(resolveChatModel("openai/gpt-5", "anthropic/claude-sonnet-4")).toBe(
+      "openai/gpt-5",
+    );
+  });
+
+  it("skips null, undefined, empty, and whitespace-only sources", () => {
+    expect(
+      resolveChatModel(undefined, null, "", "   ", "google/gemini-2.5-flash"),
+    ).toBe("google/gemini-2.5-flash");
+  });
+
+  it("trims the resolved value", () => {
+    expect(resolveChatModel("  openai/gpt-5  ")).toBe("openai/gpt-5");
+  });
+
+  it("falls back to the default when every source is blank", () => {
+    expect(resolveChatModel(undefined, "", "  ")).toBe(DEFAULT_CHAT_MODEL);
+    expect(resolveChatModel()).toBe(DEFAULT_CHAT_MODEL);
+  });
+
+  it("respects source order (override wins over setting wins over env)", () => {
+    const override = "openai/gpt-5";
+    const setting = "anthropic/claude-3.7-sonnet";
+    const env = "google/gemini-2.5-flash";
+    expect(resolveChatModel(override, setting, env)).toBe(override);
+    expect(resolveChatModel(undefined, setting, env)).toBe(setting);
+    expect(resolveChatModel("", "", env)).toBe(env);
+  });
+});
+
+describe("isValidChatModelId", () => {
+  it("accepts provider/model slugs, including optional tags", () => {
+    expect(isValidChatModelId("anthropic/claude-sonnet-4")).toBe(true);
+    expect(isValidChatModelId("openai/gpt-4o-mini")).toBe(true);
+    expect(isValidChatModelId("anthropic/claude-3.5-sonnet:beta")).toBe(true);
+  });
+
+  it("rejects blank, spaced, or over-long input", () => {
+    expect(isValidChatModelId("")).toBe(false);
+    expect(isValidChatModelId("not a model")).toBe(false);
+    expect(isValidChatModelId("a".repeat(101))).toBe(false);
+  });
+});

--- a/web/src/lib/chat-model.ts
+++ b/web/src/lib/chat-model.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared model resolution for the AI chat assistant.
+ *
+ * Keeps a single source of truth for the fallback chain used by the mobile chat
+ * route, the admin preview route, and the content-refine route.
+ */
+
+export const DEFAULT_CHAT_MODEL = "anthropic/claude-sonnet-4";
+
+/**
+ * Resolve the OpenRouter model id from an ordered list of candidate sources.
+ * The first non-blank value wins; blank/whitespace values are skipped so they
+ * fall through to the next source. Falls back to {@link DEFAULT_CHAT_MODEL}.
+ *
+ * Typical order: request override → CHAT_MODEL setting → OPENROUTER_MODEL env.
+ */
+export function resolveChatModel(
+  ...sources: (string | null | undefined)[]
+): string {
+  for (const source of sources) {
+    const value = source?.trim();
+    if (value) return value;
+  }
+  return DEFAULT_CHAT_MODEL;
+}
+
+/**
+ * Permissive validation for an OpenRouter model id. Intentionally loose: it
+ * only rejects obviously-wrong input (spaces, empty, absurd length) while
+ * allowing provider/model slugs with optional tags, e.g.
+ * "anthropic/claude-sonnet-4" or "anthropic/claude-3.5-sonnet:beta".
+ */
+export function isValidChatModelId(value: string): boolean {
+  return /^[\w./:-]+$/.test(value) && value.length <= 100;
+}


### PR DESCRIPTION
## Summary

Lets admins choose which OpenRouter model powers the chat assistant from the **Chat Guides** admin settings, instead of relying on the `OPENROUTER_MODEL` env var (which recently caused the assistant to run on `openai/gpt-5.4-nano` and fail to answer from the knowledge base).

- **New `CHAT_MODEL` site setting**, saved via the existing chat-guides settings PATCH endpoint.
- **Model resolution** in both routes: `CHAT_MODEL` setting → `OPENROUTER_MODEL` env → default `anthropic/claude-sonnet-4`. So the env var still works as a fallback, and nothing breaks if the setting is unset.
- **Admin UI**: an "AI Model" card with a free-text field (any OpenRouter slug) + recommended-model quick-pick chips, and a note steering away from underpowered nano/mini tiers.

## Files

- `api/mobile/chat/route.ts` - resolve + cache `modelId` in the shared static context.
- `api/admin/chat-guides/preview/route.ts` - resolve `modelId` from the setting.
- `api/admin/chat-guides/settings/route.ts` - accept + upsert `CHAT_MODEL`.
- `admin/chat-guides/page.tsx` - load the setting, pass to the client.
- `admin/chat-guides/chat-guides-content.tsx` - the "AI Model" card.

## Notes

- Chose a **free-text field + quick-pick chips** over a hardcoded dropdown deliberately: model slugs change over time and a fixed list would go stale. The chips give guardrails against the nano footgun without the maintenance burden.
- The mobile route caches the model in its 5-min static context, so a model change takes effect on the next cache refresh (or app restart) - same as the system prompt.
- Also cleaned up two pre-existing lint warnings in the touched file (unused `Check` import, unused catch binding).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [ ] Admin sets a model in Chat Guides settings → saved to `CHAT_MODEL`
- [ ] Chat assistant (preview + mobile) uses the configured model; falls back to default when blank

> Note: the admin Chat Guides page is auth + `CHAT_GUIDES` feature-flag gated, so I verified via typecheck/lint rather than driving the UI end-to-end in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)