### PR TITLE
test(admin): 404 e2e coverage + motion and back-button fallback

### DIFF
--- a/web/src/app/admin/not-found.tsx
+++ b/web/src/app/admin/not-found.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { ArrowLeft, Compass, LayoutDashboard } from "lucide-react";
 
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
+import { MotionPageContainer } from "@/components/motion-page-container";
 import { Button } from "@/components/ui/button";
 
 /**
@@ -17,47 +18,60 @@ import { Button } from "@/components/ui/button";
 export default function AdminNotFound() {
   const router = useRouter();
 
+  // `router.back()` is a no-op when the admin landed here with no in-app
+  // history (direct hit, external link, fresh tab), so fall back to the
+  // dashboard to guarantee an escape route.
+  const handleGoBack = () => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push("/admin");
+    }
+  };
+
   return (
     <AdminPageWrapper
       title="Page not found"
       description="We couldn't find the admin page you were looking for."
     >
-      <div
-        data-testid="admin-not-found"
-        className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center"
-      >
-        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
-          <Compass className="h-8 w-8" aria-hidden="true" />
-        </div>
+      <MotionPageContainer>
+        <div
+          data-testid="admin-not-found"
+          className="flex min-h-[60vh] flex-col items-center justify-center px-4 text-center"
+        >
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Compass className="h-8 w-8" aria-hidden="true" />
+          </div>
 
-        <p className="mt-6 text-sm font-medium text-muted-foreground">
-          Error 404
-        </p>
-        <h2 className="mt-2 text-2xl font-semibold tracking-tight">
-          This page took a wrong turn
-        </h2>
-        <p className="mt-3 max-w-md text-sm text-muted-foreground">
-          The link may be broken, or the page may have been moved or removed.
-          Kia ora — let&apos;s get you back to something useful.
-        </p>
+          <p className="mt-6 text-sm font-medium text-muted-foreground">
+            Error 404
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight">
+            This page took a wrong turn
+          </h2>
+          <p className="mt-3 max-w-md text-sm text-muted-foreground">
+            The link may be broken, or the page may have been moved or removed.
+            Kia ora - let&apos;s get you back to something useful.
+          </p>
 
-        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-          <Button asChild data-testid="admin-not-found-dashboard-link">
-            <Link href="/admin">
-              <LayoutDashboard className="h-4 w-4" aria-hidden="true" />
-              Back to dashboard
-            </Link>
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => router.back()}
-            data-testid="admin-not-found-back-button"
-          >
-            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-            Go back
-          </Button>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Button asChild data-testid="admin-not-found-dashboard-link">
+              <Link href="/admin">
+                <LayoutDashboard className="h-4 w-4" aria-hidden="true" />
+                Back to dashboard
+              </Link>
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleGoBack}
+              data-testid="admin-not-found-back-button"
+            >
+              <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+              Go back
+            </Button>
+          </div>
         </div>
-      </div>
+      </MotionPageContainer>
     </AdminPageWrapper>
   );
 }

--- a/web/tests/e2e/admin-404.spec.ts
+++ b/web/tests/e2e/admin-404.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "./base";
+import { loginAsAdmin } from "./helpers/auth";
+
+test.describe("Admin 404 page", () => {
+  test("unmatched /admin/* URL renders the 404 inside the admin chrome", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+
+    await page.goto("/admin/this-page-does-not-exist");
+
+    // The 404 boundary content is visible...
+    await expect(page.getByTestId("admin-not-found")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "This page took a wrong turn" })
+    ).toBeVisible();
+
+    // ...and it renders WITH the admin chrome (sidebar + header), which is the
+    // whole point of this fix - admins are never stranded on a bare 404.
+    await expect(page.getByTestId("admin-sidebar")).toBeVisible();
+    await expect(page.getByTestId("admin-page-header")).toHaveText(
+      "Page not found"
+    );
+  });
+
+  test("deeply-nested unmatched admin URL still renders the 404 with chrome", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+
+    await page.goto("/admin/users/nope/deeper");
+
+    await expect(page.getByTestId("admin-not-found")).toBeVisible();
+    await expect(page.getByTestId("admin-sidebar")).toBeVisible();
+  });
+
+  test("dashboard link navigates back to the admin dashboard", async ({
+    page,
+  }) => {
+    await loginAsAdmin(page);
+
+    await page.goto("/admin/does-not-exist");
+    await expect(page.getByTestId("admin-not-found")).toBeVisible();
+
+    await page.getByTestId("admin-not-found-dashboard-link").click();
+
+    await expect(page).toHaveURL(/\/admin$/);
+    // Confirm we actually landed on the working dashboard (not another 404):
+    // its content renders and the 404 copy is gone from view.
+    await expect(page.getByTestId("admin-dashboard-page")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "This page took a wrong turn" })
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Description

Follow-up to #1144, which was squash-merged before the code-review fixes could land. This PR applies that reviewer feedback on top of the merged admin 404 boundary.

- **motion.dev animation** — wrap the not-found content in `MotionPageContainer` for the fade-in admin pages use. CLAUDE.md mandates motion.dev over CSS animations, and the original page had none.
- **`router.back()` fallback** — when the admin lands on the 404 with no in-app history (direct hit, external link, fresh tab), `router.back()` is a no-op. Now it falls back to `/admin` so there's always a working escape route.
- **e2e coverage** — new `web/tests/e2e/admin-404.spec.ts` verifying:
  - an unmatched `/admin/*` URL renders the 404 **inside the admin chrome** (sidebar + header title)
  - a deeply-nested unmatched URL (`/admin/users/nope/deeper`) does the same
  - the "Back to dashboard" link recovers to a working dashboard
- **Copy fix** — replaced an em dash in the body text with a plain dash.

## Type of Change
- [x] 🧪 Tests (adding missing tests or correcting existing tests)
- [x] 🐛 Bug fix (back-button fallback)

## Version Bump Required
`version:patch`

## Testing
- [x] `npm run typecheck` passes
- [x] `eslint` clean on changed files
- [x] `npx playwright test admin-404.spec.ts --project=chromium` — **3 passed** (run against this branch on an isolated port; confirmed the 404 renders with sidebar + "Page not found" header, and the dashboard link recovers)

## Additional Notes

Testing note on the e2e: after clicking "Back to dashboard", Next's App Router leaves the (now empty/hidden) not-found subtree in the DOM on *soft* navigation, so the test asserts the positive signal — the dashboard content is visible and the 404 heading is gone from the accessibility tree — rather than raw DOM absence.