### PR TITLE
fix(mobile): keyboard hiding chat composers on Android

### DIFF
--- a/mobile/app/admin/messages/[id].tsx
+++ b/mobile/app/admin/messages/[id].tsx
@@ -14,6 +14,10 @@ import {
   TextInput,
   View,
 } from "react-native";
+import Animated, {
+  useAnimatedKeyboard,
+  useAnimatedStyle,
+} from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { Brand, Colors, FontFamily } from "@/constants/theme";
@@ -157,6 +161,20 @@ export default function AdminConversationScreen() {
     [messages, colors]
   );
 
+  /* Android is edge-to-edge (Expo SDK 55+), so the window no longer resizes
+     for the keyboard and the iOS-only KeyboardAvoidingView padding never runs
+     there. Grow the composer's bottom padding with the live IME inset instead;
+     the flex layout shrinks the message list in step. */
+  const keyboard = useAnimatedKeyboard();
+  const composerLift = useAnimatedStyle(() => ({
+    paddingBottom:
+      insets.bottom +
+      8 +
+      (Platform.OS === "android"
+        ? Math.max(keyboard.height.value - insets.bottom, 0)
+        : 0),
+  }));
+
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === "ios" ? "padding" : undefined}
@@ -260,18 +278,21 @@ export default function AdminConversationScreen() {
           onContentSizeChange={() =>
             requestAnimationFrame(() => flatListRef.current?.scrollToEnd({ animated: false }))
           }
+          // Also pin on layout changes — the list resizes when the keyboard
+          // opens (composer padding grows), which would otherwise leave the
+          // newest messages hidden behind it.
+          onLayout={() =>
+            requestAnimationFrame(() => flatListRef.current?.scrollToEnd({ animated: false }))
+          }
         />
       )}
 
       {/* Composer */}
-      <View
+      <Animated.View
         style={[
           styles.composer,
-          {
-            backgroundColor: colors.card,
-            borderTopColor: rule,
-            paddingBottom: insets.bottom + 8,
-          },
+          { backgroundColor: colors.card, borderTopColor: rule },
+          composerLift,
         ]}
       >
         <View style={[styles.inputField, { backgroundColor: colors.surfaceSunk }]}>
@@ -315,7 +336,7 @@ export default function AdminConversationScreen() {
             />
           )}
         </Pressable>
-      </View>
+      </Animated.View>
     </KeyboardAvoidingView>
   );
 }

--- a/mobile/app/help/ai.tsx
+++ b/mobile/app/help/ai.tsx
@@ -593,22 +593,25 @@ export default function ChatScreen() {
   );
 
   /* ── Floating bar vertical position ──
-     KeyboardAvoidingView (behavior="padding") lifts the message list, but it
+     KeyboardAvoidingView (iOS-only padding) lifts the message list, but it
      CANNOT move the absolutely-positioned composer (padding doesn't shift an
-     absolute bottom-anchored child). On Android the window resizes so the
-     composer rides up on its own; on iOS we lift it manually with the keyboard
-     height via reanimated. */
+     absolute bottom-anchored child) — so the composer is lifted manually with
+     the keyboard height via reanimated. That now applies on Android too: the
+     edge-to-edge window (Expo SDK 55+) no longer resizes for the keyboard. */
   const floatingBottom = insets.bottom + 8;
   const keyboard = useAnimatedKeyboard();
   const keyboardLift = useAnimatedStyle(() => ({
     transform: [
-      {
-        translateY:
-          Platform.OS === "ios"
-            ? -Math.max(keyboard.height.value - insets.bottom, 0)
-            : 0,
-      },
+      { translateY: -Math.max(keyboard.height.value - insets.bottom, 0) },
     ],
+  }));
+  /* KeyboardAvoidingView pads only on iOS; on Android an animated spacer
+     shrinks the content area in step with the IME instead. */
+  const listKeyboardSpacer = useAnimatedStyle(() => ({
+    height:
+      Platform.OS === "android"
+        ? Math.max(keyboard.height.value - insets.bottom, 0)
+        : 0,
   }));
 
   /* ── Scroll tracking: show button when not at bottom and list is scrollable ── */
