### PR TITLE
fix(shifts): enforce guardian requirement server-side for web and mobile signups

### DIFF
--- a/mobile/app/shift/[id].tsx
+++ b/mobile/app/shift/[id].tsx
@@ -738,6 +738,7 @@ export default function ShiftDetailScreen() {
           formatDate={formatNZT}
           profileIncomplete={eligibility ? !eligibility.profileComplete : false}
           missingProfileFields={eligibility?.missingProfileFields}
+          guardianRequired={eligibility?.guardianRequired ?? false}
         />
       )}
     </View>

--- a/mobile/components/shift-signup-sheet.tsx
+++ b/mobile/components/shift-signup-sheet.tsx
@@ -80,6 +80,12 @@ type ShiftSignupSheetProps = {
   profileIncomplete?: boolean;
   /** Required profile fields still missing, e.g. ["Date of birth"]. */
   missingProfileFields?: string[];
+  /**
+   * True for volunteers aged 14 and under (from the shift eligibility
+   * payload). Shows a required guardian-name field; the server rejects
+   * underage signups whose note doesn't name a guardian.
+   */
+  guardianRequired?: boolean;
 };
 
 export function ShiftSignupSheet({
@@ -91,6 +97,7 @@ export function ShiftSignupSheet({
   formatDate,
   profileIncomplete: knownProfileIncomplete,
   missingProfileFields: knownMissingFields,
+  guardianRequired = false,
 }: ShiftSignupSheetProps) {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme];
@@ -99,6 +106,7 @@ export function ShiftSignupSheet({
 
   const [note, setNote] = useState('');
   const [showNoteField, setShowNoteField] = useState(false);
+  const [guardianName, setGuardianName] = useState('');
   const [backupShiftIds, setBackupShiftIds] = useState<string[]>([]);
   const [concurrentShifts, setConcurrentShifts] = useState<ConcurrentShift[]>([]);
   const [periodFriends, setPeriodFriends] = useState<FriendOnPeriod[]>([]);
@@ -121,6 +129,7 @@ export function ShiftSignupSheet({
     if (visible) {
       setNote('');
       setShowNoteField(false);
+      setGuardianName('');
       setBackupShiftIds([]);
       setError(null);
       setProfileIncomplete(Boolean(knownProfileIncomplete));
@@ -168,11 +177,28 @@ export function ShiftSignupSheet({
   const handleSubmit = useCallback(async () => {
     setError(null);
     setProfileIncomplete(false);
+
+    if (guardianRequired && !guardianName.trim()) {
+      setError(
+        "Please enter your parent or guardian's name. It's required for volunteers aged 14 and under.",
+      );
+      return;
+    }
+
     setIsSubmitting(true);
     try {
       const body: Record<string, unknown> = {};
       if (isWaitlist) body.waitlist = true;
-      if (note.trim()) body.note = note.trim();
+
+      // The guardian name travels in the signup note (same convention as
+      // the web dialog), which the server validates for underage volunteers.
+      let finalNote = note.trim();
+      if (guardianRequired && guardianName.trim()) {
+        finalNote = finalNote
+          ? `${finalNote}\n\nGuardian: ${guardianName.trim()}`
+          : `Guardian: ${guardianName.trim()}`;
+      }
+      if (finalNote) body.note = finalNote;
       if (backupShiftIds.length > 0) body.backupShiftIds = backupShiftIds;
 
       const result = await api<SignupResult>(
@@ -202,7 +228,16 @@ export function ShiftSignupSheet({
     } finally {
       setIsSubmitting(false);
     }
-  }, [shift.id, isWaitlist, note, backupShiftIds, onSuccess, onClose]);
+  }, [
+    shift.id,
+    isWaitlist,
+    note,
+    guardianRequired,
+    guardianName,
+    backupShiftIds,
+    onSuccess,
+    onClose,
+  ]);
 
   const handleGoToProfile = useCallback(() => {
     onClose();
@@ -424,6 +459,37 @@ export function ShiftSignupSheet({
               <Text style={[ss.charCount, { color: colors.textSecondary }]}>
                 {note.length}/500
               </Text>
+            </View>
+          )}
+
+          {/* Guardian name, required for volunteers aged 14 and under */}
+          {guardianRequired && (
+            <View style={ss.noteSection}>
+              <Text style={[ss.fieldLabel, { color: colors.text }]}>
+                Guardian name{' '}
+                <Text style={{ color: isDark ? '#fca5a5' : '#dc2626' }}>*</Text>
+              </Text>
+              <Text style={[ss.fieldHint, { color: colors.textSecondary }]}>
+                Required for volunteers aged 14 and under.
+              </Text>
+              <TextInput
+                style={[
+                  ss.guardianInput,
+                  {
+                    backgroundColor: isDark ? 'rgba(253,248,239,0.05)' : colors.surfaceSunk,
+                    borderColor: colors.border,
+                    color: colors.text,
+                  },
+                ]}
+                value={guardianName}
+                onChangeText={setGuardianName}
+                placeholder="Your parent or guardian's full name"
+                placeholderTextColor={colors.textSecondary}
+                maxLength={100}
+                autoComplete="name"
+                textContentType="name"
+                accessibilityLabel="Guardian name, required"
+              />
             </View>
           )}
 
@@ -825,6 +891,15 @@ const ss = StyleSheet.create({
     fontSize: 11,
     fontFamily: FontFamily.regular,
     textAlign: 'right',
+  },
+  guardianInput: {
+    borderRadius: 12,
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    fontFamily: FontFamily.regular,
+    minHeight: 48,
   },
 
   // Backup shifts

--- a/mobile/hooks/use-shift-detail.ts
+++ b/mobile/hooks/use-shift-detail.ts
@@ -52,6 +52,12 @@ export type ShiftEligibility = {
   /** Required profile fields still missing (empty when profile is complete). */
   missingProfileFields?: string[];
   needsParentalConsent: boolean;
+  /**
+   * True for volunteers aged 14 and under, who must name a parent/guardian
+   * when signing up. Computed server-side; the signup sheet collects the
+   * name and the signup routes reject submissions without it.
+   */
+  guardianRequired?: boolean;
 };
 
 /** Raw shape returned by GET /api/mobile/shifts/[id]/concurrent */

--- a/web/src/app/api/mobile/shifts/[id]/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   shiftCapacityCountSelect,
 } from "@/lib/placeholder-utils";
 import { getMissingProfileFields } from "@/lib/profile-completion";
+import { requiresGuardianName } from "@/lib/guardian-validation";
 import { getCmsEventsForShift } from "@/lib/services/marketing-cms";
 
 /**
@@ -168,6 +169,10 @@ export async function GET(
         userRecord?.requiresParentalConsent &&
           !userRecord?.parentalConsentReceived
       ),
+      // Volunteers aged 14 and under must name a parent/guardian on signup,
+      // so the sheet can collect it up front. Computed server-side to keep
+      // the age rule in one place (the signup routes enforce it).
+      guardianRequired: requiresGuardianName(userRecord?.dateOfBirth),
     },
   });
 }

--- a/web/src/app/api/mobile/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/mobile/shifts/[id]/signup/route.ts
@@ -6,6 +6,7 @@ import { isAMShift, getShiftDate } from "@/lib/concurrent-shifts";
 import { getNotificationService } from "@/lib/notification-service";
 import { notifyManagersOfPendingSignup } from "@/lib/notifications";
 import { getShiftConfirmedCount } from "@/lib/placeholder-utils";
+import { validateGuardianRequirement } from "@/lib/guardian-validation";
 import {
   getMissingProfileFields,
   isProfileComplete,
@@ -141,6 +142,13 @@ export async function POST(
     }
   } catch {
     // No body or invalid JSON — defaults are fine
+  }
+
+  // Volunteers aged 14 and under must name a guardian in the signup note
+  // (the app sends "Guardian: <name>"). Mirrors the web signup route.
+  const guardianError = validateGuardianRequirement(user.dateOfBirth, note);
+  if (guardianError) {
+    return NextResponse.json(guardianError, { status: 400 });
   }
 
   // Count confirmed signups + unregistered volunteers

--- a/web/src/app/api/shifts/[id]/signup/route.ts
+++ b/web/src/app/api/shifts/[id]/signup/route.ts
@@ -5,7 +5,8 @@ import { authOptions } from "@/lib/auth-options";
 import { getNotificationService } from "@/lib/notification-service";
 import { notifyManagersOfPendingSignup } from "@/lib/notifications";
 import { processAutoApproval } from "@/lib/auto-accept-rules";
-import { MAX_NOTE_LENGTH, GUARDIAN_REQUIRED_AGE, calculateAge } from "@/lib/utils";
+import { MAX_NOTE_LENGTH } from "@/lib/utils";
+import { validateGuardianRequirement } from "@/lib/guardian-validation";
 import { isAMShift, getShiftDate } from "@/lib/concurrent-shifts";
 import { getShiftConfirmedCount } from "@/lib/placeholder-utils";
 import sanitizeHtml from "sanitize-html";
@@ -144,23 +145,17 @@ export async function POST(
       } else {
         note = null;
       }
-
-      // Add server-side age validation for guardian requirement
-      if (user.dateOfBirth) {
-        const userAge = calculateAge(user.dateOfBirth);
-        if (userAge <= GUARDIAN_REQUIRED_AGE && note && !note.toLowerCase().includes('guardian')) {
-          return NextResponse.json(
-            {
-              error: "Guardian name required",
-              message: "Since you are under 15, please include your guardian's name in the note."
-            },
-            { status: 400 }
-          );
-        }
-      }
     }
   } catch {
     // ignore body parse errors for non-form requests
+  }
+
+  // Volunteers aged 14 and under must name a guardian in the signup note.
+  // Runs after body parsing (outside the try/catch) so a request with no
+  // note, or no body at all, is rejected too.
+  const guardianError = validateGuardianRequirement(user.dateOfBirth, note);
+  if (guardianError) {
+    return NextResponse.json(guardianError, { status: 400 });
   }
 
   // Check if user already has a signup for this shift

--- a/web/src/components/shift-signup-dialog.tsx
+++ b/web/src/components/shift-signup-dialog.tsx
@@ -22,7 +22,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
-import { calculateAge } from "@/lib/utils";
+import { calculateAge, GUARDIAN_REQUIRED_AGE } from "@/lib/utils";
 import { getShiftDescription } from "@/lib/shift-description";
 import { MessageSquareDot, User } from "lucide-react";
 import Link from "next/link";
@@ -133,7 +133,7 @@ export function ShiftSignupDialog({
             // Check age
             if (userData.dateOfBirth) {
               const age = calculateAge(new Date(userData.dateOfBirth));
-              setIsUnderage(age <= 14);
+              setIsUnderage(age <= GUARDIAN_REQUIRED_AGE);
             }
           } else {
             console.warn("Profile fetch failed:", response.status);

--- a/web/src/lib/guardian-validation.test.ts
+++ b/web/src/lib/guardian-validation.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  requiresGuardianName,
+  noteContainsGuardianName,
+  validateGuardianRequirement,
+} from "./guardian-validation";
+import { GUARDIAN_REQUIRED_AGE } from "./utils";
+
+/**
+ * A date of birth that makes the volunteer exactly `years` old today
+ * (their birthday was yesterday, so the age is unambiguous).
+ */
+function dateOfBirthForAge(years: number): Date {
+  const dob = new Date();
+  dob.setFullYear(dob.getFullYear() - years);
+  dob.setDate(dob.getDate() - 1);
+  return dob;
+}
+
+describe("requiresGuardianName", () => {
+  it("requires a guardian at the threshold age", () => {
+    expect(requiresGuardianName(dateOfBirthForAge(GUARDIAN_REQUIRED_AGE))).toBe(
+      true
+    );
+  });
+
+  it("requires a guardian below the threshold age", () => {
+    expect(requiresGuardianName(dateOfBirthForAge(12))).toBe(true);
+  });
+
+  it("does not require a guardian just above the threshold age", () => {
+    expect(
+      requiresGuardianName(dateOfBirthForAge(GUARDIAN_REQUIRED_AGE + 1))
+    ).toBe(false);
+  });
+
+  it("does not require a guardian for adults", () => {
+    expect(requiresGuardianName(dateOfBirthForAge(30))).toBe(false);
+  });
+
+  it("passes when date of birth is missing (profile completion owns DOB)", () => {
+    expect(requiresGuardianName(null)).toBe(false);
+    expect(requiresGuardianName(undefined)).toBe(false);
+  });
+});
+
+describe("noteContainsGuardianName", () => {
+  it("accepts the standard client format", () => {
+    expect(noteContainsGuardianName("Guardian: Jane Smith")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(noteContainsGuardianName("my GUARDIAN is Jane")).toBe(true);
+  });
+
+  it("accepts a guardian mention appended to another note", () => {
+    expect(
+      noteContainsGuardianName("First shift!\n\nGuardian: Jane Smith")
+    ).toBe(true);
+  });
+
+  it("rejects notes without a guardian mention", () => {
+    expect(noteContainsGuardianName("Looking forward to it")).toBe(false);
+  });
+
+  it("rejects missing or empty notes", () => {
+    expect(noteContainsGuardianName(null)).toBe(false);
+    expect(noteContainsGuardianName(undefined)).toBe(false);
+    expect(noteContainsGuardianName("")).toBe(false);
+  });
+});
+
+describe("validateGuardianRequirement", () => {
+  const underageDob = dateOfBirthForAge(GUARDIAN_REQUIRED_AGE);
+
+  it("rejects an underage signup with no note at all", () => {
+    const result = validateGuardianRequirement(underageDob, null);
+    expect(result).not.toBeNull();
+    expect(result?.error).toBe("Guardian name required");
+    expect(result?.message).toContain("guardian");
+  });
+
+  it("rejects an underage signup whose note does not name a guardian", () => {
+    const result = validateGuardianRequirement(underageDob, "Excited to help");
+    expect(result?.error).toBe("Guardian name required");
+  });
+
+  it("allows an underage signup whose note names a guardian", () => {
+    expect(
+      validateGuardianRequirement(underageDob, "Guardian: Jane Smith")
+    ).toBeNull();
+  });
+
+  it("allows signups from volunteers above the threshold age without a note", () => {
+    expect(
+      validateGuardianRequirement(
+        dateOfBirthForAge(GUARDIAN_REQUIRED_AGE + 1),
+        null
+      )
+    ).toBeNull();
+  });
+
+  it("allows signups when date of birth is missing", () => {
+    expect(validateGuardianRequirement(null, null)).toBeNull();
+  });
+});

--- a/web/src/lib/guardian-validation.ts
+++ b/web/src/lib/guardian-validation.ts
@@ -1,0 +1,53 @@
+import { GUARDIAN_REQUIRED_AGE, calculateAge } from "@/lib/utils";
+
+/** 400 payload returned when the guardian requirement is not met. */
+export type GuardianValidationError = {
+  error: string;
+  message: string;
+};
+
+/**
+ * Whether a volunteer with this date of birth must name a parent/guardian
+ * when signing up for a shift (aged GUARDIAN_REQUIRED_AGE or under).
+ *
+ * A missing date of birth passes: profile completion enforces DOB before a
+ * signup ever reaches the guardian check.
+ */
+export function requiresGuardianName(
+  dateOfBirth: Date | null | undefined
+): boolean {
+  if (!dateOfBirth) return false;
+  return calculateAge(dateOfBirth) <= GUARDIAN_REQUIRED_AGE;
+}
+
+/**
+ * The guardian name travels in the signup note (clients send
+ * "Guardian: <name>"), so server-side we accept any note that mentions
+ * "guardian".
+ */
+export function noteContainsGuardianName(
+  note: string | null | undefined
+): boolean {
+  return Boolean(note && note.toLowerCase().includes("guardian"));
+}
+
+/**
+ * Validates the guardian requirement for a shift signup. Shared by the web
+ * and mobile signup routes so the rule cannot drift between them.
+ *
+ * Returns the 400 response payload when a volunteer aged
+ * GUARDIAN_REQUIRED_AGE or under has not supplied a guardian name in the
+ * signup note, or null when the signup may proceed.
+ */
+export function validateGuardianRequirement(
+  dateOfBirth: Date | null | undefined,
+  note: string | null | undefined
+): GuardianValidationError | null {
+  if (!requiresGuardianName(dateOfBirth)) return null;
+  if (noteContainsGuardianName(note)) return null;
+
+  return {
+    error: "Guardian name required",
+    message: `Volunteers aged ${GUARDIAN_REQUIRED_AGE} and under must provide a parent or guardian's name when signing up. Please add "Guardian: <name>" to your signup note.`,
+  };
+}

--- a/web/tests/e2e/underage-guardian-signup.spec.ts
+++ b/web/tests/e2e/underage-guardian-signup.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect } from "./base";
+import {
+  createTestUser,
+  deleteTestUsers,
+  createShift,
+  deleteTestShifts,
+  getShiftTypeByName,
+  deleteSignupsByShiftIds,
+} from "./helpers/test-helpers";
+import { loginAsAdmin, loginAsVolunteer } from "./helpers/auth";
+import { randomUUID } from "crypto";
+import { nowInNZT } from "@/lib/timezone";
+
+/**
+ * A date of birth that makes the volunteer exactly `years` old today
+ * (their birthday was yesterday, so the age is unambiguous).
+ */
+function dateOfBirthForAge(years: number): string {
+  const dob = new Date();
+  dob.setFullYear(dob.getFullYear() - years);
+  dob.setDate(dob.getDate() - 1);
+  return dob.toISOString();
+}
+
+test.describe.configure({ timeout: 60_000 });
+test.describe("Underage guardian requirement", () => {
+  let testId: string;
+  let volunteerEmail: string;
+  let testShiftIds: string[];
+  let shiftId: string;
+
+  test.beforeEach(async ({ page }) => {
+    testId = randomUUID().slice(0, 8);
+    volunteerEmail = `volunteer-guardian-${testId}@example.com`;
+    testShiftIds = [];
+
+    await loginAsAdmin(page);
+
+    // 13-year-old volunteer with parental consent already received, so the
+    // guardian-name rule is the only underage gate left to satisfy.
+    await createTestUser(page, volunteerEmail, "VOLUNTEER", {
+      dateOfBirth: dateOfBirthForAge(13),
+      requiresParentalConsent: true,
+      parentalConsentReceived: true,
+    });
+
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(11, 0, 0, 0);
+
+    const shiftType = await getShiftTypeByName(page, "Kitchen Prep");
+    const shift = await createShift(page, {
+      location: "Wellington",
+      start: tomorrow,
+      capacity: 4,
+      shiftTypeId: shiftType?.id,
+      notes: "Guardian requirement test shift",
+    });
+    shiftId = shift.id;
+    testShiftIds.push(shiftId);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await loginAsAdmin(page);
+    await deleteSignupsByShiftIds(page, testShiftIds);
+    await deleteTestUsers(page, [volunteerEmail]);
+    await deleteTestShifts(page, testShiftIds);
+  });
+
+  async function openSignupDialog(page: import("@playwright/test").Page) {
+    const tomorrow = nowInNZT();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowStr = tomorrow.toISOString().split("T")[0];
+
+    await page.goto(`/shifts/details?date=${tomorrowStr}&location=Wellington`);
+    await page.waitForLoadState("load");
+
+    // .first() avoids strict-mode violation: shift cards render twice (mobile + desktop)
+    const shiftCard = page
+      .locator(`[data-testid="shift-card-${shiftId}"]`)
+      .first();
+    await expect(shiftCard).toBeVisible({ timeout: 15000 });
+
+    await shiftCard.getByTestId("shift-signup-button").click();
+    await expect(page.getByTestId("shift-signup-dialog")).toBeVisible();
+  }
+
+  test("signup dialog requires a guardian name for volunteers 14 and under", async ({
+    page,
+  }) => {
+    await loginAsVolunteer(page, volunteerEmail);
+    await openSignupDialog(page);
+
+    // The guardian field appears once the profile (age) check resolves
+    const guardianInput = page.getByTestId("shift-signup-guardian");
+    await expect(guardianInput).toBeVisible({ timeout: 10000 });
+
+    // Submitting without a guardian name is blocked client-side
+    await page.getByTestId("shift-signup-confirm-button").click();
+    await expect(page.getByTestId("signup-error")).toContainText(
+      "Please provide your guardian's name"
+    );
+
+    // Filling in the guardian name lets the signup through
+    await guardianInput.fill("Jane Smith");
+    await page.getByTestId("shift-signup-confirm-button").click();
+    await expect(page.getByTestId("shift-signup-dialog")).not.toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test("web signup API rejects underage signups without a guardian name", async ({
+    page,
+  }) => {
+    await loginAsVolunteer(page, volunteerEmail);
+
+    // No body at all: previously this skipped the guardian check entirely
+    const noBody = await page.request.post(`/api/shifts/${shiftId}/signup`);
+    expect(noBody.status()).toBe(400);
+    expect((await noBody.json()).error).toBe("Guardian name required");
+
+    // A note that doesn't name a guardian is rejected too
+    const badNote = await page.request.post(`/api/shifts/${shiftId}/signup`, {
+      form: { note: "Excited for my first shift" },
+    });
+    expect(badNote.status()).toBe(400);
+    expect((await badNote.json()).error).toBe("Guardian name required");
+
+    // Naming a guardian in the note succeeds
+    const withGuardian = await page.request.post(
+      `/api/shifts/${shiftId}/signup`,
+      { form: { note: "Guardian: Jane Smith" } }
+    );
+    expect(withGuardian.ok()).toBeTruthy();
+  });
+
+  test("mobile signup API rejects underage signups without a guardian name", async ({
+    page,
+  }) => {
+    const loginResponse = await page.request.post("/api/auth/mobile/login", {
+      data: { email: volunteerEmail, password: "Test123456" },
+    });
+    expect(loginResponse.ok()).toBeTruthy();
+    const { token } = await loginResponse.json();
+    const authHeaders = { Authorization: `Bearer ${token}` };
+
+    // No note: the mobile route previously had no guardian check at all
+    const noNote = await page.request.post(
+      `/api/mobile/shifts/${shiftId}/signup`,
+      { headers: authHeaders, data: {} }
+    );
+    expect(noNote.status()).toBe(400);
+    expect((await noNote.json()).error).toBe("Guardian name required");
+
+    // A note that doesn't name a guardian is rejected too
+    const badNote = await page.request.post(
+      `/api/mobile/shifts/${shiftId}/signup`,
+      { headers: authHeaders, data: { note: "See you there" } }
+    );
+    expect(badNote.status()).toBe(400);
+    expect((await badNote.json()).error).toBe("Guardian name required");
+
+    // Naming a guardian in the note (the app's format) succeeds
+    const withGuardian = await page.request.post(
+      `/api/mobile/shifts/${shiftId}/signup`,
+      { headers: authHeaders, data: { note: "Guardian: Jane Smith" } }
+    );
+    expect(withGuardian.ok()).toBeTruthy();
+  });
+
+  test("mobile shift detail eligibility flags the guardian requirement", async ({
+    page,
+  }) => {
+    const loginResponse = await page.request.post("/api/auth/mobile/login", {
+      data: { email: volunteerEmail, password: "Test123456" },
+    });
+    expect(loginResponse.ok()).toBeTruthy();
+    const { token } = await loginResponse.json();
+
+    const detail = await page.request.get(`/api/mobile/shifts/${shiftId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(detail.ok()).toBeTruthy();
+    expect((await detail.json()).eligibility.guardianRequired).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Volunteers aged 14 and under (\`GUARDIAN_REQUIRED_AGE\`) must supply a parent/guardian's name when signing up for a shift. This was only partially enforced:

- The **web** signup route only ran the guardian check when a note was present, so an underage signup with no note (or no body at all) passed server-side validation.
- The **mobile** signup route had no guardian check whatsoever, and the mobile app had no way to supply a guardian name.

## Changes

**Server**
- New shared `validateGuardianRequirement(dateOfBirth, note)` in `web/src/lib/guardian-validation.ts`, built on the existing `GUARDIAN_REQUIRED_AGE` and `calculateAge`. Rejects with 400 `Guardian name required` when an underage volunteer's note doesn't name a guardian (clients send `Guardian: <name>`).
- Both `/api/shifts/[id]/signup` and `/api/mobile/shifts/[id]/signup` run it after body parsing, outside the parse try/catch, so a missing note can no longer skip the rule.
- The mobile shift detail payload now includes a server-computed `eligibility.guardianRequired` flag, keeping the age rule in one place instead of duplicating it on the client.

**Mobile app**
- The signup sheet shows a required "Guardian name" input when `eligibility.guardianRequired` is set, blocks submission with a clear error when empty, and appends `Guardian: <name>` to the note exactly like the web dialog.
- Older app versions without the field now get the server's 400 instead of silently succeeding.

**Web dialog**
- Replaced a hardcoded `age <= 14` with the shared `GUARDIAN_REQUIRED_AGE` constant.

## Tests

- `guardian-validation.test.ts`: 15 unit tests covering the 14/15 age boundary, missing note, guardian-less note, case-insensitive matching, and null DOB.
- `underage-guardian-signup.spec.ts` (e2e, 4 tests): web dialog flow for a 13-year-old (required field, client-side block, success with name), direct API rejections on the web route (no body, guardian-less note) and the mobile route (via a real mobile JWT) plus the happy path, and the new eligibility flag.
- Full unit suite (476 tests), web typecheck/lint, and mobile `tsc --noEmit` all pass. The adjacent `backup-shift-signup.spec.ts` adult flow passes, confirming volunteers over 14 are unaffected.

## Reviewer notes

- The server-side contract stays intentionally simple (note must mention "guardian"), matching the existing convention; the clients enforce a non-empty name before composing the note.
- A missing date of birth passes the check by design: profile completion enforces DOB before a signup ever reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)