### PR TITLE
fix(notifications): deliver and route location notifications beyond the default location

### DIFF
--- a/mobile/app/(tabs)/shifts.tsx
+++ b/mobile/app/(tabs)/shifts.tsx
@@ -286,7 +286,7 @@ export default function ShiftsScreen() {
 
   /* Selected date — respects ?date=YYYY-MM-DD deep links (e.g. from the
      "volunteers needed" home card), falling back to today. */
-  const params = useLocalSearchParams<{ date?: string }>();
+  const params = useLocalSearchParams<{ date?: string; location?: string }>();
   const [selectedDate, setSelectedDate] = useState<Date>(() => {
     const parsed = parseDateKey(params.date);
     return parsed ?? startOfDay(new Date());
@@ -301,6 +301,19 @@ export default function ShiftsScreen() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params.date]);
+
+  /* A deep link can carry a location too (a shortage push for a specific
+     restaurant). Switch the filter to that venue so the shifts the
+     notification is about are actually visible — otherwise a push for
+     Hopper Cafe lands on a tab still filtered to e.g. Wellington. */
+  useEffect(() => {
+    const location =
+      typeof params.location === "string" ? params.location : undefined;
+    if (location && location !== locationFilter) {
+      setLocationFilter(location);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.location]);
 
   const selectedDateKey = formatDateKey(selectedDate);
 

--- a/mobile/lib/deep-link-routing.test.ts
+++ b/mobile/lib/deep-link-routing.test.ts
@@ -19,6 +19,20 @@ describe("mapDeepLinkToRoute", () => {
     it("treats /shifts/details as the shifts tab, not a shift id", () => {
       expect(mapDeepLinkToRoute("/shifts/details")).toBe("/(tabs)/shifts");
     });
+
+    it("forwards date and location from /shifts/details links", () => {
+      expect(
+        mapDeepLinkToRoute(
+          "https://volunteers.everybodyeats.nz/shifts/details?date=2026-06-30&location=Hopper%20Cafe"
+        )
+      ).toBe("/(tabs)/shifts?date=2026-06-30&location=Hopper%20Cafe");
+    });
+
+    it("forwards just the date when /shifts/details has no location", () => {
+      expect(mapDeepLinkToRoute("/shifts/details?date=2026-06-30")).toBe(
+        "/(tabs)/shifts?date=2026-06-30"
+      );
+    });
   });
 
   describe("dashboard", () => {

--- a/mobile/lib/deep-link-routing.ts
+++ b/mobile/lib/deep-link-routing.ts
@@ -56,7 +56,23 @@ export function mapDeepLinkToRoute(rawPath: string): string {
     return `/shift/${shiftDetail[1]}`;
   }
 
-  // /shifts, /shifts/mine, /shifts/details -> shifts tab
+  // /shifts/details?date=YYYY-MM-DD&location=X -> shifts tab. Forward the
+  // date and location so the tab can jump to that day and switch its filter
+  // to the linked restaurant (mirrors notification-routing.ts). Encoded with
+  // %20 rather than URLSearchParams' "+" — expo-router percent-decodes params
+  // but doesn't apply the form-encoding plus-as-space rule.
+  if (pathname === "/shifts/details") {
+    const parts: string[] = [];
+    const date = query.get("date");
+    const location = query.get("location");
+    if (date) parts.push(`date=${encodeURIComponent(date)}`);
+    if (location) parts.push(`location=${encodeURIComponent(location)}`);
+    return parts.length > 0
+      ? `/(tabs)/shifts?${parts.join("&")}`
+      : "/(tabs)/shifts";
+  }
+
+  // /shifts, /shifts/mine -> shifts tab
   if (pathname === "/shifts" || pathname.startsWith("/shifts/")) {
     return "/(tabs)/shifts";
   }

--- a/mobile/lib/notification-routing.test.ts
+++ b/mobile/lib/notification-routing.test.ts
@@ -54,11 +54,22 @@ describe("navigateToNotificationTarget", () => {
       );
     });
 
-    // The backend may append &location=... (see send-shortage/route.ts), but
-    // the mobile shifts tab applies the user's own location filter, so only
-    // the date is forwarded. This documents that intentional drop.
-    it("forwards only the date (not location) for /shifts/details", () => {
-      navigateToNotificationTarget("/shifts/details?date=2026-06-30&location=Wellington");
+    // The backend appends &location=... when the day's shortage shifts share
+    // a restaurant (see send-shortage/route.ts). Forwarding it lets the
+    // shifts tab switch its location filter — previously it was dropped, so
+    // a push for another restaurant landed on a tab that hid those shifts.
+    it("forwards both date and location for /shifts/details", () => {
+      navigateToNotificationTarget(
+        "/shifts/details?date=2026-06-30&location=Hopper%20Cafe"
+      );
+      expect(pushMock).toHaveBeenCalledWith({
+        pathname: "/(tabs)/shifts",
+        params: { date: "2026-06-30", location: "Hopper Cafe" },
+      });
+    });
+
+    it("forwards just the date when no location is given", () => {
+      navigateToNotificationTarget("/shifts/details?date=2026-06-30");
       expect(pushMock).toHaveBeenCalledWith({
         pathname: "/(tabs)/shifts",
         params: { date: "2026-06-30" },

--- a/mobile/lib/notification-routing.ts
+++ b/mobile/lib/notification-routing.ts
@@ -53,15 +53,23 @@ export function navigateToNotificationTarget(actionUrl: unknown) {
     return;
   }
 
-  // /shifts/details?date=YYYY-MM-DD -> shifts tab focused on that day.
-  // Shortage notifications deep-link here; the shifts tab honours ?date=.
-  // (location isn't forwarded — the tab applies the user's own filter.)
+  // /shifts/details?date=YYYY-MM-DD&location=X -> shifts tab focused on that
+  // day. Shortage notifications deep-link here; the shifts tab honours ?date=
+  // and switches its location filter to ?location= — without that, a push for
+  // a restaurant other than the user's current filter landed on a tab that
+  // hid the very shifts the notification was about.
   // Must run before the generic /shifts/:id match below, otherwise
   // "details" is treated as a shift id and 404s ("Shift not found").
   if (pathname === "/shifts/details") {
     const date = query.get("date");
+    const location = query.get("location");
+    const params: Record<string, string> = {};
+    if (date) params.date = date;
+    if (location) params.location = location;
     router.push(
-      date ? { pathname: "/(tabs)/shifts", params: { date } } : "/(tabs)/shifts"
+      Object.keys(params).length > 0
+        ? { pathname: "/(tabs)/shifts", params }
+        : "/(tabs)/shifts"
     );
     return;
   }

--- a/web/src/app/admin/notifications/notifications-content.tsx
+++ b/web/src/app/admin/notifications/notifications-content.tsx
@@ -324,9 +324,16 @@ export function NotificationsContent({
       );
     }
 
-    // Filter by location
+    // Filter by location — a volunteer belongs to a location when it's their
+    // default OR one they marked themselves available at, so shortage
+    // notifications reach everyone who can actually work there.
     if (filterLocation !== "all") {
-      filtered = filtered.filter((v) => v.defaultLocation === filterLocation);
+      filtered = filtered.filter(
+        (v) =>
+          v.defaultLocation === filterLocation ||
+          (Array.isArray(v.availableLocations) &&
+            v.availableLocations.includes(filterLocation))
+      );
     }
 
     // Filter by shift type preference

--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -33,7 +33,10 @@ import {
 import { cn } from "@/lib/utils";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
-import { safeParseAvailability } from "@/lib/parse-availability";
+import {
+  safeParseAvailability,
+  safeParseLocations,
+} from "@/lib/parse-availability";
 import { WeekAvailability } from "@/components/week-availability";
 import { VolunteerGradeToggle } from "@/components/volunteer-grade-toggle";
 import { VolunteerGradeBadge } from "@/components/volunteer-grade-badge";
@@ -231,7 +234,7 @@ export default async function AdminVolunteerPage({
     : "V";
 
   const availableDays = safeParseAvailability(volunteer.availableDays);
-  const availableLocations = safeParseAvailability(
+  const availableLocations = safeParseLocations(
     volunteer.availableLocations
   );
 

--- a/web/src/app/api/admin/volunteers/route.ts
+++ b/web/src/app/api/admin/volunteers/route.ts
@@ -2,7 +2,10 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
-import { safeParseAvailability } from "@/lib/parse-availability";
+import {
+  safeParseAvailability,
+  safeParseLocations,
+} from "@/lib/parse-availability";
 
 export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
@@ -35,6 +38,7 @@ export async function GET(request: Request) {
         lastName: true,
         volunteerGrade: true,
         defaultLocation: true,
+        availableLocations: true,
         availableDays: true,
         receiveShortageNotifications: true,
         excludedShortageNotificationTypes: true,
@@ -84,6 +88,7 @@ export async function GET(request: Request) {
       return {
         ...volunteerWithoutSignups,
         availableDays: safeParseAvailability(volunteer.availableDays),
+        availableLocations: safeParseLocations(volunteer.availableLocations),
         ...(includeStats && { completedShifts }),
       };
     });

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -7,6 +7,7 @@ import {
   isSameDayInNZT,
 } from "@/lib/timezone";
 import { ANNOUNCEMENT_SHIFT_TARGET_STATUSES } from "@/lib/announcement-targeting";
+import { userMatchesTargetLocations } from "@/lib/user-locations";
 import { formatAchievementCriteria } from "@/lib/achievement-utils";
 import {
   getRecentCmsJournalPosts,
@@ -76,6 +77,7 @@ export async function GET(request: Request) {
         select: {
           volunteerGrade: true,
           defaultLocation: true,
+          availableLocations: true,
           customLabels: { select: { labelId: true } },
         },
       }),
@@ -298,11 +300,16 @@ export async function GET(request: Request) {
   const friendIdSet = new Set(friendIds);
 
   for (const ann of announcements) {
-    // Location targeting: empty = all locations
-    const locationMatch =
-      ann.targetLocations.length === 0 ||
-      (userDefaultLocation !== null &&
-        ann.targetLocations.includes(userDefaultLocation));
+    // Location targeting: empty = all locations. Matches the recipient
+    // conditions in announcement-targeting.ts (default OR available
+    // locations) so a pushed announcement is visible in the feed it links to.
+    const locationMatch = userMatchesTargetLocations(
+      {
+        defaultLocation: userDefaultLocation,
+        availableLocations: userProfile?.availableLocations ?? null,
+      },
+      ann.targetLocations
+    );
 
     // Grade targeting: empty = all grades
     const gradeMatch =

--- a/web/src/components/volunteers-data-table.tsx
+++ b/web/src/components/volunteers-data-table.tsx
@@ -45,6 +45,7 @@ export interface Volunteer {
   firstName: string | null;
   lastName: string | null;
   defaultLocation: string | null;
+  availableLocations: string[];
   availableDays: string[];
   receiveShortageNotifications: boolean;
   excludedShortageNotificationTypes: string[];
@@ -129,16 +130,36 @@ export const columns: ColumnDef<Volunteer>[] = [
   },
   {
     accessorKey: "defaultLocation",
-    header: "Default Location",
+    header: "Locations",
     cell: ({ row }) => {
-      const location = row.getValue("defaultLocation") as string | null;
-      if (!location) {
+      const defaultLocation = row.getValue("defaultLocation") as string | null;
+      // Other locations the volunteer marked themselves available at — they
+      // receive location-targeted notifications for these too, so surface
+      // them alongside the default (shown first, outlined).
+      const otherLocations = (row.original.availableLocations ?? []).filter(
+        (location) => location !== defaultLocation
+      );
+      if (!defaultLocation && otherLocations.length === 0) {
         return <span className="text-xs text-muted-foreground">—</span>;
       }
       return (
-        <Badge variant="outline" className="text-xs">
-          {location}
-        </Badge>
+        <div className="flex gap-1 flex-wrap">
+          {defaultLocation && (
+            <Badge variant="outline" className="text-xs">
+              {defaultLocation}
+            </Badge>
+          )}
+          {otherLocations.slice(0, 2).map((location) => (
+            <Badge key={location} variant="secondary" className="text-xs">
+              {location}
+            </Badge>
+          ))}
+          {otherLocations.length > 2 && (
+            <Badge variant="secondary" className="text-xs">
+              +{otherLocations.length - 2}
+            </Badge>
+          )}
+        </div>
       );
     },
   },

--- a/web/src/lib/announcement-targeting.ts
+++ b/web/src/lib/announcement-targeting.ts
@@ -45,8 +45,23 @@ function buildRecipientConditions(t: AnnouncementTargeting): Prisma.Sql {
   const conditions: Prisma.Sql[] = [Prisma.sql`TRUE`];
 
   if (t.targetLocations.length > 0) {
+    const targetLocations = Prisma.sql`ARRAY[${Prisma.join(t.targetLocations)}]::text[]`;
+    // A volunteer belongs to a location when it's their default OR in their
+    // availableLocations list. That column is a JSON-stringified array in a
+    // text column (with legacy plain-text values like "Glen Innes" in old
+    // rows), so no ::jsonb cast — one malformed row would abort the whole
+    // query. Matching the element with its JSON quotes ('"Wellington"') keeps
+    // the substring check exact for names that are prefixes of other names;
+    // the trimmed equality branch covers the legacy plain-text rows.
     conditions.push(
-      Prisma.sql`"defaultLocation" = ANY(ARRAY[${Prisma.join(t.targetLocations)}]::text[])`
+      Prisma.sql`(
+        "defaultLocation" = ANY(${targetLocations})
+        OR EXISTS (
+          SELECT 1 FROM unnest(${targetLocations}) AS target(loc)
+          WHERE POSITION('"' || target.loc || '"' IN "availableLocations") > 0
+             OR btrim("availableLocations") = target.loc
+        )
+      )`
     );
   }
 

--- a/web/src/lib/parse-availability.test.ts
+++ b/web/src/lib/parse-availability.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { safeParseLocations } from "./parse-availability";
+
+describe("safeParseLocations", () => {
+  it("parses a JSON array of locations", () => {
+    expect(safeParseLocations('["Wellington","Glen Innes"]')).toEqual([
+      "Wellington",
+      "Glen Innes",
+    ]);
+  });
+
+  it("returns an empty array for null, undefined, and blank input", () => {
+    expect(safeParseLocations(null)).toEqual([]);
+    expect(safeParseLocations(undefined)).toEqual([]);
+    expect(safeParseLocations("   ")).toEqual([]);
+  });
+
+  it("keeps a legacy single plain-text location intact", () => {
+    // safeParseAvailability would split "Glen Innes" into ["Glen", "Innes"].
+    expect(safeParseLocations("Glen Innes")).toEqual(["Glen Innes"]);
+  });
+
+  it("splits legacy comma-separated locations preserving casing", () => {
+    expect(safeParseLocations("Wellington, Glen Innes")).toEqual([
+      "Wellington",
+      "Glen Innes",
+    ]);
+  });
+
+  it("drops non-string and empty entries from JSON arrays", () => {
+    expect(safeParseLocations('["Wellington", 42, "", null, " Onehunga "]')).toEqual([
+      "Wellington",
+      "Onehunga",
+    ]);
+  });
+});

--- a/web/src/lib/parse-availability.ts
+++ b/web/src/lib/parse-availability.ts
@@ -1,4 +1,35 @@
 /**
+ * Safely parse a stored locations list that might be in JSON format or plain
+ * text. Migrated rows hold values like "Wellington" or "Wellington, Glen Innes"
+ * instead of JSON arrays.
+ *
+ * Locations need their own parser: safeParseAvailability splits on spaces and
+ * re-capitalizes, which mangles multi-word restaurant names ("Glen Innes"
+ * becomes ["Glen", "Innes"]). Here the original casing is preserved and only
+ * commas separate entries.
+ */
+export function safeParseLocations(data: string | null | undefined): string[] {
+  if (!data?.trim()) return [];
+
+  try {
+    const parsed = JSON.parse(data);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((item): item is string => typeof item === "string")
+        .map((item) => item.trim())
+        .filter(Boolean);
+    }
+  } catch {
+    // Not JSON — fall through to the legacy plain-text handling below
+  }
+
+  return data
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+/**
  * Safely parse availability data that might be in JSON format or plain text
  * Migration data might be stored as "weekdays" or "Monday, Tuesday" instead of JSON arrays
  */

--- a/web/src/lib/user-locations.test.ts
+++ b/web/src/lib/user-locations.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  getUserLocations,
+  userMatchesTargetLocations,
+} from "./user-locations";
+
+describe("getUserLocations", () => {
+  it("combines default location and available locations", () => {
+    expect(
+      getUserLocations({
+        defaultLocation: "Wellington",
+        availableLocations: JSON.stringify(["Wellington", "Glen Innes"]),
+      })
+    ).toEqual(["Wellington", "Glen Innes"]);
+  });
+
+  it("includes a default location missing from availableLocations", () => {
+    expect(
+      getUserLocations({
+        defaultLocation: "Onehunga",
+        availableLocations: JSON.stringify(["Wellington"]),
+      })
+    ).toEqual(["Wellington", "Onehunga"]);
+  });
+
+  it("handles a null availableLocations column", () => {
+    expect(
+      getUserLocations({
+        defaultLocation: "Wellington",
+        availableLocations: null,
+      })
+    ).toEqual(["Wellington"]);
+  });
+
+  it("handles a user with no locations at all", () => {
+    expect(
+      getUserLocations({ defaultLocation: null, availableLocations: null })
+    ).toEqual([]);
+  });
+
+  it("tolerates legacy non-JSON availableLocations values", () => {
+    expect(
+      getUserLocations({
+        defaultLocation: "Wellington",
+        availableLocations: "Glen Innes",
+      })
+    ).toEqual(["Glen Innes", "Wellington"]);
+  });
+
+  it("preserves multi-word names in legacy comma-separated values", () => {
+    expect(
+      getUserLocations({
+        defaultLocation: null,
+        availableLocations: "Wellington, Glen Innes",
+      })
+    ).toEqual(["Wellington", "Glen Innes"]);
+  });
+});
+
+describe("userMatchesTargetLocations", () => {
+  const user = {
+    defaultLocation: "Wellington",
+    availableLocations: JSON.stringify(["Wellington", "Glen Innes"]),
+  };
+
+  it("treats an empty target list as all locations", () => {
+    expect(userMatchesTargetLocations(user, [])).toBe(true);
+  });
+
+  it("matches on the default location", () => {
+    expect(userMatchesTargetLocations(user, ["Wellington"])).toBe(true);
+  });
+
+  it("matches on a non-default available location", () => {
+    expect(userMatchesTargetLocations(user, ["Glen Innes"])).toBe(true);
+  });
+
+  it("does not match a location the user isn't associated with", () => {
+    expect(userMatchesTargetLocations(user, ["Onehunga"])).toBe(false);
+  });
+
+  it("does not match users with no locations against a targeted list", () => {
+    expect(
+      userMatchesTargetLocations(
+        { defaultLocation: null, availableLocations: null },
+        ["Wellington"]
+      )
+    ).toBe(false);
+  });
+});

--- a/web/src/lib/user-locations.ts
+++ b/web/src/lib/user-locations.ts
@@ -1,0 +1,39 @@
+import { safeParseLocations } from "@/lib/parse-availability";
+
+/**
+ * All restaurant locations a volunteer is associated with: their default
+ * location plus every entry in their `availableLocations` list (stored as a
+ * JSON-stringified array, with legacy plain-text values in old rows).
+ *
+ * Location-targeted notifications and announcements must use this rather than
+ * `defaultLocation` alone — a volunteer available at several restaurants would
+ * otherwise only ever hear about their default one.
+ */
+export function getUserLocations(user: {
+  defaultLocation: string | null;
+  availableLocations: string | null;
+}): string[] {
+  const locations = new Set<string>(
+    safeParseLocations(user.availableLocations)
+  );
+  if (user.defaultLocation) {
+    locations.add(user.defaultLocation);
+  }
+  return [...locations];
+}
+
+/**
+ * True when any of the user's locations (default or available) is in
+ * `targetLocations`. An empty target list means "all locations".
+ */
+export function userMatchesTargetLocations(
+  user: {
+    defaultLocation: string | null;
+    availableLocations: string | null;
+  },
+  targetLocations: string[]
+): boolean {
+  if (targetLocations.length === 0) return true;
+  const userLocations = getUserLocations(user);
+  return targetLocations.some((loc) => userLocations.includes(loc));
+}

--- a/web/tests/e2e/admin-notifications.spec.ts
+++ b/web/tests/e2e/admin-notifications.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import {
   login,
   ensureAdmin,
@@ -6,7 +6,18 @@ import {
   deleteTestUsers,
   createShift,
   deleteTestShifts,
+  createSignup,
+  getUserByEmail,
 } from "./helpers/test-helpers";
+
+/**
+ * Streaming can transiently render the admin tab panel twice, making plain
+ * getByTestId lookups fail with strict-mode "resolved to 2 elements" flakes.
+ * Scope every testid lookup on this page to the visible instance.
+ */
+function byTestId(page: Page, id: string) {
+  return page.locator(`[data-testid="${id}"]:visible`).first();
+}
 
 test.describe.serial("Admin Shift Shortage Notifications", () => {
   let adminEmail: string;
@@ -74,15 +85,15 @@ test.describe.serial("Admin Shift Shortage Notifications", () => {
     ).toBeVisible();
 
     // Check filter sections exist
-    await expect(page.getByTestId("shift-filter-section")).toBeVisible();
-    await expect(page.getByTestId("volunteer-filter-section")).toBeVisible();
+    await expect(byTestId(page, "shift-filter-section")).toBeVisible();
+    await expect(byTestId(page, "volunteer-filter-section")).toBeVisible();
 
     // Check shift location filter dropdown (new UI uses date + location instead of single shift select)
-    await expect(page.getByTestId("shift-location-filter")).toBeVisible();
+    await expect(byTestId(page, "shift-location-filter")).toBeVisible();
 
     // Check basic volunteer filters
-    await expect(page.getByTestId("location-filter")).toBeVisible();
-    await expect(page.getByTestId("shift-type-filter")).toBeVisible();
+    await expect(byTestId(page, "location-filter")).toBeVisible();
+    await expect(byTestId(page, "shift-type-filter")).toBeVisible();
   });
 
   test("should show volunteer count when filters are applied", async ({
@@ -90,9 +101,10 @@ test.describe.serial("Admin Shift Shortage Notifications", () => {
   }) => {
     await page.goto("/admin/notifications");
 
-    // Volunteer count is always visible (filters apply to volunteers, not dependent on shift selection)
-    await expect(page.getByTestId("volunteer-count")).toBeVisible();
-    await expect(page.getByTestId("volunteer-count")).toContainText(
+    // Volunteer count is always visible (filters apply to volunteers, not
+    // dependent on shift selection)
+    await expect(byTestId(page, "volunteer-count")).toBeVisible();
+    await expect(byTestId(page, "volunteer-count")).toContainText(
       "volunteers match filters"
     );
   });
@@ -101,10 +113,81 @@ test.describe.serial("Admin Shift Shortage Notifications", () => {
     await page.goto("/admin/notifications");
 
     // Notification filter toggle is always visible (not dependent on shift selection)
-    await expect(page.getByTestId("notification-filter-toggle")).toBeVisible();
+    await expect(byTestId(page, "notification-filter-toggle")).toBeVisible();
 
     // Toggle it
-    await page.getByTestId("notification-filter-toggle").click();
+    await byTestId(page, "notification-filter-toggle").click();
+  });
+
+  test("location filter includes volunteers available at a non-default location", async ({
+    page,
+  }) => {
+    const baseTime = Date.now();
+
+    // Defaults to Wellington but is also available at Glen Innes — must still
+    // be reachable when notifying Glen Innes shortages (issue #1125).
+    const multiLocEmail = `volunteer-multiloc-${baseTime}@test.com`;
+    volunteerEmails.push(multiLocEmail);
+    await createTestUser(page, multiLocEmail, "VOLUNTEER", {
+      firstName: "Multiloc",
+      lastName: `Tester${baseTime}`,
+      defaultLocation: "Wellington",
+      availableLocations: JSON.stringify(["Wellington", "Glen Innes"]),
+      receiveShortageNotifications: true,
+      excludedShortageNotificationTypes: [],
+    });
+
+    // Control: Wellington only — must NOT appear under the Glen Innes filter.
+    const singleLocEmail = `volunteer-singleloc-${baseTime}@test.com`;
+    volunteerEmails.push(singleLocEmail);
+    await createTestUser(page, singleLocEmail, "VOLUNTEER", {
+      firstName: "Singleloc",
+      lastName: `Tester${baseTime}`,
+      defaultLocation: "Wellington",
+      availableLocations: JSON.stringify(["Wellington"]),
+      receiveShortageNotifications: true,
+      excludedShortageNotificationTypes: [],
+    });
+
+    // Volunteers only appear in the picker once they have a confirmed signup.
+    const multiLoc = await getUserByEmail(page, multiLocEmail);
+    const singleLoc = await getUserByEmail(page, singleLocEmail);
+    await createSignup(page, {
+      userId: multiLoc!.id,
+      shiftId,
+      status: "CONFIRMED",
+    });
+    await createSignup(page, {
+      userId: singleLoc!.id,
+      shiftId,
+      status: "CONFIRMED",
+    });
+
+    await page.goto("/admin/notifications");
+
+    // Narrow the table to just this test's volunteers, then filter by a
+    // location that is only in the multi-location volunteer's availability.
+    // .first() everywhere for the same transient-duplicate reason as byTestId.
+    await page
+      .getByPlaceholder("Filter by name or email...")
+      .first()
+      .fill(`Tester${baseTime}`);
+    await expect(
+      page.getByText(`Multiloc Tester${baseTime}`).first()
+    ).toBeVisible();
+    await expect(
+      page.getByText(`Singleloc Tester${baseTime}`).first()
+    ).toBeVisible();
+
+    await byTestId(page, "location-filter").click();
+    await page.getByRole("option", { name: "Glen Innes" }).click();
+
+    await expect(
+      page.getByText(`Multiloc Tester${baseTime}`).first()
+    ).toBeVisible();
+    await expect(
+      page.getByText(`Singleloc Tester${baseTime}`).first()
+    ).not.toBeVisible();
   });
 
   test("should show availability filter for selected shift", async ({
@@ -127,21 +210,21 @@ test.describe.serial("Admin Shift Shortage Notifications", () => {
     });
 
     // Availability filter should be disabled initially (no shifts selected yet)
-    await expect(page.getByTestId("availability-filter")).toBeDisabled();
+    await expect(byTestId(page, "availability-filter")).toBeDisabled();
 
     // Select a shift
     await page.locator('[data-testid^="shift-checkbox-"]').first().click();
 
     // Availability filter should now be enabled
-    await expect(page.getByTestId("availability-filter")).toBeEnabled();
+    await expect(byTestId(page, "availability-filter")).toBeEnabled();
   });
 
   test("should display email preview button", async ({ page }) => {
     await page.goto("/admin/notifications");
 
     // Check that preview button is visible
-    await expect(page.getByTestId("preview-email-button")).toBeVisible();
-    await expect(page.getByTestId("preview-email-button")).toContainText(
+    await expect(byTestId(page, "preview-email-button")).toBeVisible();
+    await expect(byTestId(page, "preview-email-button")).toContainText(
       "Preview Email"
     );
   });
@@ -152,7 +235,7 @@ test.describe.serial("Admin Shift Shortage Notifications", () => {
     await page.goto("/admin/notifications");
 
     // Click the preview button
-    await page.getByTestId("preview-email-button").click();
+    await byTestId(page, "preview-email-button").click();
 
     // Dialog should open
     await expect(
@@ -172,7 +255,7 @@ test.describe.serial("Admin Shift Shortage Notifications", () => {
     await page.goto("/admin/notifications");
 
     // Click the preview button
-    await page.getByTestId("preview-email-button").click();
+    await byTestId(page, "preview-email-button").click();
 
     // Wait for dialog to open
     await expect(
@@ -204,7 +287,7 @@ test.describe.serial("Admin Shift Shortage Notifications", () => {
     await page.goto("/admin/notifications");
 
     // Click the preview button
-    await page.getByTestId("preview-email-button").click();
+    await byTestId(page, "preview-email-button").click();
 
     // Wait for dialog to open
     await expect(
@@ -224,7 +307,7 @@ test.describe.serial("Admin Shift Shortage Notifications", () => {
     await page.goto("/admin/notifications");
 
     // Click the preview button
-    await page.getByTestId("preview-email-button").click();
+    await byTestId(page, "preview-email-button").click();
 
     // Dialog should open
     await expect(


### PR DESCRIPTION
Fixes #1125

## The reported scenario

You get a shortage push for Hopper Cafe while your mobile app's shifts tab is filtered to Wellington. Tapping the push landed on the shifts tab still filtered to Wellington, hiding the very shifts the notification was about.

## Mobile: notification tap now switches location

- `notification-routing.ts` forwarded only the `date` from `/shifts/details?date=...&location=...` links and deliberately dropped the location. It now forwards both (same for `deep-link-routing.ts` universal links).
- The shifts tab applies a `location` deep-link param to its persisted location filter, mirroring the existing `?date=` handling, so the tab lands on the right day *and* the right restaurant.

## Web: recipient selection had the same default-only blind spot

While tracing this, every location-based recipient path turned out to match only `defaultLocation`, so volunteers available at several restaurants never received notifications about their non-default ones:

- **Shortage sends** (`/admin/notifications`): the location filter now matches default OR available locations. The volunteers table shows all of a volunteer's locations (default outlined first). In the dev database, targeting Glen Innes matched **1** volunteer before and **52** after.
- **Announcement targeting** (`announcement-targeting.ts`): the SQL now also matches `availableLocations` (a JSON-stringified text column with some legacy plain-text rows, matched without a `jsonb` cast so one malformed row can't abort the query).
- **Mobile feed** (`/api/mobile/feed`): announcement visibility uses the same default-or-available rule, so a pushed announcement is visible in the feed it deep-links to.

New `safeParseLocations` parser keeps multi-word venue names intact; `safeParseAvailability` split legacy `"Glen Innes"` into `["Glen", "Innes"]` and re-cased comma lists. All `availableLocations` call sites switched to it.

## Tests

- New unit tests for `user-locations.ts` and `safeParseLocations` (web) and updated routing tests (mobile) covering location forwarding.
- New e2e test: a volunteer with default Wellington + available Glen Innes appears under the Glen Innes filter; a Wellington-only control does not.
- De-flaked `admin-notifications.spec.ts`: testid lookups are now scoped to the visible instance (streaming transiently duplicates the tab panel, causing strict-mode "resolved to 2 elements" failures that hit two different tests in a row while verifying this change).

Verified: web lint/typecheck/unit (492) all green, admin-notifications e2e 10/10, mobile lint/typecheck/unit (104) all green, plus live browser check of the admin filter and locations column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)