### PR TITLE
fix(shifts): show full shift notes on browse cards

### DIFF
--- a/web/src/app/shifts/details/shift-details-content.tsx
+++ b/web/src/app/shifts/details/shift-details-content.tsx
@@ -215,7 +215,7 @@ function ShiftCard({
             </div>
 
             {getShiftDescription(shift.notes, shift.shiftType.description) && (
-              <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed line-clamp-2">
+              <p className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
                 {getShiftDescription(shift.notes, shift.shiftType.description)}
               </p>
             )}


### PR DESCRIPTION
## Description
Removes the `line-clamp-2` truncation on the shift description/notes paragraph in the public shift browsing cards (`web/src/app/shifts/details/shift-details-content.tsx`). Previously long notes (e.g. "NOTE - if you can only attend for 1-2 hours…") were cut off with an ellipsis after two lines; now the full note renders so volunteers can read the whole thing before signing up.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
- `version:patch`

## Testing
- [ ] Unit tests pass
- [ ] E2E tests pass
- [ ] Manual testing completed

Note: a live preview couldn't be spun up in this worktree (its `web/node_modules` isn't installed), so this wasn't visually verified in a running app. The change is a single Tailwind utility-class removal with no logic change.

## Additional Notes
Reviewer heads-up: with the clamp removed, cards containing long notes will grow to fit the entire note, so cards in the same row may end up at different heights. If keeping the grid uniform is preferred, an alternative is bumping to a higher clamp (e.g. `line-clamp-4`) instead of removing it entirely.