### PR TITLE
fix(shifts): stop truncating shift title on browse cards

### DIFF
--- a/web/src/app/shifts/details/shift-details-content.tsx
+++ b/web/src/app/shifts/details/shift-details-content.tsx
@@ -176,13 +176,13 @@ function ShiftCard({
                   {theme.emoji}
                 </div>
                 <div className="min-w-0 flex-1">
-                  <h3 className="font-bold text-xl text-gray-900 dark:text-white truncate mb-1">
+                  <h3 className="font-bold text-xl text-gray-900 dark:text-white mb-1">
                     <Link
                       href={`/shifts/${shift.id}`}
                       className="inline-flex items-baseline gap-1 hover:underline underline-offset-4 decoration-2 focus-visible:outline-none focus-visible:underline rounded-sm"
                       data-testid={`shift-card-title-link-${shift.id}`}
                     >
-                      <span className="truncate">{shift.shiftType.name}</span>
+                      <span>{shift.shiftType.name}</span>
                       <ArrowUpRight className="h-4 w-4 shrink-0 self-center opacity-60 group-hover:opacity-100 transition-opacity" />
                     </Link>
                   </h3>


### PR DESCRIPTION
## Description
Removes the `truncate` class from the shift type title (both the `<h3>` and the inner `<span>`) on the public shift browsing cards (`web/src/app/shifts/details/shift-details-content.tsx`). Long names like "Toast Cafe Front of House Helper" were being cut off with an ellipsis on a single line; they now wrap to a second line and display in full.

The parent container already uses `min-w-0 flex-1`, so wrapping lays out cleanly, and the `ArrowUpRight` icon keeps `shrink-0` so it stays attached to the end of the title.

Follow-up to #1147 (which removed the notes truncation) — surfacing the full notes made the still-clamped title more noticeable.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Version Bump Required
- `version:patch`

## Testing
- [ ] Unit tests pass
- [ ] E2E tests pass
- [ ] Manual testing completed

Note: not visually verified in a running app — this worktree's `web/node_modules` isn't installed, so the dev server couldn't be started. The change is a Tailwind utility-class removal with no logic change.