### PR TITLE
fix(announcements): exclude archived volunteers from targeting

### DIFF
--- a/web/src/lib/announcement-targeting.test.ts
+++ b/web/src/lib/announcement-targeting.test.ts
@@ -44,7 +44,9 @@ beforeEach(() => {
 
 describe("announcement recipient targeting", () => {
   it("excludes archived volunteers when targeting everyone", async () => {
-    await countAnnouncementRecipients(emptyTargeting);
+    queryRaw.mockResolvedValueOnce([{ count: BigInt(42) }]);
+    const count = await countAnnouncementRecipients(emptyTargeting);
+    expect(count).toBe(42);
     expect(lastSql()).toContain(`"archivedAt" IS NULL`);
   });
 
@@ -70,5 +72,19 @@ describe("announcement recipient targeting", () => {
     expect(sql).toContain(`( "archivedAt" IS NULL OR "User".id = ANY(`);
     // The exemption reuses the same ids as the targeting condition itself.
     expect(lastValues()).toEqual(["user-1", "user-2", "user-1", "user-2"]);
+  });
+
+  it("keeps cross-dimension AND semantics when ids are combined with a filter", async () => {
+    await findAnnouncementRecipients({
+      ...emptyTargeting,
+      targetUserIds: ["user-1"],
+      targetGrades: ["GREEN"],
+    });
+    const sql = lastSql().replace(/\s+/g, " ");
+    // The archive exemption widens who the id list may reach — it never
+    // relaxes the other dimensions, so a named volunteer of the wrong grade
+    // is still filtered out.
+    expect(sql).toContain(`( "archivedAt" IS NULL OR "User".id = ANY(`);
+    expect(sql).toContain(`"volunteerGrade"::text = ANY(`);
   });
 });

--- a/web/src/lib/announcement-targeting.test.ts
+++ b/web/src/lib/announcement-targeting.test.ts
@@ -1,0 +1,74 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    $queryRaw: vi.fn().mockResolvedValue([{ count: BigInt(0) }]),
+  },
+}));
+
+import type { Prisma } from "@/generated/client";
+import {
+  AnnouncementTargeting,
+  countAnnouncementRecipients,
+  findAnnouncementRecipients,
+} from "./announcement-targeting";
+import { prisma } from "@/lib/prisma";
+
+type Mock = ReturnType<typeof vi.fn>;
+const queryRaw = prisma.$queryRaw as unknown as Mock;
+
+const emptyTargeting: AnnouncementTargeting = {
+  targetLocations: [],
+  targetGrades: [],
+  targetLabelIds: [],
+  targetUserIds: [],
+  targetShiftIds: [],
+};
+
+/** The SQL text (placeholders, not values) of the last $queryRaw call. */
+function lastSql(): string {
+  const arg = queryRaw.mock.calls.at(-1)?.[0] as Prisma.Sql;
+  return arg.sql;
+}
+
+/** The bound parameter values of the last $queryRaw call. */
+function lastValues(): unknown[] {
+  const arg = queryRaw.mock.calls.at(-1)?.[0] as Prisma.Sql;
+  return arg.values;
+}
+
+beforeEach(() => {
+  queryRaw.mockClear();
+  queryRaw.mockResolvedValue([{ count: BigInt(0) }]);
+});
+
+describe("announcement recipient targeting", () => {
+  it("excludes archived volunteers when targeting everyone", async () => {
+    await countAnnouncementRecipients(emptyTargeting);
+    expect(lastSql()).toContain(`"archivedAt" IS NULL`);
+  });
+
+  it("excludes archived volunteers from every broad dimension", async () => {
+    await findAnnouncementRecipients({
+      ...emptyTargeting,
+      targetLocations: ["Wellington"],
+      targetGrades: ["GREEN"],
+      targetLabelIds: ["label-1"],
+      targetShiftIds: ["shift-1"],
+    });
+    expect(lastSql()).toContain(`"archivedAt" IS NULL`);
+    // No explicit user IDs, so no escape hatch on the archive filter.
+    expect(lastSql()).not.toContain(`OR "User".id = ANY(`);
+  });
+
+  it("still reaches archived volunteers named explicitly by id", async () => {
+    await findAnnouncementRecipients({
+      ...emptyTargeting,
+      targetUserIds: ["user-1", "user-2"],
+    });
+    const sql = lastSql().replace(/\s+/g, " ");
+    expect(sql).toContain(`( "archivedAt" IS NULL OR "User".id = ANY(`);
+    // The exemption reuses the same ids as the targeting condition itself.
+    expect(lastValues()).toEqual(["user-1", "user-2", "user-1", "user-2"]);
+  });
+});

