### PR TITLE
feat(mobile): rank upcoming events and menus higher as their date approaches

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -9,6 +9,11 @@ import {
   startOfDay,
 } from "date-fns";
 import { formatNZT, formatNZDateOnly } from "@/lib/dates";
+import {
+  nzDaysUntil,
+  nzDaysUntilDateOnly,
+  upcomingLabel,
+} from "@/lib/feed-ranking";
 import { LinearGradient } from "expo-linear-gradient";
 import * as Haptics from "expo-haptics";
 import { useRouter, type Href } from "expo-router";
@@ -2554,6 +2559,10 @@ function FeedCard({
 
     if (item.type === "daily_menu") {
       const dateText = formatNZDateOnly(item.serviceDate, "EEEE d MMM");
+      // Menus resurface at the top of the feed on service day (see
+      // lib/feed-ranking.ts) — the pill explains why this one is up here.
+      const isTonight =
+        nzDaysUntilDateOnly(item.serviceDate, new Date()) === 0;
       const previewNames = [
         ...(item.mains ?? []),
         ...(item.starter ?? []),
@@ -2570,6 +2579,13 @@ function FeedCard({
             <Text style={styles.feedIconEmoji}>🍲</Text>
           </View>
           <View style={styles.feedBody}>
+            {isTonight && (
+              <View style={[styles.feedTodayPill, { backgroundColor: "#ede9fe" }]}>
+                <Text style={[styles.feedTodayPillText, { color: "#6d28d9" }]}>
+                  Tonight
+                </Text>
+              </View>
+            )}
             <Text style={[styles.feedTitle, { color: colors.text }]}>
               Menu for {dateText} · {item.location}
             </Text>
@@ -2599,6 +2615,11 @@ function FeedCard({
 
     if (item.type === "community_event") {
       const isToday = item.pinned === true;
+      // Countdown pill for the lead-in week — the visible reason this card
+      // sits above older posts, and a little hype while it's at it.
+      const countdown = isToday
+        ? null
+        : upcomingLabel(nzDaysUntil(item.eventDate, new Date()));
       const eventDateText = isToday
         ? "Today"
         : formatNZT(new Date(item.eventDate), "EEEE d MMM");
@@ -2618,6 +2639,13 @@ function FeedCard({
               <View style={[styles.feedTodayPill, { backgroundColor: "#ede9fe" }]}>
                 <Text style={[styles.feedTodayPillText, { color: "#6d28d9" }]}>
                   Happening today
+                </Text>
+              </View>
+            )}
+            {countdown && (
+              <View style={[styles.feedTodayPill, { backgroundColor: "#fef3c7" }]}>
+                <Text style={[styles.feedTodayPillText, { color: "#b45309" }]}>
+                  {countdown}
                 </Text>
               </View>
             )}

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -2581,7 +2581,10 @@ function FeedCard({
           <View style={styles.feedBody}>
             {isTonight && (
               <View style={[styles.feedTodayPill, { backgroundColor: "#ede9fe" }]}>
-                <Text style={[styles.feedTodayPillText, { color: "#6d28d9" }]}>
+                <Text
+                  accessibilityLabel="Tonight's menu"
+                  style={[styles.feedTodayPillText, { color: "#6d28d9" }]}
+                >
                   Tonight
                 </Text>
               </View>
@@ -2644,7 +2647,10 @@ function FeedCard({
             )}
             {countdown && (
               <View style={[styles.feedTodayPill, { backgroundColor: "#fef3c7" }]}>
-                <Text style={[styles.feedTodayPillText, { color: "#b45309" }]}>
+                <Text
+                  accessibilityLabel={`Happening ${countdown.toLowerCase()}`}
+                  style={[styles.feedTodayPillText, { color: "#b45309" }]}
+                >
                   {countdown}
                 </Text>
               </View>

--- a/mobile/hooks/use-feed.ts
+++ b/mobile/hooks/use-feed.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "react";
 
 import { api } from "@/lib/api";
 import type { FeedItem } from "@/lib/dummy-data";
+import { rankFeedItems } from "@/lib/feed-ranking";
 import { queryKeys } from "@/lib/query-keys";
 
 type FeedResponse = {
@@ -72,27 +73,12 @@ export function useFeed(): UseFeedReturn {
     [queryClient, queryKey]
   );
 
-  const items = useMemo(() => {
-    // Pinned items (events happening today) lead the feed — soonest event
-    // first. Everything else sorts by timestamp descending.
-    const isPinned = (item: FeedItem) =>
-      item.type === "community_event" && item.pinned === true;
-    return [...(query.data?.items ?? [])].sort((a, b) => {
-      const pinnedA = isPinned(a);
-      const pinnedB = isPinned(b);
-      if (pinnedA !== pinnedB) return pinnedA ? -1 : 1;
-      if (
-        pinnedA &&
-        a.type === "community_event" &&
-        b.type === "community_event"
-      ) {
-        return (
-          new Date(a.eventDate).getTime() - new Date(b.eventDate).getTime()
-        );
-      }
-      return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
-    });
-  }, [query.data?.items]);
+  // Ordering: hype-adjusted recency — upcoming events and menus climb the
+  // feed as their date approaches. See lib/feed-ranking.ts for the rationale.
+  const items = useMemo(
+    () => rankFeedItems(query.data?.items ?? []),
+    [query.data?.items]
+  );
 
   return {
     items,

--- a/mobile/lib/feed-ranking.test.ts
+++ b/mobile/lib/feed-ranking.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  nzDaysUntil,
+  nzDaysUntilDateOnly,
+  rankFeedItems,
+  upcomingLabel,
+} from "@/lib/feed-ranking";
+import type { FeedItem } from "@/lib/dummy-data";
+
+// 2026-07-16T00:00:00Z = midday Thursday 16 July in NZ (NZST, UTC+12).
+const NOW = new Date("2026-07-16T00:00:00.000Z");
+
+const interactions = {
+  likeCount: 0,
+  likedByMe: false,
+  recentLikers: [],
+  commentCount: 0,
+};
+
+const announcement = (id: string, timestamp: string): FeedItem => ({
+  type: "announcement",
+  id,
+  title: id,
+  body: "body",
+  timestamp,
+  author: "Admin",
+  ...interactions,
+});
+
+const event = (
+  id: string,
+  eventDate: string,
+  timestamp: string,
+  pinned?: boolean
+): FeedItem => ({
+  type: "community_event",
+  id,
+  title: id,
+  eventDate,
+  url: "https://example.org",
+  timestamp,
+  pinned,
+  ...interactions,
+});
+
+const menu = (id: string, serviceDate: string, timestamp: string): FeedItem => ({
+  type: "daily_menu",
+  id,
+  menuId: id,
+  location: "Wellington",
+  serviceDate,
+  starter: [],
+  mains: [{ name: "Kai" }],
+  drink: [],
+  dessert: [],
+  timestamp,
+  ...interactions,
+});
+
+const ids = (items: FeedItem[]) => items.map((i) => i.id);
+
+describe("nzDaysUntil", () => {
+  it("returns 0 for an instant later the same NZ day", () => {
+    // 07:00Z = 7pm NZ on the 16th
+    expect(nzDaysUntil("2026-07-16T07:00:00.000Z", NOW)).toBe(0);
+  });
+
+  it("counts NZ calendar days, not 24h periods", () => {
+    // 14:00Z on the 16th = 2am NZ on the 17th — tomorrow in NZ
+    expect(nzDaysUntil("2026-07-16T14:00:00.000Z", NOW)).toBe(1);
+    expect(nzDaysUntil("2026-07-19T06:00:00.000Z", NOW)).toBe(3);
+  });
+
+  it("returns negative for past days and NaN for garbage", () => {
+    expect(nzDaysUntil("2026-07-14T06:00:00.000Z", NOW)).toBe(-2);
+    expect(nzDaysUntil("not a date", NOW)).toBeNaN();
+  });
+});
+
+describe("nzDaysUntilDateOnly", () => {
+  it("reads the calendar day straight off the string", () => {
+    expect(nzDaysUntilDateOnly("2026-07-16", NOW)).toBe(0);
+    expect(nzDaysUntilDateOnly("2026-07-18T00:00:00.000Z", NOW)).toBe(2);
+    expect(nzDaysUntilDateOnly("2026-07-14", NOW)).toBe(-2);
+  });
+});
+
+describe("upcomingLabel", () => {
+  it("labels the next week only", () => {
+    expect(upcomingLabel(1)).toBe("Tomorrow");
+    expect(upcomingLabel(3)).toBe("In 3 days");
+    expect(upcomingLabel(7)).toBe("In 7 days");
+  });
+
+  it("returns null for today, the past, and beyond a week", () => {
+    expect(upcomingLabel(0)).toBeNull();
+    expect(upcomingLabel(-1)).toBeNull();
+    expect(upcomingLabel(8)).toBeNull();
+    expect(upcomingLabel(NaN)).toBeNull();
+  });
+});
+
+describe("rankFeedItems", () => {
+  it("keeps moment-anchored items in reverse-chronological order", () => {
+    const sorted = rankFeedItems(
+      [
+        announcement("older", "2026-07-14T00:00:00.000Z"),
+        announcement("newest", "2026-07-15T23:00:00.000Z"),
+        announcement("oldest", "2026-07-10T00:00:00.000Z"),
+      ],
+      NOW
+    );
+    expect(ids(sorted)).toEqual(["newest", "older", "oldest"]);
+  });
+
+  it("pins today's events above everything, soonest first", () => {
+    const sorted = rankFeedItems(
+      [
+        announcement("fresh-post", "2026-07-16T00:00:00.000Z"),
+        event("gala-tonight", "2026-07-16T07:00:00.000Z", "2026-07-01T00:00:00.000Z", true),
+        event("lunch-today", "2026-07-16T01:00:00.000Z", "2026-07-01T00:00:00.000Z", true),
+      ],
+      NOW
+    );
+    expect(ids(sorted)).toEqual(["lunch-today", "gala-tonight", "fresh-post"]);
+  });
+
+  it("climbs an imminent event above day-old content, but not above brand-new posts", () => {
+    // Announced two weeks ago, happening in 2 days → sorts as ~12h old.
+    const imminent = event(
+      "imminent-event",
+      "2026-07-18T06:00:00.000Z",
+      "2026-07-02T00:00:00.000Z"
+    );
+    const sorted = rankFeedItems(
+      [
+        announcement("yesterday-post", "2026-07-15T00:00:00.000Z"),
+        imminent,
+        announcement("just-posted", "2026-07-15T23:30:00.000Z"),
+      ],
+      NOW
+    );
+    expect(ids(sorted)).toEqual(["just-posted", "imminent-event", "yesterday-post"]);
+  });
+
+  it("gives a freshly announced far-out event its news moment", () => {
+    // Published an hour ago, happening in 30 days — publish time wins the max().
+    const sorted = rankFeedItems(
+      [
+        announcement("yesterday-post", "2026-07-15T00:00:00.000Z"),
+        event("far-out-event", "2026-08-15T06:00:00.000Z", "2026-07-15T23:00:00.000Z"),
+      ],
+      NOW
+    );
+    expect(ids(sorted)).toEqual(["far-out-event", "yesterday-post"]);
+  });
+
+  it("lets a far-out event sink between announcement and lead-in", () => {
+    // Published 10 days ago, happening in 10 days → ramp (60h) loses to
+    // fresher content from the last two days.
+    const sorted = rankFeedItems(
+      [
+        event("far-out-event", "2026-07-26T06:00:00.000Z", "2026-07-06T00:00:00.000Z"),
+        announcement("two-days-ago", "2026-07-14T06:00:00.000Z"),
+      ],
+      NOW
+    );
+    expect(ids(sorted)).toEqual(["two-days-ago", "far-out-event"]);
+  });
+
+  it("does not boost past events left in a stale cache", () => {
+    const sorted = rankFeedItems(
+      [
+        event("past-event", "2026-07-10T06:00:00.000Z", "2026-07-01T00:00:00.000Z"),
+        announcement("newer-post", "2026-07-14T00:00:00.000Z"),
+      ],
+      NOW
+    );
+    expect(ids(sorted)).toEqual(["newer-post", "past-event"]);
+  });
+
+  it("surfaces tonight's menu on service day", () => {
+    // Posted three days ago for tonight's service → sorts as freshly posted.
+    const sorted = rankFeedItems(
+      [
+        announcement("yesterday-post", "2026-07-15T20:00:00.000Z"),
+        menu("tonights-menu", "2026-07-16", "2026-07-13T00:00:00.000Z"),
+      ],
+      NOW
+    );
+    expect(ids(sorted)).toEqual(["tonights-menu", "yesterday-post"]);
+  });
+
+  it("lets old menus age out chronologically", () => {
+    const sorted = rankFeedItems(
+      [
+        menu("last-week-menu", "2026-07-09", "2026-07-08T00:00:00.000Z"),
+        announcement("newer-post", "2026-07-12T00:00:00.000Z"),
+      ],
+      NOW
+    );
+    expect(ids(sorted)).toEqual(["newer-post", "last-week-menu"]);
+  });
+});

--- a/mobile/lib/feed-ranking.ts
+++ b/mobile/lib/feed-ranking.ts
@@ -25,6 +25,10 @@ import type { FeedItem } from "@/lib/dummy-data";
  */
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+// The tuning knob for how hard proximity pulls an item up the feed: each day
+// closer to its date, it sorts 6h fresher. Revisit once feed impressions and
+// taps are instrumented.
 const HYPE_RAMP_MS_PER_DAY = 6 * 60 * 60 * 1000;
 
 /** Parse a "yyyy-MM-dd" day key to a comparable UTC-midnight epoch. */
@@ -88,21 +92,23 @@ function effectiveTime(item: FeedItem, now: Date): number {
  * then everything else by hype-adjusted recency (see module comment).
  */
 export function rankFeedItems(items: FeedItem[], now: Date = new Date()): FeedItem[] {
-  const byEffectiveTime = new Map<FeedItem, number>();
-  for (const item of items) {
-    byEffectiveTime.set(item, effectiveTime(item, now));
-  }
-  return [...items].sort((a, b) => {
-    const pinnedA = a.type === "community_event" && a.pinned === true;
-    const pinnedB = b.type === "community_event" && b.pinned === true;
-    if (pinnedA !== pinnedB) return pinnedA ? -1 : 1;
-    if (
-      pinnedA &&
-      a.type === "community_event" &&
-      b.type === "community_event"
-    ) {
-      return new Date(a.eventDate).getTime() - new Date(b.eventDate).getTime();
-    }
-    return byEffectiveTime.get(b)! - byEffectiveTime.get(a)!;
-  });
+  return items
+    .map((item) => ({ item, time: effectiveTime(item, now) }))
+    .sort((a, b) => {
+      const pinnedA = a.item.type === "community_event" && a.item.pinned === true;
+      const pinnedB = b.item.type === "community_event" && b.item.pinned === true;
+      if (pinnedA !== pinnedB) return pinnedA ? -1 : 1;
+      if (
+        pinnedA &&
+        a.item.type === "community_event" &&
+        b.item.type === "community_event"
+      ) {
+        return (
+          new Date(a.item.eventDate).getTime() -
+          new Date(b.item.eventDate).getTime()
+        );
+      }
+      return b.time - a.time;
+    })
+    .map(({ item }) => item);
 }

--- a/mobile/lib/feed-ranking.ts
+++ b/mobile/lib/feed-ranking.ts
@@ -1,0 +1,108 @@
+import { formatNZT } from "@/lib/dates";
+import type { FeedItem } from "@/lib/dummy-data";
+
+/**
+ * Feed ordering: hype-adjusted recency.
+ *
+ * The feed has two kinds of content. Moment-anchored items (achievements,
+ * friend signups, recaps, announcements, journal posts) are most interesting
+ * the moment they're posted, so they sort by publish time. Time-anchored
+ * items (community events, daily menus) are most interesting as their date
+ * approaches — an event should spike when announced, quieten down, then climb
+ * back up the feed during the lead-in and peak on the day.
+ *
+ * Both behaviours fall out of one rule: every item sorts by an *effective*
+ * timestamp, and a time-anchored item's effective timestamp is
+ *
+ *   max(publishedAt, now − daysUntil × 6h)
+ *
+ * The max() preserves the announcement-day spike; the ramp makes the item
+ * sort as if freshly posted on the day itself, ~6h old the day before, ~42h
+ * old a week out — climbing a little further up the feed each day without
+ * ever permanently squatting on the top slot (which would train people to
+ * scroll past it). Events happening today are the one exception: the server
+ * flags them `pinned` and they always lead the feed, soonest first.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HYPE_RAMP_MS_PER_DAY = 6 * 60 * 60 * 1000;
+
+/** Parse a "yyyy-MM-dd" day key to a comparable UTC-midnight epoch. */
+const dayKeyToMs = (dayKey: string): number =>
+  Date.parse(`${dayKey}T00:00:00Z`);
+
+const nzDayKey = (date: Date): string => formatNZT(date, "yyyy-MM-dd");
+
+/**
+ * NZ-calendar-day difference from `now` to an instant (ISO datetime):
+ * 0 = today, 1 = tomorrow, negative = past. NaN for unparseable input.
+ */
+export function nzDaysUntil(date: string | Date, now: Date): number {
+  const target = typeof date === "string" ? new Date(date) : date;
+  if (Number.isNaN(target.getTime())) return NaN;
+  return Math.round(
+    (dayKeyToMs(nzDayKey(target)) - dayKeyToMs(nzDayKey(now))) / DAY_MS
+  );
+}
+
+/**
+ * Same, for *date-only* values ("yyyy-MM-dd" or midnight-UTC ISO strings such
+ * as a menu's service date). Like formatNZDateOnly, the calendar day is read
+ * straight off the string with no timezone conversion.
+ */
+export function nzDaysUntilDateOnly(value: string, now: Date): number {
+  return Math.round(
+    (dayKeyToMs(value.slice(0, 10)) - dayKeyToMs(nzDayKey(now))) / DAY_MS
+  );
+}
+
+/**
+ * Short countdown label for a time-anchored card: "Tomorrow" or "In N days"
+ * up to a week out. Null otherwise — today has its own treatment ("Happening
+ * today" / "Tonight"), and beyond a week a countdown reads as noise, not hype.
+ */
+export function upcomingLabel(daysUntil: number): string | null {
+  if (daysUntil === 1) return "Tomorrow";
+  if (daysUntil >= 2 && daysUntil <= 7) return `In ${daysUntil} days`;
+  return null;
+}
+
+function effectiveTime(item: FeedItem, now: Date): number {
+  const posted = new Date(item.timestamp).getTime();
+  let daysUntil: number | undefined;
+  if (item.type === "community_event") {
+    daysUntil = nzDaysUntil(item.eventDate, now);
+  } else if (item.type === "daily_menu") {
+    daysUntil = nzDaysUntilDateOnly(item.serviceDate, now);
+  }
+  // Past or unparseable dates get no boost — a stale cached event or an old
+  // menu just ages out chronologically.
+  if (daysUntil === undefined || !Number.isFinite(daysUntil) || daysUntil < 0) {
+    return posted;
+  }
+  return Math.max(posted, now.getTime() - daysUntil * HYPE_RAMP_MS_PER_DAY);
+}
+
+/**
+ * Order feed items for display: events happening today first (soonest first),
+ * then everything else by hype-adjusted recency (see module comment).
+ */
+export function rankFeedItems(items: FeedItem[], now: Date = new Date()): FeedItem[] {
+  const byEffectiveTime = new Map<FeedItem, number>();
+  for (const item of items) {
+    byEffectiveTime.set(item, effectiveTime(item, now));
+  }
+  return [...items].sort((a, b) => {
+    const pinnedA = a.type === "community_event" && a.pinned === true;
+    const pinnedB = b.type === "community_event" && b.pinned === true;
+    if (pinnedA !== pinnedB) return pinnedA ? -1 : 1;
+    if (
+      pinnedA &&
+      a.type === "community_event" &&
+      b.type === "community_event"
+    ) {
+      return new Date(a.eventDate).getTime() - new Date(b.eventDate).getTime();
+    }
+    return byEffectiveTime.get(b)! - byEffectiveTime.get(a)!;
+  });
+}

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -555,29 +555,30 @@ export async function GET(request: Request) {
     });
   }
 
-  // Community events from the marketing CMS. An event appears in the feed
-  // while its announcement is fresh (published within the feed window) and
-  // resurfaces during the week leading up to it, timestamped so it sorts as
-  // if freshly posted. Events aren't location-targeted: with only a handful
-  // per year, they're relevant to the whole whānau.
+  // Community events from the marketing CMS. Upcoming events stay in the
+  // feed from the moment they're announced until they happen — the app ranks
+  // them higher the closer they get (see mobile/lib/feed-ranking.ts) to
+  // build hype. For older app versions that sort purely by timestamp, an
+  // event still "resurfaces" during the week leading up to it, timestamped
+  // so it sorts as if freshly posted. Events aren't location-targeted: with
+  // only a handful per year, they're relevant to the whole whānau.
   const startOfTodayNZ = getStartOfDayUTC(now);
-  for (const event of cmsEvents.slice(0, 10)) {
+  const upcomingEvents = cmsEvents
+    .filter((event) => new Date(event.date) >= startOfTodayNZ)
+    .slice(0, 10);
+  for (const event of upcomingEvents) {
     const eventDate = new Date(event.date);
-    if (eventDate < startOfTodayNZ) continue;
-
     const publishedAt = new Date(event.publishedAt);
     const resurfaceAt = new Date(
       eventDate.getTime() - 7 * 24 * 60 * 60 * 1000
     );
-    const isFresh = publishedAt >= since;
-    const isImminent = resurfaceAt <= now;
-    if (!isFresh && !isImminent) continue;
-
     const timestamp =
-      isImminent && resurfaceAt > publishedAt ? resurfaceAt : publishedAt;
+      resurfaceAt <= now && resurfaceAt > publishedAt
+        ? resurfaceAt
+        : publishedAt;
 
-    // Events happening today (NZ) are pinned — the app sorts them to the
-    // top of the feed regardless of when they were posted.
+    // Events happening today (NZ) are flagged — the app shows a
+    // "Happening today" pill for them.
     const isToday = isSameDayInNZT(eventDate, now);
 
     items.push({


### PR DESCRIPTION
# Pull Request

## Description
Rethinks feed ordering to build hype for upcoming community events (follow-up to #1118, which only pinned events happening *today*).

**The problem**: an upcoming event only appeared in the feed while its announcement was under 14 days old or within 7 days of the event, and outside of the day itself it sank chronologically. Events people should be getting excited about were buried or missing entirely.

**The model — hype-adjusted recency**: every feed item sorts by an *effective* timestamp. Moment-anchored items (achievements, friend signups, recaps, announcements, journal posts) use their real publish time. Time-anchored items (community events, daily menus) use:

```
max(publishedAt, now - daysUntil × 6h)
```

This one rule produces the full hype arc: an event spikes when announced (news moment), settles into the feed, then climbs back up through the lead-in week (~42h-old a week out, ~6h-old the day before) and peaks on the day. Events happening today remain hard-pinned at position 1. Deliberately *not* a permanent pin: a static top card trains banner blindness and makes the feed feel stale, which hurts return visits.

Bonus that falls out for free: tonight's menu resurfaces at the top on service day, and past menus/events stop getting any boost.

**UI**: a card boosted out of chronological order needs a visible reason, so event cards show an amber countdown pill ("Tomorrow" / "In N days") during the lead-in week, and menu cards show a violet "Tonight" pill on service day, matching the existing "Happening today" pill.

**Changes**:
- `mobile/lib/feed-ranking.ts` (new): the ranking model as pure, tested functions; `use-feed.ts` now just calls `rankFeedItems()`
- `mobile/app/(tabs)/index.tsx`: countdown and "Tonight" pills
- `web/src/app/api/mobile/feed/route.ts`: upcoming events stay in the payload from announcement until they happen

**Backwards compatibility**: older app builds are unaffected — the `pinned` flag and resurface timestamps are unchanged, so they keep the existing pinned-today + resurface-at-7-days behaviour.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required
`version:minor`

## Testing
- [x] Unit tests pass (mobile: 101/101 including 14 new feed-ranking tests; web typecheck/lint clean)
- [ ] E2E tests pass (CI)
- [x] Manual testing completed
- [x] New tests added (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
The 6h/day ramp slope is a judgment call. A good follow-up is instrumenting feed impressions/taps per item type × position in PostHog so the slope can be tuned from data instead of guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)