@@ -744,7 +747,7 @@ export default function ChatScreen() {
 
   return (
     <KeyboardAvoidingView
-      behavior="padding"
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
       keyboardVerticalOffset={0}
       style={[styles.container, { backgroundColor: paperTint.paper }]}
     >
@@ -861,6 +864,9 @@ export default function ChatScreen() {
           ListFooterComponentStyle={styles.listFooter}
         />
       )}
+
+      {/* Android: keeps the content clear of the keyboard (KAV is iOS-only) */}
+      <ReAnimated.View style={listKeyboardSpacer} pointerEvents="none" />
 
       {/* ── Floating scroll-to-bottom button ── */}
       {!showWelcome && showScrollToBottom && (

--- a/mobile/app/help/team.tsx
+++ b/mobile/app/help/team.tsx
@@ -251,19 +251,23 @@ export default function TeamThreadScreen() {
   );
 
   const floatingBottom = insets.bottom + 8;
-  /* iOS: lift the absolute composer above the keyboard (padding-based
-     KeyboardAvoidingView can't move an absolute child; Android resizes the
-     window so it rides up on its own). */
+  /* Lift the absolute composer above the keyboard on both platforms —
+     padding-based KeyboardAvoidingView can't move an absolute child, and on
+     Android the edge-to-edge window (Expo SDK 55+) no longer resizes for the
+     keyboard, so nothing rides up on its own. */
   const keyboard = useAnimatedKeyboard();
   const keyboardLift = useAnimatedStyle(() => ({
     transform: [
-      {
-        translateY:
-          Platform.OS === "ios"
-            ? -Math.max(keyboard.height.value - insets.bottom, 0)
-            : 0,
-      },
+      { translateY: -Math.max(keyboard.height.value - insets.bottom, 0) },
     ],
+  }));
+  /* KeyboardAvoidingView pads only on iOS; on Android an animated spacer
+     shrinks the message list in step with the IME instead. */
+  const listKeyboardSpacer = useAnimatedStyle(() => ({
+    height:
+      Platform.OS === "android"
+        ? Math.max(keyboard.height.value - insets.bottom, 0)
+        : 0,
   }));
 
   const useNativeGlass = isLiquidGlassAvailable();
@@ -319,7 +323,7 @@ export default function TeamThreadScreen() {
 
   return (
     <KeyboardAvoidingView
-      behavior="padding"
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
       keyboardVerticalOffset={0}
       style={[styles.container, { backgroundColor: paperTint.paper }]}
     >
@@ -395,6 +399,9 @@ export default function TeamThreadScreen() {
           }}
         />
       )}
+
+      {/* Android: keeps the list clear of the keyboard (KAV is iOS-only) */}
+      <ReAnimated.View style={listKeyboardSpacer} pointerEvents="none" />
 
       {/* Off-hours hint */}
       {hours && !hours.isOpenNow && (


### PR DESCRIPTION
# Pull Request

## Description
On Android, the message composer on the admin **Message volunteers** conversation screen was hidden behind the keyboard, making it impossible to see what you type.

**Root cause:** Android runs edge-to-edge as of Expo SDK 55 (`decorFitsSystemWindows=false`), so the OS no longer resizes the app window when the keyboard opens — `adjustResize` is effectively a no-op, and React Native core does not emulate it. The screen's `KeyboardAvoidingView` only applies `padding` behavior on iOS, so on Android nothing moved the composer. The volunteer-facing **EE Team** and **EE Assistant** chat screens had the same latent bug: their comments claimed "Android resizes the window so the composer rides up on its own", which is no longer true.

**Fix:** drive keyboard avoidance from reanimated's `useAnimatedKeyboard`, which reads the IME inset directly from `WindowInsetsAnimation` — deterministic, frame-synced with the keyboard animation, and JS-only (shippable via OTA update, no new native dependency):

- `admin/messages/[id]`: the composer's bottom padding now grows with the live keyboard inset on Android (the flex layout shrinks the message list in step), and the list re-pins to the newest message when its layout changes so messages aren't left hidden behind the keyboard.
- `help/team` + `help/ai`: the floating composer lift now applies on Android too (was iOS-only), and an animated spacer shrinks the content area in step with the IME. `KeyboardAvoidingView` is now explicitly iOS-only on these screens, so there is a single, unambiguous mechanism per platform.

iOS behavior is unchanged — the lift formula and KAV padding there are identical to before.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
`version:patch`

## Testing
- [x] Typecheck (`tsc --noEmit`) and ESLint pass on the changed files
- [ ] Manual testing completed — verification on an Android emulator (API 36) was set up but not completed in this session; worth a quick on-device check of all three chat screens (composer visible above keyboard, smooth lift, iOS unchanged)

## Additional Notes
- reanimated marks `useAnimatedKeyboard` as deprecated in favor of `react-native-keyboard-controller`. That would be a new native module (requires new store builds), so this fix intentionally sticks with the hook already used in the codebase; migrating is a possible follow-up.
- Other screens with iOS-only `KeyboardAvoidingView` (`register`, `profile/edit`, home sheet) share the underlying Android limitation but are scroll-form layouts with different fixes needed — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)