--- a/web/src/lib/announcement-targeting.ts
+++ b/web/src/lib/announcement-targeting.ts
@@ -44,6 +44,25 @@ export function targetingFromAnnouncement(
 function buildRecipientConditions(t: AnnouncementTargeting): Prisma.Sql {
   const conditions: Prisma.Sql[] = [Prisma.sql`TRUE`];
 
+  // Archived volunteers (inactive 12 months, never activated, never migrated)
+  // are people the org has deliberately stopped engaging — and they can't sign
+  // in, so an announcement email would point them at a dashboard they can't
+  // reach. Keep them out of every broad targeting dimension.
+  //
+  // Exception: user IDs named explicitly. The "Announce" button on an archived
+  // volunteer's profile links straight here with `?userIds=<id>`, so an admin
+  // hand-picking an archived volunteer means it.
+  if (t.targetUserIds.length > 0) {
+    conditions.push(
+      Prisma.sql`(
+        "archivedAt" IS NULL
+        OR "User".id = ANY(ARRAY[${Prisma.join(t.targetUserIds)}]::text[])
+      )`
+    );
+  } else {
+    conditions.push(Prisma.sql`"archivedAt" IS NULL`);
+  }
+
   if (t.targetLocations.length > 0) {
     const targetLocations = Prisma.sql`ARRAY[${Prisma.join(t.targetLocations)}]::text[]`;
     // A volunteer belongs to a location when it's their default OR in their


### PR DESCRIPTION
## Problem

`buildRecipientConditions` in [announcement-targeting.ts](web/src/lib/announcement-targeting.ts) selected from `"User"` with no filter on `archivedAt`. Both callers - `countAnnouncementRecipients` (the admin form's live counter and the per-announcement counts on /admin/announcements) and `findAnnouncementRecipients` (the email and push dispatch paths) - therefore included archived accounts in every targeting dimension except explicitly-named user IDs.

So an announcement sent to "all volunteers", or to a location / grade / label / shift, also emailed and push-notified people the org has deliberately stopped engaging: `INACTIVE_12_MONTHS`, `NEVER_ACTIVATED`, `NEVER_MIGRATED`, `MANUAL`. Archived users also can't sign in (blocked in `auth-options`, `mobile-auth`, and `passkey-auth`), so the announcement email pointed them at a `/dashboard` they can't reach.

This looks like an oversight rather than a deliberate choice - every other admin surface that lists volunteers already filters archived accounts out by default:

- `web/src/app/api/admin/users/route.ts` - `{ archivedAt: null }`
- `web/src/app/admin/users/page.tsx` - archived filter defaults to "active"
- `web/src/app/api/admin/volunteers/route.ts`, `.../volunteers/search`, `.../notifications/send-shortage`, the leaderboard, achievements, friends

## Fix

Add an archive condition to `buildRecipientConditions`, with an exemption for explicitly-targeted user IDs:

- No `targetUserIds` -> `"archivedAt" IS NULL`
- With `targetUserIds` -> `("archivedAt" IS NULL OR "User".id = ANY(<ids>))`

The exemption is deliberate: the **Announce** button on an archived volunteer's profile (`/admin/volunteers/[id]`) deep-links to `/admin/announcements?userIds=<id>`, and `/api/admin/users?ids=` hydrates archived users for the badge - so hand-picking an archived volunteer is a supported flow and should keep working. Cross-dimension AND semantics are unchanged: `userIds + grade` still intersects.

## ⚠️ Recipient counts change

`/admin/announcements` recomputes `recipientCount` for **existing** announcements on every load, so counts shown for already-sent announcements will drop by however many archived volunteers matched their targeting. The number of people actually emailed at send time didn't change retroactively - only the displayed figure. Production currently has archived users, so this will be visible there (the dev DB has none, hence the seeding below).

## Verification

Seeded 2 archived + 1 active volunteer into the dev DB (87 users -> 90, all in Wellington/GREEN) and exercised the running app as an admin:

| Targeting | Recipients | Expected |
|---|---|---|
| All volunteers | 88 | 88 active (of 90 total) ✅ |
| Location = Wellington | 79 | archived seeds excluded ✅ |
| Grade = GREEN | 36 | archived seed excluded ✅ |
| `targetUserIds` = 2 archived | 2 | both still reached ✅ |
| `targetUserIds` = 1 archived + 1 active | 2 | ✅ |
| `targetUserIds` + grade | 2 | AND semantics intact ✅ |

The admin form's live counter read **"~88 volunteers"** with 90 users in the DB. Seed rows were deleted afterwards (dev DB back to 87 users, 0 archived).

Also added `web/src/lib/announcement-targeting.test.ts` - unit tests asserting the generated SQL carries `"archivedAt" IS NULL` for broad targeting and the OR-exemption when user IDs are named.

`npm run lint`, `npm run typecheck`, and `npm run test:run` (510 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)