### PR TITLE
feat(announcements): target volunteers by shift history

### DIFF
--- a/web/prisma/migrations/20260724000000_add_announcement_activity_targeting/migration.sql
+++ b/web/prisma/migrations/20260724000000_add_announcement_activity_targeting/migration.sql
@@ -1,0 +1,14 @@
+-- Shift-history targeting for announcements: reach the volunteers who actually
+-- worked shifts matching a location / date-window / minimum-count filter,
+-- rather than everyone whose profile merely lists a location.
+--
+-- The dimension is dormant unless "targetActivityMinShifts" is set, so every
+-- existing announcement keeps its current recipient set.
+--
+-- The recipient query joins Signup to Shift; the existing
+-- Signup(userId, canceledAt) and Shift(end) indexes already serve it.
+ALTER TABLE "Announcement"
+  ADD COLUMN "targetActivityLocations" TEXT[] DEFAULT ARRAY[]::TEXT[],
+  ADD COLUMN "targetActivityFrom" TIMESTAMP(3),
+  ADD COLUMN "targetActivityTo" TIMESTAMP(3),
+  ADD COLUMN "targetActivityMinShifts" INTEGER;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -1023,6 +1023,14 @@ model Announcement {
   targetUserIds   String[] @default([]) // Specific User IDs
   targetShiftIds  String[] @default([]) // Users with non-cancelled signups on these shifts
 
+  // Shift-history targeting — volunteers who actually worked shifts matching
+  // these criteria. Dormant unless targetActivityMinShifts is set; the other
+  // three fields narrow the window (all optional, empty/null = no narrowing).
+  targetActivityLocations String[]  @default([]) // Shift locations worked at
+  targetActivityFrom      DateTime? // Shift must have ended on/after this
+  targetActivityTo        DateTime? // Shift must have ended on/before this
+  targetActivityMinShifts Int? // Minimum matching shifts; null = dimension off
+
   // Email
   sendEmail   Boolean   @default(false)
   emailSentAt DateTime?

--- a/web/src/app/admin/announcements/announcements-content.tsx
+++ b/web/src/app/admin/announcements/announcements-content.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import ReactMarkdown from "react-markdown";
-import { format } from "date-fns";
+import { format, subMonths } from "date-fns";
 import {
   Plus,
   Trash2,
@@ -79,6 +79,10 @@ type Announcement = {
   targetLabelIds: string[];
   targetUserIds: string[];
   targetShiftIds: string[];
+  targetActivityLocations: string[];
+  targetActivityFrom: string | null;
+  targetActivityTo: string | null;
+  targetActivityMinShifts: number | null;
   sendEmail: boolean;
   emailSentAt: string | null;
   sendNotification: boolean;
@@ -119,6 +123,48 @@ interface AnnouncementsContentProps {
   initialAnnouncements: Announcement[];
   labels: Label[];
   locations: string[];
+}
+
+/** Quick date ranges for shift-history targeting, newest window first. */
+const ACTIVITY_RANGE_PRESETS = [
+  { months: 3, label: "Last 3 months" },
+  { months: 6, label: "Last 6 months" },
+  { months: 12, label: "Last 12 months" },
+];
+
+/**
+ * Plain-English summary of an announcement's shift-history targeting, e.g.
+ * "worked 1+ shift at Onehunga since 24 Apr 2026". Returns null when the
+ * dimension is off.
+ */
+function describeActivityTargeting(ann: {
+  targetActivityLocations: string[];
+  targetActivityFrom: string | null;
+  targetActivityTo: string | null;
+  targetActivityMinShifts: number | null;
+}): string | null {
+  const min = ann.targetActivityMinShifts;
+  if (min === null) return null;
+
+  const where =
+    ann.targetActivityLocations.length > 0
+      ? ` at ${ann.targetActivityLocations.join(", ")}`
+      : "";
+  const from = ann.targetActivityFrom
+    ? format(new Date(ann.targetActivityFrom), "d MMM yyyy")
+    : null;
+  const to = ann.targetActivityTo
+    ? format(new Date(ann.targetActivityTo), "d MMM yyyy")
+    : null;
+  const when = from
+    ? to
+      ? ` between ${from} and ${to}`
+      : ` since ${from}`
+    : to
+      ? ` up to ${to}`
+      : "";
+
+  return `worked ${min}+ shift${min === 1 ? "" : "s"}${where}${when}`;
 }
 
 function parseCsv(value: string | null): string[] {
@@ -173,6 +219,13 @@ export function AnnouncementsContent({
   const [targetLabelIds, setTargetLabelIds] = useState<string[]>([]);
   const [targetUsers, setTargetUsers] = useState<UserOption[]>([]);
   const [targetShifts, setTargetShifts] = useState<ShiftOption[]>([]);
+  // Shift-history targeting. Off until the admin opts in, so the form keeps
+  // behaving exactly as before for everyone who doesn't need it.
+  const [activityEnabled, setActivityEnabled] = useState(false);
+  const [activityLocations, setActivityLocations] = useState<string[]>([]);
+  const [activityFrom, setActivityFrom] = useState(""); // yyyy-MM-dd
+  const [activityTo, setActivityTo] = useState("");
+  const [activityMinShifts, setActivityMinShifts] = useState(1);
   const [sendEmail, setSendEmail] = useState(false);
   const [sendNotification, setSendNotification] = useState(false);
   const [isUploadingImage, setIsUploadingImage] = useState(false);
@@ -190,6 +243,35 @@ export function AnnouncementsContent({
   const targetShiftIds = useMemo(() => targetShifts.map((s) => s.id), [
     targetShifts,
   ]);
+
+  // Every targeting dimension in one object — the same shape the recipient
+  // count preview and the create request both send, so the number the admin
+  // sees always describes the audience they're about to publish to.
+  const targeting = useMemo(
+    () => ({
+      targetLocations,
+      targetGrades,
+      targetLabelIds,
+      targetUserIds,
+      targetShiftIds,
+      targetActivityLocations: activityEnabled ? activityLocations : [],
+      targetActivityFrom: activityEnabled ? activityFrom || null : null,
+      targetActivityTo: activityEnabled ? activityTo || null : null,
+      targetActivityMinShifts: activityEnabled ? activityMinShifts : null,
+    }),
+    [
+      targetLocations,
+      targetGrades,
+      targetLabelIds,
+      targetUserIds,
+      targetShiftIds,
+      activityEnabled,
+      activityLocations,
+      activityFrom,
+      activityTo,
+      activityMinShifts,
+    ]
+  );
 
   // Sync form state from the query string whenever it changes. The effect
   // re-runs only when `prefillSignature` changes, which means subsequent
@@ -272,6 +354,11 @@ export function AnnouncementsContent({
     setTargetLabelIds([]);
     setTargetUsers([]);
     setTargetShifts([]);
+    setActivityEnabled(false);
+    setActivityLocations([]);
+    setActivityFrom("");
+    setActivityTo("");
+    setActivityMinShifts(1);
     setSendEmail(false);
     setSendNotification(false);
     setPreviewMode(false);
@@ -285,13 +372,7 @@ export function AnnouncementsContent({
 
   // Debounced recipient count preview
   const updateRecipientPreview = useCallback(
-    (
-      locs: string[],
-      grades: string[],
-      labelIds: string[],
-      userIds: string[],
-      shiftIds: string[]
-    ) => {
+    (currentTargeting: typeof targeting) => {
       if (recipientDebounceRef.current) {
         clearTimeout(recipientDebounceRef.current);
       }
@@ -303,13 +384,7 @@ export function AnnouncementsContent({
             {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                targetLocations: locs,
-                targetGrades: grades,
-                targetLabelIds: labelIds,
-                targetUserIds: userIds,
-                targetShiftIds: shiftIds,
-              }),
+              body: JSON.stringify(currentTargeting),
             }
           );
           if (response.ok) {
@@ -326,24 +401,10 @@ export function AnnouncementsContent({
     []
   );
 
-  // Recompute the preview whenever any targeting dimension changes, including
-  // user/shift selections (which are object lists, not just id arrays).
+  // Recompute the preview whenever any targeting dimension changes.
   useEffect(() => {
-    updateRecipientPreview(
-      targetLocations,
-      targetGrades,
-      targetLabelIds,
-      targetUserIds,
-      targetShiftIds
-    );
-  }, [
-    targetLocations,
-    targetGrades,
-    targetLabelIds,
-    targetUserIds,
-    targetShiftIds,
-    updateRecipientPreview,
-  ]);
+    updateRecipientPreview(targeting);
+  }, [targeting, updateRecipientPreview]);
 
   const handleLocationToggle = (loc: string) => {
     setTargetLocations((prev) =>
@@ -354,6 +415,12 @@ export function AnnouncementsContent({
   const handleGradeToggle = (grade: string) => {
     setTargetGrades((prev) =>
       prev.includes(grade) ? prev.filter((g) => g !== grade) : [...prev, grade]
+    );
+  };
+
+  const handleActivityLocationToggle = (loc: string) => {
+    setActivityLocations((prev) =>
+      prev.includes(loc) ? prev.filter((l) => l !== loc) : [...prev, loc]
     );
   };
 
@@ -410,11 +477,7 @@ export function AnnouncementsContent({
           body: body.trim(),
           imageUrl,
           expiresAt: expiresAt || null,
-          targetLocations,
-          targetGrades,
-          targetLabelIds,
-          targetUserIds,
-          targetShiftIds,
+          ...targeting,
           sendEmail,
           sendNotification,
         }),
@@ -503,6 +566,10 @@ export function AnnouncementsContent({
       parts.push(
         `${ann.targetShiftIds.length} specific shift${ann.targetShiftIds.length === 1 ? "" : "s"}`
       );
+    }
+    const activity = describeActivityTargeting(ann);
+    if (activity) {
+      parts.push(activity);
     }
     return parts.length > 0 ? parts.join(" · ") : "All volunteers";
   };
@@ -708,8 +775,187 @@ export function AnnouncementsContent({
                         </label>
                       ))}
                     </div>
+                    <p className="text-xs text-muted-foreground">
+                      Matches the locations on a volunteer&apos;s profile,
+                      including people who have never worked a shift there. To
+                      reach volunteers who actually turned up, use Shift
+                      History.
+                    </p>
                   </div>
                 )}
+
+                {/* Shift history */}
+                <div className="space-y-2">
+                  <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Shift History
+                  </Label>
+                  <label className="flex items-start gap-2 cursor-pointer">
+                    <Checkbox
+                      checked={activityEnabled}
+                      onCheckedChange={(checked) =>
+                        setActivityEnabled(checked === true)
+                      }
+                      className="mt-0.5"
+                      data-testid="announcement-activity-toggle"
+                    />
+                    <div>
+                      <span className="text-sm">
+                        Only volunteers who have worked a shift
+                      </span>
+                      <p className="text-xs text-muted-foreground">
+                        Counts shifts they were confirmed on that have already
+                        finished.
+                      </p>
+                    </div>
+                  </label>
+
+                  {activityEnabled && (
+                    <div
+                      className="space-y-4 rounded-md border bg-background p-3"
+                      data-testid="announcement-activity-filters"
+                    >
+                      {locations.length > 0 && (
+                        <div className="space-y-2">
+                          <Label className="text-xs font-medium">
+                            Worked at
+                          </Label>
+                          <div className="flex flex-wrap gap-2">
+                            {locations.map((loc) => (
+                              <label
+                                key={loc}
+                                className="flex items-center gap-1.5 cursor-pointer"
+                              >
+                                <Checkbox
+                                  checked={activityLocations.includes(loc)}
+                                  onCheckedChange={() =>
+                                    handleActivityLocationToggle(loc)
+                                  }
+                                  data-testid={`announcement-activity-location-${loc}`}
+                                />
+                                <span className="text-sm">{loc}</span>
+                              </label>
+                            ))}
+                          </div>
+                          <p className="text-xs text-muted-foreground">
+                            Leave empty to count shifts at any location.
+                          </p>
+                        </div>
+                      )}
+
+                      <div className="space-y-2">
+                        <Label className="text-xs font-medium">
+                          Shift finished between
+                        </Label>
+                        <div className="flex flex-wrap items-end gap-3">
+                          <div className="space-y-1">
+                            <Label
+                              htmlFor="activity-from"
+                              className="text-xs text-muted-foreground"
+                            >
+                              From
+                            </Label>
+                            <Input
+                              id="activity-from"
+                              type="date"
+                              value={activityFrom}
+                              max={activityTo || undefined}
+                              onChange={(e) => setActivityFrom(e.target.value)}
+                              className="h-9 w-[10.5rem]"
+                              data-testid="announcement-activity-from"
+                            />
+                          </div>
+                          <div className="space-y-1">
+                            <Label
+                              htmlFor="activity-to"
+                              className="text-xs text-muted-foreground"
+                            >
+                              To
+                            </Label>
+                            <Input
+                              id="activity-to"
+                              type="date"
+                              value={activityTo}
+                              min={activityFrom || undefined}
+                              onChange={(e) => setActivityTo(e.target.value)}
+                              className="h-9 w-[10.5rem]"
+                              data-testid="announcement-activity-to"
+                            />
+                          </div>
+                        </div>
+                        <div className="flex flex-wrap gap-2 pt-1">
+                          {ACTIVITY_RANGE_PRESETS.map((preset) => {
+                            const presetFrom = format(
+                              subMonths(new Date(), preset.months),
+                              "yyyy-MM-dd"
+                            );
+                            const isActive =
+                              activityFrom === presetFrom && activityTo === "";
+                            return (
+                              <Button
+                                key={preset.months}
+                                type="button"
+                                variant={isActive ? "default" : "outline"}
+                                size="sm"
+                                aria-pressed={isActive}
+                                className="h-7 text-xs"
+                                onClick={() => {
+                                  setActivityFrom(presetFrom);
+                                  setActivityTo("");
+                                }}
+                                data-testid={`announcement-activity-preset-${preset.months}`}
+                              >
+                                {preset.label}
+                              </Button>
+                            );
+                          })}
+                          {(activityFrom || activityTo) && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 text-xs"
+                              onClick={() => {
+                                setActivityFrom("");
+                                setActivityTo("");
+                              }}
+                            >
+                              Clear dates
+                            </Button>
+                          )}
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          Leave both empty to count shifts from any time.
+                        </p>
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label
+                          htmlFor="activity-min-shifts"
+                          className="text-xs font-medium"
+                        >
+                          Minimum shifts
+                        </Label>
+                        <Input
+                          id="activity-min-shifts"
+                          type="number"
+                          min={1}
+                          max={999}
+                          value={activityMinShifts}
+                          onChange={(e) => {
+                            const next = parseInt(e.target.value, 10);
+                            setActivityMinShifts(
+                              Number.isNaN(next)
+                                ? 1
+                                : Math.min(Math.max(next, 1), 999)
+                            );
+                          }}
+                          className="h-9 w-24"
+                          data-testid="announcement-activity-min-shifts"
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
 
                 {/* Grades */}
                 <div className="space-y-2">

--- a/web/src/app/admin/announcements/page.tsx
+++ b/web/src/app/admin/announcements/page.tsx
@@ -45,6 +45,8 @@ export default async function AnnouncementsPage() {
           expiresAt: a.expiresAt?.toISOString() ?? null,
           emailSentAt: a.emailSentAt?.toISOString() ?? null,
           notificationSentAt: a.notificationSentAt?.toISOString() ?? null,
+          targetActivityFrom: a.targetActivityFrom?.toISOString() ?? null,
+          targetActivityTo: a.targetActivityTo?.toISOString() ?? null,
         }))}
         labels={labels}
         locations={locations.map((l) => l.name)}

--- a/web/src/app/api/admin/announcements/recipient-count/route.ts
+++ b/web/src/app/api/admin/announcements/recipient-count/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth-options";
 import {
-  AnnouncementTargeting,
   countAnnouncementRecipients,
+  parseTargetingFromRequest,
 } from "@/lib/announcement-targeting";
 
 /**
@@ -19,20 +19,8 @@ export async function POST(request: Request) {
   }
 
   const body = await request.json().catch(() => ({}));
-  const targeting: AnnouncementTargeting = {
-    targetLocations: Array.isArray(body.targetLocations)
-      ? body.targetLocations
-      : [],
-    targetGrades: Array.isArray(body.targetGrades) ? body.targetGrades : [],
-    targetLabelIds: Array.isArray(body.targetLabelIds)
-      ? body.targetLabelIds
-      : [],
-    targetUserIds: Array.isArray(body.targetUserIds) ? body.targetUserIds : [],
-    targetShiftIds: Array.isArray(body.targetShiftIds)
-      ? body.targetShiftIds
-      : [],
-  };
-
-  const count = await countAnnouncementRecipients(targeting);
+  const count = await countAnnouncementRecipients(
+    parseTargetingFromRequest(body)
+  );
   return NextResponse.json({ count });
 }

--- a/web/src/app/api/admin/announcements/route.ts
+++ b/web/src/app/api/admin/announcements/route.ts
@@ -7,9 +7,9 @@ import { getEmailService } from "@/lib/email-service";
 import { createNotificationsForUsers } from "@/lib/notifications";
 import { getBaseUrl } from "@/lib/utils";
 import {
-  AnnouncementTargeting,
   countAnnouncementRecipients,
   findAnnouncementRecipients,
+  parseTargetingFromRequest,
   targetingFromAnnouncement,
 } from "@/lib/announcement-targeting";
 
@@ -65,6 +65,8 @@ export async function GET() {
  *   imageUrl?, expiresAt?,
  *   targetLocations?, targetGrades?, targetLabelIds?,
  *   targetUserIds?, targetShiftIds?,
+ *   targetActivityLocations?, targetActivityFrom?, targetActivityTo?,
+ *   targetActivityMinShifts?,
  *   sendEmail?, sendNotification?
  * }
  */
@@ -98,11 +100,6 @@ export async function POST(request: Request) {
     body: announcementBody,
     imageUrl,
     expiresAt,
-    targetLocations,
-    targetGrades,
-    targetLabelIds,
-    targetUserIds,
-    targetShiftIds,
     sendEmail,
     sendNotification,
   } = body;
@@ -114,13 +111,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Body is required" }, { status: 400 });
   }
 
-  const targeting: AnnouncementTargeting = {
-    targetLocations: Array.isArray(targetLocations) ? targetLocations : [],
-    targetGrades: Array.isArray(targetGrades) ? targetGrades : [],
-    targetLabelIds: Array.isArray(targetLabelIds) ? targetLabelIds : [],
-    targetUserIds: Array.isArray(targetUserIds) ? targetUserIds : [],
-    targetShiftIds: Array.isArray(targetShiftIds) ? targetShiftIds : [],
-  };
+  const targeting = parseTargetingFromRequest(body);
 
   const announcement = await prisma.announcement.create({
     data: {

--- a/web/src/app/api/mobile/feed/route.ts
+++ b/web/src/app/api/mobile/feed/route.ts
@@ -6,7 +6,11 @@ import {
   formatInNZT,
   isSameDayInNZT,
 } from "@/lib/timezone";
-import { ANNOUNCEMENT_SHIFT_TARGET_STATUSES } from "@/lib/announcement-targeting";
+import {
+  ANNOUNCEMENT_ACTIVITY_STATUSES,
+  ANNOUNCEMENT_SHIFT_TARGET_STATUSES,
+  userMatchesActivityTargeting,
+} from "@/lib/announcement-targeting";
 import { userMatchesTargetLocations } from "@/lib/user-locations";
 import { formatAchievementCriteria } from "@/lib/achievement-utils";
 import {
@@ -70,7 +74,7 @@ export async function GET(request: Request) {
   // Get the user's profile, friendships, blocks, and active signup shift IDs
   // in parallel. The signup shift IDs are used to match announcements that
   // target specific shifts.
-  const [userProfile, friendships, blocks, userSignupShiftRows] =
+  const [userProfile, friendships, blocks, userSignupShiftRows, workedShiftRows] =
     await Promise.all([
       prisma.user.findUnique({
         where: { id: userId },
@@ -102,6 +106,17 @@ export async function GET(request: Request) {
         },
         select: { shiftId: true },
       }),
+      // Shifts this user actually worked, for announcements that target by
+      // shift history. Unbounded on purpose — an announcement can look back
+      // as far as it likes, and the row is two columns wide.
+      prisma.signup.findMany({
+        where: {
+          userId,
+          status: { in: ANNOUNCEMENT_ACTIVITY_STATUSES.map((s) => s) },
+          shift: { end: { lt: now } },
+        },
+        select: { shift: { select: { location: true, end: true } } },
+      }),
     ]);
 
   const blockedUserIds = new Set(blocks.map((b) => b.blockedId));
@@ -120,6 +135,7 @@ export async function GET(request: Request) {
   const userSignupShiftIds = new Set(
     userSignupShiftRows.map((s) => s.shiftId)
   );
+  const workedShifts = workedShiftRows.map((row) => row.shift);
 
   // Run all data queries in parallel
   const [
@@ -331,7 +347,19 @@ export async function GET(request: Request) {
       ann.targetShiftIds.length === 0 ||
       ann.targetShiftIds.some((sid) => userSignupShiftIds.has(sid));
 
-    if (!locationMatch || !gradeMatch || !labelMatch || !userMatch || !shiftMatch)
+    // Shift-history targeting: off unless the announcement sets a minimum
+    // shift count, in which case the user needs that many matching worked
+    // shifts.
+    const activityMatch = userMatchesActivityTargeting(workedShifts, ann);
+
+    if (
+      !locationMatch ||
+      !gradeMatch ||
+      !labelMatch ||
+      !userMatch ||
+      !shiftMatch ||
+      !activityMatch
+    )
       continue;
 
     const authorName =

--- a/web/src/lib/announcement-targeting.test.ts
+++ b/web/src/lib/announcement-targeting.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasActivityTargeting,
+  parseTargetingFromRequest,
+  userMatchesActivityTargeting,
+  type ActivityTargeting,
+} from "./announcement-targeting";
+
+/** Shorthand for building activity targeting in the tests below. */
+function activity(overrides: Partial<ActivityTargeting> = {}): ActivityTargeting {
+  return {
+    targetActivityLocations: [],
+    targetActivityFrom: null,
+    targetActivityTo: null,
+    targetActivityMinShifts: 1,
+    ...overrides,
+  };
+}
+
+describe("announcement-targeting", () => {
+  describe("parseTargetingFromRequest", () => {
+    it("leaves the activity dimension off when no minimum is given", () => {
+      const t = parseTargetingFromRequest({ targetLocations: ["Onehunga"] });
+
+      expect(t.targetActivityMinShifts).toBeNull();
+      expect(hasActivityTargeting(t)).toBe(false);
+    });
+
+    it("anchors the from date to midnight of that NZ calendar day", () => {
+      // 24 April is outside NZ daylight saving, so NZST = UTC+12 and local
+      // midnight is 12:00 UTC the day before.
+      const t = parseTargetingFromRequest({
+        targetActivityFrom: "2026-04-24",
+        targetActivityMinShifts: 1,
+      });
+
+      expect(t.targetActivityFrom?.toISOString()).toBe(
+        "2026-04-23T12:00:00.000Z"
+      );
+    });
+
+    it("anchors the to date to the end of that NZ calendar day", () => {
+      // 24 January is inside daylight saving, so NZDT = UTC+13.
+      const t = parseTargetingFromRequest({
+        targetActivityTo: "2026-01-24",
+        targetActivityMinShifts: 1,
+      });
+
+      expect(t.targetActivityTo?.toISOString()).toBe(
+        "2026-01-24T10:59:59.000Z"
+      );
+    });
+
+    it("drops malformed dates rather than throwing mid-send", () => {
+      const t = parseTargetingFromRequest({
+        targetActivityFrom: "last April",
+        targetActivityTo: 1234,
+        targetActivityMinShifts: 1,
+      });
+
+      expect(t.targetActivityFrom).toBeNull();
+      expect(t.targetActivityTo).toBeNull();
+    });
+
+    it("clamps the minimum shift count into a sane range", () => {
+      expect(
+        parseTargetingFromRequest({ targetActivityMinShifts: 0 })
+          .targetActivityMinShifts
+      ).toBe(1);
+      expect(
+        parseTargetingFromRequest({ targetActivityMinShifts: -5 })
+          .targetActivityMinShifts
+      ).toBe(1);
+      expect(
+        parseTargetingFromRequest({ targetActivityMinShifts: 10_000 })
+          .targetActivityMinShifts
+      ).toBe(999);
+      expect(
+        parseTargetingFromRequest({ targetActivityMinShifts: 2.7 })
+          .targetActivityMinShifts
+      ).toBe(2);
+    });
+
+    it("ignores non-string entries in the targeting arrays", () => {
+      const t = parseTargetingFromRequest({
+        targetLocations: ["Onehunga", 42, null],
+        targetActivityLocations: "Onehunga",
+      });
+
+      expect(t.targetLocations).toEqual(["Onehunga"]);
+      expect(t.targetActivityLocations).toEqual([]);
+    });
+  });
+
+  describe("userMatchesActivityTargeting", () => {
+    const onehungaApril = { location: "Onehunga", end: new Date("2026-04-30") };
+    const onehungaJune = { location: "Onehunga", end: new Date("2026-06-15") };
+    const wellingtonJune = {
+      location: "Wellington",
+      end: new Date("2026-06-15"),
+    };
+
+    it("matches everyone when the dimension is off", () => {
+      expect(
+        userMatchesActivityTargeting(
+          [],
+          activity({ targetActivityMinShifts: null })
+        )
+      ).toBe(true);
+    });
+
+    it("requires at least one worked shift when switched on", () => {
+      expect(userMatchesActivityTargeting([], activity())).toBe(false);
+      expect(userMatchesActivityTargeting([onehungaJune], activity())).toBe(
+        true
+      );
+    });
+
+    it("counts only shifts at the targeted locations", () => {
+      const target = activity({ targetActivityLocations: ["Onehunga"] });
+
+      expect(userMatchesActivityTargeting([wellingtonJune], target)).toBe(false);
+      expect(userMatchesActivityTargeting([onehungaJune], target)).toBe(true);
+    });
+
+    it("excludes shifts with no location when locations are targeted", () => {
+      expect(
+        userMatchesActivityTargeting(
+          [{ location: null, end: new Date("2026-06-15") }],
+          activity({ targetActivityLocations: ["Onehunga"] })
+        )
+      ).toBe(false);
+    });
+
+    it("counts shifts at any location when none are targeted", () => {
+      expect(
+        userMatchesActivityTargeting([wellingtonJune], activity())
+      ).toBe(true);
+    });
+
+    it("applies the date window to the shift end time, inclusively", () => {
+      const target = activity({
+        targetActivityFrom: new Date("2026-05-01"),
+        targetActivityTo: new Date("2026-07-01"),
+      });
+
+      expect(userMatchesActivityTargeting([onehungaApril], target)).toBe(false);
+      expect(userMatchesActivityTargeting([onehungaJune], target)).toBe(true);
+      expect(
+        userMatchesActivityTargeting(
+          [{ location: "Onehunga", end: new Date("2026-05-01") }],
+          target
+        )
+      ).toBe(true);
+    });
+
+    it("requires the full minimum across matching shifts only", () => {
+      const target = activity({
+        targetActivityLocations: ["Onehunga"],
+        targetActivityMinShifts: 2,
+      });
+
+      expect(
+        userMatchesActivityTargeting([onehungaJune, wellingtonJune], target)
+      ).toBe(false);
+      expect(
+        userMatchesActivityTargeting([onehungaJune, onehungaApril], target)
+      ).toBe(true);
+    });
+  });
+});

--- a/web/src/lib/announcement-targeting.ts
+++ b/web/src/lib/announcement-targeting.ts
@@ -1,5 +1,6 @@
 import { Prisma, SignupStatus } from "@/generated/client";
 import { prisma } from "@/lib/prisma";
+import { createNZDate } from "@/lib/timezone";
 
 /**
  * Statuses that count as "currently signed up to a shift" for announcement
@@ -14,12 +15,30 @@ export const ANNOUNCEMENT_SHIFT_TARGET_STATUSES: readonly SignupStatus[] = [
   "NO_SHOW",
 ] as const;
 
+/**
+ * Statuses that count as "actually worked this shift" for shift-history
+ * targeting. Deliberately narrower than the set above: a waitlisted or
+ * no-show volunteer never worked the shift, so they don't belong in a
+ * "volunteers who worked at Onehunga recently" audience.
+ */
+export const ANNOUNCEMENT_ACTIVITY_STATUSES: readonly SignupStatus[] = [
+  "CONFIRMED",
+] as const;
+
 export interface AnnouncementTargeting {
   targetLocations: string[];
   targetGrades: string[];
   targetLabelIds: string[];
   targetUserIds: string[];
   targetShiftIds: string[];
+  /** Shift locations to count activity at. Empty = any location. */
+  targetActivityLocations: string[];
+  /** Only count shifts that ended on/after this. Null = no lower bound. */
+  targetActivityFrom: Date | null;
+  /** Only count shifts that ended on/before this. Null = no upper bound. */
+  targetActivityTo: Date | null;
+  /** Minimum matching shifts. Null switches the whole dimension off. */
+  targetActivityMinShifts: number | null;
 }
 
 /** Pluck the targeting fields out of an Announcement row. */
@@ -32,7 +51,117 @@ export function targetingFromAnnouncement(
     targetLabelIds: ann.targetLabelIds,
     targetUserIds: ann.targetUserIds,
     targetShiftIds: ann.targetShiftIds,
+    targetActivityLocations: ann.targetActivityLocations,
+    targetActivityFrom: ann.targetActivityFrom,
+    targetActivityTo: ann.targetActivityTo,
+    targetActivityMinShifts: ann.targetActivityMinShifts,
   };
+}
+
+/** Just the shift-history dimension, for callers that don't have the rest. */
+export type ActivityTargeting = Pick<
+  AnnouncementTargeting,
+  | "targetActivityLocations"
+  | "targetActivityFrom"
+  | "targetActivityTo"
+  | "targetActivityMinShifts"
+>;
+
+/** Is the shift-history dimension switched on for this targeting? */
+export function hasActivityTargeting(t: {
+  targetActivityMinShifts: number | null;
+}): boolean {
+  return t.targetActivityMinShifts !== null && t.targetActivityMinShifts >= 1;
+}
+
+/** A shift the volunteer worked — a confirmed signup on a finished shift. */
+export interface WorkedShift {
+  location: string | null;
+  end: Date;
+}
+
+/**
+ * In-memory twin of the shift-history SQL condition, for the mobile feed —
+ * which loads announcements for one known user and filters them in app code.
+ * Keep this in step with the `hasActivityTargeting` branch of
+ * `buildRecipientConditions`, or the feed will show a volunteer an
+ * announcement they were never emailed (or hide one they were).
+ *
+ * `workedShifts` must already be limited to shifts the user actually worked;
+ * this only applies the announcement's own location and date narrowing.
+ */
+export function userMatchesActivityTargeting(
+  workedShifts: WorkedShift[],
+  t: ActivityTargeting
+): boolean {
+  if (!hasActivityTargeting(t)) return true;
+
+  const matching = workedShifts.filter((shift) => {
+    if (
+      t.targetActivityLocations.length > 0 &&
+      (shift.location === null ||
+        !t.targetActivityLocations.includes(shift.location))
+    ) {
+      return false;
+    }
+    if (t.targetActivityFrom && shift.end < t.targetActivityFrom) return false;
+    if (t.targetActivityTo && shift.end > t.targetActivityTo) return false;
+    return true;
+  });
+
+  return matching.length >= (t.targetActivityMinShifts ?? 1);
+}
+
+const MAX_ACTIVITY_MIN_SHIFTS = 999;
+
+/**
+ * Coerce an untrusted request body into targeting. Shared by the create and
+ * recipient-count routes so the preview count can't drift from what actually
+ * gets sent.
+ *
+ * Activity dates arrive as `YYYY-MM-DD` from the admin form and are anchored
+ * to NZ calendar days — "from" at midnight, "to" at the end of that day — so
+ * a range reads inclusively the way an admin picked it.
+ */
+export function parseTargetingFromRequest(
+  body: Record<string, unknown>
+): AnnouncementTargeting {
+  const stringArray = (value: unknown): string[] =>
+    Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+
+  const rawMinShifts = body.targetActivityMinShifts;
+  const minShifts =
+    typeof rawMinShifts === "number" && Number.isFinite(rawMinShifts)
+      ? Math.min(Math.max(Math.trunc(rawMinShifts), 1), MAX_ACTIVITY_MIN_SHIFTS)
+      : null;
+
+  return {
+    targetLocations: stringArray(body.targetLocations),
+    targetGrades: stringArray(body.targetGrades),
+    targetLabelIds: stringArray(body.targetLabelIds),
+    targetUserIds: stringArray(body.targetUserIds),
+    targetShiftIds: stringArray(body.targetShiftIds),
+    targetActivityLocations: stringArray(body.targetActivityLocations),
+    targetActivityFrom: parseActivityDate(body.targetActivityFrom, "start"),
+    targetActivityTo: parseActivityDate(body.targetActivityTo, "end"),
+    targetActivityMinShifts: minShifts,
+  };
+}
+
+/**
+ * Turn a `YYYY-MM-DD` string from the date inputs into the UTC instant for the
+ * start or end of that NZ calendar day. Anything unparseable becomes null so a
+ * malformed date widens the window rather than throwing mid-send.
+ */
+function parseActivityDate(value: unknown, edge: "start" | "end"): Date | null {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const date =
+    edge === "start"
+      ? createNZDate(value, 0, 0, 0)
+      : createNZDate(value, 23, 59, 59);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
 /**
@@ -95,6 +224,39 @@ function buildRecipientConditions(t: AnnouncementTargeting): Prisma.Sql {
         AND "shiftId" = ANY(ARRAY[${Prisma.join(t.targetShiftIds)}]::text[])
         AND "status"::text = ANY(ARRAY[${Prisma.join(ANNOUNCEMENT_SHIFT_TARGET_STATUSES.map((s) => s))}]::text[])
       )`
+    );
+  }
+
+  if (hasActivityTargeting(t)) {
+    // Shifts the volunteer actually worked: a confirmed signup on a shift that
+    // has already finished. The optional narrowing clauses all key off the
+    // shift's end time, so "between April and July" means shifts that finished
+    // in that window rather than ones that merely started in it.
+    const activityFilters: Prisma.Sql[] = [
+      Prisma.sql`"Signup"."userId" = "User".id`,
+      Prisma.sql`"Signup"."status"::text = ANY(ARRAY[${Prisma.join(ANNOUNCEMENT_ACTIVITY_STATUSES.map((s) => s))}]::text[])`,
+      Prisma.sql`"Shift"."end" < NOW()`,
+    ];
+
+    if (t.targetActivityLocations.length > 0) {
+      activityFilters.push(
+        Prisma.sql`"Shift"."location" = ANY(ARRAY[${Prisma.join(t.targetActivityLocations)}]::text[])`
+      );
+    }
+    if (t.targetActivityFrom) {
+      activityFilters.push(Prisma.sql`"Shift"."end" >= ${t.targetActivityFrom}`);
+    }
+    if (t.targetActivityTo) {
+      activityFilters.push(Prisma.sql`"Shift"."end" <= ${t.targetActivityTo}`);
+    }
+
+    conditions.push(
+      Prisma.sql`(
+        SELECT COUNT(DISTINCT "Signup"."shiftId")
+        FROM "Signup"
+        JOIN "Shift" ON "Shift".id = "Signup"."shiftId"
+        WHERE ${Prisma.join(activityFilters, " AND ")}
+      ) >= ${t.targetActivityMinShifts}`
     );
   }
 


### PR DESCRIPTION
# Pull Request

## Description

Admins could only reach volunteers by **profile location**, which matches everyone who lists a restaurant - including people who signed up two years ago and never turned up. To reach "volunteers who worked at Onehunga in the last 3 months" the only option was picking each person by hand in the Specific Volunteers search; there was no import, and the Specific Shifts picker only lists upcoming shifts, so past shifts couldn't be selected either.

This adds a **Shift History** targeting dimension to `/admin/announcements`:

> worked at `[locations]` · shift finished between `[dates]` · at least `[N]` shifts

The audience is derived from data the portal already holds, so no list has to be assembled, uploaded, or kept up to date, and the same filter can be reused for later sends.

The difference is not cosmetic. On production-shaped data, "worked at Onehunga in the last 3 months" is **35 volunteers**; "profile lists Onehunga" is **23**. The Locations block now says what it actually matches and points at Shift History for people who turned up.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Version Bump Required

`version:minor` (label applied)

## How it works

**Definition of a worked shift.** A `CONFIRMED` signup on a shift whose `end` has passed. Waitlisted and no-show signups are deliberately excluded - a no-show never worked the shift, so they don't belong in a "thanks for volunteering" audience. This is narrower than `ANNOUNCEMENT_SHIFT_TARGET_STATUSES`, which the existing Specific Shifts dimension keeps using unchanged.

**Dormant by default.** The dimension is off unless `targetActivityMinShifts` is set. Every existing announcement keeps its exact recipient set, and the recipient counts shown on the announcements list are unchanged.

**Dates.** The window applies to when the shift *finished*, and `YYYY-MM-DD` inputs are anchored to NZ calendar days - "from 24 April" is midnight 24 April NZ, "to 24 April" is the end of that day - so a range reads inclusively the way an admin picked it. DST is handled via `createNZDate`; both sides of the transition are covered by tests.

**Consistency between channels.** `web/src/app/api/mobile/feed/route.ts` filters announcements for one known user in app code rather than SQL, so it gets an in-memory twin of the SQL condition (`userMatchesActivityTargeting`), living next to it in the same file with a comment tying them together. Without this, a volunteer could be emailed an announcement that never appeared in their feed.

**One parser, two routes.** The create route and the recipient-count route previously each hand-rolled their own body parsing. They now share `parseTargetingFromRequest`, so the live count an admin sees can't drift from the audience that actually gets sent to - the exact class of bug a new dimension would otherwise invite.

## Testing

- [x] Unit tests pass - 520 passing, 13 new in `announcement-targeting.test.ts` covering NZ date anchoring (both DST sides), malformed-date handling, min-shift clamping, and every branch of the matcher
- [x] Manual testing completed
- [x] New tests added
- [ ] E2E tests pass - not run locally; no existing announcements spec

Verified live against a dev database with realistic seed data:

| Targeting | Recipients |
|---|---|
| No targeting | 87 |
| Onehunga, last 3 months, min 1 | **35** |
| Onehunga, last 3 months, min 3 | 2 |
| Any location, last 3 months | 75 |
| Onehunga, all time | 41 |
| Onehunga activity AND Wellington profile | 30 |
| Window starting in the future | 0 |

The 35 matches a direct SQL check against the same data. Published a test announcement end to end (email and push off): stored `targetActivityFrom` was `2026-04-23 12:00 UTC` - correctly midnight 24 April NZST - and the saved announcement's recipient count and summary line ("worked 1+ shift at Onehunga since 24 Apr 2026") both rendered correctly. Test row deleted afterwards.

Checked at 1440px, 420px, and in dark mode. One defect found and fixed during review: the selected date preset rendered in a near-white `secondary` that was indistinguishable from the unselected outline buttons, so selection state was effectively invisible. Active presets are now primary green with `aria-pressed`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Migration.** `20260724000000_add_announcement_activity_targeting` adds four nullable/defaulted columns to `Announcement`. Additive and backward compatible; needs `prisma:deploy` on release. No new indexes - the existing `Signup(userId, canceledAt)` and `Shift(end)` indexes serve the recipient join.

**Out of scope, worth a look separately.** The recipient query has no `archivedAt` filter, so announcements to "all volunteers" also email and push to archived accounts (archived for `INACTIVE_12_MONTHS` or `NEVER_ACTIVATED`). Every other admin surface filters those out by default. That is pre-existing behaviour and changing it would shift the counts displayed for existing announcements, so I left it alone rather than folding it into this PR.