### PR TITLE
feat: surface marketing CMS events and journal in mobile feed and shift pages

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -43,6 +43,7 @@ import {
   useFeedInteractions,
 } from "@/hooks/use-feed-interactions";
 import { useNotifications } from "@/hooks/use-notifications";
+import { openCmsLink } from "@/lib/external-links";
 import { usePendingFeedItemStore } from "@/hooks/use-pending-feed-item";
 import { useProfile } from "@/hooks/use-profile";
 import { useShifts, type PeriodFriend } from "@/hooks/use-shifts";
@@ -2054,6 +2055,19 @@ function getRecapMessage(
   return RECAP_TEMPLATES[index](meals, volunteers);
 }
 
+/** Human label for a marketing CMS journal category slug. */
+function journalCategoryLabel(category?: string): string {
+  if (!category) return "From the journal";
+  const labels: Record<string, string> = {
+    story: "Story",
+    news: "News",
+    recipe: "Recipe",
+    "behind-the-scenes": "Behind the scenes",
+    impact: "Impact",
+  };
+  return labels[category] ?? category;
+}
+
 const SKELETON_ROWS: { title: number; body: number[] }[] = [
   { title: 55, body: [92, 68] },
   { title: 45, body: [88] },
@@ -2158,13 +2172,13 @@ function FeedCard({
   isReported?: boolean;
 }) {
   // Only human-authored posts are reportable. System-generated items
-  // (achievement, friend_signup, shift_recap, new_shift, daily_menu)
-  // have no author-written content to moderate — but comments on them
-  // are still reportable via the sheet.
+  // (achievement, friend_signup, shift_recap, new_shift, daily_menu,
+  // community_event, journal_post) have no author-written content to
+  // moderate — but comments on them are still reportable via the sheet.
   const canReport = item.type === "photo_post" || item.type === "announcement";
-  // Track announcement image failures so a missing/404 image doesn't leave
-  // the 160px image slot reserved (a tall blank gap above the title).
-  const [announcementImageFailed, setAnnouncementImageFailed] = useState(false);
+  // Track hero image failures so a missing/404 image doesn't leave the
+  // 160px image slot reserved (a tall blank gap above the title).
+  const [heroImageFailed, setHeroImageFailed] = useState(false);
   const timeAgo = formatDistanceToNow(new Date(item.timestamp), {
     addSuffix: true,
   });
@@ -2259,7 +2273,7 @@ function FeedCard({
         </>
       );
 
-      const showImage = !!item.imageUrl && !announcementImageFailed;
+      const showImage = !!item.imageUrl && !heroImageFailed;
       return (
         <>
           {showImage && (
@@ -2273,7 +2287,7 @@ function FeedCard({
                 source={{ uri: item.imageUrl }}
                 style={styles.announcementImage}
                 resizeMode="cover"
-                onError={() => setAnnouncementImageFailed(true)}
+                onError={() => setHeroImageFailed(true)}
               />
             </Pressable>
           )}
@@ -2583,13 +2597,161 @@ function FeedCard({
       );
     }
 
+    if (item.type === "community_event") {
+      const eventDateText = formatNZT(new Date(item.eventDate), "EEEE d MMM");
+      const metaParts = [
+        item.location ? `📍 ${item.location}` : null,
+        eventDateText,
+        item.displayTime,
+      ].filter(Boolean);
+      const iconAndBody = (
+        <>
+          <View style={[styles.feedIcon, { backgroundColor: "#ede9fe" }]}>
+            <Text style={styles.feedIconEmoji}>🎟️</Text>
+          </View>
+          <View style={styles.feedBody}>
+            <Text style={[styles.feedTitle, { color: colors.text }]}>
+              {item.title}
+            </Text>
+            <Text
+              style={[styles.feedDescription, { color: colors.textSecondary }]}
+              numberOfLines={1}
+            >
+              {metaParts.join(" · ")}
+            </Text>
+            {item.description ? (
+              <Text
+                style={[
+                  styles.feedDescription,
+                  { color: colors.textSecondary },
+                ]}
+                numberOfLines={2}
+              >
+                {item.description}
+              </Text>
+            ) : null}
+            <View style={styles.feedFooter}>
+              <Text
+                style={[styles.feedMetaText, { color: colors.textSecondary }]}
+              >
+                {timeAgo}
+              </Text>
+              {socialButtons}
+            </View>
+          </View>
+        </>
+      );
+
+      const showImage = !!item.imageUrl && !heroImageFailed;
+      return (
+        <>
+          {showImage && (
+            <Pressable
+              onPress={() => onOpenImages([item.imageUrl!], 0)}
+              style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
+              accessibilityLabel="View event image"
+              accessibilityRole="imagebutton"
+            >
+              <Image
+                source={{ uri: item.imageUrl }}
+                style={styles.announcementImage}
+                resizeMode="cover"
+                onError={() => setHeroImageFailed(true)}
+              />
+            </Pressable>
+          )}
+          {showImage ? (
+            <View style={styles.feedCard}>{iconAndBody}</View>
+          ) : (
+            iconAndBody
+          )}
+        </>
+      );
+    }
+
+    if (item.type === "journal_post") {
+      const iconAndBody = (
+        <>
+          <View style={[styles.feedIcon, { backgroundColor: "#e0f2fe" }]}>
+            <Text style={styles.feedIconEmoji}>📖</Text>
+          </View>
+          <View style={styles.feedBody}>
+            <Text style={[styles.feedTitle, { color: colors.text }]}>
+              {item.title}
+            </Text>
+            {item.summary ? (
+              <Text
+                style={[
+                  styles.feedDescription,
+                  { color: colors.textSecondary },
+                ]}
+                numberOfLines={3}
+              >
+                {item.summary}
+              </Text>
+            ) : null}
+            <View style={styles.feedFooter}>
+              <View
+                style={[
+                  styles.feedMeta,
+                  { flexDirection: "column", alignItems: "flex-start", gap: 2 },
+                ]}
+              >
+                <Text
+                  style={[styles.feedMetaText, { color: colors.textSecondary }]}
+                  numberOfLines={1}
+                >
+                  {journalCategoryLabel(item.category)}
+                  {item.author ? ` · ${item.author}` : ""}
+                </Text>
+                <Text
+                  style={[styles.feedMetaText, { color: colors.textSecondary }]}
+                >
+                  {timeAgo}
+                </Text>
+              </View>
+              {socialButtons}
+            </View>
+          </View>
+        </>
+      );
+
+      const showImage = !!item.imageUrl && !heroImageFailed;
+      return (
+        <>
+          {showImage && (
+            <Pressable
+              onPress={() => onOpenImages([item.imageUrl!], 0)}
+              style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
+              accessibilityLabel="View journal image"
+              accessibilityRole="imagebutton"
+            >
+              <Image
+                source={{ uri: item.imageUrl }}
+                style={styles.announcementImage}
+                resizeMode="cover"
+                onError={() => setHeroImageFailed(true)}
+              />
+            </Pressable>
+          )}
+          {showImage ? (
+            <View style={styles.feedCard}>{iconAndBody}</View>
+          ) : (
+            iconAndBody
+          )}
+        </>
+      );
+    }
+
     return null;
   };
 
-  const hasAnnouncementImage =
-    item.type === "announcement" &&
+  const hasHeroImage =
+    (item.type === "announcement" ||
+      item.type === "community_event" ||
+      item.type === "journal_post") &&
     !!item.imageUrl &&
-    !announcementImageFailed;
+    !heroImageFailed;
 
   return (
     <Pressable
@@ -2597,7 +2759,7 @@ function FeedCard({
       style={({ pressed }) => [
         styles.feedCard,
         borderStyle,
-        hasAnnouncementImage && styles.feedCardColumn,
+        hasHeroImage && styles.feedCardColumn,
         { opacity: pressed ? 0.7 : 1 },
       ]}
       accessibilityRole="button"
@@ -2704,6 +2866,26 @@ const SHEET_TYPE_CONFIG = {
     accentDark: "#fcd34d",
     accentSoft: "#fffbeb",
     accentSoftDark: "rgba(245, 158, 11, 0.10)",
+  },
+  community_event: {
+    emoji: "🎟️",
+    label: "Community Event",
+    bg: "#ede9fe",
+    bgDark: "rgba(139, 92, 246, 0.12)",
+    accent: "#6d28d9",
+    accentDark: "#c4b5fd",
+    accentSoft: "#f5f3ff",
+    accentSoftDark: "rgba(139, 92, 246, 0.10)",
+  },
+  journal_post: {
+    emoji: "📖",
+    label: "From the Journal",
+    bg: "#e0f2fe",
+    bgDark: "rgba(14, 165, 233, 0.12)",
+    accent: "#0369a1",
+    accentDark: "#7dd3fc",
+    accentSoft: "#f0f9ff",
+    accentSoftDark: "rgba(14, 165, 233, 0.10)",
   },
 } as const;
 
@@ -2972,6 +3154,12 @@ function FeedItemSheet({
     ].filter((s): s is string => s !== null);
     sections.push(...courses);
     body = sections.join("\n\n");
+  } else if (item.type === "community_event") {
+    title = item.title;
+    body = item.description ?? "";
+  } else if (item.type === "journal_post") {
+    title = item.title;
+    body = item.summary ?? "";
   }
 
   const likeCount = likers.length;
@@ -3235,6 +3423,141 @@ function FeedItemSheet({
                         {item.period}
                       </Text>
                     </View>
+                  </>
+                )}
+                {item.type === "community_event" && (
+                  <>
+                    {item.location ? (
+                      <View
+                        style={[
+                          sheet.metaPill,
+                          {
+                            backgroundColor: isDark
+                              ? "rgba(255,255,255,0.05)"
+                              : colors.surfaceSoft,
+                          },
+                        ]}
+                      >
+                        <Ionicons
+                          name="location"
+                          size={11}
+                          color={colors.textSecondary}
+                        />
+                        <Text
+                          style={[
+                            sheet.metaPillText,
+                            { color: colors.textSecondary },
+                          ]}
+                        >
+                          {item.location}
+                        </Text>
+                      </View>
+                    ) : null}
+                    <View
+                      style={[
+                        sheet.metaPill,
+                        {
+                          backgroundColor: isDark
+                            ? "rgba(255,255,255,0.05)"
+                            : colors.surfaceSoft,
+                        },
+                      ]}
+                    >
+                      <Ionicons
+                        name="calendar"
+                        size={11}
+                        color={colors.textSecondary}
+                      />
+                      <Text
+                        style={[
+                          sheet.metaPillText,
+                          { color: colors.textSecondary },
+                        ]}
+                      >
+                        {formatNZT(new Date(item.eventDate), "EEE d MMM")}
+                        {item.displayTime ? ` · ${item.displayTime}` : ""}
+                      </Text>
+                    </View>
+                    {item.priceLabel ? (
+                      <View
+                        style={[
+                          sheet.metaPill,
+                          {
+                            backgroundColor: isDark
+                              ? "rgba(255,255,255,0.05)"
+                              : colors.surfaceSoft,
+                          },
+                        ]}
+                      >
+                        <Ionicons
+                          name="pricetag"
+                          size={11}
+                          color={colors.textSecondary}
+                        />
+                        <Text
+                          style={[
+                            sheet.metaPillText,
+                            { color: colors.textSecondary },
+                          ]}
+                        >
+                          {item.priceLabel}
+                        </Text>
+                      </View>
+                    ) : null}
+                  </>
+                )}
+                {item.type === "journal_post" && (
+                  <>
+                    <View
+                      style={[
+                        sheet.metaPill,
+                        {
+                          backgroundColor: isDark
+                            ? "rgba(255,255,255,0.05)"
+                            : colors.surfaceSoft,
+                        },
+                      ]}
+                    >
+                      <Ionicons
+                        name="bookmark"
+                        size={11}
+                        color={colors.textSecondary}
+                      />
+                      <Text
+                        style={[
+                          sheet.metaPillText,
+                          { color: colors.textSecondary },
+                        ]}
+                      >
+                        {journalCategoryLabel(item.category)}
+                      </Text>
+                    </View>
+                    {item.author ? (
+                      <View
+                        style={[
+                          sheet.metaPill,
+                          {
+                            backgroundColor: isDark
+                              ? "rgba(255,255,255,0.05)"
+                              : colors.surfaceSoft,
+                          },
+                        ]}
+                      >
+                        <Ionicons
+                          name="person"
+                          size={11}
+                          color={colors.textSecondary}
+                        />
+                        <Text
+                          style={[
+                            sheet.metaPillText,
+                            { color: colors.textSecondary },
+                          ]}
+                        >
+                          {item.author}
+                        </Text>
+                      </View>
+                    ) : null}
                   </>
                 )}
                 <View
@@ -3538,24 +3861,130 @@ function FeedItemSheet({
                 </Pressable>
               )}
 
-            {/* ── Photo gallery (for photo_post type) ── */}
-            {/* Announcement image */}
-            {item.type === "announcement" && item.imageUrl && (
-              <Pressable
-                onPress={() => openSheetViewer([item.imageUrl!], 0)}
-                accessibilityLabel="View announcement image"
-                accessibilityRole="imagebutton"
-              >
-                <Image
-                  source={{ uri: item.imageUrl }}
-                  style={[
-                    sheet.photoSingle,
-                    { borderRadius: 12, marginBottom: 12 },
+            {/* ── Community event CTAs: tickets + marketing site ── */}
+            {item.type === "community_event" && (
+              <View style={sheet.linkCTAGroup}>
+                {item.ticketUrl ? (
+                  <Pressable
+                    onPress={() => {
+                      Haptics.selectionAsync();
+                      openCmsLink(item.ticketUrl!);
+                    }}
+                    style={({ pressed }) => [
+                      sheet.shiftListCTA,
+                      {
+                        backgroundColor: Brand.green,
+                        opacity: pressed ? 0.85 : 1,
+                      },
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel="Get tickets"
+                  >
+                    <Text
+                      style={[
+                        sheet.shiftListCTAText,
+                        { color: Palette.cream50 },
+                      ]}
+                    >
+                      Get tickets
+                    </Text>
+                    <Ionicons
+                      name="arrow-forward"
+                      size={16}
+                      color={Palette.cream50}
+                    />
+                  </Pressable>
+                ) : null}
+                <Pressable
+                  onPress={() => {
+                    Haptics.selectionAsync();
+                    openCmsLink(item.url);
+                  }}
+                  style={({ pressed }) => [
+                    sheet.shiftListCTA,
+                    {
+                      backgroundColor: isDark
+                        ? "rgba(134, 239, 172, 0.12)"
+                        : Brand.greenLight,
+                      opacity: pressed ? 0.7 : 1,
+                    },
                   ]}
-                  resizeMode="cover"
-                />
-              </Pressable>
+                  accessibilityRole="button"
+                  accessibilityLabel="View event on everybodyeats.nz"
+                >
+                  <Text
+                    style={[
+                      sheet.shiftListCTAText,
+                      { color: isDark ? colors.tint : Brand.green },
+                    ]}
+                  >
+                    View on everybodyeats.nz
+                  </Text>
+                  <Ionicons
+                    name="open-outline"
+                    size={16}
+                    color={isDark ? colors.tint : Brand.green}
+                  />
+                </Pressable>
+              </View>
             )}
+
+            {/* ── Journal post CTA: read the full story ── */}
+            {item.type === "journal_post" && (
+              <View style={sheet.linkCTAGroup}>
+                <Pressable
+                  onPress={() => {
+                    Haptics.selectionAsync();
+                    openCmsLink(item.url);
+                  }}
+                  style={({ pressed }) => [
+                    sheet.shiftListCTA,
+                    {
+                      backgroundColor: Brand.green,
+                      opacity: pressed ? 0.85 : 1,
+                    },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Read the full story on everybodyeats.nz"
+                >
+                  <Text
+                    style={[
+                      sheet.shiftListCTAText,
+                      { color: Palette.cream50 },
+                    ]}
+                  >
+                    Read the full story
+                  </Text>
+                  <Ionicons
+                    name="arrow-forward"
+                    size={16}
+                    color={Palette.cream50}
+                  />
+                </Pressable>
+              </View>
+            )}
+
+            {/* ── Photo gallery (for photo_post type) ── */}
+            {/* Hero image (announcements + CMS content) */}
+            {(item.type === "announcement" ||
+              item.type === "community_event" ||
+              item.type === "journal_post") &&
+              item.imageUrl && (
+                <Pressable
+                  onPress={() => openSheetViewer([item.imageUrl!], 0)}
+                  accessibilityLabel="View image"
+                  accessibilityRole="imagebutton"
+                >
+                  <Image
+                    source={{ uri: item.imageUrl }}
+                    style={[
+                      sheet.photoSingle,
+                      { borderRadius: 12, marginBottom: 12 },
+                    ]}
+                    resizeMode="cover"
+                  />
+                </Pressable>
+              )}
 
             {item.type === "photo_post" && item.photos.length > 0 && (
               <View
@@ -4724,6 +5153,11 @@ const sheet = StyleSheet.create({
   shiftListCTAText: {
     fontSize: 14,
     fontFamily: FontFamily.semiBold,
+  },
+  linkCTAGroup: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    gap: 2,
   },
   photoSingle: {
     width: "100%",

--- a/mobile/app/shift/[id].tsx
+++ b/mobile/app/shift/[id].tsx
@@ -28,7 +28,12 @@ import { formatNZT } from "@/lib/dates";
 import { ThemedText } from "@/components/themed-text";
 import { Colors, Brand, FontFamily, Palette } from "@/constants/theme";
 import { useColorScheme } from "@/hooks/use-color-scheme";
-import { useShiftDetail, type PeriodFriend } from "@/hooks/use-shift-detail";
+import {
+  useShiftDetail,
+  type PeriodFriend,
+  type ShiftEvent,
+} from "@/hooks/use-shift-detail";
+import { openCmsLink } from "@/lib/external-links";
 import { useShifts } from "@/hooks/use-shifts";
 import {
   findConflictingShift,
@@ -69,6 +74,7 @@ export default function ShiftDetailScreen() {
   const {
     shift,
     signups: shiftSignups,
+    events,
     periodFriends,
     eligibility,
     isLoading,
@@ -607,6 +613,11 @@ export default function ShiftDetailScreen() {
           </View>
         </View>
 
+        {/* ═══ Marketing event at this restaurant on the shift's day ═══ */}
+        {events.length > 0 && (
+          <EventsSection events={events} colors={colors} isDark={isDark} />
+        )}
+
         {/* ═══ Volunteers on this shift ═══ */}
         {(visibleOnYourShift.length > 0 ||
           friendsInSession.length > 0 ||
@@ -837,6 +848,87 @@ function VolunteersSection({
           </View>
         </View>
       )}
+    </View>
+  );
+}
+
+function EventsSection({
+  events,
+  colors,
+  isDark,
+}: {
+  events: ShiftEvent[];
+  colors: (typeof Colors)["light"];
+  isDark: boolean;
+}) {
+  return (
+    <View style={s.section}>
+      <SectionHeader
+        label="Special event"
+        title="On at the restaurant"
+        caption="Running on the day of this shift"
+        colors={colors}
+      />
+      <View style={s.eventList}>
+        {events.map((event) => (
+          <Pressable
+            key={event.id}
+            onPress={() => {
+              Haptics.selectionAsync();
+              openCmsLink(event.url);
+            }}
+            style={({ pressed }) => [
+              s.eventCard,
+              { backgroundColor: colors.card, opacity: pressed ? 0.85 : 1 },
+            ]}
+            accessibilityRole="link"
+            accessibilityLabel={`View ${event.name} on everybodyeats.nz`}
+          >
+            {event.imageUrl ? (
+              <Image
+                source={{ uri: event.imageUrl }}
+                style={s.eventImage}
+                contentFit="cover"
+                accessibilityLabel={`${event.name} image`}
+              />
+            ) : null}
+            <View style={s.eventCardBody}>
+              <Text style={[s.eventName, { color: colors.text }]}>
+                {event.name}
+              </Text>
+              <Text style={[s.eventMeta, { color: colors.textSecondary }]}>
+                🎟️{" "}
+                {event.displayTime ??
+                  formatNZT(new Date(event.date), "h:mma").toLowerCase()}
+                {event.priceLabel ? ` · ${event.priceLabel}` : ""}
+              </Text>
+              {event.description ? (
+                <Text
+                  style={[s.eventDescription, { color: colors.textSecondary }]}
+                  numberOfLines={3}
+                >
+                  {event.description}
+                </Text>
+              ) : null}
+              <View style={s.eventLinkRow}>
+                <Text
+                  style={[
+                    s.eventLink,
+                    { color: isDark ? Brand.accent : Brand.green },
+                  ]}
+                >
+                  Details & tickets
+                </Text>
+                <Ionicons
+                  name="arrow-forward"
+                  size={14}
+                  color={isDark ? Brand.accent : Brand.green}
+                />
+              </View>
+            </View>
+          </Pressable>
+        ))}
+      </View>
     </View>
   );
 }
@@ -1257,6 +1349,47 @@ const s = StyleSheet.create({
   section: {
     paddingHorizontal: 20,
     gap: 14,
+  },
+
+  /* ── Marketing events ── */
+  eventList: {
+    gap: 12,
+  },
+  eventCard: {
+    borderRadius: 18,
+    overflow: "hidden",
+  },
+  eventImage: {
+    width: "100%",
+    height: 150,
+  },
+  eventCardBody: {
+    padding: 16,
+    gap: 6,
+  },
+  eventName: {
+    fontSize: 16,
+    fontFamily: FontFamily.semiBold,
+  },
+  eventMeta: {
+    fontSize: 13,
+    fontFamily: FontFamily.regular,
+  },
+  eventDescription: {
+    fontSize: 13.5,
+    lineHeight: 19,
+    fontFamily: FontFamily.regular,
+  },
+  eventLinkRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 4,
+    minHeight: 32,
+  },
+  eventLink: {
+    fontSize: 14,
+    fontFamily: FontFamily.semiBold,
   },
   sectionHeaderBlock: {
     gap: 4,

--- a/mobile/hooks/use-shift-detail.ts
+++ b/mobile/hooks/use-shift-detail.ts
@@ -25,7 +25,24 @@ type ShiftDetailResponse = {
     profilePhotoUrl: string | null;
     isFriend: boolean;
   }[];
+  events?: ShiftEvent[];
   eligibility?: ShiftEligibility;
+};
+
+/** Marketing CMS event at the same restaurant on the shift's day. */
+export type ShiftEvent = {
+  id: number;
+  name: string;
+  /** Event start (ISO). */
+  date: string;
+  /** Human-readable time range, e.g. "6:30pm - 11pm". */
+  displayTime: string | null;
+  description: string | null;
+  imageUrl: string | null;
+  /** Marketing site page for the event. */
+  url: string;
+  priceLabel: string | null;
+  ticketUrl: string | null;
 };
 
 /** Account-level signup gates, mirrored from the web signup checks. */
@@ -67,6 +84,8 @@ export type PeriodFriend = {
 type UseShiftDetailReturn = {
   shift: Shift | null;
   signups: ShiftSignup[];
+  /** Marketing CMS events at this restaurant on the shift's day */
+  events: ShiftEvent[];
   /** Friends signed up for any shift at the same location/date/AM-PM, with their role */
   periodFriends: PeriodFriend[];
   /** Account-level signup gates (email/profile/parental consent); null until loaded */
@@ -135,6 +154,7 @@ export function useShiftDetail(shiftId: string | undefined): UseShiftDetailRetur
   return {
     shift,
     signups,
+    events: data?.events ?? [],
     periodFriends,
     eligibility: data?.eligibility ?? null,
     isLoading: enabled ? detail.isPending : false,

--- a/mobile/lib/dummy-data.ts
+++ b/mobile/lib/dummy-data.ts
@@ -751,7 +751,9 @@ export type FeedItem =
   | ({ type: 'friend_signup'; id: string; userId?: string; userName: string; profilePhotoUrl?: string; shiftId: string; shiftTypeName: string; shiftDate: string; location: string; timestamp: string; isFriend: boolean } & FeedInteractions)
   | ({ type: 'shift_recap'; id: string; location: string; date: string; mealsServed: number; volunteerCount: number; timestamp: string } & FeedInteractions)
   | ({ type: 'new_shift'; id: string; location: string; count: number; shiftIds: string[]; shiftTypes: string[]; earliestStart: string; latestStart: string; preview: NewShiftPreview[]; timestamp: string } & FeedInteractions)
-  | ({ type: 'daily_menu'; id: string; menuId: string; location: string; serviceDate: string; chefName?: string; announcement?: string; starter: MenuCourseItem[]; mains: MenuCourseItem[]; drink: MenuCourseItem[]; dessert: MenuCourseItem[]; timestamp: string } & FeedInteractions);
+  | ({ type: 'daily_menu'; id: string; menuId: string; location: string; serviceDate: string; chefName?: string; announcement?: string; starter: MenuCourseItem[]; mains: MenuCourseItem[]; drink: MenuCourseItem[]; dessert: MenuCourseItem[]; timestamp: string } & FeedInteractions)
+  | ({ type: 'community_event'; id: string; title: string; description?: string; location?: string; eventDate: string; displayTime?: string; imageUrl?: string; url: string; priceLabel?: string; ticketUrl?: string; timestamp: string } & FeedInteractions)
+  | ({ type: 'journal_post'; id: string; title: string; summary?: string; category?: string; imageUrl?: string; author?: string; url: string; timestamp: string } & FeedInteractions);
 
 export type MenuCourseItem = { name: string; description?: string };
 

--- a/mobile/lib/external-links.ts
+++ b/mobile/lib/external-links.ts
@@ -1,0 +1,23 @@
+import {
+  openBrowserAsync,
+  WebBrowserPresentationStyle,
+} from "expo-web-browser";
+import { Linking } from "react-native";
+
+/**
+ * Open a link supplied by the marketing CMS. Web URLs open in the in-app
+ * browser; plain email addresses (some event "ticket links" are just a
+ * contact email) open the mail composer. Bare domains get https:// added.
+ */
+export async function openCmsLink(raw: string): Promise<void> {
+  const value = raw.trim();
+  if (!value) return;
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+    await Linking.openURL(`mailto:${value}`);
+    return;
+  }
+  const url = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+  await openBrowserAsync(url, {
+    presentationStyle: WebBrowserPresentationStyle.AUTOMATIC,
+  });
+}

--- a/web/.env.example
+++ b/web/.env.example
@@ -69,3 +69,9 @@ SUPABASE_SERVICE_ROLE_KEY=""
 # Test keys: site 1x00000000000000000000AA / secret 1x0000000000000000000000000000000AA (always pass)
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=""
 TURNSTILE_SECRET_KEY=""
+
+# Marketing CMS (optional — events/journal in the mobile feed and on shift pages
+# are skipped when unset). Base URL of the Payload-powered marketing site,
+# e.g. "https://www.everybodyeats.nz". Left empty here because CI copies this
+# file verbatim and e2e runs must not depend on the live site.
+MARKETING_CMS_URL=""

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -4,6 +4,10 @@ import { requireMobileUser } from "@/lib/mobile-auth";
 import { getStartOfDayUTC, formatInNZT } from "@/lib/timezone";
 import { ANNOUNCEMENT_SHIFT_TARGET_STATUSES } from "@/lib/announcement-targeting";
 import { formatAchievementCriteria } from "@/lib/achievement-utils";
+import {
+  getRecentCmsJournalPosts,
+  getUpcomingCmsEvents,
+} from "@/lib/services/marketing-cms";
 
 function parseCriteriaShiftTypeId(criteria: string): string | undefined {
   try {
@@ -25,6 +29,7 @@ function parseCriteriaShiftTypeId(criteria: string): string | undefined {
  * - Shift recaps (aggregate stats for completed shifts at user's locations)
  * - New shifts published for the user's default location
  * - Daily menus published for the user's default location
+ * - Community events and journal posts from the marketing CMS
  *
  * Every item includes likeCount, likedByMe, recentLikers, commentCount.
  * Items are sorted by timestamp descending and limited to the last 14 days.
@@ -50,6 +55,12 @@ export async function GET(request: Request) {
     .map((id) => id.trim())
     .filter((id) => id.length > 0 && id.length <= 200)
     .slice(0, 50);
+
+  // Marketing CMS content doesn't depend on the user, so kick those requests
+  // off first and await them alongside the per-user queries below. Both
+  // resolve to [] when the CMS is unconfigured or unreachable.
+  const cmsEventsPromise = getUpcomingCmsEvents();
+  const cmsJournalPostsPromise = getRecentCmsJournalPosts();
 
   // Get the user's profile, friendships, blocks, and active signup shift IDs
   // in parallel. The signup shift IDs are used to match announcements that
@@ -263,6 +274,11 @@ export async function GET(request: Request) {
           take: 20,
         })
       : Promise.resolve([]),
+  ]);
+
+  const [cmsEvents, cmsJournalPosts] = await Promise.all([
+    cmsEventsPromise,
+    cmsJournalPostsPromise,
   ]);
 
   type FeedItem = {
@@ -528,6 +544,72 @@ export async function GET(request: Request) {
       drink,
       dessert,
       timestamp: menu.createdAt.toISOString(),
+      likeCount: 0,
+      likedByMe: false,
+      recentLikers: [],
+      commentCount: 0,
+    });
+  }
+
+  // Community events from the marketing CMS. An event appears in the feed
+  // while its announcement is fresh (published within the feed window) and
+  // resurfaces during the week leading up to it, timestamped so it sorts as
+  // if freshly posted. Events aren't location-targeted: with only a handful
+  // per year, they're relevant to the whole whānau.
+  const startOfTodayNZ = getStartOfDayUTC(now);
+  for (const event of cmsEvents.slice(0, 10)) {
+    const eventDate = new Date(event.date);
+    if (eventDate < startOfTodayNZ) continue;
+
+    const publishedAt = new Date(event.publishedAt);
+    const resurfaceAt = new Date(
+      eventDate.getTime() - 7 * 24 * 60 * 60 * 1000
+    );
+    const isFresh = publishedAt >= since;
+    const isImminent = resurfaceAt <= now;
+    if (!isFresh && !isImminent) continue;
+
+    const timestamp =
+      isImminent && resurfaceAt > publishedAt ? resurfaceAt : publishedAt;
+
+    items.push({
+      type: "community_event",
+      id: `cms-event-${event.id}`,
+      title: event.name,
+      description: event.shortDescription ?? undefined,
+      location: event.location ?? undefined,
+      eventDate: event.date,
+      displayTime: event.displayTime ?? undefined,
+      imageUrl: event.imageUrl ?? undefined,
+      url: event.url,
+      priceLabel: event.priceLabel ?? undefined,
+      ticketUrl: event.ticketUrl ?? undefined,
+      timestamp: timestamp.toISOString(),
+      likeCount: 0,
+      likedByMe: false,
+      recentLikers: [],
+      commentCount: 0,
+    });
+  }
+
+  // Journal posts from the marketing CMS. The journal publishes less often
+  // than the 14-day feed window turns over, so use a wider 30-day window to
+  // keep the latest stories around.
+  const journalSince = new Date(now);
+  journalSince.setDate(journalSince.getDate() - 30);
+  for (const post of cmsJournalPosts
+    .filter((p) => new Date(p.publishedAt) >= journalSince)
+    .slice(0, 5)) {
+    items.push({
+      type: "journal_post",
+      id: `journal-post-${post.id}`,
+      title: post.title,
+      summary: post.summary ?? undefined,
+      category: post.category ?? undefined,
+      imageUrl: post.imageUrl ?? undefined,
+      author: post.author ?? undefined,
+      url: post.url,
+      timestamp: post.publishedAt,
       likeCount: 0,
       likedByMe: false,
       recentLikers: [],

--- a/web/src/app/api/mobile/shifts/[id]/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   shiftCapacityCountSelect,
 } from "@/lib/placeholder-utils";
 import { getMissingProfileFields } from "@/lib/profile-completion";
+import { getCmsEventsForShift } from "@/lib/services/marketing-cms";
 
 /**
  * GET /api/mobile/shifts/[id]
@@ -15,6 +16,7 @@ import { getMissingProfileFields } from "@/lib/profile-completion";
  * - signedUp count (CONFIRMED signups)
  * - The current user's signup status for this shift (if any)
  * - List of signups with friend status
+ * - Marketing CMS events at the same restaurant on the same day
  */
 export async function GET(
   request: Request,
@@ -101,6 +103,10 @@ export async function GET(
     }
   }
 
+  // Marketing CMS events at this restaurant on the shift's day, so volunteers
+  // know when a special event runs during their service.
+  const cmsEvents = await getCmsEventsForShift(shift.location, shift.start);
+
   // Find the current user's signup for this shift (any active status)
   const userSignup = shift.signups.find((s) => s.userId === userId);
   const userStatus = userSignup?.status ?? null;
@@ -138,6 +144,17 @@ export async function GET(
     status: userStatus,
     notes: shift.notes,
     signups,
+    events: cmsEvents.map((event) => ({
+      id: event.id,
+      name: event.name,
+      date: event.date,
+      displayTime: event.displayTime,
+      description: event.shortDescription,
+      imageUrl: event.imageUrl,
+      url: event.url,
+      priceLabel: event.priceLabel,
+      ticketUrl: event.ticketUrl,
+    })),
     eligibility: {
       emailVerified: Boolean(userRecord?.emailVerified),
       profileComplete: Boolean(userRecord?.profileCompleted),

--- a/web/src/app/shifts/[id]/page.tsx
+++ b/web/src/app/shifts/[id]/page.tsx
@@ -18,7 +18,10 @@ import {
   ArrowLeft,
   AlertCircle,
   CalendarPlus,
+  ExternalLink,
+  Ticket,
 } from "lucide-react";
+import { getCmsEventsForShift } from "@/lib/services/marketing-cms";
 import Link from "next/link";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { ProfileCompletionBannerServer } from "@/components/profile-completion-banner-server";
@@ -143,7 +146,7 @@ export default async function ShiftDetailPage({
   }
 
   // Parallelize all remaining queries
-  const [friendships, userSignup, currentUser, concurrentShifts] =
+  const [friendships, userSignup, currentUser, concurrentShifts, cmsEvents] =
     await Promise.all([
       // Friends
       userId
@@ -189,6 +192,9 @@ export default async function ShiftDetailPage({
 
       // Concurrent shifts for backup options
       getConcurrentShifts(id),
+
+      // Marketing CMS events at this restaurant on the shift's day
+      getCmsEventsForShift(shift.location, shift.start),
     ]);
 
   const userFriendIds = friendships.flatMap((f) =>
@@ -527,6 +533,55 @@ export default async function ShiftDetailPage({
                   )}&t=&z=15&ie=UTF8&iwloc=&output=embed`}
                 />
               </div>
+            </div>
+          )}
+
+          {cmsEvents.length > 0 && (
+            <div className="space-y-3" data-testid="shift-cms-events">
+              <p className="text-sm text-muted-foreground">
+                Special event at {shift.location} on this day
+              </p>
+              {cmsEvents.map((event) => (
+                <div
+                  key={event.id}
+                  className="rounded-lg border overflow-hidden sm:flex"
+                >
+                  {event.imageUrl && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={event.imageUrl}
+                      alt={event.name}
+                      className="h-40 w-full object-cover sm:h-auto sm:w-44 sm:shrink-0"
+                    />
+                  )}
+                  <div className="p-4 space-y-1.5">
+                    <p className="font-medium">{event.name}</p>
+                    <p className="text-sm text-muted-foreground inline-flex items-center gap-1.5">
+                      <Ticket className="h-3.5 w-3.5" />
+                      {event.displayTime ??
+                        formatInNZT(new Date(event.date), "h:mma").toLowerCase()}
+                      {event.priceLabel ? ` · ${event.priceLabel}` : ""}
+                    </p>
+                    {event.shortDescription && (
+                      <p className="text-sm text-muted-foreground">
+                        {event.shortDescription}
+                      </p>
+                    )}
+                    <div className="pt-1.5">
+                      <Button variant="outline" size="sm" className="gap-1.5" asChild>
+                        <a
+                          href={event.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Details & tickets
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ))}
             </div>
           )}
 

--- a/web/src/lib/feed/feed-item-owner.ts
+++ b/web/src/lib/feed/feed-item-owner.ts
@@ -36,6 +36,7 @@ export async function resolveFeedItemOwner(
       : null;
   }
 
-  // System-generated items (new-shift-*, shift-recap-*, daily-menu-*) have no owner to notify.
+  // System-generated items (new-shift-*, shift-recap-*, daily-menu-*,
+  // cms-event-*, journal-post-*) have no owner to notify.
   return null;
 }

--- a/web/src/lib/services/marketing-cms.test.ts
+++ b/web/src/lib/services/marketing-cms.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  clearMarketingCmsCache,
+  getCmsEventsForShift,
+  getRecentCmsJournalPosts,
+  getUpcomingCmsEvents,
+} from "./marketing-cms";
+
+const BASE_URL = "https://cms.test";
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const eventDoc = {
+  id: 62,
+  name: "Wine Dinner",
+  slug: "wine-dinner-29-august",
+  date: "2026-08-29T06:00:00.000Z",
+  displayTime: "6 - 9pm",
+  location: {
+    name: "Everybody Eats Onehunga",
+    menuLocationName: "Onehunga",
+  },
+  image: {
+    url: "/api/media/file/wine.webp",
+    sizes: { card: { url: "/api/media/file/wine-800.png" } },
+  },
+  shortDescription: "A very special dining experience.",
+  tickets: {
+    priceLabel: "$110",
+    ticketUrl: "https://tickets.test/wine",
+    caption: "",
+  },
+  createdAt: "2026-07-09T03:41:04.000Z",
+  _status: "published",
+};
+
+const journalDoc = {
+  id: 7,
+  title: "Winter stories from the kitchen",
+  slug: "winter-stories",
+  category: "story",
+  summary: "What happens behind the pass in July.",
+  mainImage: { url: "/api/media/file/winter.webp" },
+  author: "Nick Loosley",
+  publishedAt: "2026-07-10T00:00:00.000Z",
+  createdAt: "2026-07-08T00:00:00.000Z",
+  _status: "published",
+};
+
+describe("marketing-cms service", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    clearMarketingCmsCache();
+    vi.stubEnv("MARKETING_CMS_URL", BASE_URL);
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns empty lists without fetching when MARKETING_CMS_URL is unset", async () => {
+    vi.stubEnv("MARKETING_CMS_URL", "");
+
+    expect(await getUpcomingCmsEvents()).toEqual([]);
+    expect(await getRecentCmsJournalPosts()).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("maps event docs to CmsEvent with absolute URLs and portal location name", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ docs: [eventDoc] }));
+
+    const events = await getUpcomingCmsEvents();
+
+    expect(events).toEqual([
+      {
+        id: 62,
+        slug: "wine-dinner-29-august",
+        name: "Wine Dinner",
+        date: "2026-08-29T06:00:00.000Z",
+        displayTime: "6 - 9pm",
+        location: "Onehunga",
+        imageUrl: `${BASE_URL}/api/media/file/wine.webp`,
+        shortDescription: "A very special dining experience.",
+        priceLabel: "$110",
+        ticketUrl: "https://tickets.test/wine",
+        url: `${BASE_URL}/events/wine-dinner-29-august`,
+        publishedAt: "2026-07-09T03:41:04.000Z",
+      },
+    ]);
+
+    const requestedUrl = fetchMock.mock.calls[0][0] as string;
+    expect(requestedUrl).toContain(`${BASE_URL}/api/events?`);
+    expect(requestedUrl).toContain(
+      `${encodeURIComponent("where[_status][equals]")}=published`
+    );
+    expect(requestedUrl).toContain(
+      encodeURIComponent("where[date][greater_than_equal]")
+    );
+  });
+
+  it("handles events without location or image and drops invalid docs", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        docs: [
+          { ...eventDoc, id: 1, location: null, image: null },
+          // Unresolved relationships come back as numeric IDs at depth 0.
+          { ...eventDoc, id: 2, slug: "second", location: 5, image: 9 },
+          { ...eventDoc, id: 3, slug: null },
+          { ...eventDoc, id: 4, date: "not-a-date" },
+        ],
+      })
+    );
+
+    const events = await getUpcomingCmsEvents();
+
+    expect(events.map((e) => e.id)).toEqual([1, 2]);
+    expect(events[0].location).toBeNull();
+    expect(events[0].imageUrl).toBeNull();
+    expect(events[1].location).toBeNull();
+    expect(events[1].imageUrl).toBeNull();
+  });
+
+  it("falls back to the CMS location name when menuLocationName is blank", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        docs: [
+          {
+            ...eventDoc,
+            location: { name: "Wellington", menuLocationName: "  " },
+          },
+        ],
+      })
+    );
+
+    const events = await getUpcomingCmsEvents();
+    expect(events[0].location).toBe("Wellington");
+  });
+
+  it("maps journal docs to CmsJournalPost, falling back to createdAt", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        docs: [journalDoc, { ...journalDoc, id: 8, publishedAt: null }],
+      })
+    );
+
+    const posts = await getRecentCmsJournalPosts();
+
+    expect(posts[0]).toEqual({
+      id: 7,
+      slug: "winter-stories",
+      title: "Winter stories from the kitchen",
+      category: "story",
+      summary: "What happens behind the pass in July.",
+      imageUrl: `${BASE_URL}/api/media/file/winter.webp`,
+      author: "Nick Loosley",
+      publishedAt: "2026-07-10T00:00:00.000Z",
+      url: `${BASE_URL}/journal/winter-stories`,
+    });
+    expect(posts[1].publishedAt).toBe("2026-07-08T00:00:00.000Z");
+
+    const requestedUrl = fetchMock.mock.calls[0][0] as string;
+    expect(requestedUrl).toContain(`${BASE_URL}/api/journal-posts?`);
+  });
+
+  it("serves cached data within the TTL without re-fetching", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ docs: [eventDoc] }));
+
+    await getUpcomingCmsEvents();
+    await getUpcomingCmsEvents();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves stale data when a refresh fails after the TTL expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T00:00:00.000Z"));
+    fetchMock.mockResolvedValueOnce(jsonResponse({ docs: [eventDoc] }));
+
+    const first = await getUpcomingCmsEvents();
+    expect(first).toHaveLength(1);
+
+    vi.setSystemTime(new Date("2026-07-15T00:10:00.000Z"));
+    fetchMock.mockRejectedValueOnce(new Error("CMS down"));
+
+    const second = await getUpcomingCmsEvents();
+    expect(second).toEqual(first);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns [] when the CMS is unreachable and nothing is cached", async () => {
+    fetchMock.mockRejectedValue(new Error("CMS down"));
+
+    expect(await getUpcomingCmsEvents()).toEqual([]);
+    expect(await getRecentCmsJournalPosts()).toEqual([]);
+  });
+
+  it("returns [] on a non-OK response with nothing cached", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, false, 500));
+
+    expect(await getUpcomingCmsEvents()).toEqual([]);
+  });
+
+  describe("getCmsEventsForShift", () => {
+    it("matches events on the same NZ day at the same portal location", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          docs: [
+            eventDoc, // Onehunga, 2026-08-29 6pm NZ
+            {
+              ...eventDoc,
+              id: 70,
+              slug: "wellington-quiz",
+              location: { name: "Wellington", menuLocationName: "Wellington" },
+            },
+            {
+              ...eventDoc,
+              id: 71,
+              slug: "onehunga-next-week",
+              date: "2026-09-05T06:00:00.000Z",
+            },
+          ],
+        })
+      );
+
+      // 12:30pm NZ on the same day as the 6pm event.
+      const shiftStart = new Date("2026-08-29T00:30:00.000Z");
+      const events = await getCmsEventsForShift("Onehunga", shiftStart);
+
+      expect(events.map((e) => e.id)).toEqual([62]);
+    });
+
+    it("returns [] for shifts without a location", async () => {
+      const events = await getCmsEventsForShift(null, new Date());
+      expect(events).toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/lib/services/marketing-cms.ts
+++ b/web/src/lib/services/marketing-cms.ts
@@ -1,0 +1,320 @@
+/**
+ * Marketing CMS service — read-only client for the Everybody Eats marketing
+ * site's Payload CMS REST API (events and journal posts).
+ *
+ * The CMS lives in the marketing-cms repo (Payload 3 inside Next.js) and
+ * exposes public read endpoints at {MARKETING_CMS_URL}/api/<collection>.
+ * Set MARKETING_CMS_URL (e.g. https://www.everybodyeats.nz) to enable the
+ * integration; when unset, all fetchers return empty lists so the portal
+ * works without the CMS.
+ *
+ * CMS events carry a relationship to the CMS `locations` collection, whose
+ * `menuLocationName` field holds the exact portal location name (the same
+ * join key the marketing site already uses to pull menus from this portal).
+ */
+
+import { isSameDayInNZT } from "@/lib/timezone";
+
+interface CmsMediaSize {
+  url?: string | null;
+}
+
+interface CmsMedia {
+  url?: string | null;
+  alt?: string | null;
+  sizes?: {
+    thumbnail?: CmsMediaSize | null;
+    card?: CmsMediaSize | null;
+    feature?: CmsMediaSize | null;
+    hero?: CmsMediaSize | null;
+  } | null;
+}
+
+interface CmsLocationDoc {
+  name?: string | null;
+  menuLocationName?: string | null;
+}
+
+interface CmsEventDoc {
+  id: number;
+  name?: string | null;
+  slug?: string | null;
+  date?: string | null;
+  displayTime?: string | null;
+  location?: CmsLocationDoc | number | null;
+  image?: CmsMedia | number | null;
+  shortDescription?: string | null;
+  tickets?: {
+    priceLabel?: string | null;
+    ticketUrl?: string | null;
+  } | null;
+  createdAt?: string | null;
+}
+
+interface CmsJournalPostDoc {
+  id: number;
+  title?: string | null;
+  slug?: string | null;
+  category?: string | null;
+  summary?: string | null;
+  mainImage?: CmsMedia | number | null;
+  author?: string | null;
+  publishedAt?: string | null;
+  createdAt?: string | null;
+}
+
+export interface CmsEvent {
+  id: number;
+  slug: string;
+  name: string;
+  /** Event start as an ISO string. */
+  date: string;
+  /** Human-readable time range, e.g. "6:30pm - 11pm". */
+  displayTime: string | null;
+  /** Portal location name (CMS menuLocationName, falling back to the CMS location name). */
+  location: string | null;
+  /** Absolute image URL, or null when the event has no image. */
+  imageUrl: string | null;
+  shortDescription: string | null;
+  priceLabel: string | null;
+  ticketUrl: string | null;
+  /** Public marketing site page for the event. */
+  url: string;
+  /** When the event was published in the CMS (ISO). */
+  publishedAt: string;
+}
+
+export interface CmsJournalPost {
+  id: number;
+  slug: string;
+  title: string;
+  category: string | null;
+  summary: string | null;
+  imageUrl: string | null;
+  author: string | null;
+  /** Display/publish date of the post (ISO). */
+  publishedAt: string;
+  /** Public marketing site page for the post. */
+  url: string;
+}
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 8000;
+
+interface CacheEntry {
+  data: unknown;
+  fetchedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+/** Test hook — clears the module-level TTL cache. */
+export function clearMarketingCmsCache(): void {
+  cache.clear();
+}
+
+function getCmsBaseUrl(): string | null {
+  const raw = process.env.MARKETING_CMS_URL?.trim();
+  if (!raw) return null;
+  return raw.replace(/\/+$/, "");
+}
+
+function absoluteUrl(baseUrl: string, url: string): string {
+  if (/^https?:\/\//i.test(url)) return url;
+  return `${baseUrl}${url.startsWith("/") ? "" : "/"}${url}`;
+}
+
+function resolveImageUrl(
+  baseUrl: string,
+  media: CmsMedia | number | null | undefined
+): string | null {
+  if (!media || typeof media === "number") return null;
+  // Prefer the original upload (webp) — the CMS's resized variants are PNGs
+  // that are typically larger files than the original.
+  const url =
+    media.url ?? media.sizes?.card?.url ?? media.sizes?.feature?.url ?? null;
+  return url ? absoluteUrl(baseUrl, url) : null;
+}
+
+function resolveLocationName(
+  location: CmsLocationDoc | number | null | undefined
+): string | null {
+  if (!location || typeof location === "number") return null;
+  const menuName = location.menuLocationName?.trim();
+  if (menuName) return menuName;
+  const name = location.name?.trim();
+  return name || null;
+}
+
+function normalizeText(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+async function fetchCollection<TDoc>(
+  baseUrl: string,
+  collection: string,
+  params: Record<string, string>
+): Promise<TDoc[]> {
+  const search = new URLSearchParams({
+    "where[_status][equals]": "published",
+    ...params,
+  });
+  const response = await fetch(
+    `${baseUrl}/api/${collection}?${search.toString()}`,
+    {
+      cache: "no-store",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: "application/json" },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Marketing CMS request failed: ${collection} ${response.status}`
+    );
+  }
+  const body = (await response.json()) as { docs?: TDoc[] };
+  return Array.isArray(body.docs) ? body.docs : [];
+}
+
+/**
+ * TTL-cached fetch. On upstream failure, serves stale data when available so
+ * a CMS blip never blanks the feed; otherwise returns the empty fallback.
+ */
+async function getCached<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+  const entry = cache.get(key);
+  const now = Date.now();
+  if (entry && now - entry.fetchedAt < CACHE_TTL_MS) {
+    return entry.data as T;
+  }
+  try {
+    const data = await fetcher();
+    cache.set(key, { data, fetchedAt: now });
+    return data;
+  } catch (error) {
+    console.error(`Marketing CMS fetch failed (${key}):`, error);
+    if (entry) return entry.data as T;
+    throw error;
+  }
+}
+
+function mapEvent(baseUrl: string, doc: CmsEventDoc): CmsEvent | null {
+  const slug = normalizeText(doc.slug);
+  const name = normalizeText(doc.name);
+  const date = normalizeText(doc.date);
+  if (!slug || !name || !date || Number.isNaN(new Date(date).getTime())) {
+    return null;
+  }
+  return {
+    id: doc.id,
+    slug,
+    name,
+    date,
+    displayTime: normalizeText(doc.displayTime),
+    location: resolveLocationName(doc.location),
+    imageUrl: resolveImageUrl(baseUrl, doc.image),
+    shortDescription: normalizeText(doc.shortDescription),
+    priceLabel: normalizeText(doc.tickets?.priceLabel),
+    ticketUrl: normalizeText(doc.tickets?.ticketUrl),
+    url: `${baseUrl}/events/${slug}`,
+    publishedAt: doc.createdAt ?? date,
+  };
+}
+
+function mapJournalPost(
+  baseUrl: string,
+  doc: CmsJournalPostDoc
+): CmsJournalPost | null {
+  const slug = normalizeText(doc.slug);
+  const title = normalizeText(doc.title);
+  if (!slug || !title) return null;
+  const publishedAt = doc.publishedAt ?? doc.createdAt;
+  if (!publishedAt || Number.isNaN(new Date(publishedAt).getTime())) {
+    return null;
+  }
+  return {
+    id: doc.id,
+    slug,
+    title,
+    category: normalizeText(doc.category),
+    summary: normalizeText(doc.summary),
+    imageUrl: resolveImageUrl(baseUrl, doc.mainImage),
+    author: normalizeText(doc.author),
+    publishedAt,
+    url: `${baseUrl}/journal/${slug}`,
+  };
+}
+
+/**
+ * Published CMS events whose date is today (NZ) or later, soonest first.
+ * Returns [] when the CMS is not configured or unreachable with no cached data.
+ */
+export async function getUpcomingCmsEvents(): Promise<CmsEvent[]> {
+  const baseUrl = getCmsBaseUrl();
+  if (!baseUrl) return [];
+  try {
+    return await getCached("events", async () => {
+      // Fetch from the start of the current UTC day; "today in NZ" is always
+      // within that window, and callers apply precise NZ-day filtering.
+      const from = new Date();
+      from.setUTCHours(0, 0, 0, 0);
+      from.setUTCDate(from.getUTCDate() - 1);
+      const docs = await fetchCollection<CmsEventDoc>(baseUrl, "events", {
+        "where[date][greater_than_equal]": from.toISOString(),
+        depth: "2",
+        sort: "date",
+        limit: "50",
+      });
+      return docs
+        .map((doc) => mapEvent(baseUrl, doc))
+        .filter((event): event is CmsEvent => event !== null);
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Most recently published CMS journal posts, newest first.
+ * Returns [] when the CMS is not configured or unreachable with no cached data.
+ */
+export async function getRecentCmsJournalPosts(): Promise<CmsJournalPost[]> {
+  const baseUrl = getCmsBaseUrl();
+  if (!baseUrl) return [];
+  try {
+    return await getCached("journal-posts", async () => {
+      const docs = await fetchCollection<CmsJournalPostDoc>(
+        baseUrl,
+        "journal-posts",
+        {
+          depth: "1",
+          sort: "-publishedAt",
+          limit: "10",
+        }
+      );
+      return docs
+        .map((doc) => mapJournalPost(baseUrl, doc))
+        .filter((post): post is CmsJournalPost => post !== null);
+    });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Published CMS events at the given portal location on the same NZ calendar
+ * day as `date`. Matching is by exact portal location name (the CMS
+ * `menuLocationName` join key), consistent with the menu integration.
+ */
+export async function getCmsEventsForShift(
+  location: string | null | undefined,
+  date: Date
+): Promise<CmsEvent[]> {
+  const shiftLocation = location?.trim();
+  if (!shiftLocation) return [];
+  const events = await getUpcomingCmsEvents();
+  return events.filter(
+    (event) =>
+      event.location === shiftLocation && isSameDayInNZT(event.date, date)
+  );
+}

--- a/web/tests/e2e/parental-consent.spec.ts
+++ b/web/tests/e2e/parental-consent.spec.ts
@@ -63,14 +63,17 @@ test.describe("Parental Consent System", () => {
       await page.getByTestId("next-submit-button").click();
       await waitForPageLoad(page);
 
-      // Step 2: Enter birth date that makes user 16 years old
+      // Step 2: Enter a birth date that keeps the user under 16 year-round.
+      // selectDateOfBirth pins the DOB to July 15, so `year - 16` flips to
+      // exactly 16 (no consent notice) once July 15 passes; `year - 15` is
+      // 14 or 15 on every calendar day.
       await page.getByRole("textbox", { name: /first name/i }).fill("Test");
       await page.getByRole("textbox", { name: /last name/i }).fill("Minor");
       await page
         .getByRole("textbox", { name: /mobile number/i })
         .fill("(555) 123-4567");
 
-      const birthYear = new Date().getFullYear() - 16;
+      const birthYear = new Date().getFullYear() - 15;
       await selectDateOfBirth(page, birthYear);
 
       // Should show parental consent notice


### PR DESCRIPTION
## Summary

Integrates the Payload marketing CMS (everybodyeats.nz) into the volunteer portal so volunteers see what's happening across the charity:

- **Mobile feed**: two new item types — `community_event` 🎟️ and `journal_post` 📖. Events show when newly published and **resurface a week before they run**; journal posts use a 30-day window (they publish less often than the 14-day feed window turns over). Likes/comments work out of the box via the existing namespaced feed-item IDs (`cms-event-<id>`, `journal-post-<id>`).
- **Shift pages** (web page + mobile API/screen): shifts at a restaurant that has a CMS event on the same NZ day show an "On at the restaurant" section with time, price, description, and a tickets/details link — so volunteers know a special event runs during their service.

## How it works

- New service [`web/src/lib/services/marketing-cms.ts`](../blob/claude/marketing-cms-events-feed-cfac1c/web/src/lib/services/marketing-cms.ts): typed client for the CMS public REST API (`/api/events`, `/api/journal-posts`, published only), 5-minute TTL cache with stale-on-error fallback, and a graceful no-op when `MARKETING_CMS_URL` is unset (Campaign Monitor convention).
- Location matching uses the CMS location's `menuLocationName` — the **same join key the marketing site already uses** to pull tonight's menu from this portal, just in the reverse direction.
- Image URLs are absolutized against the CMS origin; feed cards use the plain-text `shortDescription`/`summary` and link out for the full (Lexical) content.
- Ticket "URLs" that are plain email addresses (e.g. the Gala's `gala@everybodyeats.nz`) open the mail composer on mobile.

## Config

- `MARKETING_CMS_URL` (optional) — set to `https://www.everybodyeats.nz` in production. Left empty in `.env.example` because CI copies it verbatim and e2e must not depend on the live site. **Needs to be added to the Coolify env for the integration to go live.**

## Testing

- 11 new unit tests for the service (mapping, caching, stale-on-error, shift matching); full suite 460/460 green; web+mobile typecheck and lint clean.
- Verified end-to-end against a local mock CMS: feed returns both new item types with correct windowing (stale events/posts excluded), shift detail API returns same-day/same-location events only, likes+comments work on CMS items, and the web shift page renders the event card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)