### PR TITLE
fix(flaky): scope admin-notes/admin-locations e2e locators to visible elements

### DIFF
--- a/web/docs/testing-guide.md
+++ b/web/docs/testing-guide.md
@@ -924,6 +924,22 @@ npm run test:run && npm run test:e2e:ci
 9. **Test responsive design** on different devices
 10. **Run tests in Chromium only** for faster feedback (use `--project=chromium`)
 
+#### Hydration duplicates and strict mode violations
+
+You may hit `strict mode violation: resolved to 2 elements` even when a
+testid or text is unique in source. A hidden duplicate of the
+server-rendered tree can linger in the DOM alongside the hydrated one (the
+two matches carry different React `useId` prefixes, and only one instance
+is visible). Scope the locator to visible elements:
+
+```typescript
+const card = page.getByTestId("admin-notes-card").filter({ visible: true });
+await expect(card).toBeVisible();
+```
+
+Plain `.first()` is not a safe substitute — depending on DOM order it can
+select the hidden copy and then fail `toBeVisible()`.
+
 ### General Testing Best Practices
 
 1. **Choose the right testing tool** - Vitest for units, Playwright for workflows

--- a/web/tests/e2e/admin-locations.spec.ts
+++ b/web/tests/e2e/admin-locations.spec.ts
@@ -109,13 +109,20 @@ test.describe("Admin Location Disable/Enable", () => {
     await page.goto("/admin/locations");
     await page.waitForLoadState("load");
 
-    // Check active locations section is visible
-    const activeSection = page.getByTestId("active-locations-section");
+    // Check active locations section is visible. The testid is unique in
+    // source, but a hidden duplicate of the server-rendered tree can linger
+    // in the DOM alongside the hydrated one — scope to visible elements to
+    // avoid strict-mode violations.
+    const activeSection = page
+      .getByTestId("active-locations-section")
+      .filter({ visible: true });
     await expect(activeSection).toBeVisible();
     await expect(activeSection).toContainText("Active Locations");
 
     // Check location appears in active section
-    await expect(page.getByText(location.name)).toBeVisible();
+    await expect(
+      page.getByText(location.name).filter({ visible: true })
+    ).toBeVisible();
   });
 
   test("should disable a location without upcoming shifts", async ({

--- a/web/tests/e2e/admin-notes.spec.ts
+++ b/web/tests/e2e/admin-notes.spec.ts
@@ -94,12 +94,19 @@ test.describe("Admin Notes Management", () => {
     // Navigate to volunteer profile
     await navigateToVolunteerProfile(page, testVolunteerId!);
 
-    // Check that the admin notes card is visible
-    const adminNotesCard = page.getByTestId("admin-notes-card");
+    // Check that the admin notes card is visible. The testid is unique in
+    // source, but a hidden duplicate of the server-rendered tree can linger
+    // in the DOM alongside the hydrated one — scope to visible elements to
+    // avoid strict-mode violations.
+    const adminNotesCard = page
+      .getByTestId("admin-notes-card")
+      .filter({ visible: true });
     await expect(adminNotesCard).toBeVisible();
 
     // Check that the admin notes manager is present
-    const adminNotesManager = page.getByTestId("admin-notes-manager");
+    const adminNotesManager = page
+      .getByTestId("admin-notes-manager")
+      .filter({ visible: true });
     await expect(adminNotesManager).toBeVisible();
   });
 


### PR DESCRIPTION
## Problem

`admin-notes.spec.ts` and `admin-locations.spec.ts` intermittently fail with `strict mode violation: resolved to 2 elements` (admin-notes failed hard on PR #1118's CI run; admin-locations reproduced locally). Each testid/text is unique in source — the second match is a **hidden leftover of the server-rendered tree** coexisting with the hydrated one (the two matches carry different React `useId` prefix formats, and the accessibility snapshot at failure time shows only one visible instance).

## Fix

Scope the affected locators with `filter({ visible: true })`. Plain `.first()` is not enough — depending on DOM order it can select the hidden copy and fail `toBeVisible()` (this exact case reproduced locally on admin-locations).

Both tests verified passing locally with `--project=chromium`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)