### PR TITLE
fix(mobile): show in-progress shifts in the app's shift list

### DIFF
--- a/web/src/app/api/mobile/shifts/route.test.ts
+++ b/web/src/app/api/mobile/shifts/route.test.ts
@@ -1,0 +1,150 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+vi.stubEnv("AUTH_SECRET", "test-secret");
+
+// Mock dependencies before importing the route
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    signup: { findMany: vi.fn() },
+    shift: { findMany: vi.fn() },
+    friendship: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/mobile-auth", () => ({
+  requireMobileUser: vi.fn(),
+}));
+
+vi.mock("@/lib/live-locations", () => ({
+  getLiveLocations: vi.fn().mockResolvedValue([]),
+}));
+
+import { GET } from "./route";
+import { requireMobileUser } from "@/lib/mobile-auth";
+import { prisma } from "@/lib/prisma";
+
+const mockRequireMobileUser = requireMobileUser as ReturnType<typeof vi.fn>;
+const mockPrisma = prisma as unknown as {
+  user: { findUnique: ReturnType<typeof vi.fn> };
+  signup: { findMany: ReturnType<typeof vi.fn> };
+  shift: { findMany: ReturnType<typeof vi.fn> };
+  friendship: { findMany: ReturnType<typeof vi.fn> };
+};
+
+// Freeze "now" so the in-progress window is deterministic.
+const NOW = new Date("2026-07-15T19:29:00Z");
+
+/** A shift the signed-up user is on: 5:30pm–9:30pm, currently in progress at NOW. */
+function makeSignup(
+  id: string,
+  start: Date,
+  end: Date,
+  status = "CONFIRMED"
+) {
+  return {
+    id: `signup-${id}`,
+    status,
+    shift: {
+      id: `shift-${id}`,
+      start,
+      end,
+      location: "Onehunga",
+      capacity: 10,
+      notes: null,
+      shiftType: {
+        id: "st-1",
+        name: "Kitchen Service & Pack Down",
+        description: "Evening service",
+      },
+      _count: { signups: 3, placeholders: 0 },
+    },
+  };
+}
+
+function makeRequest() {
+  return new Request("http://localhost/api/mobile/shifts", {
+    method: "GET",
+    headers: { Authorization: "Bearer valid-token" },
+  });
+}
+
+describe("GET /api/mobile/shifts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    mockRequireMobileUser.mockResolvedValue({
+      user: { id: "user-1" },
+      userId: "user-1",
+    });
+    mockPrisma.user.findUnique.mockResolvedValue({ defaultLocation: "Onehunga" });
+    mockPrisma.shift.findMany.mockResolvedValue([]); // no available shifts
+    mockPrisma.friendship.findMany.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("includes an in-progress shift (started but not yet ended) in myShifts", async () => {
+    // Shift started at 5:30pm, ends 9:30pm; NOW (7:29pm) is mid-shift.
+    const inProgress = makeSignup(
+      "in-progress",
+      new Date("2026-07-15T17:30:00Z"),
+      new Date("2026-07-15T21:30:00Z")
+    );
+
+    mockPrisma.signup.findMany.mockImplementation((args?: { where?: Record<string, unknown> }) => {
+      const where = (args?.where ?? {}) as {
+        status?: { in?: string[] };
+        shift?: { end?: { lt?: Date } };
+        shiftId?: unknown;
+      };
+      // visibleSignups (friends) query: filters by shiftId
+      if (where.shiftId) {
+        return Promise.resolve([]);
+      }
+      // pastSignups query: filters on shift.end < now
+      if (where.shift?.end?.lt) {
+        return Promise.resolve([]);
+      }
+      // mySignups query: active statuses include PENDING, keyed on end >= now
+      if (where.status?.in?.includes("PENDING")) {
+        return Promise.resolve([inProgress]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(200);
+
+    const json = await response.json();
+    expect(json.myShifts).toHaveLength(1);
+    expect(json.myShifts[0].id).toBe("shift-in-progress");
+    expect(json.past).toHaveLength(0);
+  });
+
+  it("buckets myShifts by shift.end >= now, not shift.start", async () => {
+    mockPrisma.signup.findMany.mockResolvedValue([]);
+
+    await GET(makeRequest());
+
+    // The first signup.findMany call is the myShifts query.
+    const myShiftsCall = mockPrisma.signup.findMany.mock.calls.find(
+      (call) => call[0]?.where?.status?.in?.includes("PENDING")
+    );
+    expect(myShiftsCall).toBeDefined();
+    // Regression guard: must filter on end (keeps in-progress shifts), not start.
+    expect(myShiftsCall![0].where.shift).toEqual({ end: { gte: NOW } });
+    expect(myShiftsCall![0].where.shift.start).toBeUndefined();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireMobileUser.mockResolvedValue(null);
+
+    const response = await GET(makeRequest());
+    expect(response.status).toBe(401);
+  });
+});

--- a/web/src/app/api/mobile/shifts/route.ts
+++ b/web/src/app/api/mobile/shifts/route.ts
@@ -51,12 +51,16 @@ export async function GET(request: Request) {
   // Active signup statuses (not canceled/no-show/etc)
   const activeStatuses = ["CONFIRMED", "PENDING", "WAITLISTED", "REGULAR_PENDING"] as const;
 
-  // Fetch upcoming shifts the user is signed up for (always all — typically small)
+  // Fetch upcoming shifts the user is signed up for (always all — typically small).
+  // Bucket by `end >= now` (not `start`) so a shift that is currently in progress
+  // (started but not yet ended) still appears in the user's shifts. This mirrors the
+  // `past` query below (`end < now`), so every signup falls into exactly one bucket
+  // with no gap — otherwise an in-progress confirmed shift vanishes from the app.
   const mySignups = await prisma.signup.findMany({
     where: {
       userId,
       status: { in: [...activeStatuses] },
-      shift: { start: { gte: now } },
+      shift: { end: { gte: now } },
     },
     include: {
       shift: {


### PR DESCRIPTION
## Problem

A volunteer reported (via Nic) that a confirmed shift showed up on the **web** platform and in their **confirmation email**, but was **missing from the mobile app**.

## Root cause

The mobile shifts endpoint (`web/src/app/api/mobile/shifts/route.ts`) builds the app's entire shift view from two **disjoint** queries:

- `myShifts`: `shift.start >= now` — only shifts that haven't *started*
- `past`: `shift.end < now` — only shifts that have *ended*

A shift that has **started but not yet ended** (in progress right now) matches **neither** bucket, so it disappears from the app entirely. The web "My Shifts" list is an unfiltered per-month query, so it keeps rendering the in-progress shift — which is exactly the web-vs-mobile discrepancy.

The bug report screenshots confirm it: at ~7:29 PM, the Onehunga "Kitchen Service & Pack Down" shift (5:30–9:30 PM, Confirmed) is mid-shift, and the app skips straight to "Your next shift **In 6 days**" (July 21). The shift would reappear on its own once it ended (falling into `past`), which is why these reports are intermittent.

## Fix

Bucket `myShifts` by `end >= now` instead of `start >= now`:

```diff
-      shift: { start: { gte: now } },
+      shift: { end: { gte: now } },
```

"Upcoming" now means "not yet finished" (correctly including in-progress shifts) and cleanly complements the `past` query's `end < now` — every signup falls into exactly one bucket with no gap. The in-progress shift also sorts first, so it correctly becomes "Your next shift" while it's happening.

The `available` (browse) query still uses `start >= now` — you can't sign up for a shift already underway — so it's intentionally left unchanged.

## Testing

- Added `web/src/app/api/mobile/shifts/route.test.ts`:
  - regression guard asserting the `myShifts` query keys on `end >= now` (not `start`)
  - a test that an in-progress shift appears in `myShifts`
- Verified the guard bites: reverting to `start >= now` fails the suite; the fix passes it.
- `npm run typecheck` and `eslint` both clean.

## Reviewer notes

Out of scope but worth flagging: the web's **stat count tiles** (`my-shifts-content.tsx` "Upcoming"/"Completed") have the same `start`/`end` gap, so an in-progress shift is momentarily counted in neither. Cosmetic and separate — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)