### PR TITLE
fix(resources): hide chat-only guides from the public Resource Hub

### DIFF
--- a/web/src/app/api/resources/[id]/route.ts
+++ b/web/src/app/api/resources/[id]/route.ts
@@ -13,6 +13,8 @@ export async function GET(
       where: {
         id,
         isPublished: true,
+        // Chat-only guides are not part of the public resource catalogue.
+        includeInChat: false,
       },
       include: {
         uploader: {

--- a/web/src/app/api/resources/route.ts
+++ b/web/src/app/api/resources/route.ts
@@ -13,6 +13,9 @@ export async function GET(request: Request) {
   try {
     const whereClause: Prisma.ResourceWhereInput = {
       isPublished: true,
+      // Exclude chat-only guides (managed on the admin Chat Guides page as AI
+      // context); they should not surface in the public resources list.
+      includeInChat: false,
     };
 
     // Search by title and description

--- a/web/src/app/resources/resources-content.tsx
+++ b/web/src/app/resources/resources-content.tsx
@@ -16,8 +16,12 @@ export async function ResourcesContent({
   tagsFilter,
 }: ResourcesContentProps) {
   // Build where clause
+  // Exclude chat-only guides: resources flagged `includeInChat` are managed on
+  // the admin Chat Guides page as AI context and should not surface in the
+  // public Resource Hub, even though they're stored in the same table.
   const whereClause: Prisma.ResourceWhereInput = {
     isPublished: true,
+    includeInChat: false,
   };
 
   if (searchQuery) {

--- a/web/src/components/resources-search-server.tsx
+++ b/web/src/components/resources-search-server.tsx
@@ -3,7 +3,9 @@ import { ResourcesSearch } from "@/components/resources-search";
 
 export async function ResourcesSearchServer() {
   const allResources = await prisma.resource.findMany({
-    where: { isPublished: true },
+    // Match the Resource Hub grid: exclude chat-only guides so their tags
+    // don't appear in the public filter list.
+    where: { isPublished: true, includeInChat: false },
     select: { tags: true },
   });
   const uniqueTags = Array.from(


### PR DESCRIPTION
## Problem

Chat guides were showing up in the public Resource Hub.

Chat guides aren't a separate model - they're `Resource` rows flagged `includeInChat=true`. When you create a guide on the **Chat Guides** admin page (import a URL or write one manually), it's saved with `isPublished=true` **and** `includeInChat=true`. The `isPublished=true` is only set because the chat-context query requires it - but the public Resource Hub shows everything with `isPublished=true`, so chat-only guides leaked into:

- the Resource Hub grid
- the hub's tag filter list
- `GET /api/resources` and `GET /api/resources/[id]`

## Fix

Exclude `includeInChat` resources from every public resource surface (query-level, no schema change, no data migration - fixes existing production data immediately):

- `resources-content.tsx` (hub grid)
- `resources-search-server.tsx` (tag filters)
- `GET /api/resources`
- `GET /api/resources/[id]`

Chat context (mobile chat) and the website-refresh cron intentionally target `includeInChat` resources, so those are left unchanged.

## Note

At the DB level a "chat guide" is any resource with `includeInChat=true`. This includes both dedicated guides *and* any existing hub resource an admin has pulled into chat context via "Add existing resource to chat". Both are now hidden from the public hub - if a resource is being used as AI context, it's treated as chat-managed. Flag if you deliberately want a resource visible in both places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)