### PR TITLE
fix(mobile): unblock shift signups for volunteers with incomplete profiles

### DIFF
--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -269,7 +269,7 @@ export default function RegisterScreen({
               Create your account
             </ThemedText>
             <ThemedText style={[styles.cardSubtitle, { color: mutedText }]}>
-              A few details and you're ready to volunteer
+              A few details and you&apos;re ready to volunteer
             </ThemedText>
 
             {/* Quick sign-up with a provider */}
@@ -498,7 +498,7 @@ export default function RegisterScreen({
                 <ThemedText
                   style={[styles.fieldError, { color: colors.destructive }]}
                 >
-                  Passwords don't match
+                  Passwords don&apos;t match
                 </ThemedText>
               )}
             </View>

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -157,21 +157,21 @@ export default function HomeScreen() {
     [apiToggleLike, updateFeedItem]
   );
 
-  const ME_AS_LIKER: LikeUser = {
-    id: profile?.id ?? "",
-    name: "You",
-    profilePhotoUrl: profile?.image ?? undefined,
-  };
-
   const getLikersForItem = useCallback(
     (item: FeedItem): LikeUser[] => {
       const myId = profile?.id;
       const others = myId
         ? item.recentLikers.filter((l) => l.id !== myId)
         : item.recentLikers;
-      return item.likedByMe ? [ME_AS_LIKER, ...others] : others;
+      if (!item.likedByMe) return others;
+      const meAsLiker: LikeUser = {
+        id: myId ?? "",
+        name: "You",
+        profilePhotoUrl: profile?.image ?? undefined,
+      };
+      return [meAsLiker, ...others];
     },
-    [ME_AS_LIKER, profile?.id]
+    [profile?.id, profile?.image]
   );
 
   const handleOpenSheet = useCallback((item: FeedItem) => {
@@ -2054,7 +2054,7 @@ function getRecapMessage(
   return RECAP_TEMPLATES[index](meals, volunteers);
 }
 
-const SKELETON_ROWS: Array<{ title: number; body: number[] }> = [
+const SKELETON_ROWS: { title: number; body: number[] }[] = [
   { title: 55, body: [92, 68] },
   { title: 45, body: [88] },
   { title: 60, body: [94, 74, 40] },

--- a/mobile/app/notifications.tsx
+++ b/mobile/app/notifications.tsx
@@ -7,7 +7,7 @@ import {
   isYesterday,
 } from "date-fns";
 import * as Haptics from "expo-haptics";
-import { Stack, useRouter } from "expo-router";
+import { Stack } from "expo-router";
 import { useCallback, useMemo } from "react";
 import {
   ActivityIndicator,
@@ -160,7 +160,6 @@ export default function NotificationsScreen() {
   const isDark = colorScheme === "dark";
   const insets = useSafeAreaInsets();
   const headerHeight = useHeaderHeight();
-  const router = useRouter();
 
   const {
     notifications,

--- a/mobile/app/profile/edit.tsx
+++ b/mobile/app/profile/edit.tsx
@@ -68,6 +68,21 @@ type FormData = {
   allowFriendSuggestions: boolean;
 };
 
+/**
+ * Fields a volunteer must fill in before they can sign up for shifts
+ * (mirrors isProfileComplete on the server; agreements are handled by the
+ * post-login gate and the Agreements section below).
+ */
+const REQUIRED_FIELDS = [
+  "firstName",
+  "phone",
+  "dateOfBirth",
+  "emergencyContactName",
+  "emergencyContactPhone",
+] as const;
+type RequiredField = (typeof REQUIRED_FIELDS)[number];
+type FieldErrors = Partial<Record<RequiredField, string>>;
+
 type VisibilityOption = {
   value: FormData["friendVisibility"];
   label: string;
@@ -229,6 +244,7 @@ export default function EditProfileScreen() {
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushBusy, setPushBusy] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [errors, setErrors] = useState<FieldErrors>({});
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
   const [localImage, setLocalImage] = useState<string | null>(null);
   const [shiftTypes, setShiftTypes] = useState<ShiftType[]>([]);
@@ -355,11 +371,60 @@ export default function EditProfileScreen() {
     }
   }, [profile, initialized]);
 
+  // ── Required-field validation ──
+  // DOB is exempt once locked (already set server-side, shown read-only).
+  const dobLocked = Boolean(profile?.dateOfBirth);
+
+  const validateField = (
+    key: RequiredField,
+    value: string
+  ): string | undefined => {
+    const trimmed = value.trim();
+    switch (key) {
+      case "firstName":
+        return trimmed ? undefined : "Enter your first name.";
+      case "phone":
+        return trimmed ? undefined : "Enter a phone number.";
+      case "dateOfBirth":
+        if (dobLocked) return undefined;
+        if (!trimmed) return "Enter your date of birth.";
+        return displayDateToIso(trimmed)
+          ? undefined
+          : "Enter a real past date as DD/MM/YYYY.";
+      case "emergencyContactName":
+        return trimmed ? undefined : "Enter an emergency contact name.";
+      case "emergencyContactPhone":
+        return trimmed ? undefined : "Enter their phone number.";
+    }
+  };
+
   const updateField = <K extends keyof FormData>(
     key: K,
     value: FormData[K]
   ) => {
     setForm((prev) => ({ ...prev, [key]: value }));
+    // Reward early: once a field shows an error, re-validate as the user
+    // types so the message clears the moment it's fixed.
+    if (
+      typeof value === "string" &&
+      errors[key as RequiredField] !== undefined &&
+      (REQUIRED_FIELDS as readonly string[]).includes(key)
+    ) {
+      setErrors((prev) => ({
+        ...prev,
+        [key]: validateField(key as RequiredField, value),
+      }));
+    }
+  };
+
+  // Punish late: format problems (a half-typed DOB) surface on blur, but
+  // required-empty errors wait for the save attempt.
+  const handleDobBlur = () => {
+    if (!form.dateOfBirth.trim()) return;
+    setErrors((prev) => ({
+      ...prev,
+      dateOfBirth: validateField("dateOfBirth", form.dateOfBirth),
+    }));
   };
 
   // ── Photo picker ──
@@ -480,26 +545,30 @@ export default function EditProfileScreen() {
   // ── Save ──
 
   const handleSave = async () => {
-    if (!form.firstName.trim()) {
-      Alert.alert("Required", "First name cannot be empty.");
+    // Validate every required field up front and show the problems inline,
+    // so it's clear exactly what still needs filling in.
+    const validationErrors: FieldErrors = {};
+    for (const key of REQUIRED_FIELDS) {
+      const error = validateField(key, form[key]);
+      if (error) validationErrors[key] = error;
+    }
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+      Alert.alert(
+        "A few details still needed",
+        "Fill in the highlighted fields — they're required before you can sign up for shifts."
+      );
       return;
     }
+    setErrors({});
 
     // DOB is set-once (admins change it after that), so only send it while
-    // still unset. Validate before sending — mirrors the server rule.
-    const dobLocked = Boolean(profile?.dateOfBirth);
-    let dateOfBirthIso: string | undefined;
-    if (!dobLocked && form.dateOfBirth.trim()) {
-      const iso = displayDateToIso(form.dateOfBirth.trim());
-      if (!iso) {
-        Alert.alert(
-          "Check date of birth",
-          "Enter your date of birth as DD/MM/YYYY — it must be a real date in the past."
-        );
-        return;
-      }
-      dateOfBirthIso = iso;
-    }
+    // still unset. Format is already validated above.
+    const dateOfBirthIso =
+      !dobLocked && form.dateOfBirth.trim()
+        ? displayDateToIso(form.dateOfBirth.trim()) ?? undefined
+        : undefined;
 
     setIsSaving(true);
     try {
@@ -685,6 +754,7 @@ export default function EditProfileScreen() {
             isDark={isDark}
             autoCapitalize="words"
             required
+            error={errors.firstName}
           />
           <FormField
             label="Last Name"
@@ -704,6 +774,7 @@ export default function EditProfileScreen() {
             isDark={isDark}
             keyboardType="phone-pad"
             required
+            error={errors.phone}
           />
           {profile.dateOfBirth ? (
             <View style={s.fieldContainer}>
@@ -748,11 +819,13 @@ export default function EditProfileScreen() {
                 onChangeText={(v) =>
                   updateField("dateOfBirth", formatDobInput(v))
                 }
+                onBlur={handleDobBlur}
                 placeholder="DD/MM/YYYY"
                 colors={colors}
                 isDark={isDark}
                 keyboardType="number-pad"
                 required
+                error={errors.dateOfBirth}
               />
               <Text style={[s.fieldHint, { color: colors.textSecondary }]}>
                 We ask so we can look after volunteers under 16. It can only be
@@ -852,6 +925,7 @@ export default function EditProfileScreen() {
             isDark={isDark}
             autoCapitalize="words"
             required
+            error={errors.emergencyContactName}
           />
           <FormField
             label="Relationship"
@@ -871,6 +945,7 @@ export default function EditProfileScreen() {
             isDark={isDark}
             keyboardType="phone-pad"
             required
+            error={errors.emergencyContactPhone}
           />
         </View>
 
@@ -1647,6 +1722,7 @@ function FormField({
   label,
   value,
   onChangeText,
+  onBlur,
   placeholder,
   colors,
   isDark,
@@ -1654,10 +1730,12 @@ function FormField({
   autoCapitalize,
   multiline,
   required,
+  error,
 }: {
   label: string;
   value: string;
   onChangeText: (text: string) => void;
+  onBlur?: () => void;
   placeholder: string;
   colors: (typeof Colors)["light"];
   isDark: boolean;
@@ -1665,6 +1743,8 @@ function FormField({
   autoCapitalize?: "none" | "sentences" | "words";
   multiline?: boolean;
   required?: boolean;
+  /** Validation message shown below the input; also tints the border. */
+  error?: string;
 }) {
   return (
     <View style={s.fieldContainer}>
@@ -1680,19 +1760,35 @@ function FormField({
           multiline && s.fieldInputMultiline,
           {
             color: colors.text,
-            borderColor: colors.border,
+            borderColor: error ? colors.destructive : colors.border,
             backgroundColor: isDark ? colors.surfaceSunk : colors.card,
           },
         ]}
         value={value}
         onChangeText={onChangeText}
+        onBlur={onBlur}
         placeholder={placeholder}
         placeholderTextColor={colors.textSecondary}
         keyboardType={keyboardType ?? "default"}
         autoCapitalize={autoCapitalize ?? "sentences"}
         multiline={multiline}
         textAlignVertical={multiline ? "top" : "center"}
+        accessibilityLabel={
+          error ? `${label}. ${error}` : required ? `${label}, required` : label
+        }
       />
+      {error && (
+        <View style={s.fieldErrorRow} accessibilityLiveRegion="polite">
+          <Ionicons
+            name="alert-circle"
+            size={13}
+            color={colors.destructive}
+          />
+          <Text style={[s.fieldErrorText, { color: colors.destructive }]}>
+            {error}
+          </Text>
+        </View>
+      )}
     </View>
   );
 }
@@ -1799,6 +1895,17 @@ const s = StyleSheet.create({
     fontSize: 12,
     fontFamily: FontFamily.regular,
     lineHeight: 16,
+  },
+  fieldErrorRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+  },
+  fieldErrorText: {
+    flex: 1,
+    fontSize: 12.5,
+    fontFamily: FontFamily.medium,
+    lineHeight: 17,
   },
   lockedField: {
     flexDirection: "row",

--- a/mobile/app/profile/edit.tsx
+++ b/mobile/app/profile/edit.tsx
@@ -616,6 +616,9 @@ export default function EditProfileScreen() {
       await refresh();
       // Signup eligibility on shift screens depends on profile completion —
       // refetch so a just-completed profile unlocks the signup CTA.
+      // Deliberately not awaited: the shift screen stays mounted in the nav
+      // stack, so its active query refetches in the background (and the
+      // signup sheet re-syncs from props) while back-navigation stays instant.
       queryClient.invalidateQueries({ queryKey: queryKeys.shifts.all });
       router.back();
     } catch (err) {

--- a/mobile/app/profile/edit.tsx
+++ b/mobile/app/profile/edit.tsx
@@ -22,13 +22,21 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useQueryClient } from "@tanstack/react-query";
 
+import { AgreementGate, AgreementModal } from "@/components/agreement-modal";
 import { Brand, Colors, FontFamily, Palette } from "@/constants/theme";
+import {
+  AGREEMENTS,
+  type AgreementKey,
+  useAgreementPolicies,
+} from "@/hooks/use-agreement-policies";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { useProfile } from "@/hooks/use-profile";
 import { api, ApiError, apiUpload } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { posthog } from "@/lib/posthog";
+import { queryKeys } from "@/lib/query-keys";
 import {
   syncPushTokenWithServer,
   unregisterPushTokenFromServer,
@@ -41,6 +49,10 @@ type FormData = {
   lastName: string;
   phone: string;
   pronouns: string;
+  /** Displayed and edited as DD/MM/YYYY; empty when never provided. */
+  dateOfBirth: string;
+  volunteerAgreementAccepted: boolean;
+  healthSafetyPolicyAccepted: boolean;
   emergencyContactName: string;
   emergencyContactRelationship: string;
   emergencyContactPhone: string;
@@ -116,6 +128,46 @@ function preferenceToChannels(pref: FormData["notificationPreference"]): {
   };
 }
 
+// ── Date of birth helpers ──
+// Entered as DD/MM/YYYY (NZ convention); stored/sent as ISO YYYY-MM-DD.
+
+function isoToDisplayDate(iso: string | null): string {
+  if (!iso) return "";
+  const [year, month, day] = iso.slice(0, 10).split("-");
+  return `${day}/${month}/${year}`;
+}
+
+/** Progressive input mask: digits only, slashes inserted at DD/MM/YYYY. */
+function formatDobInput(value: string): string {
+  const digits = value.replace(/\D/g, "").slice(0, 8);
+  return [digits.slice(0, 2), digits.slice(2, 4), digits.slice(4, 8)]
+    .filter(Boolean)
+    .join("/");
+}
+
+/**
+ * Parse a DD/MM/YYYY string to ISO, or null when invalid. Mirrors the server
+ * rule: must be a real calendar date at least 1 year in the past.
+ */
+function displayDateToIso(display: string): string | null {
+  const match = display.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (!match) return null;
+  const [, dd, mm, yyyy] = match;
+  const day = Number(dd);
+  const month = Number(mm);
+  const year = Number(yyyy);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  const isRealDate =
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day;
+  if (!isRealDate || year < 1900) return null;
+  const oneYearAgo = new Date();
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+  if (date > oneYearAgo) return null;
+  return `${yyyy}-${mm}-${dd}`;
+}
+
 const CHANNEL_OPTIONS: {
   key: "email" | "sms" | "push";
   label: string;
@@ -150,12 +202,16 @@ export default function EditProfileScreen() {
   const router = useRouter();
   const { profile, availableLocations, refresh } = useProfile();
   const deleteAccount = useAuth((state) => state.deleteAccount);
+  const queryClient = useQueryClient();
 
   const [form, setForm] = useState<FormData>({
     firstName: "",
     lastName: "",
     phone: "",
     pronouns: "",
+    dateOfBirth: "",
+    volunteerAgreementAccepted: false,
+    healthSafetyPolicyAccepted: false,
     emergencyContactName: "",
     emergencyContactRelationship: "",
     emergencyContactPhone: "",
@@ -255,6 +311,20 @@ export default function EditProfileScreen() {
   // Populate form once when profile first loads
   const [initialized, setInitialized] = useState(false);
   const [locationSheetVisible, setLocationSheetVisible] = useState(false);
+
+  // ── Agreements ──
+  // Normally accepted at the post-login gate, but surfaced here too so a
+  // volunteer with an unaccepted agreement can read and accept it in place.
+  const [activeAgreement, setActiveAgreement] = useState<AgreementKey | null>(
+    null
+  );
+  const policies = useAgreementPolicies();
+
+  const openAgreement = (key: AgreementKey) => {
+    Haptics.selectionAsync();
+    if (!policies.text[key] && !policies.loading[key]) policies.load(key);
+    setActiveAgreement(key);
+  };
   useEffect(() => {
     if (profile && !initialized) {
       setForm({
@@ -262,6 +332,9 @@ export default function EditProfileScreen() {
         lastName: profile.lastName,
         phone: profile.phone,
         pronouns: profile.pronouns,
+        dateOfBirth: isoToDisplayDate(profile.dateOfBirth),
+        volunteerAgreementAccepted: profile.volunteerAgreementAccepted,
+        healthSafetyPolicyAccepted: profile.healthSafetyPolicyAccepted,
         emergencyContactName: profile.emergencyContactName,
         emergencyContactRelationship: profile.emergencyContactRelationship,
         emergencyContactPhone: profile.emergencyContactPhone,
@@ -412,6 +485,22 @@ export default function EditProfileScreen() {
       return;
     }
 
+    // DOB is set-once (admins change it after that), so only send it while
+    // still unset. Validate before sending — mirrors the server rule.
+    const dobLocked = Boolean(profile?.dateOfBirth);
+    let dateOfBirthIso: string | undefined;
+    if (!dobLocked && form.dateOfBirth.trim()) {
+      const iso = displayDateToIso(form.dateOfBirth.trim());
+      if (!iso) {
+        Alert.alert(
+          "Check date of birth",
+          "Enter your date of birth as DD/MM/YYYY — it must be a real date in the past."
+        );
+        return;
+      }
+      dateOfBirthIso = iso;
+    }
+
     setIsSaving(true);
     try {
       await api("/api/mobile/profile", {
@@ -421,6 +510,14 @@ export default function EditProfileScreen() {
           lastName: form.lastName.trim(),
           phone: form.phone.trim(),
           pronouns: form.pronouns.trim(),
+          ...(dateOfBirthIso ? { dateOfBirth: dateOfBirthIso } : {}),
+          // One-way: only ever send acceptance, never revoke.
+          ...(form.volunteerAgreementAccepted
+            ? { volunteerAgreementAccepted: true }
+            : {}),
+          ...(form.healthSafetyPolicyAccepted
+            ? { healthSafetyPolicyAccepted: true }
+            : {}),
           emergencyContactName: form.emergencyContactName.trim(),
           emergencyContactRelationship:
             form.emergencyContactRelationship.trim(),
@@ -444,14 +541,20 @@ export default function EditProfileScreen() {
       posthog?.capture("profile_updated", {
         notification_preference: form.notificationPreference,
         has_emergency_contact: !!form.emergencyContactName.trim(),
+        has_date_of_birth: dobLocked || !!dateOfBirthIso,
         newsletter_subscribed: form.emailNewsletterSubscription,
       });
       await refresh();
+      // Signup eligibility on shift screens depends on profile completion —
+      // refetch so a just-completed profile unlocks the signup CTA.
+      queryClient.invalidateQueries({ queryKey: queryKeys.shifts.all });
       router.back();
-    } catch {
+    } catch (err) {
       Alert.alert(
         "Save failed",
-        "Couldn't save your changes. Please try again."
+        err instanceof ApiError
+          ? err.message
+          : "Couldn't save your changes. Please try again."
       );
     } finally {
       setIsSaving(false);
@@ -569,6 +672,9 @@ export default function EditProfileScreen() {
           <Text style={[s.sectionTitle, { color: colors.text }]}>
             Personal Details
           </Text>
+          <Text style={[s.sectionHint, { color: colors.textSecondary }]}>
+            Fields marked * are needed before you can sign up for shifts.
+          </Text>
 
           <FormField
             label="First Name"
@@ -597,7 +703,63 @@ export default function EditProfileScreen() {
             colors={colors}
             isDark={isDark}
             keyboardType="phone-pad"
+            required
           />
+          {profile.dateOfBirth ? (
+            <View style={s.fieldContainer}>
+              <Text style={[s.fieldLabel, { color: colors.text }]}>
+                Date of Birth
+              </Text>
+              <View
+                style={[
+                  s.fieldInput,
+                  s.lockedField,
+                  {
+                    borderColor: colors.border,
+                    backgroundColor: isDark
+                      ? colors.surfaceSunk
+                      : colors.surfaceSoft,
+                  },
+                ]}
+                accessibilityLabel={`Date of birth: ${isoToDisplayDate(
+                  profile.dateOfBirth
+                )}. Contact the team to change it.`}
+              >
+                <Text
+                  style={[s.lockedFieldText, { color: colors.textSecondary }]}
+                >
+                  {isoToDisplayDate(profile.dateOfBirth)}
+                </Text>
+                <Ionicons
+                  name="lock-closed-outline"
+                  size={16}
+                  color={colors.textSecondary}
+                />
+              </View>
+              <Text style={[s.fieldHint, { color: colors.textSecondary }]}>
+                Contact the Everybody Eats team if this needs changing.
+              </Text>
+            </View>
+          ) : (
+            <View style={s.fieldContainer}>
+              <FormField
+                label="Date of Birth"
+                value={form.dateOfBirth}
+                onChangeText={(v) =>
+                  updateField("dateOfBirth", formatDobInput(v))
+                }
+                placeholder="DD/MM/YYYY"
+                colors={colors}
+                isDark={isDark}
+                keyboardType="number-pad"
+                required
+              />
+              <Text style={[s.fieldHint, { color: colors.textSecondary }]}>
+                We ask so we can look after volunteers under 16. It can only be
+                set once.
+              </Text>
+            </View>
+          )}
           <FormField
             label="Pronouns"
             value={form.pronouns}
@@ -689,6 +851,7 @@ export default function EditProfileScreen() {
             colors={colors}
             isDark={isDark}
             autoCapitalize="words"
+            required
           />
           <FormField
             label="Relationship"
@@ -707,6 +870,7 @@ export default function EditProfileScreen() {
             colors={colors}
             isDark={isDark}
             keyboardType="phone-pad"
+            required
           />
         </View>
 
@@ -1148,6 +1312,44 @@ export default function EditProfileScreen() {
           </Pressable>
         </View>
 
+        {/* ── Agreements ── */}
+        <View style={s.section}>
+          <Text style={[s.sectionTitle, { color: colors.text }]}>
+            Agreements
+          </Text>
+          <Text style={[s.sectionHint, { color: colors.textSecondary }]}>
+            Both are required before you can sign up for shifts. Tap one to
+            read it{form.volunteerAgreementAccepted &&
+            form.healthSafetyPolicyAccepted
+              ? " again"
+              : " and agree"}
+            .
+          </Text>
+
+          <AgreementGate
+            title="Volunteer Agreement"
+            agreed={form.volunteerAgreementAccepted}
+            onPress={() => openAgreement("volunteer")}
+            inputBg={isDark ? "rgba(255,255,255,0.06)" : "rgba(14,58,35,0.04)"}
+            inputStroke={
+              isDark ? "rgba(255,255,255,0.10)" : "rgba(14,58,35,0.12)"
+            }
+            mutedText={colors.textSecondary}
+            textColor={colors.text}
+          />
+          <AgreementGate
+            title="Health & Safety Policy"
+            agreed={form.healthSafetyPolicyAccepted}
+            onPress={() => openAgreement("safety")}
+            inputBg={isDark ? "rgba(255,255,255,0.06)" : "rgba(14,58,35,0.04)"}
+            inputStroke={
+              isDark ? "rgba(255,255,255,0.10)" : "rgba(14,58,35,0.12)"
+            }
+            mutedText={colors.textSecondary}
+            textColor={colors.text}
+          />
+        </View>
+
         {/* ── Danger zone ── */}
         <View style={s.section}>
           <Text style={[s.sectionTitle, { color: colors.destructive }]}>
@@ -1248,6 +1450,27 @@ export default function EditProfileScreen() {
           </View>
         </View>
       </ScrollView>
+
+      {activeAgreement && (
+        <AgreementModal
+          visible
+          title={AGREEMENTS[activeAgreement].title}
+          content={policies.text[activeAgreement]}
+          loading={policies.loading[activeAgreement]}
+          error={policies.error[activeAgreement]}
+          onRetry={() => policies.load(activeAgreement)}
+          onClose={() => setActiveAgreement(null)}
+          onAgree={() => {
+            updateField(
+              activeAgreement === "volunteer"
+                ? "volunteerAgreementAccepted"
+                : "healthSafetyPolicyAccepted",
+              true
+            );
+            setActiveAgreement(null);
+          }}
+        />
+      )}
 
       <DefaultLocationSheet
         visible={locationSheetVisible}
@@ -1438,7 +1661,7 @@ function FormField({
   placeholder: string;
   colors: (typeof Colors)["light"];
   isDark: boolean;
-  keyboardType?: "default" | "phone-pad" | "email-address";
+  keyboardType?: "default" | "phone-pad" | "email-address" | "number-pad";
   autoCapitalize?: "none" | "sentences" | "words";
   multiline?: boolean;
   required?: boolean;
@@ -1571,6 +1794,21 @@ const s = StyleSheet.create({
     minHeight: 80,
     textAlignVertical: "top",
     paddingTop: 12,
+  },
+  fieldHint: {
+    fontSize: 12,
+    fontFamily: FontFamily.regular,
+    lineHeight: 16,
+  },
+  lockedField: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 10,
+  },
+  lockedFieldText: {
+    fontSize: 15,
+    fontFamily: FontFamily.regular,
   },
 
   // Toggle rows

--- a/mobile/app/shift/[id].tsx
+++ b/mobile/app/shift/[id].tsx
@@ -725,6 +725,8 @@ export default function ShiftDetailScreen() {
           shift={shift}
           isWaitlist={signupSheetWaitlist}
           formatDate={formatNZT}
+          profileIncomplete={eligibility ? !eligibility.profileComplete : false}
+          missingProfileFields={eligibility?.missingProfileFields}
         />
       )}
     </View>
@@ -833,62 +835,6 @@ function VolunteersSection({
               />
             ))}
           </View>
-        </View>
-      )}
-    </View>
-  );
-}
-
-function FriendStackAvatar({
-  friend,
-  index,
-  isDark,
-}: {
-  friend: PeriodFriend;
-  index: number;
-  isDark: boolean;
-}) {
-  const initial = friend.name.charAt(0).toUpperCase();
-  const roleTheme = friend.shiftTypeName
-    ? getShiftThemeByName(friend.shiftTypeName)
-    : null;
-  const roleBg = roleTheme
-    ? isDark
-      ? roleTheme.bgDark
-      : roleTheme.bgLight
-    : isDark
-    ? "rgba(29,83,55,0.3)"
-    : Palette.forest100;
-  const roleInk = roleTheme
-    ? isDark
-      ? roleTheme.colorDark
-      : roleTheme.color
-    : Brand.green;
-
-  const borderColor = isDark ? Colors.dark.background : Brand.warmWhite;
-
-  return (
-    <View
-      style={[
-        s.friendsStackItem,
-        {
-          marginLeft: index === 0 ? 0 : -12,
-          borderColor,
-          zIndex: 10 - index,
-        },
-      ]}
-    >
-      {friend.profilePhotoUrl ? (
-        <Image
-          source={{ uri: friend.profilePhotoUrl }}
-          style={s.friendsStackImg}
-          contentFit="cover"
-        />
-      ) : (
-        <View style={[s.friendsStackFallback, { backgroundColor: roleBg }]}>
-          <Text style={[s.friendsStackInitial, { color: roleInk }]}>
-            {initial}
-          </Text>
         </View>
       )}
     </View>

--- a/mobile/components/agreement-modal.tsx
+++ b/mobile/components/agreement-modal.tsx
@@ -150,7 +150,7 @@ export function AgreementModal({
               color={mutedText}
             />
             <ThemedText style={[styles.centerText, { color: mutedText }]}>
-              Couldn't load the agreement.
+              Couldn&apos;t load the agreement.
             </ThemedText>
             <Pressable
               onPress={onRetry}

--- a/mobile/components/shift-signup-sheet.tsx
+++ b/mobile/components/shift-signup-sheet.tsx
@@ -72,6 +72,14 @@ type ShiftSignupSheetProps = {
   };
   isWaitlist: boolean;
   formatDate: (date: Date, fmt: string) => string;
+  /**
+   * Known-incomplete profile from the shift eligibility payload, so the sheet
+   * can explain what's missing up front instead of only after a failed
+   * signup. The server re-checks on submit either way.
+   */
+  profileIncomplete?: boolean;
+  /** Required profile fields still missing, e.g. ["Date of birth"]. */
+  missingProfileFields?: string[];
 };
 
 export function ShiftSignupSheet({
@@ -81,6 +89,8 @@ export function ShiftSignupSheet({
   shift,
   isWaitlist,
   formatDate,
+  profileIncomplete: knownProfileIncomplete,
+  missingProfileFields: knownMissingFields,
 }: ShiftSignupSheetProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme];
@@ -99,22 +109,25 @@ export function ShiftSignupSheet({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [profileIncomplete, setProfileIncomplete] = useState(false);
+  const [missingFields, setMissingFields] = useState<string[]>([]);
 
   const spotsLeft = Math.max(0, shift.capacity - shift.signedUp);
   const date = new Date(shift.start);
   const endDate = new Date(shift.end);
 
-  // Reset state when sheet opens
+  // Reset state when sheet opens. Seed the profile warning from the shift
+  // eligibility payload so the volunteer sees what's missing before trying.
   useEffect(() => {
     if (visible) {
       setNote('');
       setShowNoteField(false);
       setBackupShiftIds([]);
       setError(null);
-      setProfileIncomplete(false);
+      setProfileIncomplete(Boolean(knownProfileIncomplete));
+      setMissingFields(knownMissingFields ?? []);
       setAutoApproval({ eligible: false, loading: true });
     }
-  }, [visible]);
+  }, [visible, knownProfileIncomplete, knownMissingFields]);
 
   // Fetch auto-approval eligibility + concurrent shifts when sheet opens
   useEffect(() => {
@@ -176,6 +189,10 @@ export function ShiftSignupSheet({
           setError('This shift just filled up. You can join the waitlist instead.');
         } else if (err.message === 'Profile incomplete') {
           setProfileIncomplete(true);
+          const serverMissing = err.data?.missingFields;
+          if (Array.isArray(serverMissing)) {
+            setMissingFields(serverMissing.filter((f) => typeof f === 'string'));
+          }
         } else {
           setError(err.message);
         }
@@ -495,9 +512,30 @@ export function ShiftSignupSheet({
                   ss.profileIncompleteBody,
                   { color: isDark ? '#fca5a5' : '#dc2626' },
                 ]}>
-                Your profile is missing some required information. Finish
-                filling it in and we&apos;ll get you signed up.
+                {missingFields.length > 0
+                  ? 'Your profile still needs:'
+                  : "Your profile is missing some required information. Finish filling it in and we'll get you signed up."}
               </Text>
+              {missingFields.length > 0 && (
+                <View style={ss.missingFieldsList}>
+                  {missingFields.map((field) => (
+                    <View key={field} style={ss.missingFieldRow}>
+                      <Ionicons
+                        name="ellipse"
+                        size={5}
+                        color={isDark ? '#fca5a5' : '#dc2626'}
+                      />
+                      <Text
+                        style={[
+                          ss.missingFieldText,
+                          { color: isDark ? '#fca5a5' : '#dc2626' },
+                        ]}>
+                        {field}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              )}
               <Pressable
                 onPress={handleGoToProfile}
                 style={({ pressed }) => [
@@ -844,6 +882,21 @@ const ss = StyleSheet.create({
     fontSize: 14,
     fontFamily: FontFamily.regular,
     lineHeight: 20,
+  },
+  missingFieldsList: {
+    gap: 4,
+    marginTop: -4,
+    paddingLeft: 4,
+  },
+  missingFieldRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  missingFieldText: {
+    fontSize: 14,
+    fontFamily: FontFamily.medium,
+    lineHeight: 19,
   },
   profileIncompleteButton: {
     flexDirection: 'row',

--- a/mobile/components/shift-signup-sheet.tsx
+++ b/mobile/components/shift-signup-sheet.tsx
@@ -592,15 +592,26 @@ export function ShiftSignupSheet({
             <Text style={[ss.footerButtonSecondaryText, { color: colors.text }]}>Cancel</Text>
           </Pressable>
 
+          {/* While the profile is incomplete the signup would only 403, so
+              the sheet's "Complete Profile" button is the real action —
+              disable the confirm CTA rather than letting it dead-end. It
+              re-enables live once the refetched eligibility clears the flag. */}
           <Pressable
             onPress={handleSubmit}
-            disabled={isSubmitting}
+            disabled={isSubmitting || profileIncomplete}
+            accessibilityState={{
+              disabled: isSubmitting || profileIncomplete,
+              busy: isSubmitting,
+            }}
             style={({ pressed }) => [
               ss.footerButtonPrimary,
               {
-                backgroundColor: isSubmitting ? colors.textSecondary : Brand.green,
-                opacity: pressed ? 0.9 : 1,
-                transform: [{ scale: pressed ? 0.98 : 1 }],
+                backgroundColor:
+                  isSubmitting || profileIncomplete
+                    ? colors.textSecondary
+                    : Brand.green,
+                opacity: profileIncomplete ? 0.5 : pressed ? 0.9 : 1,
+                transform: [{ scale: pressed && !profileIncomplete ? 0.98 : 1 }],
                 flex: 1,
               },
             ]}>

--- a/mobile/hooks/use-profile.ts
+++ b/mobile/hooks/use-profile.ts
@@ -24,6 +24,9 @@ type ProfileResponse = {
     emergencyContactRelationship: string | null;
     emergencyContactPhone: string | null;
     medicalConditions: string | null;
+    volunteerAgreementAccepted: boolean;
+    healthSafetyPolicyAccepted: boolean;
+    profileCompleted: boolean;
     notificationPreference: "EMAIL" | "SMS" | "BOTH" | "NONE";
     receiveShortageNotifications: boolean;
     excludedShortageNotificationTypes: string[];
@@ -78,13 +81,17 @@ export function useProfile(): UseProfileReturn {
         email: data.profile.email,
         role: data.profile.role as "VOLUNTEER" | "ADMIN",
         image: data.profile.image,
-        profileComplete: true,
-        // The profile screen is only reachable inside the app, past the gate.
-        agreementsAccepted: true,
+        profileComplete: data.profile.profileCompleted,
+        agreementsAccepted:
+          data.profile.volunteerAgreementAccepted &&
+          data.profile.healthSafetyPolicyAccepted,
         firstName: data.profile.firstName ?? "",
         lastName: data.profile.lastName ?? "",
         phone: data.profile.phone ?? "",
         pronouns: data.profile.pronouns ?? "",
+        dateOfBirth: data.profile.dateOfBirth,
+        volunteerAgreementAccepted: data.profile.volunteerAgreementAccepted,
+        healthSafetyPolicyAccepted: data.profile.healthSafetyPolicyAccepted,
         volunteerGrade: data.profile.volunteerGrade,
         emergencyContactName: data.profile.emergencyContactName ?? "",
         emergencyContactRelationship: data.profile.emergencyContactRelationship ?? "",

--- a/mobile/hooks/use-shift-detail.ts
+++ b/mobile/hooks/use-shift-detail.ts
@@ -32,6 +32,8 @@ type ShiftDetailResponse = {
 export type ShiftEligibility = {
   emailVerified: boolean;
   profileComplete: boolean;
+  /** Required profile fields still missing (empty when profile is complete). */
+  missingProfileFields?: string[];
   needsParentalConsent: boolean;
 };
 

--- a/mobile/lib/api.ts
+++ b/mobile/lib/api.ts
@@ -37,7 +37,7 @@ export async function api<T = unknown>(
     const error = await response
       .json()
       .catch(() => ({ error: "Request failed" }));
-    throw new ApiError(response.status, error.error ?? "Request failed");
+    throw new ApiError(response.status, error.error ?? "Request failed", error);
   }
 
   return response.json() as Promise<T>;
@@ -76,7 +76,12 @@ export async function apiUpload<T = unknown>(
 }
 
 export class ApiError extends Error {
-  constructor(public status: number, message: string) {
+  constructor(
+    public status: number,
+    message: string,
+    /** Full parsed error body, for endpoints that return extra detail. */
+    public data?: Record<string, unknown>
+  ) {
     super(message);
     this.name = "ApiError";
   }

--- a/mobile/lib/dummy-data.ts
+++ b/mobile/lib/dummy-data.ts
@@ -20,6 +20,10 @@ export type UserProfile = User & {
   lastName: string;
   phone: string;
   pronouns: string;
+  /** ISO date string, or null when never provided (e.g. OAuth signups). */
+  dateOfBirth: string | null;
+  volunteerAgreementAccepted: boolean;
+  healthSafetyPolicyAccepted: boolean;
   volunteerGrade: 'GREEN' | 'YELLOW' | 'PINK';
   emergencyContactName: string;
   emergencyContactRelationship: string;
@@ -44,6 +48,9 @@ export const DUMMY_PROFILE: UserProfile = {
   lastName: 'Williams',
   phone: '021 123 4567',
   pronouns: 'she/her',
+  dateOfBirth: '1994-03-12',
+  volunteerAgreementAccepted: true,
+  healthSafetyPolicyAccepted: true,
   volunteerGrade: 'YELLOW',
   emergencyContactName: 'Hemi Williams',
   emergencyContactRelationship: 'Partner',

--- a/web/src/app/api/mobile/profile/route.ts
+++ b/web/src/app/api/mobile/profile/route.ts
@@ -9,6 +9,10 @@ import {
   type UserProgress,
 } from "@/lib/achievements";
 import { formatAchievementCriteria } from "@/lib/achievement-utils";
+import { isProfileComplete } from "@/lib/profile-completion";
+import { isUserUnder16, autoLabelUnder16User } from "@/lib/auto-label-utils";
+import { getEmailService } from "@/lib/email-service";
+import { captureFunnelEvent, FunnelEvent } from "@/lib/funnel";
 import { z } from "zod";
 
 /**
@@ -46,6 +50,9 @@ export async function GET(request: Request) {
         emergencyContactRelationship: true,
         emergencyContactPhone: true,
         medicalConditions: true,
+        volunteerAgreementAccepted: true,
+        healthSafetyPolicyAccepted: true,
+        profileCompleted: true,
         notificationPreference: true,
         receiveShortageNotifications: true,
         excludedShortageNotificationTypes: true,
@@ -66,6 +73,17 @@ export async function GET(request: Request) {
 
     if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Self-heal a stale completion flag: older mobile clients could fill in
+    // every required field without profileCompleted ever being recomputed,
+    // leaving the volunteer blocked from shift signups. Fix it on read.
+    if (!user.profileCompleted && isProfileComplete(user)) {
+      await prisma.user.update({
+        where: { id: userId },
+        data: { profileCompleted: true },
+      });
+      user.profileCompleted = true;
     }
 
     // Calculate stats from signup history
@@ -295,6 +313,9 @@ export async function GET(request: Request) {
         emergencyContactRelationship: user.emergencyContactRelationship,
         emergencyContactPhone: user.emergencyContactPhone,
         medicalConditions: user.medicalConditions,
+        volunteerAgreementAccepted: user.volunteerAgreementAccepted,
+        healthSafetyPolicyAccepted: user.healthSafetyPolicyAccepted,
+        profileCompleted: user.profileCompleted,
         notificationPreference: user.notificationPreference,
         receiveShortageNotifications: user.receiveShortageNotifications,
         excludedShortageNotificationTypes: user.excludedShortageNotificationTypes,
@@ -394,6 +415,22 @@ const updateMobileProfileSchema = z.object({
   lastName: z.string().optional(),
   phone: z.string().optional(),
   pronouns: z.string().optional(),
+  dateOfBirth: z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true; // Allow empty/null
+        const date = new Date(val);
+        const oneYearAgo = new Date();
+        oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+        // Date must be at least 1 year in the past
+        return !isNaN(date.getTime()) && date <= oneYearAgo;
+      },
+      { message: "Date of birth must be at least 1 year in the past" }
+    ),
+  volunteerAgreementAccepted: z.boolean().optional(),
+  healthSafetyPolicyAccepted: z.boolean().optional(),
   emergencyContactName: z.string().optional(),
   emergencyContactRelationship: z.string().optional(),
   emergencyContactPhone: z.string().optional(),
@@ -426,7 +463,7 @@ export async function PUT(request: Request) {
       );
     }
 
-    const profileFields = parsed.data;
+    const { dateOfBirth: dateOfBirthInput, ...profileFields } = parsed.data;
 
     const data: Record<string, unknown> = { ...profileFields };
 
@@ -435,14 +472,50 @@ export async function PUT(request: Request) {
       data.defaultLocation = profileFields.defaultLocation || null;
     }
 
+    const user = await prisma.user.findUnique({
+      where: { id: auth.userId },
+      select: {
+        firstName: true,
+        lastName: true,
+        dateOfBirth: true,
+        profileCompleted: true,
+        requiresParentalConsent: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Date of birth mirrors the web profile rules: volunteers may set it once
+    // (OAuth/mobile signups don't capture it at registration), but only
+    // administrators can change it after that.
+    if (dateOfBirthInput !== undefined) {
+      const newDateOfBirth = dateOfBirthInput
+        ? new Date(dateOfBirthInput).toISOString().split("T")[0]
+        : null;
+      const currentDateOfBirth = user.dateOfBirth
+        ? user.dateOfBirth.toISOString().split("T")[0]
+        : null;
+
+      if (currentDateOfBirth && newDateOfBirth !== currentDateOfBirth) {
+        return NextResponse.json(
+          { error: "Only administrators can change date of birth once set" },
+          { status: 403 }
+        );
+      }
+
+      const dateOfBirth = dateOfBirthInput ? new Date(dateOfBirthInput) : null;
+      data.dateOfBirth = dateOfBirth;
+      // Recompute the parental-consent requirement whenever DOB changes so
+      // under-16 signups can't bypass the consent gate.
+      data.requiresParentalConsent = isUserUnder16(dateOfBirth);
+    }
+
     // Update name field for display consistency
     if (profileFields.firstName || profileFields.lastName) {
-      const user = await prisma.user.findUnique({
-        where: { id: auth.userId },
-        select: { firstName: true, lastName: true },
-      });
-      const first = profileFields.firstName ?? user?.firstName ?? "";
-      const last = profileFields.lastName ?? user?.lastName ?? "";
+      const first = profileFields.firstName ?? user.firstName ?? "";
+      const last = profileFields.lastName ?? user.lastName ?? "";
       data.name = [first, last].filter(Boolean).join(" ");
     }
 
@@ -450,19 +523,112 @@ export async function PUT(request: Request) {
       where: { id: auth.userId },
       data,
       select: {
+        name: true,
+        email: true,
         firstName: true,
         lastName: true,
         phone: true,
         pronouns: true,
         profilePhotoUrl: true,
+        dateOfBirth: true,
         emergencyContactName: true,
         emergencyContactRelationship: true,
         emergencyContactPhone: true,
         medicalConditions: true,
+        volunteerAgreementAccepted: true,
+        healthSafetyPolicyAccepted: true,
+        requiresParentalConsent: true,
+        parentalConsentReceived: true,
+        profileCompleted: true,
       },
     });
 
-    return NextResponse.json({ profile: updatedUser });
+    if (dateOfBirthInput !== undefined) {
+      await autoLabelUnder16User(auth.userId, updatedUser.dateOfBirth);
+
+      // Notify admins when a user newly requires parental consent (e.g. an
+      // OAuth signup setting DOB for the first time). Mirrors the web
+      // PUT /api/profile.
+      const becameUnderage =
+        !user.requiresParentalConsent &&
+        updatedUser.requiresParentalConsent &&
+        !updatedUser.parentalConsentReceived;
+
+      if (becameUnderage) {
+        try {
+          const admins = await prisma.user.findMany({
+            where: { role: "ADMIN" },
+            select: { id: true },
+          });
+
+          await Promise.all(
+            admins.map((admin) =>
+              prisma.notification.create({
+                data: {
+                  userId: admin.id,
+                  type: "UNDERAGE_USER_REGISTERED",
+                  title: "New Underage Volunteer",
+                  message: `${updatedUser.name || updatedUser.email} (under 16) has registered and requires parental consent approval.`,
+                  actionUrl: "/admin/parental-consent",
+                  relatedId: auth.userId,
+                },
+              })
+            )
+          );
+        } catch (notificationError) {
+          console.error(
+            "Failed to send admin notifications for underage user:",
+            notificationError
+          );
+        }
+      }
+    }
+
+    // Flip the completion flag once every required field is present — this is
+    // what unlocks shift signups. Mirrors the web PUT /api/profile.
+    let profileCompleted = updatedUser.profileCompleted;
+    if (!user.profileCompleted && isProfileComplete(updatedUser)) {
+      profileCompleted = true;
+      await prisma.user.update({
+        where: { id: auth.userId },
+        data: { profileCompleted: true },
+      });
+
+      captureFunnelEvent({
+        event: FunnelEvent.REGISTER_COMPLETED,
+        userId: auth.userId,
+        properties: { platform: "mobile" },
+      });
+
+      try {
+        const emailService = getEmailService();
+        await emailService.sendProfileCompletion({
+          to: updatedUser.email,
+          firstName: updatedUser.firstName,
+        });
+      } catch (emailError) {
+        console.error("Failed to send profile completion email:", emailError);
+        // Don't fail the profile update if email sending fails
+      }
+    }
+
+    return NextResponse.json({
+      profile: {
+        firstName: updatedUser.firstName,
+        lastName: updatedUser.lastName,
+        phone: updatedUser.phone,
+        pronouns: updatedUser.pronouns,
+        profilePhotoUrl: updatedUser.profilePhotoUrl,
+        dateOfBirth: updatedUser.dateOfBirth?.toISOString() ?? null,
+        emergencyContactName: updatedUser.emergencyContactName,
+        emergencyContactRelationship: updatedUser.emergencyContactRelationship,
+        emergencyContactPhone: updatedUser.emergencyContactPhone,
+        medicalConditions: updatedUser.medicalConditions,
+        volunteerAgreementAccepted: updatedUser.volunteerAgreementAccepted,
+        healthSafetyPolicyAccepted: updatedUser.healthSafetyPolicyAccepted,
+        profileCompleted,
+      },
+    });
   } catch (error) {
     console.error("Mobile profile update error:", error);
     return NextResponse.json(

--- a/web/src/app/api/mobile/shifts/[id]/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/route.ts
@@ -5,6 +5,7 @@ import {
   getShiftEffectiveCount,
   shiftCapacityCountSelect,
 } from "@/lib/placeholder-utils";
+import { getMissingProfileFields } from "@/lib/profile-completion";
 
 /**
  * GET /api/mobile/shifts/[id]
@@ -68,6 +69,13 @@ export async function GET(
       profileCompleted: true,
       requiresParentalConsent: true,
       parentalConsentReceived: true,
+      firstName: true,
+      phone: true,
+      dateOfBirth: true,
+      emergencyContactName: true,
+      emergencyContactPhone: true,
+      volunteerAgreementAccepted: true,
+      healthSafetyPolicyAccepted: true,
     },
   });
 
@@ -133,6 +141,12 @@ export async function GET(
     eligibility: {
       emailVerified: Boolean(userRecord?.emailVerified),
       profileComplete: Boolean(userRecord?.profileCompleted),
+      // Which required profile fields still need filling in, so the signup
+      // sheet can tell the volunteer exactly what to complete.
+      missingProfileFields:
+        userRecord && !userRecord.profileCompleted
+          ? getMissingProfileFields(userRecord)
+          : [],
       needsParentalConsent: Boolean(
         userRecord?.requiresParentalConsent &&
           !userRecord?.parentalConsentReceived

--- a/web/src/app/api/mobile/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/signup/route.ts
@@ -6,6 +6,10 @@ import { isAMShift, getShiftDate } from "@/lib/concurrent-shifts";
 import { getNotificationService } from "@/lib/notification-service";
 import { notifyManagersOfPendingSignup } from "@/lib/notifications";
 import { getShiftConfirmedCount } from "@/lib/placeholder-utils";
+import {
+  getMissingProfileFields,
+  isProfileComplete,
+} from "@/lib/profile-completion";
 
 /**
  * POST /api/mobile/shifts/[id]/signup
@@ -43,7 +47,13 @@ export async function POST(
       profileCompleted: true,
       requiresParentalConsent: true,
       parentalConsentReceived: true,
+      firstName: true,
+      phone: true,
       dateOfBirth: true,
+      emergencyContactName: true,
+      emergencyContactPhone: true,
+      volunteerAgreementAccepted: true,
+      healthSafetyPolicyAccepted: true,
     },
   });
 
@@ -65,14 +75,25 @@ export async function POST(
 
   // Mirror the web gate: a complete profile is required before signing up.
   if (!user.profileCompleted) {
-    return NextResponse.json(
-      {
-        error: "Profile incomplete",
-        message:
-          "Please complete your profile before signing up for shifts. Visit your profile to fill in the remaining required fields.",
-      },
-      { status: 403 }
-    );
+    // Self-heal a stale flag: older mobile clients could fill in every
+    // required field without profileCompleted ever being recomputed. If the
+    // fields are all present, flip the flag and let the signup proceed.
+    if (isProfileComplete(user)) {
+      await prisma.user.update({
+        where: { id: user.id },
+        data: { profileCompleted: true },
+      });
+    } else {
+      return NextResponse.json(
+        {
+          error: "Profile incomplete",
+          message:
+            "Please complete your profile before signing up for shifts. Visit your profile to fill in the remaining required fields.",
+          missingFields: getMissingProfileFields(user),
+        },
+        { status: 403 }
+      );
+    }
   }
 
   // Check parental consent for minors

--- a/web/src/lib/profile-completion.test.ts
+++ b/web/src/lib/profile-completion.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMissingProfileFields,
+  isProfileComplete,
+  type ProfileCompletionInput,
+} from "./profile-completion";
+
+const completeProfile: ProfileCompletionInput = {
+  firstName: "Aroha",
+  phone: "021 123 4567",
+  dateOfBirth: new Date("1994-03-12"),
+  emergencyContactName: "Hemi Williams",
+  emergencyContactPhone: "021 765 4321",
+  volunteerAgreementAccepted: true,
+  healthSafetyPolicyAccepted: true,
+};
+
+describe("isProfileComplete", () => {
+  it("returns true when every required field is present", () => {
+    expect(isProfileComplete(completeProfile)).toBe(true);
+  });
+
+  it("accepts an ISO string date of birth", () => {
+    expect(
+      isProfileComplete({ ...completeProfile, dateOfBirth: "1994-03-12" })
+    ).toBe(true);
+  });
+
+  it.each([
+    ["firstName", { firstName: null }],
+    ["phone", { phone: "" }],
+    ["dateOfBirth", { dateOfBirth: null }],
+    ["emergencyContactName", { emergencyContactName: null }],
+    ["emergencyContactPhone", { emergencyContactPhone: null }],
+    ["volunteerAgreementAccepted", { volunteerAgreementAccepted: false }],
+    ["healthSafetyPolicyAccepted", { healthSafetyPolicyAccepted: false }],
+  ] as const)("returns false when %s is missing", (_field, override) => {
+    expect(isProfileComplete({ ...completeProfile, ...override })).toBe(false);
+  });
+});
+
+describe("getMissingProfileFields", () => {
+  it("returns an empty list for a complete profile", () => {
+    expect(getMissingProfileFields(completeProfile)).toEqual([]);
+  });
+
+  it("labels every missing field for an empty profile", () => {
+    expect(getMissingProfileFields({})).toEqual([
+      "First name",
+      "Mobile number",
+      "Date of birth",
+      "Emergency contact name",
+      "Emergency contact phone",
+      "Volunteer agreement",
+      "Health & safety policy",
+    ]);
+  });
+
+  it("only lists the fields that are actually missing", () => {
+    expect(
+      getMissingProfileFields({
+        ...completeProfile,
+        phone: null,
+        dateOfBirth: null,
+      })
+    ).toEqual(["Mobile number", "Date of birth"]);
+  });
+
+  it("agrees with isProfileComplete", () => {
+    expect(getMissingProfileFields(completeProfile)).toHaveLength(0);
+    const incomplete = { ...completeProfile, dateOfBirth: null };
+    expect(isProfileComplete(incomplete)).toBe(false);
+    expect(getMissingProfileFields(incomplete).length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/lib/profile-completion.ts
+++ b/web/src/lib/profile-completion.ts
@@ -48,6 +48,25 @@ export function isProfileComplete<T extends ProfileCompletionInput>(
   );
 }
 
+/**
+ * Human-readable labels for each required field that is still missing,
+ * in display order. Shared by the profile-completion status check and the
+ * shift signup gates so the labels never drift between surfaces.
+ */
+export function getMissingProfileFields(
+  input: ProfileCompletionInput
+): string[] {
+  const missing: string[] = [];
+  if (!input.firstName) missing.push("First name");
+  if (!input.phone) missing.push("Mobile number");
+  if (!input.dateOfBirth) missing.push("Date of birth");
+  if (!input.emergencyContactName) missing.push("Emergency contact name");
+  if (!input.emergencyContactPhone) missing.push("Emergency contact phone");
+  if (!input.volunteerAgreementAccepted) missing.push("Volunteer agreement");
+  if (!input.healthSafetyPolicyAccepted) missing.push("Health & safety policy");
+  return missing;
+}
+
 export async function checkProfileCompletion(userId: string): Promise<ProfileCompletionStatus> {
   const { prisma } = await import("@/lib/prisma");
 
@@ -75,15 +94,7 @@ export async function checkProfileCompletion(userId: string): Promise<ProfileCom
       };
     }
 
-    const missingFields = [];
-
-    if (!user.firstName) missingFields.push("First name");
-    if (!user.phone) missingFields.push("Mobile number");
-    if (!user.dateOfBirth) missingFields.push("Date of birth");
-    if (!user.emergencyContactName) missingFields.push("Emergency contact name");
-    if (!user.emergencyContactPhone) missingFields.push("Emergency contact phone");
-    if (!user.volunteerAgreementAccepted) missingFields.push("Volunteer agreement");
-    if (!user.healthSafetyPolicyAccepted) missingFields.push("Health & safety policy");
+    const missingFields = getMissingProfileFields(user);
 
     const profileComplete = isProfileComplete(user);
     const needsParentalConsent = user.requiresParentalConsent && !user.parentalConsentReceived;


### PR DESCRIPTION
# Pull Request

## Description

Volunteers who registered via mobile or OAuth got permanently stuck unable to sign up for shifts: the signup endpoint requires `profileCompleted`, but the mobile app had **no date of birth field**, the mobile profile PUT **didn't accept** the required fields, and it **never recomputed** `profileCompleted` — so the gate could never open from the app. (Agreements were already captured at the post-login gate, which also recomputes the flag; DOB and the missing recompute were the real blockers.)

### Backend (`web/`)

- **`PUT /api/mobile/profile`** now accepts `dateOfBirth` (set-once; only admins can change it after, mirroring the web rule — including `requiresParentalConsent` recompute, under-16 auto-labeling, and admin notifications) plus the two agreement flags, and flips `profileCompleted` via the shared `isProfileComplete` helper with the same welcome email + funnel event as the web `PUT /api/profile`.
- **`GET /api/mobile/profile`** returns the agreement flags and `profileCompleted`, and **self-heals** a stale flag for volunteers who already filled everything in before this fix.
- **`POST /api/mobile/shifts/[id]/signup`** also self-heals a stale flag instead of rejecting, and its 403 now includes `missingFields`.
- **`GET /api/mobile/shifts/[id]`** eligibility now includes `missingProfileFields`, via a new shared `getMissingProfileFields()` in `profile-completion.ts` so labels can't drift between surfaces.

### Mobile (`mobile/`)

- **Profile edit screen**: required Date of Birth field (DD/MM/YYYY masked numeric input, shown locked with a hint once set), required-field markers on phone + emergency contact fields with a "needed before you can sign up for shifts" hint, and an Agreements section reusing the existing `AgreementGate`/`AgreementModal` read-to-agree flow. Saving invalidates shift queries so the signup CTA unlocks immediately.
- **Shift signup sheet**: shows the incomplete-profile warning proactively from the eligibility payload, listing exactly which fields are missing (refreshed from the server 403 body via a new `ApiError.data` field), with the existing one-tap "Complete Profile" button.
- Also fixes 7 pre-existing mobile lint problems (unescaped entities, unused `router`/`FriendStackAvatar`, `Array<T>` style, `useCallback` dependency churn in the feed screen).

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
`version:patch`

## Testing
- [x] Unit tests pass (web 449 incl. 13 new for `profile-completion`; mobile 87)
- [x] Manual testing completed — full flow driven via curl against a local dev server:
  - register → signup 403 with `["Mobile number", "Date of birth", "Emergency contact name", "Emergency contact phone"]`
  - mobile PUT with phone/DOB/emergency contact → response `profileCompleted: true` → signup succeeds (PENDING)
  - DOB change rejected 403, same-DOB resend 200, future DOB 400
  - under-16 DOB → consent flag set, admin notification created, "Under 16" label applied
  - stale `profileCompleted=false` with complete fields → GET self-heals
- [x] New tests added (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (lint + typecheck clean in both apps)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
- The verify-email flow already sends the "profile completion" welcome email on verification; the completion email from the mobile PUT matches the existing web PUT behavior, so a credentials user can receive both — pre-existing pattern, unchanged.
- The new RN screens passed typecheck/lint/tests and reuse proven components, but haven't been eyeballed on a device/simulator — worth a visual pass before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)