### PR TITLE
fix(login): remove delayed duplicate post-login navigation that aborts in-flight navigations

### DIFF
--- a/web/src/app/login/login-client.tsx
+++ b/web/src/app/login/login-client.tsx
@@ -236,20 +236,17 @@ export default function LoginClient({ providers }: LoginClientProps) {
       callbackUrl,
     });
 
-    setReactivateLoading(false);
-
-    if (res?.error) {
-      setError(
-        "We couldn't reactivate your account. Please double-check your password and try again."
-      );
+    if (res?.ok) {
+      // The authenticated-session effect above performs the redirect once the
+      // refreshed session lands; navigating here as well would race it.
+      setShowReactivation(false);
       return;
     }
 
-    if (res?.ok) {
-      setShowReactivation(false);
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      window.location.href = callbackUrl;
-    }
+    setReactivateLoading(false);
+    setError(
+      "We couldn't reactivate your account. Please double-check your password and try again."
+    );
   }
 
   async function handleOAuthSignIn(providerId: string) {
@@ -363,15 +360,17 @@ export default function LoginClient({ providers }: LoginClientProps) {
       callbackUrl,
     });
 
-    setIsLoading(false);
-
-    if (res?.error) {
-      setError("Login failed");
-    } else if (res?.ok) {
-      // Add a small delay to ensure session is established
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      window.location.href = callbackUrl;
+    if (res?.ok) {
+      // signIn (redirect: false) refreshes the session before resolving, so
+      // the authenticated-session effect above performs the redirect.
+      // Navigating here as well would fire a second, delayed navigation that
+      // aborts whatever navigation is in flight by then. Keep the loading
+      // state active until the redirect unmounts this page.
+      return;
     }
+
+    setIsLoading(false);
+    setError("Login failed");
   }
 
   // OAuth providers are already filtered server-side


### PR DESCRIPTION
# Pull Request

## Description

Root-causes and fixes the CI flakiness in `admin-impersonation.spec.ts`, `admin-locations.spec.ts`, and `admin-notes.spec.ts` (e.g. [run 29465573385](https://github.com/everybody-eats-nz/volunteer-portal/actions/runs/29465573385) shard 3: 1 failed + 8 flaky, all in these specs).

**Root cause: a double post-login navigation in `login-client.tsx`, not SSE stream accumulation.**

`handleQuickLogin` (and `handleReactivate`) called `signIn("credentials", { redirect: false })`, then slept 500ms and set `window.location.href = callbackUrl`. But next-auth's `signIn({ redirect: false })` refreshes the session **before resolving**, so the "redirect if already authenticated" effect in the same component had already navigated via `router.push("/admin")` by the time the timer was armed. Because an App Router SPA navigation does not destroy the JS context, the timer survived onto the freshly loaded `/admin` page and fired a second, full document navigation to `/admin` ~500ms later.

In e2e, `loginAsAdmin()` returns as soon as the `router.push` lands and the dashboard testid attaches (often < 500ms on a warm server), so the leftover timer detonates while the test's next action is in flight. That one bug produces every observed failure signature:

- `page.goto: net::ERR_ABORTED at .../admin/volunteers/<id>` (goto aborted by the stray navigation)
- `Navigation to ".../admin/volunteers/..." is interrupted by another navigation to ".../admin"` (the literal smoking gun in the shard 3 log)
- `page.evaluate: TypeError: Failed to fetch` during cleanup (execution context destroyed mid-fetch)
- `locator.click` timeouts (page silently replaced by the admin dashboard after a successful goto)

The fix makes the authenticated-session effect the single owner of the post-login redirect - the same pattern the passkey login flow already uses - and keeps the loading state active until the redirect unmounts the page. The reactivation flow had the same latent bug (it affects real production users, not just tests) and is fixed the same way.

Why these three specs specifically: they are alphabetically adjacent (same CI shard), all use `loginAsAdmin()` in `beforeEach`, and immediately `page.goto()` a slow-to-render page (`/admin/volunteers/[id]`), maximizing the race window. `loginAsVolunteer()` accidentally masked the same bug with its `waitForTimeout(1000)`.

Note: the previously suspected SSE stream accumulation (see #1119 context) shows up in local long-running dev servers but was not the CI culprit - the shard log shows only routine client-side `[SSE]` reconnect noise and no server-side SSE errors.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
`version:patch`

## Testing
- [x] Local repro before the fix: the three specs run together against a fresh dev server -> **9 failed / 5 did not run / 16 passed**, failing tests matching the CI run
- [x] After the fix: repeated runs of all three specs with `--project=chromium` (results being posted in a follow-up comment)
- [x] `npm run typecheck` and `eslint` pass
- [ ] CI e2e green

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes
No test files changed - this is an app bug that e2e was (correctly) tripping over. The 500ms-delayed `window.location.href` also caused a needless full page reload for every quick-login/demo user; login now completes with a single client-side navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
