### PR TITLE
fix: load newly created locations immediately on create-shift page

### DIFF
--- a/web/src/app/admin/analytics/coverage/page.tsx
+++ b/web/src/app/admin/analytics/coverage/page.tsx
@@ -4,7 +4,7 @@ import { authOptions } from "@/lib/auth-options";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { CoverageAnalyticsClient } from "./coverage-analytics-client";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 import { getShiftCoverage } from "@/lib/shift-coverage";
 import { parseDaysParam } from "@/lib/parse-days-param";
 
@@ -32,7 +32,7 @@ export default async function CoverageAnalyticsPage({
 
   const data = await getShiftCoverage(parseInt(months, 10), location, daysFilter);
 
-  const locationOptions = LOCATIONS.map((loc) => ({
+  const locationOptions = (await getActiveLocationNames()).map((loc) => ({
     value: loc,
     label: loc,
   }));

--- a/web/src/app/admin/analytics/engagement/page.tsx
+++ b/web/src/app/admin/analytics/engagement/page.tsx
@@ -4,7 +4,7 @@ import { authOptions } from "@/lib/auth-options";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { EngagementAnalyticsClient } from "./engagement-analytics-client";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 import { getEngagementSummary, getEngagementVolunteers, getEngagementByShiftType, getRetentionHeatmap } from "@/lib/engagement";
 import { parseDaysParam } from "@/lib/parse-days-param";
 
@@ -57,7 +57,7 @@ export default async function EngagementAnalyticsPage({
     getRetentionHeatmap(location, daysFilter),
   ]);
 
-  const locationOptions = LOCATIONS.map((loc) => ({
+  const locationOptions = (await getActiveLocationNames()).map((loc) => ({
     value: loc,
     label: loc,
   }));

--- a/web/src/app/admin/analytics/milestones/page.tsx
+++ b/web/src/app/admin/analytics/milestones/page.tsx
@@ -4,7 +4,7 @@ import { authOptions } from "@/lib/auth-options";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { MilestoneAnalyticsClient } from "./milestone-analytics-client";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 import { getMilestoneData } from "@/lib/milestone-analytics";
 
 export default async function MilestoneAnalyticsPage({
@@ -28,7 +28,7 @@ export default async function MilestoneAnalyticsPage({
 
   const data = await getMilestoneData(parseInt(months, 10), location);
 
-  const locationOptions = LOCATIONS.map((loc) => ({
+  const locationOptions = (await getActiveLocationNames()).map((loc) => ({
     value: loc,
     label: loc,
   }));

--- a/web/src/app/admin/analytics/page.tsx
+++ b/web/src/app/admin/analytics/page.tsx
@@ -4,7 +4,7 @@ import { authOptions } from "@/lib/auth-options";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { AnalyticsDashboard } from "./_components/analytics-dashboard";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 import { prisma } from "@/lib/prisma";
 import { getRestaurantAnalytics } from "@/lib/restaurant-analytics";
 import { getRestaurantReports } from "@/lib/restaurant-reports";
@@ -65,7 +65,10 @@ export default async function AnalyticsPage({
       select: { location: true },
     })
   ).map((l) => l.location);
-  const locationOptions = Array.from(new Set([...LOCATIONS, ...dataLocations]))
+  const activeLocationNames = await getActiveLocationNames();
+  const locationOptions = Array.from(
+    new Set([...activeLocationNames, ...dataLocations])
+  )
     .sort((a, b) => a.localeCompare(b))
     .map((loc) => ({ value: loc, label: loc }));
 

--- a/web/src/app/admin/analytics/recruitment/page.tsx
+++ b/web/src/app/admin/analytics/recruitment/page.tsx
@@ -4,7 +4,7 @@ import { authOptions } from "@/lib/auth-options";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { RecruitmentAnalyticsClient } from "./recruitment-analytics-client";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 import { getRecruitmentData } from "@/lib/recruitment";
 
 export default async function RecruitmentAnalyticsPage({
@@ -28,7 +28,7 @@ export default async function RecruitmentAnalyticsPage({
 
   const data = await getRecruitmentData(parseInt(months, 10), location);
 
-  const locationOptions = LOCATIONS.map((loc) => ({
+  const locationOptions = (await getActiveLocationNames()).map((loc) => ({
     value: loc,
     label: loc,
   }));

--- a/web/src/app/admin/analytics/shortage-notifications/page.tsx
+++ b/web/src/app/admin/analytics/shortage-notifications/page.tsx
@@ -4,7 +4,7 @@ import { authOptions } from "@/lib/auth-options";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { PageContainer } from "@/components/page-container";
 import { ShortageNotificationsAnalyticsClient } from "./shortage-notifications-analytics-client";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 import {
   getShortageNotificationAnalytics,
   getShortageConverters,
@@ -38,7 +38,7 @@ export default async function ShortageNotificationsAnalyticsPage({
     getShortageConverters(monthsNum, location),
   ]);
 
-  const locationOptions = LOCATIONS.map((loc) => ({
+  const locationOptions = (await getActiveLocationNames()).map((loc) => ({
     value: loc,
     label: loc,
   }));

--- a/web/src/app/admin/auto-accept-rules/page.tsx
+++ b/web/src/app/admin/auto-accept-rules/page.tsx
@@ -1,6 +1,7 @@
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 import AutoAcceptRulesClient from "./auto-accept-rules-client";
 
 export default async function NotificationsPage() {
-  return <AutoAcceptRulesClient locations={LOCATIONS} />;
+  const locations = await getActiveLocationNames();
+  return <AutoAcceptRulesClient locations={locations} />;
 }

--- a/web/src/app/admin/notifications/page.tsx
+++ b/web/src/app/admin/notifications/page.tsx
@@ -3,7 +3,7 @@ import { connection } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { NotificationsContent } from "./notifications-content";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 
 export const metadata: Metadata = {
   title: "Shift Shortage Notifications | Admin",
@@ -24,13 +24,15 @@ export default async function NotificationsPage() {
     },
   });
 
+  const locations = await getActiveLocationNames();
+
   return (
     <AdminPageWrapper
       title="Shift Shortage Notifications"
       description="Send shift shortage notifications to volunteers"
     >
       <div className="container mx-auto py-8 px-4">
-        <NotificationsContent shiftTypes={shiftTypes} locations={LOCATIONS} />
+        <NotificationsContent shiftTypes={shiftTypes} locations={locations} />
       </div>
     </AdminPageWrapper>
   );

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { LocationFilterTabs } from "@/components/location-filter-tabs";
-import { LOCATIONS, LocationOption } from "@/lib/locations";
+import { getActiveLocationNames, LocationOption } from "@/lib/locations";
 import { AdminDashboardContent } from "./admin-dashboard-content";
 import { AdminDashboardContentSkeleton } from "./loading";
 import type { Metadata } from "next";
@@ -33,6 +33,8 @@ export default async function AdminDashboardPage({
   }
 
   const params = await searchParams;
+
+  const LOCATIONS = await getActiveLocationNames();
 
   // Normalize and validate selected location
   const rawLocation = Array.isArray(params.location)

--- a/web/src/app/admin/regulars/page.tsx
+++ b/web/src/app/admin/regulars/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import { StarIcon, PauseIcon, CalendarIcon } from "lucide-react";
 import { RegularsTable } from "./regulars-table";
 import { RegularVolunteerForm } from "./regular-volunteer-form";
-import { LOCATIONS, LocationOption } from "@/lib/locations";
+import { getActiveLocationNames, LocationOption } from "@/lib/locations";
 
 interface RegularVolunteersPageProps {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -25,6 +25,8 @@ export default async function RegularVolunteersPage({
   if (role !== "ADMIN") redirect("/dashboard");
 
   const params = await searchParams;
+
+  const LOCATIONS = await getActiveLocationNames();
 
   // Normalize and validate selected location
   const rawLocation = Array.isArray(params.location)

--- a/web/src/app/admin/restaurant-managers/page.tsx
+++ b/web/src/app/admin/restaurant-managers/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { RestaurantManagersContent } from "./restaurant-managers-content";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { prisma } from "@/lib/prisma";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 
 export default async function RestaurantManagersPage() {
   const session = await getServerSession(authOptions);
@@ -36,7 +36,7 @@ export default async function RestaurantManagersPage() {
   });
 
   // Get available locations
-  const locations = LOCATIONS.map(location => ({
+  const locations = (await getActiveLocationNames()).map(location => ({
     value: location,
     label: location,
   }));

--- a/web/src/app/admin/shifts/new/page.tsx
+++ b/web/src/app/admin/shifts/new/page.tsx
@@ -24,7 +24,7 @@ import {
   nowInNZT,
   toUTC,
 } from "@/lib/timezone";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 import { createShiftRecord } from "@/lib/services/shift-service";
 import { createRegularVolunteerSignups } from "@/lib/regular-volunteer-utils";
 
@@ -43,9 +43,10 @@ export default async function NewShiftPage({
     : "bulk";
   const session = await getServerSession(authOptions);
   const role = session?.user?.role;
-  const sortedLocations = LOCATIONS;
   if (!session?.user) redirect("/login?callbackUrl=/admin/shifts/new");
   if (role !== "ADMIN") redirect("/shifts");
+
+  const sortedLocations = await getActiveLocationNames();
 
   async function createShift(formData: FormData) {
     "use server";

--- a/web/src/app/admin/shifts/page.tsx
+++ b/web/src/app/admin/shifts/page.tsx
@@ -18,7 +18,11 @@ import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { ShiftLocationSelector } from "@/components/shift-location-selector";
 import { ShiftCalendarWrapper } from "@/components/shift-calendar-wrapper";
 import { ShiftsByTimeOfDay } from "@/components/shifts-by-time-of-day";
-import { LocationOption, DEFAULT_LOCATION, LOCATIONS } from "@/lib/locations";
+import {
+  LocationOption,
+  DEFAULT_LOCATION,
+  getActiveLocationNames,
+} from "@/lib/locations";
 import { MealsServedInput } from "@/components/meals-served-input";
 import { DeleteShiftsMenu } from "@/components/delete-shifts-menu";
 
@@ -36,6 +40,8 @@ export default async function AdminShiftsPage({
   }
 
   const params = await searchParams;
+
+  const LOCATIONS = await getActiveLocationNames();
 
   // Parse search parameters (handle dates consistently in NZ timezone)
   const today = formatInNZT(new Date(), "yyyy-MM-dd");

--- a/web/src/app/admin/volunteers/[id]/page.tsx
+++ b/web/src/app/admin/volunteers/[id]/page.tsx
@@ -45,7 +45,7 @@ import { UserRoleToggle } from "@/components/user-role-toggle";
 import { AdminNotesManager } from "@/components/admin-notes-manager";
 import { UserCustomLabelsManager } from "@/components/user-custom-labels-manager";
 import { type VolunteerGrade } from "@/generated/client";
-import { LOCATIONS, LocationOption } from "@/lib/locations";
+import { getActiveLocationNames, LocationOption } from "@/lib/locations";
 import { ImpersonateUserButton } from "@/components/impersonate-user-button";
 import { MessageVolunteerButton } from "@/components/admin/messages/message-volunteer-button";
 import { AdminContactInfoSection } from "@/components/admin-contact-info-section";
@@ -86,6 +86,8 @@ export default async function AdminVolunteerPage({
 
   const { id } = await params;
   const searchParamsResolved = await searchParams;
+
+  const LOCATIONS = await getActiveLocationNames();
 
   // Get location filter from search params
   const rawLocation = Array.isArray(searchParamsResolved.location)

--- a/web/src/app/api/admin/regulars/[id]/route.ts
+++ b/web/src/app/api/admin/regulars/[id]/route.ts
@@ -3,12 +3,14 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
-import { LocationSchema } from "@/lib/validation-schemas";
+import { createLocationEnum } from "@/lib/validation-schemas";
 
-// Validation schema for updating a regular volunteer
-const updateRegularVolunteerSchema = z.object({
+// Validation schema for updating a regular volunteer. Built per-request via a
+// factory so the location enum reflects the currently active locations.
+const buildUpdateRegularVolunteerSchema = (location: z.ZodType<string>) =>
+  z.object({
   shiftTypeId: z.string().optional(),
-  location: LocationSchema.optional(),
+  location: location.optional(),
   frequency: z.enum(["WEEKLY", "FORTNIGHTLY", "MONTHLY"]).optional(),
   availableDays: z
     .array(
@@ -102,6 +104,9 @@ export async function PUT(
 
     const { id } = await params;
     const body = await req.json();
+    const updateRegularVolunteerSchema = buildUpdateRegularVolunteerSchema(
+      await createLocationEnum()
+    );
     const validated = updateRegularVolunteerSchema.parse(body);
 
     // Check if regular volunteer exists

--- a/web/src/app/api/admin/regulars/route.ts
+++ b/web/src/app/api/admin/regulars/route.ts
@@ -3,15 +3,17 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
-import { LocationSchema } from "@/lib/validation-schemas";
+import { createLocationEnum } from "@/lib/validation-schemas";
 import { formatInNZT } from "@/lib/timezone";
 import { createRegularVolunteerSignups } from "@/lib/regular-volunteer-utils";
 
-// Validation schema for creating a regular volunteer
-const createRegularVolunteerSchema = z.object({
+// Validation schema for creating a regular volunteer. Built per-request via a
+// factory so the location enum reflects the currently active locations.
+const buildCreateRegularVolunteerSchema = (location: z.ZodType<string>) =>
+  z.object({
   userId: z.string(),
   shiftTypeId: z.string(),
-  location: LocationSchema,
+  location,
   frequency: z.enum(["WEEKLY", "FORTNIGHTLY", "MONTHLY"]),
   availableDays: z.array(
     z.enum([
@@ -129,6 +131,9 @@ export async function POST(req: NextRequest) {
 
     const body = await req.json();
     console.log("Creating regular volunteer with data:", body);
+    const createRegularVolunteerSchema = buildCreateRegularVolunteerSchema(
+      await createLocationEnum()
+    );
     const validated = createRegularVolunteerSchema.parse(body);
 
     // Check if user already has a regular volunteer record for this shift type

--- a/web/src/app/api/admin/shifts/[id]/assign/route.ts
+++ b/web/src/app/api/admin/shifts/[id]/assign/route.ts
@@ -5,7 +5,7 @@ import { authOptions } from "@/lib/auth-options";
 import { createShiftConfirmedNotification } from "@/lib/notifications";
 import { getEmailService } from "@/lib/email-service";
 import { formatInNZT } from "@/lib/timezone";
-import { LOCATION_ADDRESSES } from "@/lib/locations";
+import { getLocationAddresses } from "@/lib/locations";
 import { isFirstConfirmedShift } from "@/lib/shift-helpers";
 import { isAMShift, getShiftDate } from "@/lib/concurrent-shifts";
 
@@ -204,9 +204,9 @@ export async function POST(
         shift.end,
         "h:mm a"
       )}`;
+      const locationAddresses = await getLocationAddresses();
       const fullAddress = shift.location
-        ? LOCATION_ADDRESSES[shift.location as keyof typeof LOCATION_ADDRESSES] ||
-          shift.location
+        ? locationAddresses[shift.location] || shift.location
         : "TBD";
 
       Promise.race([

--- a/web/src/app/api/shifts/[id]/calendar/route.ts
+++ b/web/src/app/api/shifts/[id]/calendar/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { generateICSContent } from "@/lib/calendar-utils";
+import { getLocationAddresses } from "@/lib/locations";
 
 /**
  * Public API endpoint to download ICS calendar file for a shift
@@ -25,18 +26,22 @@ export async function GET(
       return NextResponse.json({ error: "Shift not found" }, { status: 404 });
     }
 
-    // Generate ICS content
-    const icsContent = generateICSContent({
-      id: shift.id,
-      start: shift.start,
-      end: shift.end,
-      location: shift.location,
-      notes: shift.notes,
-      shiftType: {
-        name: shift.shiftType.name,
-        description: shift.shiftType.description,
+    // Generate ICS content (addresses fetched fresh so newly created
+    // locations resolve without a server restart)
+    const icsContent = generateICSContent(
+      {
+        id: shift.id,
+        start: shift.start,
+        end: shift.end,
+        location: shift.location,
+        notes: shift.notes,
+        shiftType: {
+          name: shift.shiftType.name,
+          description: shift.shiftType.description,
+        },
       },
-    });
+      await getLocationAddresses()
+    );
 
     // Return ICS file with proper headers
     return new NextResponse(icsContent, {

--- a/web/src/app/shifts/[id]/page.tsx
+++ b/web/src/app/shifts/[id]/page.tsx
@@ -27,7 +27,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { ProfileCompletionBannerServer } from "@/components/profile-completion-banner-server";
 import { generateCalendarUrls } from "@/lib/calendar-utils";
 import { getShiftDescription } from "@/lib/shift-description";
-import { LOCATION_ADDRESSES, type Location } from "@/lib/locations";
+import { getLocationAddresses, type Location } from "@/lib/locations";
 import { ShiftSignupButton } from "@/components/shift-signup-button";
 import { ShareShiftButton } from "@/components/share-shift-button";
 import { getShiftTheme } from "@/lib/shift-themes";
@@ -144,6 +144,8 @@ export default async function ShiftDetailPage({
   if (!shift) {
     notFound();
   }
+
+  const locationAddresses = await getLocationAddresses();
 
   // Parallelize all remaining queries
   const [friendships, userSignup, currentUser, concurrentShifts, cmsEvents] =
@@ -489,7 +491,7 @@ export default async function ShiftDetailPage({
                   <a
                     href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
                       `Everybody Eats ${
-                        LOCATION_ADDRESSES[shift.location as Location] ||
+                        locationAddresses[shift.location as Location] ||
                         shift.location
                       }`
                     )}`}
@@ -498,7 +500,7 @@ export default async function ShiftDetailPage({
                     className="text-sm text-muted-foreground hover:text-primary transition-colors inline-flex items-center gap-1"
                   >
                     <MapPin className="h-3.5 w-3.5" />
-                    {LOCATION_ADDRESSES[shift.location as Location] ||
+                    {locationAddresses[shift.location as Location] ||
                       shift.location}
                   </a>
                 </div>
@@ -506,7 +508,7 @@ export default async function ShiftDetailPage({
                   <a
                     href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
                       `Everybody Eats ${
-                        LOCATION_ADDRESSES[shift.location as Location] ||
+                        locationAddresses[shift.location as Location] ||
                         shift.location
                       }`
                     )}`}
@@ -527,7 +529,7 @@ export default async function ShiftDetailPage({
                   referrerPolicy="no-referrer-when-downgrade"
                   src={`https://maps.google.com/maps?q=${encodeURIComponent(
                     `Everybody Eats ${
-                      LOCATION_ADDRESSES[shift.location as Location] ||
+                      locationAddresses[shift.location as Location] ||
                       shift.location
                     }`
                   )}&t=&z=15&ie=UTF8&iwloc=&output=embed`}
@@ -620,7 +622,7 @@ export default async function ShiftDetailPage({
                 </div>
                 <div className="flex gap-2 flex-wrap">
                   {(() => {
-                    const urls = generateCalendarUrls(shift);
+                    const urls = generateCalendarUrls(shift, locationAddresses);
                     return (
                       <>
                         <Button variant="outline" size="sm" className="gap-1.5" asChild>
@@ -676,6 +678,9 @@ export default async function ShiftDetailPage({
                   startDate: new Date(shift.start),
                   endDate: new Date(shift.end),
                   location: shift.location,
+                  locationAddress: shift.location
+                    ? locationAddresses[shift.location]
+                    : undefined,
                   capacity: shift.capacity,
                   spotsAvailable: spotsRemaining,
                 })

--- a/web/src/app/shifts/details/page.tsx
+++ b/web/src/app/shifts/details/page.tsx
@@ -16,11 +16,7 @@ import { ShiftDetailsContent } from "./shift-details-content";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  LOCATION_ADDRESSES,
-  Location,
-  getLocationMapsUrl,
-} from "@/lib/locations";
+import { getLocationAddresses, getGoogleMapsUrl } from "@/lib/locations";
 import type { Metadata } from "next";
 import { buildPageMetadata } from "@/lib/seo";
 import { getBaseUrl } from "@/lib/utils";
@@ -148,6 +144,15 @@ export default async function ShiftDetailsPage({
     ? decodeURIComponent(locationParam)
     : undefined;
 
+  // Resolve the address fresh so a newly created location shows immediately.
+  const locationAddresses = await getLocationAddresses();
+  const selectedLocationAddress = selectedLocation
+    ? locationAddresses[selectedLocation]
+    : undefined;
+  const selectedLocationMapsUrl = selectedLocationAddress
+    ? getGoogleMapsUrl(selectedLocationAddress)
+    : undefined;
+
   const previousDate = subDays(selectedDate, 1);
   const nextDate = addDays(selectedDate, 1);
   const previousDateParam = formatInNZT(previousDate, "yyyy-MM-dd");
@@ -232,16 +237,16 @@ export default async function ShiftDetailsPage({
                   {selectedLocation}
                 </span>
               </div>
-              {LOCATION_ADDRESSES[selectedLocation as unknown as Location] && (
+              {selectedLocationAddress && (
                 <div className="flex items-start gap-2 text-sm text-muted-foreground pl-6">
                   <a
-                    href={getLocationMapsUrl(selectedLocation as Location)}
+                    href={selectedLocationMapsUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     data-testid="restaurant-address"
                     className="text-left hover:text-primary hover:underline"
                   >
-                    {LOCATION_ADDRESSES[selectedLocation as Location]}
+                    {selectedLocationAddress}
                   </a>
                 </div>
               )}

--- a/web/src/app/shifts/mine/shift-details-dialog.tsx
+++ b/web/src/app/shifts/mine/shift-details-dialog.tsx
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { formatInNZT, getStartOfDayUTC } from "@/lib/timezone";
 import { differenceInHours } from "date-fns";
 import { generateCalendarUrls } from "@/lib/calendar-utils";
+import { getLocationAddresses } from "@/lib/locations";
 import { Button } from "@/components/ui/button";
 import { AvatarList } from "@/components/ui/avatar-list";
 import {
@@ -28,6 +29,7 @@ export async function ShiftDetailsDialog({
 }) {
   const theme = getShiftTheme(shift.shift.shiftType.name);
   const isPastShift = shift.shift.end < now;
+  const locationAddresses = await getLocationAddresses();
 
   // Fetch meals served for this shift's date and location
   let mealsServedData = null;
@@ -178,7 +180,10 @@ export async function ShiftDetailsDialog({
                 </div>
                 <div className="flex gap-2 flex-wrap">
                   {(() => {
-                    const urls = generateCalendarUrls(shift.shift);
+                    const urls = generateCalendarUrls(
+                      shift.shift,
+                      locationAddresses
+                    );
                     return (
                       <>
                         <Button

--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -462,6 +462,9 @@ export default async function ShiftsCalendarPage({
       startDate: shift.start,
       endDate: shift.end,
       location: shift.location,
+      locationAddress: shift.location
+        ? addressByName.get(shift.location) ?? undefined
+        : undefined,
       capacity: shift.capacity,
       spotsAvailable:
         shift.capacity -

--- a/web/src/components/dashboard-next-shift.tsx
+++ b/web/src/components/dashboard-next-shift.tsx
@@ -8,7 +8,7 @@ import { MotionContentCard } from "@/components/motion-content-card";
 import { AvatarList } from "@/components/ui/avatar-list";
 import { Clock, Calendar, MapPin, CalendarPlus } from "lucide-react";
 import Link from "next/link";
-import { LOCATION_ADDRESSES, type Location } from "@/lib/locations";
+import { getLocationAddresses, type Location } from "@/lib/locations";
 import { generateCalendarUrls } from "@/lib/calendar-utils";
 
 interface DashboardNextShiftProps {
@@ -17,6 +17,7 @@ interface DashboardNextShiftProps {
 
 export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
   const now = new Date();
+  const locationAddresses = await getLocationAddresses();
 
   // Get user's friend IDs
   const friendships = await prisma.friendship.findMany({
@@ -109,7 +110,7 @@ export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
                 {nextShift.shift.location && (
                   <a
                     href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
-                      `Everybody Eats ${LOCATION_ADDRESSES[nextShift.shift.location as Location] || nextShift.shift.location}`
+                      `Everybody Eats ${locationAddresses[nextShift.shift.location as Location] || nextShift.shift.location}`
                     )}`}
                     target="_blank"
                     rel="noopener noreferrer"
@@ -117,7 +118,7 @@ export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
                     data-testid="shift-location-link"
                   >
                     <MapPin className="w-4 h-4" />
-                    {LOCATION_ADDRESSES[
+                    {locationAddresses[
                       nextShift.shift.location as Location
                     ]?.replace(", New Zealand", "") || nextShift.shift.location}
                   </a>
@@ -177,7 +178,10 @@ export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
               </div>
               <div className="flex gap-2 flex-wrap">
                 {(() => {
-                  const urls = generateCalendarUrls(nextShift.shift);
+                  const urls = generateCalendarUrls(
+                    nextShift.shift,
+                    locationAddresses
+                  );
                   return (
                     <>
                       <Button

--- a/web/src/lib/calendar-utils.ts
+++ b/web/src/lib/calendar-utils.ts
@@ -1,11 +1,18 @@
 import { formatInNZT } from "./timezone";
-import { LOCATION_ADDRESSES } from "./locations";
 import { getBaseUrl } from "./utils";
 import { getShiftDescription } from "./shift-description";
 
 /**
  * Calendar utilities for generating calendar links for shifts
  */
+
+/**
+ * Map of location name -> street address. Passed in by callers (from
+ * `getLocationAddresses()`) rather than read from a module-level snapshot, so
+ * newly created locations resolve immediately. Unknown locations fall back to
+ * their raw name.
+ */
+export type LocationAddressMap = Record<string, string>;
 
 interface ShiftCalendarData {
   id: string;
@@ -36,13 +43,13 @@ function escapeICSText(text: string): string {
  */
 function getFullAddress(
   location: string | null,
+  addresses: LocationAddressMap,
   escapeForICS: boolean = false
 ): string {
   if (!location || location === "TBD") {
     return "TBD";
   }
-  const address =
-    LOCATION_ADDRESSES[location as keyof typeof LOCATION_ADDRESSES] || location;
+  const address = addresses[location] || location;
   const fullAddress = `Everybody Eats, ${address}`;
   return escapeForICS ? escapeICSText(fullAddress) : fullAddress;
 }
@@ -54,10 +61,11 @@ function getFullAddress(
  */
 function buildCalendarDescription(
   shift: ShiftCalendarData,
+  addresses: LocationAddressMap,
   format: "ics" | "url" = "url"
 ): string {
   const shiftDetailsLink = `${getBaseUrl()}/shifts/${shift.id}`;
-  const fullAddress = getFullAddress(shift.location, false); // Don't escape yet
+  const fullAddress = getFullAddress(shift.location, addresses, false); // Don't escape yet
   const shiftDescription =
     getShiftDescription(shift.notes, shift.shiftType.description) || "";
 
@@ -88,7 +96,10 @@ export interface CalendarData {
  * Generate calendar URLs for Google Calendar, Outlook, and ICS file download
  * Times are formatted in NZ timezone (Pacific/Auckland)
  */
-export function generateCalendarUrls(shift: ShiftCalendarData): CalendarUrls {
+export function generateCalendarUrls(
+  shift: ShiftCalendarData,
+  addresses: LocationAddressMap = {}
+): CalendarUrls {
   // Format dates in NZ timezone for calendar exports
   const startDate = formatInNZT(shift.start, "yyyyMMdd'T'HHmmss");
   const endDate = formatInNZT(shift.end, "yyyyMMdd'T'HHmmss");
@@ -98,11 +109,13 @@ export function generateCalendarUrls(shift: ShiftCalendarData): CalendarUrls {
   const outlookEndDate = formatInNZT(shift.end, "yyyy-MM-dd'T'HH:mm:ss");
 
   const title = encodeURIComponent(`Everybody Eats - ${shift.shiftType.name}`);
-  const description = encodeURIComponent(buildCalendarDescription(shift));
-  const location = encodeURIComponent(getFullAddress(shift.location));
+  const description = encodeURIComponent(
+    buildCalendarDescription(shift, addresses)
+  );
+  const location = encodeURIComponent(getFullAddress(shift.location, addresses));
 
   // Generate ICS content using the shared function
-  const icsContent = generateICSContent(shift);
+  const icsContent = generateICSContent(shift, addresses);
   const icsDataUrl = `data:text/calendar;charset=utf8,${encodeURIComponent(
     icsContent
   )}`;
@@ -118,12 +131,15 @@ export function generateCalendarUrls(shift: ShiftCalendarData): CalendarUrls {
  * Generate raw ICS file content (not a data URL) for email attachments
  * Times are formatted in NZ timezone (Pacific/Auckland)
  */
-export function generateICSContent(shift: ShiftCalendarData): string {
+export function generateICSContent(
+  shift: ShiftCalendarData,
+  addresses: LocationAddressMap = {}
+): string {
   const startDate = formatInNZT(shift.start, "yyyyMMdd'T'HHmmss");
   const endDate = formatInNZT(shift.end, "yyyyMMdd'T'HHmmss");
   const title = `Everybody Eats - ${shift.shiftType.name}`;
-  const description = buildCalendarDescription(shift, "ics");
-  const location = getFullAddress(shift.location, true); // Escape for ICS format
+  const description = buildCalendarDescription(shift, addresses, "ics");
+  const location = getFullAddress(shift.location, addresses, true); // Escape for ICS format
 
   return `BEGIN:VCALENDAR
 VERSION:2.0
@@ -161,7 +177,10 @@ END:VCALENDAR`;
  * Generate calendar data with ICS content for email attachments
  * Times are formatted in NZ timezone (Pacific/Auckland)
  */
-export function generateCalendarData(shift: ShiftCalendarData): CalendarData {
+export function generateCalendarData(
+  shift: ShiftCalendarData,
+  addresses: LocationAddressMap = {}
+): CalendarData {
   const startDate = formatInNZT(shift.start, "yyyyMMdd'T'HHmmss");
   const endDate = formatInNZT(shift.end, "yyyyMMdd'T'HHmmss");
 
@@ -170,33 +189,40 @@ export function generateCalendarData(shift: ShiftCalendarData): CalendarData {
   const outlookEndDate = formatInNZT(shift.end, "yyyy-MM-dd'T'HH:mm:ss");
 
   const title = encodeURIComponent(`Everybody Eats - ${shift.shiftType.name}`);
-  const description = encodeURIComponent(buildCalendarDescription(shift));
-  const location = encodeURIComponent(getFullAddress(shift.location));
+  const description = encodeURIComponent(
+    buildCalendarDescription(shift, addresses)
+  );
+  const location = encodeURIComponent(getFullAddress(shift.location, addresses));
 
   return {
     google: `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${title}&dates=${startDate}/${endDate}&details=${description}&location=${location}&ctz=Pacific/Auckland`,
     outlook: `https://outlook.live.com/calendar/0/deeplink/compose?subject=${title}&startdt=${outlookStartDate}&enddt=${outlookEndDate}&body=${description}&location=${location}`,
-    icsContent: generateICSContent(shift),
+    icsContent: generateICSContent(shift, addresses),
   };
 }
 
 /**
  * Generate a Google Calendar link for email templates
  */
-export function generateGoogleCalendarLink(shift: ShiftCalendarData): string {
-  return generateCalendarUrls(shift).google;
+export function generateGoogleCalendarLink(
+  shift: ShiftCalendarData,
+  addresses: LocationAddressMap = {}
+): string {
+  return generateCalendarUrls(shift, addresses).google;
 }
 
 /**
  * Generate a Google Maps link for a location
  */
-export function generateGoogleMapsLink(location: string | null): string {
+export function generateGoogleMapsLink(
+  location: string | null,
+  addresses: LocationAddressMap = {}
+): string {
   if (!location || location === "TBD") {
     return "";
   }
 
-  const address =
-    LOCATION_ADDRESSES[location as keyof typeof LOCATION_ADDRESSES] || location;
+  const address = addresses[location] || location;
   return `https://maps.google.com/maps?q=${encodeURIComponent(
     `Everybody Eats ${address}`
   )}`;

--- a/web/src/lib/email-service.ts
+++ b/web/src/lib/email-service.ts
@@ -1,4 +1,5 @@
 import { generateGoogleMapsLink, generateCalendarData } from "./calendar-utils";
+import { getLocationAddresses } from "./locations";
 import { getBaseUrl } from "./utils";
 import { getShiftTheme } from "./shift-themes";
 
@@ -903,8 +904,13 @@ class EmailService {
     const firstName =
       params.volunteerName.split(" ")[0] || params.volunteerName;
 
-    // Generate calendar and maps links
-    const locationMapLink = generateGoogleMapsLink(params.location);
+    // Generate calendar and maps links (addresses fetched fresh so newly
+    // created locations resolve without a server restart)
+    const locationAddresses = await getLocationAddresses();
+    const locationMapLink = generateGoogleMapsLink(
+      params.location,
+      locationAddresses
+    );
 
     // Generate calendar data and ICS attachment if we have the start/end dates
     let calendarData = { google: "", outlook: "", icsContent: "" };
@@ -922,7 +928,7 @@ class EmailService {
           description: null,
         },
       };
-      calendarData = generateCalendarData(shiftData);
+      calendarData = generateCalendarData(shiftData, locationAddresses);
 
       // Generate public ICS download link
       icsDownloadLink = `${getBaseUrl()}/api/shifts/${params.shiftId}/calendar`;

--- a/web/src/lib/locations.test.ts
+++ b/web/src/lib/locations.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+// Normal import -> the globally mocked prisma (see test-setup.ts), the same
+// instance the real locations module reads through.
+import { prisma } from "@/lib/prisma";
+
+// test-setup.ts globally mocks `@/lib/locations`, so a normal import would
+// return the stubbed helpers. Load the REAL module here to exercise the actual
+// query logic. Its `prisma` dependency stays mocked, and that mock's
+// `location.findMany` returns Auckland + Wellington (see test-setup.ts).
+async function loadReal() {
+  return vi.importActual<typeof import("@/lib/locations")>("@/lib/locations");
+}
+
+describe("locations helpers", () => {
+  it("getActiveLocationNames returns location names from the database", async () => {
+    const { getActiveLocationNames } = await loadReal();
+    expect(await getActiveLocationNames()).toEqual(["Auckland", "Wellington"]);
+  });
+
+  it("getLocationAddresses maps each location name to its address", async () => {
+    const { getLocationAddresses } = await loadReal();
+    expect(await getLocationAddresses()).toEqual({
+      Auckland: "123 Auckland St, Auckland",
+      Wellington: "456 Wellington St, Wellington",
+    });
+  });
+
+  it("queries fresh on every call (not a cached module snapshot)", async () => {
+    const findMany = prisma.location.findMany as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    const { getActiveLocationNames } = await loadReal();
+
+    const before = findMany.mock.calls.length;
+    await getActiveLocationNames();
+    await getActiveLocationNames();
+    // Two calls -> two queries; nothing is memoized at module scope.
+    expect(findMany.mock.calls.length).toBe(before + 2);
+  });
+});

--- a/web/src/lib/locations.ts
+++ b/web/src/lib/locations.ts
@@ -3,23 +3,22 @@
 import { prisma } from "@/lib/prisma";
 import type { LocationOption as ShiftLocationOption } from "@/lib/location-utils";
 
-const dbLocations = await prisma.location.findMany({
-  where: { isActive: true },
-  select: { name: true, address: true },
-  orderBy: { name: "asc" },
-});
-export const LOCATIONS = dbLocations.map((loc) => loc.name);
+// A location is identified by its display name. This is a plain string alias
+// (rather than a union derived from a one-time database snapshot) so that
+// locations created at runtime are always valid without a rebuild or restart.
+export type Location = string;
 
-export type Location = (typeof LOCATIONS)[number];
+export type LocationOption = Location;
+
+// Default location
+export const DEFAULT_LOCATION: Location = "Wellington";
 
 /**
  * Fetch active location names fresh from the database.
  *
- * Unlike the module-level `LOCATIONS` constant - which is evaluated once when
- * this module is first imported and then cached for the lifetime of the server
- * process - this reads current data on every call. Use it anywhere newly
- * created locations must appear immediately (e.g. the shift-creation forms)
- * rather than only after a server restart.
+ * This reads current data on every call. Use it anywhere newly created
+ * locations must appear immediately (shift-creation forms, admin filters,
+ * validation, etc.) rather than only after the server process restarts.
  */
 export async function getActiveLocationNames(): Promise<string[]> {
   const rows = await prisma.location.findMany({
@@ -30,29 +29,28 @@ export async function getActiveLocationNames(): Promise<string[]> {
   return rows.map((loc) => loc.name);
 }
 
-export type LocationOption = Location;
-
-// Restaurant addresses for Google Maps
-export const LOCATION_ADDRESSES: Record<Location, string> = dbLocations.reduce(
-  (acc, loc) => {
+/**
+ * Fetch the map of location name -> street address, fresh from the database.
+ *
+ * Includes every location (active or not) so addresses still resolve for
+ * shifts at venues that have since been deactivated. Reads current data on
+ * every call, so newly created locations resolve immediately.
+ */
+export async function getLocationAddresses(): Promise<Record<string, string>> {
+  const rows = await prisma.location.findMany({
+    select: { name: true, address: true },
+    orderBy: { name: "asc" },
+  });
+  return rows.reduce<Record<string, string>>((acc, loc) => {
     acc[loc.name] = loc.address;
     return acc;
-  },
-  {} as Record<Location, string>
-);
-
-// Default location
-export const DEFAULT_LOCATION: Location = "Wellington";
+  }, {});
+}
 
 // Helper function to generate Google Maps URL for an address
 export function getGoogleMapsUrl(address: string): string {
   const encodedAddress = encodeURIComponent(address);
   return `https://www.google.com/maps/search/?api=1&query=${encodedAddress}`;
-}
-
-// Helper function to get Google Maps URL for a location
-export function getLocationMapsUrl(location: Location): string {
-  return getGoogleMapsUrl(LOCATION_ADDRESSES[location]);
 }
 
 /**

--- a/web/src/lib/locations.ts
+++ b/web/src/lib/locations.ts
@@ -12,6 +12,24 @@ export const LOCATIONS = dbLocations.map((loc) => loc.name);
 
 export type Location = (typeof LOCATIONS)[number];
 
+/**
+ * Fetch active location names fresh from the database.
+ *
+ * Unlike the module-level `LOCATIONS` constant - which is evaluated once when
+ * this module is first imported and then cached for the lifetime of the server
+ * process - this reads current data on every call. Use it anywhere newly
+ * created locations must appear immediately (e.g. the shift-creation forms)
+ * rather than only after a server restart.
+ */
+export async function getActiveLocationNames(): Promise<string[]> {
+  const rows = await prisma.location.findMany({
+    where: { isActive: true },
+    select: { name: true },
+    orderBy: { name: "asc" },
+  });
+  return rows.map((loc) => loc.name);
+}
+
 export type LocationOption = Location;
 
 // Restaurant addresses for Google Maps

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { getBaseUrl } from "@/lib/utils";
-import { LOCATION_ADDRESSES } from "./locations";
 
 // SEO Configuration
 export const SEO_CONFIG = {
@@ -177,6 +176,9 @@ interface ShiftEventData {
   startDate: Date;
   endDate: Date;
   location: string | null;
+  // Street address for `location`, resolved fresh by the caller (via
+  // `getLocationAddresses()`) so newly created locations resolve immediately.
+  locationAddress?: string;
   capacity: number;
   spotsAvailable: number;
 }
@@ -185,9 +187,7 @@ interface ShiftEventData {
 export function buildShiftEventSchema(shift: ShiftEventData) {
   const baseUrl = getBaseUrl();
 
-  const locationAddress = shift.location
-    ? LOCATION_ADDRESSES[shift.location]
-    : undefined;
+  const locationAddress = shift.location ? shift.locationAddress : undefined;
 
   return {
     "@context": "https://schema.org",

--- a/web/src/lib/services/signup-actions.ts
+++ b/web/src/lib/services/signup-actions.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/notifications";
 import { getEmailService } from "@/lib/email-service";
 import { formatInNZT } from "@/lib/timezone";
-import { LOCATION_ADDRESSES } from "@/lib/locations";
+import { getLocationAddresses } from "@/lib/locations";
 import { autoCancelOtherPendingSignupsForDay } from "@/lib/signup-utils.server";
 import { isFirstConfirmedShift } from "@/lib/shift-helpers";
 
@@ -140,10 +140,9 @@ export async function applySignupAction({
   const volunteerName =
     signup.user.name ||
     `${signup.user.firstName || ""} ${signup.user.lastName || ""}`.trim();
+  const locationAddresses = await getLocationAddresses();
   const fullAddress = signup.shift.location
-    ? LOCATION_ADDRESSES[
-        signup.shift.location as keyof typeof LOCATION_ADDRESSES
-      ] || signup.shift.location
+    ? locationAddresses[signup.shift.location] || signup.shift.location
     : "TBD";
   const shiftTime = `${formatInNZT(signup.shift.start, "h:mm a")} - ${formatInNZT(
     signup.shift.end,

--- a/web/src/lib/test-setup.ts
+++ b/web/src/lib/test-setup.ts
@@ -14,14 +14,15 @@ vi.mock('./prisma', () => ({
   },
 }));
 
-// Mock locations module that uses top-level await
+// Mock locations module (fresh DB-backed helpers)
+const MOCK_LOCATION_ADDRESSES: Record<string, string> = {
+  'Auckland': '123 Auckland St, Auckland',
+  'Wellington': '456 Wellington St, Wellington',
+};
 vi.mock('./locations', () => ({
-  LOCATIONS: ['Auckland', 'Wellington'],
-  LOCATION_ADDRESSES: {
-    'Auckland': '123 Auckland St, Auckland',
-    'Wellington': '456 Wellington St, Wellington',
-  },
   DEFAULT_LOCATION: 'Wellington',
+  getActiveLocationNames: vi.fn().mockResolvedValue(['Auckland', 'Wellington']),
+  getLocationAddresses: vi.fn().mockResolvedValue(MOCK_LOCATION_ADDRESSES),
+  getShiftLocationOptions: vi.fn().mockResolvedValue([]),
   getGoogleMapsUrl: (address: string) => `https://www.google.com/maps/search/?api=1&query=Everybody+Eats+${encodeURIComponent(address)}`,
-  getLocationMapsUrl: (location: string) => `https://www.google.com/maps/search/?api=1&query=Everybody+Eats+${location}`,
 }));

--- a/web/src/lib/validation-schemas.ts
+++ b/web/src/lib/validation-schemas.ts
@@ -1,12 +1,21 @@
 import { z } from "zod";
-import { LOCATIONS } from "@/lib/locations";
+import { getActiveLocationNames } from "@/lib/locations";
 
-// Location validation schema
-export const LocationSchema = z.enum(LOCATIONS);
-
-// Reusable location validation for Zod schemas
-export function createLocationEnum() {
-  return z.enum(LOCATIONS);
+/**
+ * Build a Zod schema that validates a value is one of the currently active
+ * location names. Queries the database on each call, so locations created at
+ * runtime validate immediately (a module-level enum would be frozen at import
+ * time and reject new locations until the server restarted).
+ *
+ * Falls back to a non-empty string check when no active locations exist, since
+ * `z.enum` requires a non-empty set.
+ */
+export async function createLocationEnum() {
+  const names = await getActiveLocationNames();
+  if (names.length === 0) {
+    return z.string().min(1);
+  }
+  return z.enum(names as [string, ...string[]]);
 }
 
 // --- Restaurant service-night stats ---


### PR DESCRIPTION
## Description
Newly created locations did not appear across the app until the server was restarted. This fixes the staleness at its root.

**Root cause:** `web/src/lib/locations.ts` built its `LOCATIONS` list and `LOCATION_ADDRESSES` map with a **top-level `await`**. Top-level await runs once, when the module is first imported, and the result is cached for the entire lifetime of the server process - so any location created afterward was invisible until a restart/redeploy.

**Fix:** removed the module-load snapshot entirely. `locations.ts` now exposes fresh async helpers - `getActiveLocationNames()` and `getLocationAddresses()` - that read current data on every call, and every consumer was migrated off the cached constants.

### What changed
- **Location name lists** (dropdowns / filters / selectors) now query fresh: create-shift page, admin dashboard, regulars, restaurant-managers, auto-accept-rules, notifications, all analytics pages (coverage, engagement, milestones, recruitment, shortage-notifications, overview), volunteer detail, and the shifts admin filter.
- **Location validation**: `createLocationEnum()` is now async and built per-request; the two admin `regulars` API routes construct their Zod schemas fresh so a new location validates immediately.
- **Address map**: `calendar-utils` takes an address-map argument (threaded from callers via `getLocationAddresses()`) instead of importing the constant, and `seo`'s `buildShiftEventSchema` takes a caller-resolved address. Email, ICS download, Google Maps links, signup-confirmation, admin assign, and the shift detail pages all pass a fresh map. Unknown locations still fall back to the raw name.
- `Location` is now a plain `string` alias (previously a union derived from the DB snapshot), so runtime-created locations are always type-valid.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
- `version:patch`

## Testing
- [x] `npm run typecheck` - clean (full project)
- [x] `npm run lint` - clean
- [x] `npm run test:run` - 504/504 unit tests pass (includes calendar-utils; the `./locations` test mock was updated to the new async helpers)
- [ ] Manual: create a location in `/admin/locations`, then confirm it appears in the shift-creation forms, admin filters, and analytics selectors without a restart

## Additional Notes
The address-map path touches transactional email + ICS generation, so it was verified via typecheck and the existing unit suite rather than a live email send. `DEFAULT_LOCATION` (a hardcoded `"Wellington"`) and the separate `VOLUNTEER_LOCATIONS` marketing list were already static and are unaffected.
