### PR TITLE
chore(web): fix all eslint warnings

### DIFF
--- a/web/src/app/admin/analytics/engagement/engagement-analytics-client.tsx
+++ b/web/src/app/admin/analytics/engagement/engagement-analytics-client.tsx
@@ -18,10 +18,7 @@ import { staggerContainer, staggerItem } from "@/lib/motion";
 import {
   Users,
   TrendingUp,
-  Zap,
   UserCheck,
-  UserMinus,
-  UserX,
   RefreshCw,
   UserPlus,
   Activity,
@@ -181,7 +178,6 @@ export function EngagementAnalyticsClient({
   function rollUpToMonthly(
     weekData: typeof data.monthlyTrend
   ): Array<{ month: string; activeVolunteers: number }> {
-    const monthMap = new Map<string, Set<string>>();
     // We need to track unique volunteer IDs per month, but we only have counts.
     // Use max-per-week as a reasonable rollup (distinct volunteers active in any week).
     const monthMaxMap = new Map<string, number>();

--- a/web/src/app/admin/analytics/engagement/engagement-volunteer-table.tsx
+++ b/web/src/app/admin/analytics/engagement/engagement-volunteer-table.tsx
@@ -366,6 +366,10 @@ export function EngagementVolunteerTable({
     },
   ];
 
+  // TanStack Table's useReactTable returns non-memoizable functions, so the
+  // React Compiler correctly bails out of optimizing this hook. That bailout
+  // is expected here, not a defect.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: volunteers,
     columns,

--- a/web/src/app/admin/chat-guides/chat-guides-content.tsx
+++ b/web/src/app/admin/chat-guides/chat-guides-content.tsx
@@ -7,7 +7,6 @@ import {
   Trash2,
   Pencil,
   FileText,
-  Check,
   X,
   Info,
   Send,
@@ -689,7 +688,7 @@ export function ChatGuidesContent({
       toast({ title: "Removed from chat context", description: removingResource.title });
       setRemoveDialogOpen(false);
       setRemovingResource(null);
-    } catch (error) {
+    } catch {
       toast({
         title: "Error",
         description: "Failed to remove resource from chat",

--- a/web/src/app/shifts/details/og/route.tsx
+++ b/web/src/app/shifts/details/og/route.tsx
@@ -1,3 +1,6 @@
+// This route renders an Open Graph image via Satori (`next/og`), which only
+// supports raw <img> elements — `next/image` cannot be used here.
+/* eslint-disable @next/next/no-img-element */
 import { ImageResponse } from "next/og";
 import { startOfDay, endOfDay } from "date-fns";
 import { prisma } from "@/lib/prisma";

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -45,22 +45,6 @@ const descriptionVariants: Variants = {
   },
 };
 
-const dividerVariants: Variants = {
-  hidden: {
-    scaleX: 0,
-    opacity: 0,
-  },
-  visible: {
-    scaleX: 1,
-    opacity: 1,
-    transition: {
-      duration: 0.5,
-      delay: 0.25,
-      ease: [0.22, 1, 0.36, 1] as [number, number, number, number],
-    },
-  },
-};
-
 const actionsVariants: Variants = {
   hidden: {
     opacity: 0,

--- a/web/src/components/users-data-table.tsx
+++ b/web/src/components/users-data-table.tsx
@@ -413,6 +413,10 @@ export function UsersDataTable({
     setIsLoading(false);
   }, [users]);
 
+  // TanStack Table's useReactTable returns non-memoizable functions, so the
+  // React Compiler correctly bails out of optimizing this hook. That bailout
+  // is expected here, not a defect.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: users,
     columns,

--- a/web/src/components/volunteers-data-table.tsx
+++ b/web/src/components/volunteers-data-table.tsx
@@ -212,6 +212,10 @@ export function VolunteersDataTable({
     return acc;
   }, {} as Record<string, boolean>);
 
+  // TanStack Table's useReactTable returns non-memoizable functions, so the
+  // React Compiler correctly bails out of optimizing this hook. That bailout
+  // is expected here, not a defect.
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: volunteers,
     columns,

--- a/web/src/lib/archive-service.ts
+++ b/web/src/lib/archive-service.ts
@@ -113,7 +113,7 @@ export function whereNeverActivatedArchive(now: Date): Prisma.UserWhereInput {
  * Get users with a "lastConfirmedShiftAt" computed per user — uses raw SQL
  * because Prisma's groupBy can't aggregate across relations.
  */
-async function getUsersWithLastShift(now: Date): Promise<
+async function getUsersWithLastShift(): Promise<
   Array<{
     id: string;
     email: string;
@@ -196,7 +196,7 @@ export async function getInactiveWarningCandidates(
   now: Date = new Date()
 ): Promise<CandidateUser[]> {
   const warningCutoff = subMonths(now, ARCHIVE_THRESHOLDS.INACTIVE_WARNING_MONTHS);
-  const users = await getUsersWithLastShift(now);
+  const users = await getUsersWithLastShift();
   return users
     .filter((u) => !u.isMigrated || u.profileCompleted) // unmigrated handled separately
     .map((u) => ({
@@ -233,7 +233,7 @@ export async function getInactiveArchiveCandidates(
     now.getTime() -
       ARCHIVE_THRESHOLDS.WARNING_TO_ARCHIVE_MIN_DAYS * 24 * 60 * 60 * 1000
   );
-  const users = await getUsersWithLastShift(now);
+  const users = await getUsersWithLastShift();
   return users
     .filter((u) => !u.isMigrated || u.profileCompleted)
     .map((u) => ({

--- a/web/src/lib/scrape-url.ts
+++ b/web/src/lib/scrape-url.ts
@@ -11,14 +11,6 @@ const REMOVE_CLASSES = new Set([
   "nav-wrapper", "footer",
 ]);
 
-/** Inline elements — should NOT cause line breaks. */
-const INLINE_TAGS = new Set([
-  "a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data",
-  "dfn", "em", "i", "kbd", "mark", "q", "rp", "rt", "ruby",
-  "s", "samp", "small", "span", "strong", "sub", "sup", "time",
-  "u", "var", "wbr",
-]);
-
 /** Block elements that get line separators. */
 const BLOCK_RE = /^(div|section|article|main|aside|p|h[1-6]|ul|ol|li|table|tr|blockquote|figure|figcaption|details|summary|address|dl|dt|dd)$/;
 


### PR DESCRIPTION
## Description

Cleans up all 18 pre-existing eslint warnings in `web/` so the lint output is warning-free. No functional changes.

**Dead code removed:**
- Unused `now` parameter in `archive-service.ts` (`getUsersWithLastShift`) plus its two call sites
- Unused `INLINE_TAGS` set in `scrape-url.ts`
- Unused `dividerVariants` motion variant in `page-header.tsx`
- Unused `Zap` / `UserMinus` / `UserX` imports and `monthMap` var in `engagement-analytics-client.tsx`
- Unused `Check` import and unused `error` catch binding in `chat-guides-content.tsx`

**Inherent-warning suppressions (with explanatory comments):**
- `shifts/details/og/route.tsx` — file-level disable of `@next/next/no-img-element`. This route renders an Open Graph image via `next/og`'s Satori engine, which only supports raw `<img>` (`next/image` cannot be used here).
- `engagement-volunteer-table.tsx`, `users-data-table.tsx`, `volunteers-data-table.tsx` — localized `react-hooks/incompatible-library` disables on the three `useReactTable` call sites. TanStack Table returns non-memoizable functions, so the React Compiler correctly bails out; there is no code fix, and the bailout is now documented at each site.

## Type of Change
- [x] 🧹 Code refactoring (no functional changes)

## Version Bump Required
`version:patch`

## Testing
- [x] `npm run lint` (web) — clean, zero warnings
- [x] `npm run typecheck` (web) — passes
- [x] `npx tsc --noEmit` (mobile) — passes

## Additional Notes

A related mobile typecheck issue (`router.push("/admin/approvals")` / `router.push("/admin/messages")` flagged as invalid routes) was investigated and found to be a **stale generated types file**, not a code bug. The `/admin/approvals` and `/admin/messages` routes genuinely exist (`app/admin/approvals.tsx`, `app/admin/messages/index.tsx`, added in #1005/#1006). The errors came from an out-of-date `.expo/types/router.d.ts` (generated and gitignored). Regenerating the types resolves it — no source change was needed, so no mobile files are included in this PR.
