### PR TITLE
feat(auth): persistent verify-email banner for unverified logins

### DIFF
--- a/web/src/app/api/test/users/route.ts
+++ b/web/src/app/api/test/users/route.ts
@@ -73,7 +73,8 @@ export async function POST(request: NextRequest) {
     // Test users get a password and completed profile
     userData.hashedPassword = await bcrypt.hash(password || "Test123456", 10);
     userData.profileCompleted = profileCompleted;
-    userData.emailVerified = true; // Test users have verified emails by default
+    // Test users have verified emails unless the test explicitly opts out
+    userData.emailVerified = userData.emailVerified ?? true;
 
     const user = await prisma.user.create({
       data: userData,

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Providers } from "@/components/providers";
 import { MainContentWrapper } from "@/components/main-content-wrapper";
 import { Toaster } from "sonner";
 import { ImpersonationBanner } from "@/components/impersonation-banner";
+import { EmailVerificationBanner } from "@/components/email-verification-banner";
 import { getBaseUrl } from "@/lib/utils";
 import { SEO_CONFIG } from "@/lib/seo";
 
@@ -125,6 +126,7 @@ export default function RootLayout({
           <Suspense>
             <SiteHeaderClientWrapper />
           </Suspense>
+          <EmailVerificationBanner />
           <main className="min-h-screen">
             <Suspense>
               <MainContentWrapper>{children}</MainContentWrapper>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -126,7 +126,11 @@ export default function RootLayout({
           <Suspense>
             <SiteHeaderClientWrapper />
           </Suspense>
-          <EmailVerificationBanner />
+          {/* Suspense: reads usePathname, which cacheComponents treats as
+              uncached request data during prerender */}
+          <Suspense>
+            <EmailVerificationBanner />
+          </Suspense>
           <main className="min-h-screen">
             <Suspense>
               <MainContentWrapper>{children}</MainContentWrapper>

--- a/web/src/app/login/login-client.tsx
+++ b/web/src/app/login/login-client.tsx
@@ -199,15 +199,9 @@ export default function LoginClient({ providers }: LoginClientProps) {
     setIsLoading(false);
 
     if (res?.error) {
-      // Check for specific error types that indicate email verification issues
-      if (res.error === "EmailNotVerified") {
-        // Redirect to verify-email page with email pre-filled for resending
-        window.location.href = `/verify-email?email=${encodeURIComponent(
-          email || ""
-        )}&from=login`;
-        return;
-      }
-
+      // Note: unverified emails do NOT block login. The credentials provider
+      // signs unverified users in, and EmailVerificationBanner (root layout)
+      // prompts them to verify; shift signup enforces the hard gate.
       if (res.error === "AccountArchived") {
         setShowReactivation(true);
         return;

--- a/web/src/components/email-verification-banner.tsx
+++ b/web/src/components/email-verification-banner.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { MotionSpinner } from "@/components/motion-spinner";
+import { Turnstile, type TurnstileHandle } from "@/components/turnstile";
+import { CheckCircle2, MailWarning } from "lucide-react";
+
+/**
+ * Site-wide notice for signed-in users whose email is still unverified.
+ *
+ * Credentials logins are allowed without verification (the hard gate lives in
+ * shift signup), so this banner is what tells volunteers they still have a
+ * step to finish - and lets them resend the verification email in place.
+ *
+ * The session JWT snapshots emailVerified at login, so it can be stale in
+ * both directions; the banner only renders after /api/profile confirms the
+ * address is genuinely unverified.
+ */
+export function EmailVerificationBanner() {
+  const { data: session, status } = useSession();
+  const pathname = usePathname();
+  const turnstileRef = useRef<TurnstileHandle>(null);
+
+  const [confirmedUnverified, setConfirmedUnverified] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const [resent, setResent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const sessionUnverified =
+    status === "authenticated" && session?.user?.emailVerified === false;
+
+  // Re-check on navigation so the banner disappears soon after the user
+  // clicks the verification link (e.g. in another tab) - the JWT itself
+  // won't refresh until the next login.
+  useEffect(() => {
+    if (!sessionUnverified) {
+      setConfirmedUnverified(false);
+      return;
+    }
+
+    let cancelled = false;
+    fetch("/api/profile")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((profile) => {
+        if (!cancelled && profile) {
+          setConfirmedUnverified(profile.emailVerified === false);
+        }
+      })
+      .catch(() => {
+        // Leave the banner as-is if the check fails
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionUnverified, pathname]);
+
+  if (!sessionUnverified || !confirmedUnverified) {
+    return null;
+  }
+
+  // Admin pages have their own sidebar layout, and /verify-email already
+  // shows its own resend form.
+  if (pathname.startsWith("/admin") || pathname.startsWith("/verify-email")) {
+    return null;
+  }
+
+  const handleResend = async () => {
+    setIsResending(true);
+    setError(null);
+    try {
+      const turnstileToken = await turnstileRef.current?.getToken();
+      const response = await fetch("/api/auth/resend-verification", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(turnstileToken ? { "x-turnstile-token": turnstileToken } : {}),
+        },
+        body: JSON.stringify({}),
+      });
+
+      if (response.ok) {
+        setResent(true);
+      } else {
+        const data = await response.json();
+        setError(data.error || "Failed to send verification email");
+      }
+    } catch {
+      setError("Failed to send verification email. Please try again.");
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  return (
+    <div
+      className="border-b border-amber-200 bg-amber-50 dark:border-amber-900/50 dark:bg-amber-950/30"
+      data-testid="email-verification-banner"
+    >
+      <div className="max-w-[88rem] mx-auto px-5 sm:px-8 lg:px-12 py-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex items-start gap-3 flex-1 min-w-0">
+          <MailWarning
+            className="h-5 w-5 mt-0.5 text-amber-600 dark:text-amber-400 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <div className="text-sm text-amber-800 dark:text-amber-200">
+            <span className="font-semibold">Verify your email address.</span>{" "}
+            <span className="text-amber-700 dark:text-amber-300">
+              We sent a verification link to{" "}
+              <span className="font-medium">{session?.user?.email}</span>.
+              You&apos;ll need to verify before you can sign up for shifts.
+            </span>
+            {error && (
+              <p
+                className="mt-1 text-red-700 dark:text-red-400"
+                role="alert"
+                data-testid="email-verification-resend-error"
+              >
+                {error}
+              </p>
+            )}
+          </div>
+        </div>
+        <Turnstile ref={turnstileRef} />
+        <div aria-live="polite" className="flex-shrink-0 sm:self-center pl-8 sm:pl-0">
+          {resent ? (
+            <div
+              className="flex items-center gap-2 text-sm font-medium text-green-700 dark:text-green-400"
+              data-testid="email-verification-resend-success"
+            >
+              <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+              Email sent. Check your inbox.
+            </div>
+          ) : (
+            <Button
+              onClick={handleResend}
+              disabled={isResending}
+              size="sm"
+              variant="outline"
+              className="border-amber-300 text-amber-800 hover:bg-amber-100 hover:text-amber-900 dark:border-amber-700 dark:text-amber-200 dark:hover:bg-amber-900/40 dark:hover:text-amber-100 bg-transparent"
+              data-testid="email-verification-resend-button"
+            >
+              {isResending ? (
+                <span className="flex items-center gap-2">
+                  <MotionSpinner size="sm" />
+                  Sending...
+                </span>
+              ) : (
+                "Resend verification email"
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/types/next-auth.d.ts
+++ b/web/src/types/next-auth.d.ts
@@ -7,6 +7,7 @@ declare module "next-auth" {
       role: "ADMIN" | "VOLUNTEER";
       firstName?: string;
       lastName?: string;
+      emailVerified?: boolean;
     } & DefaultSession["user"];
     impersonating?: {
       adminId: string;

--- a/web/tests/e2e/email-verification-banner.spec.ts
+++ b/web/tests/e2e/email-verification-banner.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "./base";
+import type { Page } from "@playwright/test";
+import { createTestUser, deleteTestUsers } from "./helpers/test-helpers";
+
+const PASSWORD = "Test123456";
+
+// Tests in this file run in parallel workers, so each test uses its own
+// email - sharing one would race (creating a test user deletes any existing
+// user with the same email first).
+let createdEmails: string[] = [];
+
+async function createUser(page: Page, email: string, emailVerified: boolean) {
+  await createTestUser(page, email, "VOLUNTEER", { emailVerified });
+  createdEmails.push(email);
+}
+
+async function loginViaForm(page: Page, email: string) {
+  await page.goto("/login");
+  await page.waitForLoadState("load");
+
+  await page.getByTestId("email-input").fill(email);
+  await page.getByTestId("password-input").fill(PASSWORD);
+  await page.getByTestId("login-submit-button").click();
+
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"), {
+    timeout: 20000,
+  });
+}
+
+test.describe("Email verification banner", () => {
+  test.afterEach(async ({ page }) => {
+    await deleteTestUsers(page, createdEmails);
+    createdEmails = [];
+  });
+
+  test("unverified volunteer can log in and sees the banner across pages", async ({
+    page,
+  }) => {
+    const email = "banner-unverified-nav@example.com";
+    await createUser(page, email, false);
+
+    // Login must succeed even though the email is unverified - verification
+    // is enforced at shift signup, not at login.
+    await loginViaForm(page, email);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    const banner = page.getByTestId("email-verification-banner");
+    await expect(banner).toBeVisible({ timeout: 15000 });
+    await expect(banner).toContainText("Verify your email address");
+    await expect(banner).toContainText(email);
+
+    // Banner persists on other volunteer pages
+    await page.goto("/shifts");
+    await page.waitForLoadState("load");
+    await expect(banner).toBeVisible({ timeout: 15000 });
+  });
+
+  test("resend button sends a verification email and confirms", async ({
+    page,
+  }) => {
+    const email = "banner-unverified-resend@example.com";
+    await createUser(page, email, false);
+    await loginViaForm(page, email);
+
+    const banner = page.getByTestId("email-verification-banner");
+    await expect(banner).toBeVisible({ timeout: 15000 });
+
+    const resendButton = page.getByTestId("email-verification-resend-button");
+    await expect(resendButton).toBeVisible();
+    await resendButton.click();
+
+    // Success confirmation replaces the button
+    const success = page.getByTestId("email-verification-resend-success");
+    await expect(success).toBeVisible({ timeout: 15000 });
+    await expect(success).toContainText("Email sent");
+    await expect(resendButton).not.toBeVisible();
+  });
+
+  test("verified volunteer does not see the banner", async ({ page }) => {
+    const email = "banner-verified@example.com";
+    await createUser(page, email, true);
+    await loginViaForm(page, email);
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    // Give the page a moment to settle so a late-appearing banner would show.
+    // (networkidle never fires here - the dashboard holds an SSE stream open.)
+    await page.waitForLoadState("load");
+    await page.waitForTimeout(2000);
+    await expect(
+      page.getByTestId("email-verification-banner")
+    ).not.toBeVisible();
+  });
+});

--- a/web/tests/e2e/login.spec.ts
+++ b/web/tests/e2e/login.spec.ts
@@ -306,10 +306,13 @@ test.describe("Login Page", () => {
   test.describe("Navigation and Links", () => {
     test("should navigate to register page", async ({ page }) => {
       const registerLink = page.getByTestId("register-link");
-      await registerLink.click();
 
-      // Should navigate to register page
-      await expect(page).toHaveURL(/\/register/);
+      // Retry the click until navigation happens - under parallel load the
+      // first click can land before React hydration attaches the Link handler.
+      await expect(async () => {
+        await registerLink.click();
+        await expect(page).toHaveURL(/\/register/, { timeout: 2000 });
+      }).toPass({ timeout: 15000 });
 
       // Verify register page loaded
       const registerPage = page.getByTestId("register-page");


### PR DESCRIPTION
# Pull Request

## Description
Unverified credentials users could log in but were never told their email was unverified. The login client checked for an `EmailNotVerified` error that the credentials `authorize` callback never returns, so the redirect to `/verify-email` was dead code - volunteers only discovered the problem when shift signup returned a 403.

This PR keeps login open for unverified users (the shift-signup dialog remains the hard gate) and adds a persistent "Verify your email address" banner below the site header on all volunteer-facing pages:

- Shows the user's email, explains verification is needed before booking shifts, and resends the verification email in place (reuses `POST /api/auth/resend-verification` with the Turnstile token header, same as the shift-signup dialog).
- Double-checks `/api/profile` before rendering (and re-checks on navigation), so a stale JWT never shows the banner to someone who already verified, and it disappears soon after they verify in another tab.
- Hidden on `/admin` (own sidebar layout) and `/verify-email` (has its own resend form).
- OAuth logins auto-verify, so this only affects credentials users.

Supporting changes:
- Removed the dead `EmailNotVerified` branch from `login-client.tsx` with a comment pointing at the new enforcement points.
- Typed `session.user.emailVerified` in `next-auth.d.ts` (already present at runtime, previously untyped).
- Fixed `/api/test/users` which unconditionally forced `emailVerified: true`, making unverified test users impossible to create.
- Deflaked the login register-link navigation test (click could land before hydration under parallel load).

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Tests (adding missing tests or correcting existing tests)

## Version Bump Required
`version:minor`

## Testing
- [x] Unit tests pass (436/436)
- [x] E2E tests pass (new spec + login, email-verification, and login-reactivation suites: 42/42 locally with `--project=chromium`)
- [x] Manual testing completed (verified banner in light/dark/mobile and the resend success state against a local dev server)
- [x] New tests added (`web/tests/e2e/email-verification-banner.spec.ts`: unverified login succeeds and banner shows across pages, resend confirms, verified users never see it)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
Reviewers may want to sanity-check the decision to allow unverified logins rather than block them at `authorize` - the shift-signup dialog already enforces the hard gate with its own resend flow, so a visible prompt seemed better UX than locking people out of the whole portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
