### PR TITLE
fix(admin): render 404s inside the admin dashboard chrome

### DIFF
--- a/web/src/app/admin/[...not-found]/page.tsx
+++ b/web/src/app/admin/[...not-found]/page.tsx
@@ -1,0 +1,14 @@
+import { notFound } from "next/navigation";
+
+/**
+ * Catch-all for unmatched `/admin/*` URLs.
+ *
+ * Next.js only renders a nested `not-found.tsx` for explicit `notFound()`
+ * calls — unmatched URLs fall back to the root (chrome-less) 404. This
+ * lowest-priority catch-all intercepts those URLs and calls `notFound()`, so
+ * they render `admin/not-found.tsx` inside the admin layout (sidebar + header)
+ * instead. Real admin routes always take precedence over this catch-all.
+ */
+export default function AdminCatchAllNotFound() {
+  notFound();
+}

--- a/web/src/app/admin/not-found.tsx
+++ b/web/src/app/admin/not-found.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Compass, LayoutDashboard } from "lucide-react";
+
+import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { Button } from "@/components/ui/button";
+
+/**
+ * 404 boundary for the admin area. Because it lives under `admin/layout.tsx`,
+ * it renders inside the full admin chrome (sidebar + header), so admins always
+ * have a way back to a working page. Triggered both by explicit `notFound()`
+ * calls in admin routes and by unmatched `/admin/*` URLs via the sibling
+ * `[...not-found]` catch-all route.
+ */
+export default function AdminNotFound() {
+  const router = useRouter();
+
+  return (
+    <AdminPageWrapper
+      title="Page not found"
+      description="We couldn't find the admin page you were looking for."
+    >
+      <div
+        data-testid="admin-not-found"
+        className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center"
+      >
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <Compass className="h-8 w-8" aria-hidden="true" />
+        </div>
+
+        <p className="mt-6 text-sm font-medium text-muted-foreground">
+          Error 404
+        </p>
+        <h2 className="mt-2 text-2xl font-semibold tracking-tight">
+          This page took a wrong turn
+        </h2>
+        <p className="mt-3 max-w-md text-sm text-muted-foreground">
+          The link may be broken, or the page may have been moved or removed.
+          Kia ora — let&apos;s get you back to something useful.
+        </p>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <Button asChild data-testid="admin-not-found-dashboard-link">
+            <Link href="/admin">
+              <LayoutDashboard className="h-4 w-4" aria-hidden="true" />
+              Back to dashboard
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => router.back()}
+            data-testid="admin-not-found-back-button"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            Go back
+          </Button>
+        </div>
+      </div>
+    </AdminPageWrapper>
+  );
+}


### PR DESCRIPTION
## Description

Admin 404 pages were rendering as Next.js's bare default 404 - no sidebar, no header - leaving admins with no easy way back to a working page.

**Root cause:** there was no `not-found.tsx` anywhere in the app, and Next.js only renders a *nested* `not-found.tsx` for explicit `notFound()` calls. Unmatched URLs (e.g. `/admin/typo`) fall straight through to the chrome-less root 404.

**Fix - two files:**

- `web/src/app/admin/not-found.tsx` - the 404 boundary. Because it lives under `admin/layout.tsx`, it renders inside the full admin chrome (sidebar + header). Uses `AdminPageWrapper` to set the header title and offers two escape routes: **Back to dashboard** (`/admin`) and **Go back** (`router.back()`), styled to match the existing admin design language.
- `web/src/app/admin/[...not-found]/page.tsx` - a lowest-priority catch-all that calls `notFound()`, so unmatched `/admin/*` URLs render the boundary above *with chrome* instead of the bare root 404. Real admin routes always take precedence over the catch-all.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
`version:patch`

## Testing
- [x] `npm run typecheck` passes
- [x] `eslint` clean on both new files
- [x] `npm run build` - `✓ Compiled successfully`; Next's route collection accepted the catch-all + not-found with no route conflicts (the build's non-zero exit is only the post-compile PostHog source-map upload failing on a missing local API key, unrelated to this change and green in CI)

## Additional Notes

Scope is the **admin** area, as requested. Non-admin 404s still hit Next's default page - a follow-up could add a root `src/app/not-found.tsx` with the public site header/footer for consistent site-wide 404 chrome.

No live browser check: it requires an admin login, and the repo-root `launch.json`'s `web` config points at the main checkout rather than this worktree, so it wouldn't exercise these files. The production build directly validates the routing behavior that was the actual risk.