### PR TITLE
fix(flaky): should navigate to registration page from hero join button

### DIFF
--- a/web/tests/e2e/home.spec.ts
+++ b/web/tests/e2e/home.spec.ts
@@ -181,7 +181,11 @@ test.describe("Home Page", () => {
       await joinVolunteerButton.click();
       await page.waitForLoadState("load");
 
-      await expect(page).toHaveURL("/register");
+      // /register is client-rendered via next/link (no "load" event on
+      // navigation), and in CI the Next.js dev server JIT-compiles the route
+      // on its first hit in a shard, which can exceed the default 5s
+      // assertion timeout. Give this specific assertion more headroom.
+      await expect(page).toHaveURL("/register", { timeout: 15000 });
     });
 
     test("should navigate to registration page from final get started button", async ({


### PR DESCRIPTION
## Description

Weekly flaky-test audit of the last 7 days of `Test` workflow CI runs on `main` (2026-07-13 → 2026-07-20). Scanned ~150 Playwright shard job logs across 11 runs to find tests that failed on one attempt and passed on a retry of the same commit.

`tests/e2e/home.spec.ts` › **"should navigate to registration page from hero join button"** was the single most consistently flaky test found: it showed up as flaky in 9 out of 9 CI runs I was able to check it in, spanning five different commits across five different days — a ~100% flake rate, always recovering on retry, never a hard failure.

**Root cause**: the button navigates via `next/link` (client-side navigation — no `window` `load` event fires), and CI runs the app against `next dev`, not a production build, so each route is JIT-compiled on its first hit. When this test is the first in a shard to hit `/register`, compilation occasionally pushes the navigation past Playwright's default 5000ms assertion timeout. This matches the CI error signature exactly (`Timeout: 5000ms`, `Received: ".../"`), and I reproduced it locally against a cold `next dev` server with the unmodified test. The neighboring "hero browse button" test (identical pattern, targets the already-warm `/shifts` route) never flakes, and the sibling "final get started button" test (also targets `/register`, but runs after this one) is unaffected once the route is warm — both consistent with this being a first-hit compile cost, not a product bug.

**Fix**: give the `/register` URL assertion a longer timeout (15s) so it tolerates the one-time JIT compile instead of racing it. No product code changes — the app behaves correctly, the test's timeout budget was just too tight for CI's `next dev` characteristics.

**Verified**: reverted the fix and reproduced the failure against a cold local dev server (identical `Timeout: 5000ms` error). Reapplied the fix and ran the test against 3 separate cold dev-server boots — passed all 3 times.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes

## Version Bump Required
`version:patch` (test-only reliability fix)

## Testing
- [x] E2E tests pass (target test verified 3/3 against cold dev server; failure reproduced pre-fix)
- [x] Manual testing completed
- [ ] Unit tests pass (no unit tests touched)
- [ ] New tests added (existing test modified, not added)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective (existing test modified; verified manually per above)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This is a scoped, single-test fix. The underlying "first route hit in a shard pays Next.js dev-server JIT compile cost" pattern is broader — several other tests across the week's CI logs show the same signature (assertion timeout on a URL/navigation check, recovers on retry) on their own first-hit routes (e.g. `/admin/*` pages, `/profile/edit`, `/friends`). A systemic fix (e.g. pre-warming key routes before the suite runs, or raising the default CI assertion timeout) would address that whole class, but is out of scope here — flagging for a possible follow-up.

Full flaky-test report (top 5, ranked by flake rate) available on request — this PR addresses only #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPGYhFPVovqEVQdQtvcdyj)_