### PR TITLE
fix(mobile): CMS feed cards render compact thumbnails instead of blank hero strips

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -2604,7 +2604,8 @@ function FeedCard({
         eventDateText,
         item.displayTime,
       ].filter(Boolean);
-      const iconAndBody = (
+      const showThumb = !!item.imageUrl && !heroImageFailed;
+      return (
         <>
           <View style={[styles.feedIcon, { backgroundColor: "#ede9fe" }]}>
             <Text style={styles.feedIconEmoji}>🎟️</Text>
@@ -2639,38 +2640,31 @@ function FeedCard({
               {socialButtons}
             </View>
           </View>
-        </>
-      );
-
-      const showImage = !!item.imageUrl && !heroImageFailed;
-      return (
-        <>
-          {showImage && (
+          {showThumb && (
             <Pressable
-              onPress={() => onOpenImages([item.imageUrl!], 0)}
-              style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
-              accessibilityLabel="View event image"
+              onPress={(e) => {
+                e.stopPropagation();
+                onOpenImages([item.imageUrl!], 0);
+              }}
+              style={({ pressed }) => ({ opacity: pressed ? 0.8 : 1 })}
+              accessibilityLabel="View event poster"
               accessibilityRole="imagebutton"
             >
               <Image
                 source={{ uri: item.imageUrl }}
-                style={styles.announcementImage}
+                style={[styles.feedThumb, { backgroundColor: colors.border }]}
                 resizeMode="cover"
                 onError={() => setHeroImageFailed(true)}
               />
             </Pressable>
-          )}
-          {showImage ? (
-            <View style={styles.feedCard}>{iconAndBody}</View>
-          ) : (
-            iconAndBody
           )}
         </>
       );
     }
 
     if (item.type === "journal_post") {
-      const iconAndBody = (
+      const showThumb = !!item.imageUrl && !heroImageFailed;
+      return (
         <>
           <View style={[styles.feedIcon, { backgroundColor: "#e0f2fe" }]}>
             <Text style={styles.feedIconEmoji}>📖</Text>
@@ -2713,31 +2707,23 @@ function FeedCard({
               {socialButtons}
             </View>
           </View>
-        </>
-      );
-
-      const showImage = !!item.imageUrl && !heroImageFailed;
-      return (
-        <>
-          {showImage && (
+          {showThumb && (
             <Pressable
-              onPress={() => onOpenImages([item.imageUrl!], 0)}
-              style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}
+              onPress={(e) => {
+                e.stopPropagation();
+                onOpenImages([item.imageUrl!], 0);
+              }}
+              style={({ pressed }) => ({ opacity: pressed ? 0.8 : 1 })}
               accessibilityLabel="View journal image"
               accessibilityRole="imagebutton"
             >
               <Image
                 source={{ uri: item.imageUrl }}
-                style={styles.announcementImage}
+                style={[styles.feedThumb, { backgroundColor: colors.border }]}
                 resizeMode="cover"
                 onError={() => setHeroImageFailed(true)}
               />
             </Pressable>
-          )}
-          {showImage ? (
-            <View style={styles.feedCard}>{iconAndBody}</View>
-          ) : (
-            iconAndBody
           )}
         </>
       );
@@ -2747,11 +2733,7 @@ function FeedCard({
   };
 
   const hasHeroImage =
-    (item.type === "announcement" ||
-      item.type === "community_event" ||
-      item.type === "journal_post") &&
-    !!item.imageUrl &&
-    !heroImageFailed;
+    item.type === "announcement" && !!item.imageUrl && !heroImageFailed;
 
   return (
     <Pressable
@@ -3320,8 +3302,11 @@ function FeedItemSheet({
               {/* Title */}
               <Text style={[sheet.title, { color: colors.text }]}>{title}</Text>
 
-              {/* Body text — use Markdown renderer for announcements and menus */}
-              {item.type === "announcement" || item.type === "daily_menu" ? (
+              {/* Body text — use Markdown renderer for announcements and menus.
+                  Skip entirely when empty (e.g. a CMS event without a short
+                  description) so it doesn't reserve a blank line. */}
+              {body.length === 0 ? null : item.type === "announcement" ||
+                item.type === "daily_menu" ? (
                 <Markdown
                   style={{
                     body: {
@@ -3861,6 +3846,32 @@ function FeedItemSheet({
                 </Pressable>
               )}
 
+            {/* ── Hero image (announcements + CMS content) ── */}
+            {(item.type === "announcement" ||
+              item.type === "community_event" ||
+              item.type === "journal_post") &&
+              item.imageUrl && (
+                <Pressable
+                  onPress={() => openSheetViewer([item.imageUrl!], 0)}
+                  accessibilityLabel="View image"
+                  accessibilityRole="imagebutton"
+                >
+                  <Image
+                    source={{ uri: item.imageUrl }}
+                    // Event images are portrait posters (4:5 / 9:16) — show
+                    // them in a 4:5 frame instead of a shallow strip that
+                    // crops away the poster's content.
+                    style={[
+                      item.type === "community_event"
+                        ? sheet.posterImage
+                        : sheet.photoSingle,
+                      { borderRadius: 12, marginBottom: 12 },
+                    ]}
+                    resizeMode="cover"
+                  />
+                </Pressable>
+              )}
+
             {/* ── Community event CTAs: tickets + marketing site ── */}
             {item.type === "community_event" && (
               <View style={sheet.linkCTAGroup}>
@@ -3965,27 +3976,6 @@ function FeedItemSheet({
             )}
 
             {/* ── Photo gallery (for photo_post type) ── */}
-            {/* Hero image (announcements + CMS content) */}
-            {(item.type === "announcement" ||
-              item.type === "community_event" ||
-              item.type === "journal_post") &&
-              item.imageUrl && (
-                <Pressable
-                  onPress={() => openSheetViewer([item.imageUrl!], 0)}
-                  accessibilityLabel="View image"
-                  accessibilityRole="imagebutton"
-                >
-                  <Image
-                    source={{ uri: item.imageUrl }}
-                    style={[
-                      sheet.photoSingle,
-                      { borderRadius: 12, marginBottom: 12 },
-                    ]}
-                    resizeMode="cover"
-                  />
-                </Pressable>
-              )}
-
             {item.type === "photo_post" && item.photos.length > 0 && (
               <View
                 style={[
@@ -4634,6 +4624,12 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     marginBottom: 10,
   },
+  feedThumb: {
+    width: 64,
+    height: 64,
+    borderRadius: 10,
+    marginTop: 2,
+  },
   feedIcon: {
     width: 42,
     height: 42,
@@ -5162,6 +5158,10 @@ const sheet = StyleSheet.create({
   photoSingle: {
     width: "100%",
     height: 220,
+  },
+  posterImage: {
+    width: "100%",
+    aspectRatio: 4 / 5,
   },
   photoScrollContent: {
     gap: 3,

--- a/mobile/app/shift/[id].tsx
+++ b/mobile/app/shift/[id].tsx
@@ -1359,9 +1359,11 @@ const s = StyleSheet.create({
     borderRadius: 18,
     overflow: "hidden",
   },
+  // Event images are portrait posters (4:5 / 9:16) — a 4:5 frame shows the
+  // poster content instead of a shallow cover-cropped strip.
   eventImage: {
     width: "100%",
-    height: 150,
+    aspectRatio: 4 / 5,
   },
   eventCardBody: {
     padding: 16,

--- a/web/src/lib/services/marketing-cms.test.ts
+++ b/web/src/lib/services/marketing-cms.test.ts
@@ -133,6 +133,24 @@ describe("marketing-cms service", () => {
     expect(events[1].imageUrl).toBeNull();
   });
 
+  it("collapses newlines and whitespace runs in text fields", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        docs: [
+          {
+            ...eventDoc,
+            shortDescription: "5 courses\nLocal artisan drinks\nOnehunga Eats ",
+          },
+        ],
+      })
+    );
+
+    const events = await getUpcomingCmsEvents();
+    expect(events[0].shortDescription).toBe(
+      "5 courses Local artisan drinks Onehunga Eats"
+    );
+  });
+
   it("falls back to the CMS location name when menuLocationName is blank", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({

--- a/web/src/lib/services/marketing-cms.ts
+++ b/web/src/lib/services/marketing-cms.ts
@@ -147,7 +147,9 @@ function resolveLocationName(
 }
 
 function normalizeText(value: string | null | undefined): string | null {
-  const trimmed = value?.trim();
+  // CMS blurbs often contain hard line breaks (pasted from posters); collapse
+  // all whitespace runs so single-line UI surfaces don't render fragments.
+  const trimmed = value?.trim().replace(/\s+/g, " ");
   return trimmed ? trimmed : null;
 }
 


### PR DESCRIPTION
## Problem

With real production CMS data, the new feed cards rendered badly on device (see screenshots in the session): each event/journal card reserved a full-width 160pt hero slot that sat as a giant blank void while the ~300KB portrait webp posters loaded over cellular — and even once loaded, a 160pt cover-crop of a 4:5/9:16 poster shows an arbitrary middle band. The feed sheet also had an awkward blank gap when an event has no short description, and multi-line poster-style blurbs (`5 courses\nLocal artisan drinks\n…`) rendered as odd stacked fragments.

## Fixes

- **Feed cards** (`community_event`, `journal_post`): full-bleed hero strip replaced with a 64pt rounded trailing thumbnail with a placeholder tint while loading (tap opens the full-screen viewer). Announcements keep their existing hero treatment.
- **Feed sheet**: body line is skipped entirely when empty (no more title→pills gap); the image now sits between the content card and the CTA buttons; event posters render in a 4:5 frame instead of a 220pt strip.
- **Shift screen**: event card image switched to the same 4:5 poster frame.
- **Service**: `normalizeText` collapses whitespace runs so hard line breaks in CMS blurbs read as one sentence on single-line surfaces (+ test, 12/12 green).

Mobile + web typecheck clean, web lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)