### PR TITLE
feat(mobile): pin events happening today to the top of the feed

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -2598,7 +2598,10 @@ function FeedCard({
     }
 
     if (item.type === "community_event") {
-      const eventDateText = formatNZT(new Date(item.eventDate), "EEEE d MMM");
+      const isToday = item.pinned === true;
+      const eventDateText = isToday
+        ? "Today"
+        : formatNZT(new Date(item.eventDate), "EEEE d MMM");
       const metaParts = [
         item.location ? `📍 ${item.location}` : null,
         eventDateText,
@@ -2611,6 +2614,13 @@ function FeedCard({
             <Text style={styles.feedIconEmoji}>🎟️</Text>
           </View>
           <View style={styles.feedBody}>
+            {isToday && (
+              <View style={[styles.feedTodayPill, { backgroundColor: "#ede9fe" }]}>
+                <Text style={[styles.feedTodayPillText, { color: "#6d28d9" }]}>
+                  Happening today
+                </Text>
+              </View>
+            )}
             <Text style={[styles.feedTitle, { color: colors.text }]}>
               {item.title}
             </Text>
@@ -3459,7 +3469,9 @@ function FeedItemSheet({
                           { color: colors.textSecondary },
                         ]}
                       >
-                        {formatNZT(new Date(item.eventDate), "EEE d MMM")}
+                        {item.pinned
+                          ? "Today"
+                          : formatNZT(new Date(item.eventDate), "EEE d MMM")}
                         {item.displayTime ? ` · ${item.displayTime}` : ""}
                       </Text>
                     </View>
@@ -4629,6 +4641,19 @@ const styles = StyleSheet.create({
     height: 64,
     borderRadius: 10,
     marginTop: 2,
+  },
+  feedTodayPill: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 999,
+    marginBottom: 4,
+  },
+  feedTodayPillText: {
+    fontSize: 11,
+    fontFamily: FontFamily.semiBold,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
   },
   feedIcon: {
     width: 42,

--- a/mobile/hooks/use-feed.ts
+++ b/mobile/hooks/use-feed.ts
@@ -72,14 +72,27 @@ export function useFeed(): UseFeedReturn {
     [queryClient, queryKey]
   );
 
-  const items = useMemo(
-    () =>
-      [...(query.data?.items ?? [])].sort(
-        (a, b) =>
-          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-      ),
-    [query.data?.items]
-  );
+  const items = useMemo(() => {
+    // Pinned items (events happening today) lead the feed — soonest event
+    // first. Everything else sorts by timestamp descending.
+    const isPinned = (item: FeedItem) =>
+      item.type === "community_event" && item.pinned === true;
+    return [...(query.data?.items ?? [])].sort((a, b) => {
+      const pinnedA = isPinned(a);
+      const pinnedB = isPinned(b);
+      if (pinnedA !== pinnedB) return pinnedA ? -1 : 1;
+      if (
+        pinnedA &&
+        a.type === "community_event" &&
+        b.type === "community_event"
+      ) {
+        return (
+          new Date(a.eventDate).getTime() - new Date(b.eventDate).getTime()
+        );
+      }
+      return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+    });
+  }, [query.data?.items]);
 
   return {
     items,

--- a/mobile/lib/dummy-data.ts
+++ b/mobile/lib/dummy-data.ts
@@ -752,7 +752,7 @@ export type FeedItem =
   | ({ type: 'shift_recap'; id: string; location: string; date: string; mealsServed: number; volunteerCount: number; timestamp: string } & FeedInteractions)
   | ({ type: 'new_shift'; id: string; location: string; count: number; shiftIds: string[]; shiftTypes: string[]; earliestStart: string; latestStart: string; preview: NewShiftPreview[]; timestamp: string } & FeedInteractions)
   | ({ type: 'daily_menu'; id: string; menuId: string; location: string; serviceDate: string; chefName?: string; announcement?: string; starter: MenuCourseItem[]; mains: MenuCourseItem[]; drink: MenuCourseItem[]; dessert: MenuCourseItem[]; timestamp: string } & FeedInteractions)
-  | ({ type: 'community_event'; id: string; title: string; description?: string; location?: string; eventDate: string; displayTime?: string; imageUrl?: string; url: string; priceLabel?: string; ticketUrl?: string; timestamp: string } & FeedInteractions)
+  | ({ type: 'community_event'; id: string; title: string; description?: string; location?: string; eventDate: string; displayTime?: string; imageUrl?: string; url: string; priceLabel?: string; ticketUrl?: string; timestamp: string; pinned?: boolean } & FeedInteractions)
   | ({ type: 'journal_post'; id: string; title: string; summary?: string; category?: string; imageUrl?: string; author?: string; url: string; timestamp: string } & FeedInteractions);
 
 export type MenuCourseItem = { name: string; description?: string };

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireMobileUser } from "@/lib/mobile-auth";
-import { getStartOfDayUTC, formatInNZT } from "@/lib/timezone";
+import {
+  getStartOfDayUTC,
+  formatInNZT,
+  isSameDayInNZT,
+} from "@/lib/timezone";
 import { ANNOUNCEMENT_SHIFT_TARGET_STATUSES } from "@/lib/announcement-targeting";
 import { formatAchievementCriteria } from "@/lib/achievement-utils";
 import {
@@ -572,9 +576,14 @@ export async function GET(request: Request) {
     const timestamp =
       isImminent && resurfaceAt > publishedAt ? resurfaceAt : publishedAt;
 
+    // Events happening today (NZ) are pinned — the app sorts them to the
+    // top of the feed regardless of when they were posted.
+    const isToday = isSameDayInNZT(eventDate, now);
+
     items.push({
       type: "community_event",
       id: `cms-event-${event.id}`,
+      pinned: isToday || undefined,
       title: event.name,
       description: event.shortDescription ?? undefined,
       location: event.location ?? undefined,


### PR DESCRIPTION
## Summary

Community events keep their existing feed behavior (appear when posted, resurface a week out) — but on the day they run, they're now **pinned to the top of the feed**:

- The feed API flags `community_event` items with `pinned: true` when the event date is today (NZ calendar day, `isSameDayInNZT`).
- The app sorts pinned events above everything else; if several run the same day, soonest start first.
- The card shows a **"Happening today"** chip (violet, matching the event card theme) and the date label reads **"Today"** instead of the weekday — same in the detail sheet's calendar pill.

## Testing

- Verified end-to-end against a mock CMS with a same-day event: the feed response carries `pinned: true` on today's event and no flag on future ones.
- Mobile + web typecheck clean, web lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)