### PR TITLE
fix(resources): gate hub visibility on isPublished, not includeInChat

### DIFF
--- a/web/prisma/migrations/20260723000000_unpublish_chat_only_guides/migration.sql
+++ b/web/prisma/migrations/20260723000000_unpublish_chat_only_guides/migration.sql
@@ -1,0 +1,15 @@
+-- Chat-only guides (created on the admin Chat Guides page) were previously
+-- saved with isPublished = true only to satisfy the chat-context query, which
+-- leaked them into the public Resource Hub. Chat inclusion no longer depends on
+-- publication, so unpublish the guides that provably cannot be hub resources:
+-- those with neither an uploaded file nor a URL (pure AI-context text guides).
+--
+-- This deliberately leaves any resource that has a file or URL untouched, so a
+-- real hub resource that was also added to chat context stays published and
+-- visible in the hub.
+UPDATE "Resource"
+SET "isPublished" = false
+WHERE "includeInChat" = true
+  AND "isPublished" = true
+  AND "fileUrl" IS NULL
+  AND "url" IS NULL;

--- a/web/src/app/admin/chat-guides/chat-guides-content.tsx
+++ b/web/src/app/admin/chat-guides/chat-guides-content.tsx
@@ -450,7 +450,10 @@ export function ChatGuidesContent({
           type: "LINK",
           category: importCategory,
           url: importUrl.trim(),
-          isPublished: true,
+          // Chat-only guide: kept out of the public Resource Hub. Hub
+          // visibility is a separate action (publish it from the admin
+          // Resources page).
+          isPublished: false,
           includeInChat: true,
           chatContent: importContent.trim(),
           lastScrapedContent: importRawScrape.trim() || undefined,
@@ -556,7 +559,8 @@ export function ChatGuidesContent({
           title: newTitle.trim(),
           type: "DOCUMENT",
           category: newCategory,
-          isPublished: true,
+          // Chat-only guide: kept out of the public Resource Hub.
+          isPublished: false,
           includeInChat: true,
           chatContent: newContent.trim(),
         }),

--- a/web/src/app/api/resources/[id]/route.ts
+++ b/web/src/app/api/resources/[id]/route.ts
@@ -13,8 +13,6 @@ export async function GET(
       where: {
         id,
         isPublished: true,
-        // Chat-only guides are not part of the public resource catalogue.
-        includeInChat: false,
       },
       include: {
         uploader: {

--- a/web/src/app/api/resources/route.ts
+++ b/web/src/app/api/resources/route.ts
@@ -13,9 +13,6 @@ export async function GET(request: Request) {
   try {
     const whereClause: Prisma.ResourceWhereInput = {
       isPublished: true,
-      // Exclude chat-only guides (managed on the admin Chat Guides page as AI
-      // context); they should not surface in the public resources list.
-      includeInChat: false,
     };
 
     // Search by title and description

--- a/web/src/app/resources/resources-content.tsx
+++ b/web/src/app/resources/resources-content.tsx
@@ -15,13 +15,11 @@ export async function ResourcesContent({
   typeFilter,
   tagsFilter,
 }: ResourcesContentProps) {
-  // Build where clause
-  // Exclude chat-only guides: resources flagged `includeInChat` are managed on
-  // the admin Chat Guides page as AI context and should not surface in the
-  // public Resource Hub, even though they're stored in the same table.
+  // Build where clause. `isPublished` is the single gate for hub visibility:
+  // chat-only guides are created unpublished, while a real hub resource that is
+  // also fed to the AI chat stays published and therefore visible here.
   const whereClause: Prisma.ResourceWhereInput = {
     isPublished: true,
-    includeInChat: false,
   };
 
   if (searchQuery) {

--- a/web/src/components/resources-search-server.tsx
+++ b/web/src/components/resources-search-server.tsx
@@ -3,9 +3,7 @@ import { ResourcesSearch } from "@/components/resources-search";
 
 export async function ResourcesSearchServer() {
   const allResources = await prisma.resource.findMany({
-    // Match the Resource Hub grid: exclude chat-only guides so their tags
-    // don't appear in the public filter list.
-    where: { isPublished: true, includeInChat: false },
+    where: { isPublished: true },
     select: { tags: true },
   });
   const uniqueTags = Array.from(

--- a/web/src/lib/chat-context.ts
+++ b/web/src/lib/chat-context.ts
@@ -50,7 +50,10 @@ export async function getStaticChatContext(
   const [resources, promptSetting, modelSetting, locations, shiftTypes, totalVolunteers, recentMeals, totalMeals, recentShifts] =
     await Promise.all([
       prisma.resource.findMany({
-        where: { includeInChat: true, isPublished: true, chatContent: { not: null } },
+        // Chat inclusion is controlled solely by `includeInChat`; it is
+        // independent of hub publication so chat-only guides (which are
+        // unpublished) still feed the assistant.
+        where: { includeInChat: true, chatContent: { not: null } },
         select: { title: true, category: true, chatContent: true },
         orderBy: { category: "asc" },
       }),


### PR DESCRIPTION
## Follow-up to #1150

#1150 excluded **every** `includeInChat` resource from the public Resource Hub. That was too broad: a resource can legitimately be **both** a published hub resource **and** fed to the AI chat (via "Add existing resource to chat" on the Chat Guides page). Those were getting wrongly hidden from the hub.

## Correct model

`isPublished` is the single gate for hub visibility. Chat inclusion (`includeInChat`) is independent of it.

- **Revert** the `includeInChat` filters on the hub grid, tag list, and public resources API (`/api/resources`, `/api/resources/[id]`) - a published resource stays visible even when it's also in chat context.
- **Decouple** chat context from `isPublished` (`chat-context.ts` now keys off `includeInChat` alone), so a chat-only guide can be unpublished yet still feed the assistant.
- **Create** chat-only guides (URL import + manual) with `isPublished: false`, so they never enter the hub in the first place.
- **Backfill migration**: unpublish existing chat-only guides that provably cannot be hub resources - those with **no file and no URL**. Anything with a file or URL is left untouched, so real hub resources are never hidden.

## Result

| Resource | In hub? | In chat? |
|---|---|---|
| Published hub resource | ✅ | - |
| Hub resource added to chat | ✅ | ✅ |
| Chat-only guide (created on Chat Guides page) | ❌ | ✅ |

## Note

The backfill is deliberately conservative. A hub resource always has a file or URL (enforced at creation), so the `fileUrl IS NULL AND url IS NULL` condition can only ever match pure text guides. Imported website-page guides (which carry a URL) created *before* this change stay in the hub until an admin unpublishes them - they can't be told apart from real hub links by data alone. All new guides are handled correctly going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)