### PR TITLE
feat(admin): add suggested koha value input to service night report

### DIFF
--- a/web/prisma/migrations/20260715000000_add_meals_served_suggested_value/migration.sql
+++ b/web/prisma/migrations/20260715000000_add_meals_served_suggested_value/migration.sql
@@ -1,0 +1,2 @@
+-- Suggested koha value on the night ($)
+ALTER TABLE "MealsServed" ADD COLUMN "suggestedValue" DECIMAL(10,2);

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -789,6 +789,7 @@ model MealsServed {
   cash               Decimal? @db.Decimal(10, 2) // Cash koha ($)
   eftpos             Decimal? @db.Decimal(10, 2) // Eftpos koha ($)
   stripe             Decimal? @db.Decimal(10, 2) // Stripe koha ($)
+  suggestedValue     Decimal? @db.Decimal(10, 2) // Suggested koha value on the night ($)
   protein            String? // Protein served (e.g. "Beef")
 
   createdAt DateTime @default(now())

--- a/web/src/app/api/admin/meals-served/route.ts
+++ b/web/src/app/api/admin/meals-served/route.ts
@@ -26,6 +26,7 @@ function serializeStats(record: MealsServedRecord) {
     cash: toNumber(record.cash),
     eftpos: toNumber(record.eftpos),
     stripe: toNumber(record.stripe),
+    suggestedValue: toNumber(record.suggestedValue),
     protein: record.protein,
   };
 }

--- a/web/src/components/meals-served-input.tsx
+++ b/web/src/components/meals-served-input.tsx
@@ -56,6 +56,7 @@ type StatKey =
   | "cash"
   | "eftpos"
   | "stripe"
+  | "suggestedValue"
   | "protein";
 
 type FormState = Record<StatKey, string>; // all held as strings; "" === empty
@@ -72,6 +73,7 @@ const EMPTY_FORM: FormState = {
   cash: "",
   eftpos: "",
   stripe: "",
+  suggestedValue: "",
   protein: "",
 };
 
@@ -585,6 +587,12 @@ export function MealsServedInput({ date, location }: MealsServedInputProps) {
                 </button>
               )
             }
+          />
+          <MoneyField
+            id="suggestedValue"
+            label="Suggested value"
+            value={form.suggestedValue}
+            onChange={(v) => set("suggestedValue", v)}
           />
           <CountField
             id="eftposTransactions"

--- a/web/src/lib/validation-schemas.ts
+++ b/web/src/lib/validation-schemas.ts
@@ -55,6 +55,7 @@ export const restaurantNightStatsSchema = z.object({
   cash: optionalMoney,
   eftpos: optionalMoney,
   stripe: optionalMoney,
+  suggestedValue: optionalMoney,
   protein: optionalString,
 });
 


### PR DESCRIPTION
## Description
Adds a **Suggested value** money input to the *Koha collected* section of the admin Service Night Report (admin shifts page), placed after the Stripe field. The value is persisted end-to-end:

- New nullable `suggestedValue Decimal(10,2)` column on `MealsServed` + migration
- `suggestedValue: optionalMoney` in `restaurantNightStatsSchema`
- GET/POST serialization in `/api/admin/meals-served`
- `MoneyField` in the report form, counted in the Logged n/13 progress like other stats

Note: the suggested value is intentionally **excluded** from the derived Total koha / per-head figures, since a suggested amount is not money collected.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Unit tests pass (461/461)
- [x] Manual testing completed - verified in the browser: entered 12.50, saved (POST 200), confirmed the value in Postgres, reloaded and saw the field pre-filled with the record badge showing Recorded
- [ ] E2E tests pass
- [ ] New tests added (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
Typecheck and lint are clean. The migration was also applied to the local dev database via `prisma migrate resolve` to avoid a destructive reset (the dev DB contained a migration from another branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)