### PR TITLE
feat(announcements): redesign admin console with live feed preview

### DIFF
--- a/web/prisma/migrations/20260724144327_add_announcement_activity_max_shifts/migration.sql
+++ b/web/prisma/migrations/20260724144327_add_announcement_activity_max_shifts/migration.sql
@@ -1,0 +1,3 @@
+-- Add an optional upper bound to shift-history targeting so announcements can
+-- target e.g. volunteers who have worked exactly one shift.
+ALTER TABLE "Announcement" ADD COLUMN "targetActivityMaxShifts" INTEGER;

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -1030,6 +1030,7 @@ model Announcement {
   targetActivityFrom      DateTime? // Shift must have ended on/after this
   targetActivityTo        DateTime? // Shift must have ended on/before this
   targetActivityMinShifts Int? // Minimum matching shifts; null = dimension off
+  targetActivityMaxShifts Int? // Maximum matching shifts; null = no upper bound
 
   // Email
   sendEmail   Boolean   @default(false)

--- a/web/src/app/admin/announcements/announcement-list.tsx
+++ b/web/src/app/admin/announcements/announcement-list.tsx
@@ -1,0 +1,471 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { format, formatDistanceToNow } from "date-fns";
+import {
+  Bell,
+  ChevronDown,
+  Clock,
+  Mail,
+  Megaphone,
+  Search,
+  Trash2,
+  Users,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import {
+  audienceSummary,
+  authorDisplayName,
+  expiresWithin,
+  isExpired,
+  stripMarkdown,
+  type Announcement,
+  type LabelOption,
+} from "./types";
+
+interface AnnouncementListProps {
+  announcements: Announcement[];
+  labels: LabelOption[];
+  onDelete: (ann: Announcement) => void;
+  onCompose: () => void;
+}
+
+/**
+ * The overview: a pulse strip of the numbers that matter, then the ledger —
+ * what's live in the feed now, followed by what has expired.
+ */
+export function AnnouncementList({
+  announcements,
+  labels,
+  onDelete,
+  onCompose,
+}: AnnouncementListProps) {
+  const [query, setQuery] = useState("");
+
+  const { live, expired } = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const matches = (ann: Announcement) =>
+      q === "" ||
+      ann.title.toLowerCase().includes(q) ||
+      ann.body.toLowerCase().includes(q) ||
+      authorDisplayName(ann.author).toLowerCase().includes(q);
+    const filtered = announcements.filter(matches);
+    return {
+      live: filtered.filter((a) => !isExpired(a)),
+      expired: filtered.filter((a) => isExpired(a)),
+    };
+  }, [announcements, query]);
+
+  const liveTotal = announcements.filter((a) => !isExpired(a)).length;
+  const nextToExpire = announcements
+    .filter((a) => !isExpired(a) && a.expiresAt)
+    .sort(
+      (a, b) =>
+        new Date(a.expiresAt!).getTime() - new Date(b.expiresAt!).getTime()
+    )[0];
+
+  if (announcements.length === 0) {
+    return (
+      <div className="rounded-2xl border border-forest-500/15 bg-card px-6 py-20 text-center dark:border-white/10">
+        <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-[#fef9c3] dark:bg-[#fef9c3]/15">
+          <Megaphone className="h-6 w-6 text-[#b45309] dark:text-amber-400" />
+        </div>
+        <h2 className="font-accent text-xl font-semibold">
+          Nothing in the feed yet
+        </h2>
+        <p className="mx-auto mt-1.5 max-w-sm text-sm text-muted-foreground">
+          Announcements land in every volunteer&apos;s mobile feed — and can
+          go out by push notification or email too.
+        </p>
+        <Button
+          onClick={onCompose}
+          className="mt-5 gap-2 bg-forest-500 text-white hover:bg-forest-600 dark:bg-[#86d99b] dark:text-[#0f1114] dark:hover:bg-[#9be3ae]"
+        >
+          <Megaphone className="h-4 w-4" />
+          Write the first announcement
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Pulse strip */}
+      <div className="grid grid-cols-1 divide-y divide-forest-500/10 rounded-2xl border border-forest-500/15 bg-card sm:grid-cols-3 sm:divide-x sm:divide-y-0 dark:divide-white/[0.07] dark:border-white/10">
+        <PulseStat
+          label="Live in the feed"
+          value={String(liveTotal)}
+          detail={liveTotal === 0 ? "Feed is quiet" : "Visible to volunteers"}
+          live={liveTotal > 0}
+        />
+        <PulseStat
+          label="Next to expire"
+          value={
+            nextToExpire
+              ? formatDistanceToNow(new Date(nextToExpire.expiresAt!))
+              : "—"
+          }
+          detail={
+            nextToExpire ? nextToExpire.title : "Nothing scheduled to leave"
+          }
+        />
+        <PulseStat
+          label="Published all-time"
+          value={String(announcements.length)}
+          detail="Including expired"
+        />
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-xs">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search announcements…"
+          className="h-9 border-forest-500/20 pl-9 dark:border-white/15"
+          data-testid="announcement-search"
+        />
+      </div>
+
+      {live.length === 0 && expired.length === 0 ? (
+        <p className="px-1 py-8 text-center text-sm text-muted-foreground">
+          No announcements match &ldquo;{query}&rdquo;.
+        </p>
+      ) : (
+        <>
+          {live.length > 0 && (
+            <section>
+              <SectionHeading live>
+                In the feed now · {live.length}
+              </SectionHeading>
+              <div className="space-y-3">
+                {live.map((ann) => (
+                  <AnnouncementRow
+                    key={ann.id}
+                    ann={ann}
+                    labels={labels}
+                    onDelete={() => onDelete(ann)}
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {expired.length > 0 && (
+            <section>
+              <SectionHeading>Expired · {expired.length}</SectionHeading>
+              <div className="space-y-2">
+                {expired.map((ann) => (
+                  <AnnouncementRow
+                    key={ann.id}
+                    ann={ann}
+                    labels={labels}
+                    onDelete={() => onDelete(ann)}
+                    expired
+                  />
+                ))}
+              </div>
+            </section>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function PulseStat({
+  label,
+  value,
+  detail,
+  live,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  live?: boolean;
+}) {
+  return (
+    <div className="px-5 py-4">
+      <p className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-forest-500/70 dark:text-[#86d99b]/70">
+        {live && (
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-forest-500 opacity-40 motion-reduce:animate-none dark:bg-[#86d99b]" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-forest-500 dark:bg-[#86d99b]" />
+          </span>
+        )}
+        {label}
+      </p>
+      <p className="mt-1 font-accent text-2xl font-semibold tabular-nums leading-none">
+        {value}
+      </p>
+      <p className="mt-1 truncate text-xs text-muted-foreground">{detail}</p>
+    </div>
+  );
+}
+
+function SectionHeading({
+  children,
+  live,
+}: {
+  children: React.ReactNode;
+  live?: boolean;
+}) {
+  return (
+    <h2 className="mb-2.5 flex items-center gap-2 px-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+      {live && (
+        <span className="h-2 w-2 rounded-full bg-forest-500 dark:bg-[#86d99b]" />
+      )}
+      {children}
+    </h2>
+  );
+}
+
+// ─── Ledger row ─────────────────────────────────────────────────────────────
+
+function AnnouncementRow({
+  ann,
+  labels,
+  onDelete,
+  expired,
+}: {
+  ann: Announcement;
+  labels: LabelOption[];
+  onDelete: () => void;
+  expired?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [matchCount, setMatchCount] = useState<number | null>(null);
+  const [matchLoading, setMatchLoading] = useState(false);
+
+  const created = new Date(ann.createdAt);
+  const expiresSoon = !expired && expiresWithin(ann, 48);
+
+  const toggleExpanded = () => {
+    const next = !expanded;
+    setExpanded(next);
+    // Lazily ask how many volunteers this announcement's stored targeting
+    // matches today — same endpoint the composer preview uses.
+    if (next && matchCount === null && !matchLoading) {
+      setMatchLoading(true);
+      fetch("/api/admin/announcements/recipient-count", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          targetLocations: ann.targetLocations,
+          targetGrades: ann.targetGrades,
+          targetLabelIds: ann.targetLabelIds,
+          targetUserIds: ann.targetUserIds,
+          targetShiftIds: ann.targetShiftIds,
+          targetActivityLocations: ann.targetActivityLocations,
+          // The count route expects NZ calendar days (yyyy-MM-dd); format in
+          // the admin's local tz, which matches how the dates were entered.
+          targetActivityFrom: ann.targetActivityFrom
+            ? format(new Date(ann.targetActivityFrom), "yyyy-MM-dd")
+            : null,
+          targetActivityTo: ann.targetActivityTo
+            ? format(new Date(ann.targetActivityTo), "yyyy-MM-dd")
+            : null,
+          targetActivityMinShifts: ann.targetActivityMinShifts,
+          targetActivityMaxShifts: ann.targetActivityMaxShifts,
+        }),
+      })
+        .then((r) => (r.ok ? r.json() : Promise.reject(r)))
+        .then((data) => setMatchCount(data.count ?? null))
+        .catch(() => {})
+        .finally(() => setMatchLoading(false));
+    }
+  };
+
+  return (
+    <article
+      className={cn(
+        "group rounded-2xl border transition-colors",
+        expired
+          ? "border-forest-500/10 bg-card/50 dark:border-white/[0.06] dark:bg-card/40"
+          : "border-forest-500/15 bg-card shadow-[0_1px_2px_rgb(29_83_55/0.06)] dark:border-white/10"
+      )}
+      data-testid="announcement-row"
+    >
+      <div className="flex items-start gap-4 p-4">
+        {/* Date tile */}
+        <div
+          className={cn(
+            "flex w-12 shrink-0 flex-col items-center rounded-xl border py-1.5",
+            expired
+              ? "border-forest-500/10 text-muted-foreground dark:border-white/[0.06]"
+              : "border-[#b45309]/15 bg-[#fef9c3]/60 text-[#7c4a10] dark:border-amber-400/15 dark:bg-[#fef9c3]/10 dark:text-amber-300"
+          )}
+          aria-hidden="true"
+        >
+          <span className="font-accent text-lg font-semibold leading-none tabular-nums">
+            {format(created, "d")}
+          </span>
+          <span className="mt-0.5 text-[10px] font-semibold uppercase tracking-wide">
+            {format(created, "MMM")}
+          </span>
+        </div>
+
+        {/* Main */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-3">
+            <button
+              type="button"
+              onClick={toggleExpanded}
+              className="min-w-0 cursor-pointer text-left"
+              aria-expanded={expanded}
+            >
+              <h3
+                className={cn(
+                  "font-accent text-base font-semibold leading-snug",
+                  expired && "text-muted-foreground"
+                )}
+              >
+                {ann.title}
+              </h3>
+              {!expanded && (
+                <p className="mt-0.5 line-clamp-1 text-sm text-muted-foreground">
+                  {stripMarkdown(ann.body)}
+                </p>
+              )}
+            </button>
+
+            <div className="flex shrink-0 items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground"
+                onClick={toggleExpanded}
+                aria-label={expanded ? "Collapse" : "Expand"}
+                aria-expanded={expanded}
+              >
+                <ChevronDown
+                  className={cn(
+                    "h-4 w-4 transition-transform duration-200",
+                    expanded && "rotate-180"
+                  )}
+                />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                onClick={onDelete}
+                aria-label="Delete announcement"
+                data-testid="announcement-delete"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Meta line */}
+          <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            <span>
+              {format(created, "h:mm a")} · {authorDisplayName(ann.author)}
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <Users className="h-3 w-3" />
+              {audienceSummary(ann, labels)}
+            </span>
+          </div>
+
+          {/* Status chips */}
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            {ann.sendNotification && (
+              <StatusChip
+                icon={<Bell className="h-3 w-3" />}
+                sent={!!ann.notificationSentAt}
+              >
+                {ann.notificationSentAt ? "Push sent" : "Push queued"}
+              </StatusChip>
+            )}
+            {ann.sendEmail && (
+              <StatusChip
+                icon={<Mail className="h-3 w-3" />}
+                sent={!!ann.emailSentAt}
+              >
+                {ann.emailSentAt ? "Email sent" : "Email queued"}
+              </StatusChip>
+            )}
+            {expired ? (
+              <span className="inline-flex items-center gap-1 rounded-full border border-forest-500/15 px-2 py-0.5 text-[11px] font-medium text-muted-foreground dark:border-white/10">
+                <Clock className="h-3 w-3" />
+                Expired{" "}
+                {formatDistanceToNow(new Date(ann.expiresAt!), {
+                  addSuffix: true,
+                })}
+              </span>
+            ) : ann.expiresAt ? (
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+                  expiresSoon
+                    ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+                    : "border-forest-500/15 text-muted-foreground dark:border-white/10"
+                )}
+              >
+                <Clock className="h-3 w-3" />
+                Expires{" "}
+                {formatDistanceToNow(new Date(ann.expiresAt), {
+                  addSuffix: true,
+                })}
+              </span>
+            ) : null}
+          </div>
+
+          {/* Expanded detail */}
+          {expanded && (
+            <div className="mt-3 space-y-3 border-t border-forest-500/10 pt-3 dark:border-white/[0.07]">
+              {ann.imageUrl && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={ann.imageUrl}
+                  alt=""
+                  className="h-36 w-auto rounded-lg object-cover"
+                />
+              )}
+              <div className="prose prose-sm max-w-none dark:prose-invert">
+                <ReactMarkdown>{ann.body}</ReactMarkdown>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {matchLoading
+                  ? "Counting who this audience matches today…"
+                  : matchCount !== null
+                    ? `This audience matches ~${matchCount} volunteer${matchCount === 1 ? "" : "s"} today.`
+                    : null}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function StatusChip({
+  icon,
+  sent,
+  children,
+}: {
+  icon: React.ReactNode;
+  sent: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+        sent
+          ? "border-forest-500/25 bg-forest-500/[0.07] text-forest-500 dark:border-[#86d99b]/25 dark:bg-[#86d99b]/10 dark:text-[#86d99b]"
+          : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+      )}
+    >
+      {icon}
+      {children}
+    </span>
+  );
+}

--- a/web/src/app/admin/announcements/announcements-content.tsx
+++ b/web/src/app/admin/announcements/announcements-content.tsx
@@ -1,44 +1,9 @@
 "use client";
 
-import { useState, useRef, useCallback, useEffect, useMemo } from "react";
+import { useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import ReactMarkdown from "react-markdown";
-import { format, subMonths } from "date-fns";
-import {
-  Plus,
-  Trash2,
-  Eye,
-  EyeOff,
-  Upload,
-  X,
-  Megaphone,
-  Users,
-  Clock,
-  ImageIcon,
-  ChevronDown,
-  ChevronUp,
-  Search,
-  Mail,
-  Bell,
-  CalendarClock,
-  CalendarIcon,
-  ClockIcon,
-  UserPlus2,
-  CheckCircle2,
-} from "lucide-react";
+import { Megaphone, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -49,145 +14,41 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { Calendar } from "@/components/ui/calendar";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { toast } from "sonner";
-import { cn } from "@/lib/utils";
-import { useDebounce } from "@/hooks/use-debounce";
-
-const VOLUNTEER_GRADES = [
-  { value: "GREEN", label: "Green", description: "Standard volunteers" },
-  { value: "YELLOW", label: "Yellow", description: "Experienced volunteers" },
-  { value: "PINK", label: "Pink", description: "Shift leaders" },
-];
-
-type Announcement = {
-  id: string;
-  title: string;
-  body: string;
-  imageUrl: string | null;
-  createdAt: string;
-  expiresAt: string | null;
-  createdBy: string;
-  targetLocations: string[];
-  targetGrades: string[];
-  targetLabelIds: string[];
-  targetUserIds: string[];
-  targetShiftIds: string[];
-  targetActivityLocations: string[];
-  targetActivityFrom: string | null;
-  targetActivityTo: string | null;
-  targetActivityMinShifts: number | null;
-  sendEmail: boolean;
-  emailSentAt: string | null;
-  sendNotification: boolean;
-  notificationSentAt: string | null;
-  author: {
-    id: string;
-    name: string | null;
-    firstName: string | null;
-    email: string;
-  };
-};
-
-type Label = {
-  id: string;
-  name: string;
-  color: string;
-  icon: string | null;
-};
-
-type UserOption = {
-  id: string;
-  email: string;
-  name: string | null;
-  firstName: string | null;
-  lastName: string | null;
-};
-
-type ShiftOption = {
-  id: string;
-  start: string;
-  end: string;
-  location: string | null;
-  shiftTypeName: string;
-  signupCount: number;
-};
+import { AnnouncementList } from "./announcement-list";
+import { Composer, type ComposerPrefill } from "./composer";
+import {
+  parseCsv,
+  type Announcement,
+  type LabelOption,
+} from "./types";
 
 interface AnnouncementsContentProps {
   initialAnnouncements: Announcement[];
-  labels: Label[];
+  labels: LabelOption[];
   locations: string[];
+  authorName: string;
 }
-
-/** Quick date ranges for shift-history targeting, newest window first. */
-const ACTIVITY_RANGE_PRESETS = [
-  { months: 3, label: "Last 3 months" },
-  { months: 6, label: "Last 6 months" },
-  { months: 12, label: "Last 12 months" },
-];
 
 /**
- * Plain-English summary of an announcement's shift-history targeting, e.g.
- * "worked 1+ shift at Onehunga since 24 Apr 2026". Returns null when the
- * dimension is off.
+ * The announcements console. Two views: the overview (pulse strip + ledger)
+ * and the composer, which takes over the page while writing. "Announce"
+ * links elsewhere in the admin deep-link here with query params that seed
+ * and open the composer.
  */
-function describeActivityTargeting(ann: {
-  targetActivityLocations: string[];
-  targetActivityFrom: string | null;
-  targetActivityTo: string | null;
-  targetActivityMinShifts: number | null;
-}): string | null {
-  const min = ann.targetActivityMinShifts;
-  if (min === null) return null;
-
-  const where =
-    ann.targetActivityLocations.length > 0
-      ? ` at ${ann.targetActivityLocations.join(", ")}`
-      : "";
-  const from = ann.targetActivityFrom
-    ? format(new Date(ann.targetActivityFrom), "d MMM yyyy")
-    : null;
-  const to = ann.targetActivityTo
-    ? format(new Date(ann.targetActivityTo), "d MMM yyyy")
-    : null;
-  const when = from
-    ? to
-      ? ` between ${from} and ${to}`
-      : ` since ${from}`
-    : to
-      ? ` up to ${to}`
-      : "";
-
-  return `worked ${min}+ shift${min === 1 ? "" : "s"}${where}${when}`;
-}
-
-function parseCsv(value: string | null): string[] {
-  if (!value) return [];
-  return value
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
 export function AnnouncementsContent({
   initialAnnouncements,
   labels,
   locations,
+  authorName,
 }: AnnouncementsContentProps) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  // Stable, hashable signature of the prefill query string. This is what
-  // `useEffect` watches — recomputing on every render gives us a fresh
-  // string each time but the value only *changes* when the query actually
-  // changes, so the syncing effect runs once per URL update.
+  // Stable signature of the prefill query string — the effect below watches
+  // it so a fresh "Announce" link click re-seeds the composer even though
+  // this component never unmounts.
   const prefillSignature = [
     searchParams.get("userIds") ?? "",
     searchParams.get("shiftIds") ?? "",
@@ -200,313 +61,31 @@ export function AnnouncementsContent({
 
   const [announcements, setAnnouncements] =
     useState<Announcement[]>(initialAnnouncements);
-  const [showForm, setShowForm] = useState(hasPrefill);
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [composerOpen, setComposerOpen] = useState(hasPrefill);
+  const [prefill, setPrefill] = useState<ComposerPrefill | null>(() =>
+    hasPrefill ? prefillFromParams(searchParams) : null
+  );
+  // Remount the composer whenever a new prefill arrives so it re-seeds.
+  const [composerKey, setComposerKey] = useState(prefillSignature);
   const [deleteTarget, setDeleteTarget] = useState<Announcement | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [previewMode, setPreviewMode] = useState(false);
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
 
-  // Form state — synced from the query string by the effect below whenever
-  // it changes, so navigating to `/admin/announcements?shiftIds=...` from
-  // anywhere always lands on a freshly-seeded form.
-  const [title, setTitle] = useState("");
-  const [body, setBody] = useState("");
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const [expiresAt, setExpiresAt] = useState("");
-  const [targetLocations, setTargetLocations] = useState<string[]>([]);
-  const [targetGrades, setTargetGrades] = useState<string[]>([]);
-  const [targetLabelIds, setTargetLabelIds] = useState<string[]>([]);
-  const [targetUsers, setTargetUsers] = useState<UserOption[]>([]);
-  const [targetShifts, setTargetShifts] = useState<ShiftOption[]>([]);
-  // Shift-history targeting. Off until the admin opts in, so the form keeps
-  // behaving exactly as before for everyone who doesn't need it.
-  const [activityEnabled, setActivityEnabled] = useState(false);
-  const [activityLocations, setActivityLocations] = useState<string[]>([]);
-  const [activityFrom, setActivityFrom] = useState(""); // yyyy-MM-dd
-  const [activityTo, setActivityTo] = useState("");
-  const [activityMinShifts, setActivityMinShifts] = useState(1);
-  const [sendEmail, setSendEmail] = useState(false);
-  const [sendNotification, setSendNotification] = useState(false);
-  const [isUploadingImage, setIsUploadingImage] = useState(false);
-  const [recipientPreview, setRecipientPreview] = useState<number | null>(null);
-  const [isCountingRecipients, setIsCountingRecipients] = useState(false);
-
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const recipientDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
-  );
-
-  const targetUserIds = useMemo(() => targetUsers.map((u) => u.id), [
-    targetUsers,
-  ]);
-  const targetShiftIds = useMemo(() => targetShifts.map((s) => s.id), [
-    targetShifts,
-  ]);
-
-  // Every targeting dimension in one object — the same shape the recipient
-  // count preview and the create request both send, so the number the admin
-  // sees always describes the audience they're about to publish to.
-  const targeting = useMemo(
-    () => ({
-      targetLocations,
-      targetGrades,
-      targetLabelIds,
-      targetUserIds,
-      targetShiftIds,
-      targetActivityLocations: activityEnabled ? activityLocations : [],
-      targetActivityFrom: activityEnabled ? activityFrom || null : null,
-      targetActivityTo: activityEnabled ? activityTo || null : null,
-      targetActivityMinShifts: activityEnabled ? activityMinShifts : null,
-    }),
-    [
-      targetLocations,
-      targetGrades,
-      targetLabelIds,
-      targetUserIds,
-      targetShiftIds,
-      activityEnabled,
-      activityLocations,
-      activityFrom,
-      activityTo,
-      activityMinShifts,
-    ]
-  );
-
-  // Sync form state from the query string whenever it changes. The effect
-  // re-runs only when `prefillSignature` changes, which means subsequent
-  // "Announce" link clicks (with different params) re-seed the form even
-  // though the page component never unmounts.
   useEffect(() => {
-    const userIds = parseCsv(searchParams.get("userIds"));
-    const shiftIds = parseCsv(searchParams.get("shiftIds"));
-    const locs = parseCsv(searchParams.get("locations"));
-    const grades = parseCsv(searchParams.get("grades"));
-    const lbls = parseCsv(searchParams.get("labels"));
-    const wantsEmail =
-      searchParams.get("sendEmail") === "1" ||
-      searchParams.get("sendEmail") === "true";
-    const empty =
-      userIds.length === 0 &&
-      shiftIds.length === 0 &&
-      locs.length === 0 &&
-      grades.length === 0 &&
-      lbls.length === 0 &&
-      !wantsEmail;
-    if (empty) return;
-
-    setShowForm(true);
-    setTargetLocations(locs);
-    setTargetGrades(grades);
-    setTargetLabelIds(lbls);
-    setSendEmail(wantsEmail);
-
-    let cancelled = false;
-    const run = async () => {
-      // Hydrate selected users by their IDs so the badges render with names.
-      if (userIds.length > 0) {
-        try {
-          const r = await fetch(
-            `/api/admin/users?ids=${encodeURIComponent(userIds.join(","))}`
-          );
-          if (r.ok) {
-            const data = (await r.json()) as UserOption[];
-            if (!cancelled) setTargetUsers(data);
-          }
-        } catch {
-          // leave selection empty if hydration fails — IDs aren't useful
-          // without names since the UI shows badge labels
-        }
-      } else {
-        setTargetUsers([]);
-      }
-
-      if (shiftIds.length > 0) {
-        try {
-          const r = await fetch(
-            `/api/admin/announcements/shifts?ids=${encodeURIComponent(shiftIds.join(","))}`
-          );
-          if (r.ok) {
-            const data = await r.json();
-            if (!cancelled) setTargetShifts(data.shifts ?? []);
-          }
-        } catch {
-          // see above
-        }
-      } else {
-        setTargetShifts([]);
-      }
-    };
-    run();
-    return () => {
-      cancelled = true;
-    };
+    if (!hasPrefill) return;
+    setPrefill(prefillFromParams(searchParams));
+    setComposerKey(prefillSignature);
+    setComposerOpen(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prefillSignature]);
 
-  const resetForm = () => {
-    setTitle("");
-    setBody("");
-    setImageUrl(null);
-    setExpiresAt("");
-    setTargetLocations([]);
-    setTargetGrades([]);
-    setTargetLabelIds([]);
-    setTargetUsers([]);
-    setTargetShifts([]);
-    setActivityEnabled(false);
-    setActivityLocations([]);
-    setActivityFrom("");
-    setActivityTo("");
-    setActivityMinShifts(1);
-    setSendEmail(false);
-    setSendNotification(false);
-    setPreviewMode(false);
-    setRecipientPreview(null);
-    // Drop any prefill query string so reopening the form doesn't re-seed
-    // it. We use replace so this doesn't add a history entry.
+  const closeComposer = () => {
+    setComposerOpen(false);
+    setPrefill(null);
+    setComposerKey(`closed-${Date.now()}`);
+    // Drop any prefill query string so reopening doesn't re-seed. replace
+    // avoids adding a history entry.
     if (hasPrefill) {
       router.replace(pathname);
-    }
-  };
-
-  // Debounced recipient count preview
-  const updateRecipientPreview = useCallback(
-    (currentTargeting: typeof targeting) => {
-      if (recipientDebounceRef.current) {
-        clearTimeout(recipientDebounceRef.current);
-      }
-      setIsCountingRecipients(true);
-      recipientDebounceRef.current = setTimeout(async () => {
-        try {
-          const response = await fetch(
-            "/api/admin/announcements/recipient-count",
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(currentTargeting),
-            }
-          );
-          if (response.ok) {
-            const data = await response.json();
-            setRecipientPreview(data.count ?? null);
-          }
-        } catch {
-          // ignore preview errors
-        } finally {
-          setIsCountingRecipients(false);
-        }
-      }, 600);
-    },
-    []
-  );
-
-  // Recompute the preview whenever any targeting dimension changes.
-  useEffect(() => {
-    updateRecipientPreview(targeting);
-  }, [targeting, updateRecipientPreview]);
-
-  const handleLocationToggle = (loc: string) => {
-    setTargetLocations((prev) =>
-      prev.includes(loc) ? prev.filter((l) => l !== loc) : [...prev, loc]
-    );
-  };
-
-  const handleGradeToggle = (grade: string) => {
-    setTargetGrades((prev) =>
-      prev.includes(grade) ? prev.filter((g) => g !== grade) : [...prev, grade]
-    );
-  };
-
-  const handleActivityLocationToggle = (loc: string) => {
-    setActivityLocations((prev) =>
-      prev.includes(loc) ? prev.filter((l) => l !== loc) : [...prev, loc]
-    );
-  };
-
-  const handleLabelToggle = (labelId: string) => {
-    setTargetLabelIds((prev) =>
-      prev.includes(labelId)
-        ? prev.filter((l) => l !== labelId)
-        : [...prev, labelId]
-    );
-  };
-
-  const handleImageUpload = async (file: File) => {
-    setIsUploadingImage(true);
-    try {
-      const fd = new FormData();
-      fd.append("file", file);
-      const response = await fetch("/api/admin/announcements/upload-image", {
-        method: "POST",
-        body: fd,
-      });
-      if (!response.ok) {
-        const err = await response.json();
-        throw new Error(err.error ?? "Upload failed");
-      }
-      const { url } = await response.json();
-      setImageUrl(url);
-      toast.success("Image uploaded");
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Image upload failed");
-    } finally {
-      setIsUploadingImage(false);
-    }
-  };
-
-  const handleFileDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const file = e.dataTransfer.files[0];
-    if (file) handleImageUpload(file);
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!title.trim() || !body.trim()) {
-      toast.error("Title and body are required");
-      return;
-    }
-    setIsSubmitting(true);
-    try {
-      const response = await fetch("/api/admin/announcements", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: title.trim(),
-          body: body.trim(),
-          imageUrl,
-          expiresAt: expiresAt || null,
-          ...targeting,
-          sendEmail,
-          sendNotification,
-        }),
-      });
-
-      if (!response.ok) {
-        const err = await response.json();
-        throw new Error(err.error ?? "Failed to create announcement");
-      }
-
-      const { announcement } = await response.json();
-      setAnnouncements((prev) => [announcement, ...prev]);
-      resetForm();
-      setShowForm(false);
-      const dispatchedVia = [
-        sendEmail ? "emails" : null,
-        sendNotification ? "push notifications" : null,
-      ].filter(Boolean) as string[];
-      toast.success(
-        dispatchedVia.length > 0
-          ? `Announcement published — ${dispatchedVia.join(" + ")} sending in the background`
-          : "Announcement published"
-      );
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Failed to create announcement"
-      );
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -534,735 +113,78 @@ export function AnnouncementsContent({
     }
   };
 
-  const isExpired = (ann: Announcement) =>
-    ann.expiresAt ? new Date(ann.expiresAt) < new Date() : false;
-
-  const getTargetingSummary = (ann: Announcement): string => {
-    const parts: string[] = [];
-    if (ann.targetLocations.length > 0) {
-      parts.push(ann.targetLocations.join(", "));
-    }
-    if (ann.targetGrades.length > 0) {
-      parts.push(
-        ann.targetGrades
-          .map(
-            (g) => VOLUNTEER_GRADES.find((vg) => vg.value === g)?.label ?? g
-          )
-          .join(", ") + " grade"
-      );
-    }
-    if (ann.targetLabelIds.length > 0) {
-      const labelNames = ann.targetLabelIds
-        .map((id) => labels.find((l) => l.id === id)?.name ?? id)
-        .join(", ");
-      parts.push(labelNames);
-    }
-    if (ann.targetUserIds.length > 0) {
-      parts.push(
-        `${ann.targetUserIds.length} specific volunteer${ann.targetUserIds.length === 1 ? "" : "s"}`
-      );
-    }
-    if (ann.targetShiftIds.length > 0) {
-      parts.push(
-        `${ann.targetShiftIds.length} specific shift${ann.targetShiftIds.length === 1 ? "" : "s"}`
-      );
-    }
-    const activity = describeActivityTargeting(ann);
-    if (activity) {
-      parts.push(activity);
-    }
-    return parts.length > 0 ? parts.join(" · ") : "All volunteers";
-  };
-
   return (
-    <div className="space-y-6">
-      {/* Header action */}
-      <div className="flex justify-end">
-        <Button
-          onClick={() => {
-            setShowForm(!showForm);
-            if (showForm) resetForm();
-          }}
-          className="gap-2"
-        >
-          {showForm ? (
-            <>
-              <X className="w-4 h-4" /> Cancel
-            </>
-          ) : (
-            <>
-              <Plus className="w-4 h-4" /> New Announcement
-            </>
-          )}
-        </Button>
+    <div className="space-y-5">
+      {/* Page header row */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-accent text-2xl font-semibold leading-tight">
+            {composerOpen ? (
+              <>
+                New <em>announcement</em>
+              </>
+            ) : (
+              <>
+                What&apos;s <em>live</em> right now
+              </>
+            )}
+          </h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            {composerOpen
+              ? "It lands in volunteers' feeds the moment you publish."
+              : "Broadcasts to volunteers — in their feed, by push, or by email."}
+          </p>
+        </div>
+        {composerOpen ? (
+          <Button
+            variant="outline"
+            onClick={closeComposer}
+            className="gap-2"
+            data-testid="announcement-composer-close"
+          >
+            <X className="h-4 w-4" />
+            Back to overview
+          </Button>
+        ) : (
+          <Button
+            onClick={() => {
+              setComposerKey(`fresh-${Date.now()}`);
+              setPrefill(null);
+              setComposerOpen(true);
+            }}
+            className="gap-2 bg-forest-500 text-white hover:bg-forest-600 dark:bg-[#86d99b] dark:text-[#0f1114] dark:hover:bg-[#9be3ae]"
+            data-testid="announcement-new"
+          >
+            <Megaphone className="h-4 w-4" />
+            New announcement
+          </Button>
+        )}
       </div>
 
-      {/* Create form */}
-      {showForm && (
-        <Card className="border-2 border-primary/20">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-lg">
-              <Megaphone className="w-5 h-5 text-orange-500" />
-              New Announcement
-            </CardTitle>
-            <CardDescription>
-              Write your announcement in Markdown. Use targeting to reach
-              specific volunteer groups, and optionally send via email.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-6">
-              {/* Title */}
-              <div className="space-y-2">
-                <Label htmlFor="ann-title">Title *</Label>
-                <Input
-                  id="ann-title"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  placeholder="e.g. Important update for Auckland volunteers"
-                  maxLength={200}
-                  required
-                />
-              </div>
-
-              {/* Body with Markdown editor/preview tabs */}
-              <div className="space-y-2">
-                <Label>Body * (Markdown supported)</Label>
-                <Tabs
-                  value={previewMode ? "preview" : "edit"}
-                  onValueChange={(v) => setPreviewMode(v === "preview")}
-                >
-                  <TabsList className="h-8">
-                    <TabsTrigger value="edit" className="gap-1.5 text-xs h-7">
-                      <EyeOff className="w-3 h-3" /> Edit
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="preview"
-                      className="gap-1.5 text-xs h-7"
-                    >
-                      <Eye className="w-3 h-3" /> Preview
-                    </TabsTrigger>
-                  </TabsList>
-                  <TabsContent value="edit" className="mt-2">
-                    <Textarea
-                      value={body}
-                      onChange={(e) => setBody(e.target.value)}
-                      placeholder={`Write your announcement here...\n\nMarkdown tips:\n**bold**, *italic*, [link](url)\n- bullet points\n1. numbered lists`}
-                      className="min-h-[200px] font-mono text-sm resize-y"
-                      required
-                    />
-                  </TabsContent>
-                  <TabsContent value="preview" className="mt-2">
-                    <div className="min-h-[200px] rounded-md border bg-muted/30 px-4 py-3">
-                      {body ? (
-                        <div className="prose prose-sm dark:prose-invert max-w-none">
-                          <ReactMarkdown>{body}</ReactMarkdown>
-                        </div>
-                      ) : (
-                        <p className="text-sm text-muted-foreground italic">
-                          Nothing to preview yet — start typing in the Edit
-                          tab.
-                        </p>
-                      )}
-                    </div>
-                  </TabsContent>
-                </Tabs>
-              </div>
-
-              {/* Image upload */}
-              <div className="space-y-2">
-                <Label>Featured Image (optional)</Label>
-                {imageUrl ? (
-                  <div className="relative inline-block">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={imageUrl}
-                      alt="Announcement image"
-                      className="h-40 w-auto rounded-lg object-cover border"
-                    />
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      size="icon"
-                      className="absolute -top-2 -right-2 h-6 w-6"
-                      onClick={() => setImageUrl(null)}
-                    >
-                      <X className="w-3 h-3" />
-                    </Button>
-                  </div>
-                ) : (
-                  <div
-                    className={cn(
-                      "border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors",
-                      "hover:border-primary/50 hover:bg-muted/30",
-                      isUploadingImage && "opacity-50 pointer-events-none"
-                    )}
-                    onDrop={handleFileDrop}
-                    onDragOver={(e) => e.preventDefault()}
-                    onClick={() => fileInputRef.current?.click()}
-                  >
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      accept="image/jpeg,image/png,image/webp,image/gif"
-                      className="hidden"
-                      onChange={(e) => {
-                        const file = e.target.files?.[0];
-                        if (file) handleImageUpload(file);
-                      }}
-                    />
-                    <ImageIcon className="w-8 h-8 mx-auto mb-2 text-muted-foreground" />
-                    <p className="text-sm text-muted-foreground">
-                      {isUploadingImage
-                        ? "Uploading…"
-                        : "Drag & drop or click to upload (JPEG, PNG, WebP, GIF · max 5MB)"}
-                    </p>
-                  </div>
-                )}
-              </div>
-
-              {/* Expiry */}
-              <div className="space-y-2">
-                <Label>Expiry Date (optional)</Label>
-                <ExpiryDateTimePicker
-                  value={expiresAt}
-                  onChange={setExpiresAt}
-                />
-                <p className="text-xs text-muted-foreground">
-                  If set, the announcement will stop appearing in the feed
-                  after this date/time.
-                </p>
-              </div>
-
-              {/* Targeting */}
-              <div className="space-y-4 rounded-lg border bg-muted/20 p-4">
-                <div className="flex items-center justify-between">
-                  <h3 className="font-medium text-sm flex items-center gap-2">
-                    <Users className="w-4 h-4" />
-                    Targeting
-                  </h3>
-                  {recipientPreview !== null && (
-                    <span className="text-xs text-muted-foreground">
-                      {isCountingRecipients
-                        ? "Counting…"
-                        : `~${recipientPreview} volunteer${recipientPreview === 1 ? "" : "s"}`}
-                    </span>
-                  )}
-                </div>
-                <p className="text-xs text-muted-foreground -mt-2">
-                  Leave all empty to send to all volunteers. Multiple
-                  selections within a category use OR logic; across categories
-                  use AND logic.
-                </p>
-
-                {/* Locations */}
-                {locations.length > 0 && (
-                  <div className="space-y-2">
-                    <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                      Locations
-                    </Label>
-                    <div className="flex flex-wrap gap-2">
-                      {locations.map((loc) => (
-                        <label
-                          key={loc}
-                          className="flex items-center gap-1.5 cursor-pointer"
-                        >
-                          <Checkbox
-                            checked={targetLocations.includes(loc)}
-                            onCheckedChange={() => handleLocationToggle(loc)}
-                          />
-                          <span className="text-sm">{loc}</span>
-                        </label>
-                      ))}
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      Matches the locations on a volunteer&apos;s profile,
-                      including people who have never worked a shift there. To
-                      reach volunteers who actually turned up, use Shift
-                      History.
-                    </p>
-                  </div>
-                )}
-
-                {/* Shift history */}
-                <div className="space-y-2">
-                  <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    Shift History
-                  </Label>
-                  <label className="flex items-start gap-2 cursor-pointer">
-                    <Checkbox
-                      checked={activityEnabled}
-                      onCheckedChange={(checked) =>
-                        setActivityEnabled(checked === true)
-                      }
-                      className="mt-0.5"
-                      data-testid="announcement-activity-toggle"
-                    />
-                    <div>
-                      <span className="text-sm">
-                        Only volunteers who have worked a shift
-                      </span>
-                      <p className="text-xs text-muted-foreground">
-                        Counts shifts they were confirmed on that have already
-                        finished.
-                      </p>
-                    </div>
-                  </label>
-
-                  {activityEnabled && (
-                    <div
-                      className="space-y-4 rounded-md border bg-background p-3"
-                      data-testid="announcement-activity-filters"
-                    >
-                      {locations.length > 0 && (
-                        <div className="space-y-2">
-                          <Label className="text-xs font-medium">
-                            Worked at
-                          </Label>
-                          <div className="flex flex-wrap gap-2">
-                            {locations.map((loc) => (
-                              <label
-                                key={loc}
-                                className="flex items-center gap-1.5 cursor-pointer"
-                              >
-                                <Checkbox
-                                  checked={activityLocations.includes(loc)}
-                                  onCheckedChange={() =>
-                                    handleActivityLocationToggle(loc)
-                                  }
-                                  data-testid={`announcement-activity-location-${loc}`}
-                                />
-                                <span className="text-sm">{loc}</span>
-                              </label>
-                            ))}
-                          </div>
-                          <p className="text-xs text-muted-foreground">
-                            Leave empty to count shifts at any location.
-                          </p>
-                        </div>
-                      )}
-
-                      <div className="space-y-2">
-                        <Label className="text-xs font-medium">
-                          Shift finished between
-                        </Label>
-                        <div className="flex flex-wrap items-end gap-3">
-                          <div className="space-y-1">
-                            <Label
-                              htmlFor="activity-from"
-                              className="text-xs text-muted-foreground"
-                            >
-                              From
-                            </Label>
-                            <Input
-                              id="activity-from"
-                              type="date"
-                              value={activityFrom}
-                              max={activityTo || undefined}
-                              onChange={(e) => setActivityFrom(e.target.value)}
-                              className="h-9 w-[10.5rem]"
-                              data-testid="announcement-activity-from"
-                            />
-                          </div>
-                          <div className="space-y-1">
-                            <Label
-                              htmlFor="activity-to"
-                              className="text-xs text-muted-foreground"
-                            >
-                              To
-                            </Label>
-                            <Input
-                              id="activity-to"
-                              type="date"
-                              value={activityTo}
-                              min={activityFrom || undefined}
-                              onChange={(e) => setActivityTo(e.target.value)}
-                              className="h-9 w-[10.5rem]"
-                              data-testid="announcement-activity-to"
-                            />
-                          </div>
-                        </div>
-                        <div className="flex flex-wrap gap-2 pt-1">
-                          {ACTIVITY_RANGE_PRESETS.map((preset) => {
-                            const presetFrom = format(
-                              subMonths(new Date(), preset.months),
-                              "yyyy-MM-dd"
-                            );
-                            const isActive =
-                              activityFrom === presetFrom && activityTo === "";
-                            return (
-                              <Button
-                                key={preset.months}
-                                type="button"
-                                variant={isActive ? "default" : "outline"}
-                                size="sm"
-                                aria-pressed={isActive}
-                                className="h-7 text-xs"
-                                onClick={() => {
-                                  setActivityFrom(presetFrom);
-                                  setActivityTo("");
-                                }}
-                                data-testid={`announcement-activity-preset-${preset.months}`}
-                              >
-                                {preset.label}
-                              </Button>
-                            );
-                          })}
-                          {(activityFrom || activityTo) && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="h-7 text-xs"
-                              onClick={() => {
-                                setActivityFrom("");
-                                setActivityTo("");
-                              }}
-                            >
-                              Clear dates
-                            </Button>
-                          )}
-                        </div>
-                        <p className="text-xs text-muted-foreground">
-                          Leave both empty to count shifts from any time.
-                        </p>
-                      </div>
-
-                      <div className="space-y-2">
-                        <Label
-                          htmlFor="activity-min-shifts"
-                          className="text-xs font-medium"
-                        >
-                          Minimum shifts
-                        </Label>
-                        <Input
-                          id="activity-min-shifts"
-                          type="number"
-                          min={1}
-                          max={999}
-                          value={activityMinShifts}
-                          onChange={(e) => {
-                            const next = parseInt(e.target.value, 10);
-                            setActivityMinShifts(
-                              Number.isNaN(next)
-                                ? 1
-                                : Math.min(Math.max(next, 1), 999)
-                            );
-                          }}
-                          className="h-9 w-24"
-                          data-testid="announcement-activity-min-shifts"
-                        />
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* Grades */}
-                <div className="space-y-2">
-                  <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    Volunteer Grade
-                  </Label>
-                  <div className="flex flex-wrap gap-4">
-                    {VOLUNTEER_GRADES.map((g) => (
-                      <label
-                        key={g.value}
-                        className="flex items-center gap-1.5 cursor-pointer"
-                      >
-                        <Checkbox
-                          checked={targetGrades.includes(g.value)}
-                          onCheckedChange={() => handleGradeToggle(g.value)}
-                        />
-                        <span className="text-sm">
-                          {g.label}{" "}
-                          <span className="text-muted-foreground text-xs">
-                            ({g.description})
-                          </span>
-                        </span>
-                      </label>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Labels */}
-                {labels.length > 0 && (
-                  <div className="space-y-2">
-                    <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                      Custom Labels
-                    </Label>
-                    <div className="flex flex-wrap gap-2">
-                      {labels.map((label) => (
-                        <label
-                          key={label.id}
-                          className="flex items-center gap-1.5 cursor-pointer"
-                        >
-                          <Checkbox
-                            checked={targetLabelIds.includes(label.id)}
-                            onCheckedChange={() => handleLabelToggle(label.id)}
-                          />
-                          <span
-                            className={cn(
-                              "text-xs px-2 py-0.5 rounded-full border font-medium",
-                              label.color
-                            )}
-                          >
-                            {label.icon && (
-                              <span className="mr-1">{label.icon}</span>
-                            )}
-                            {label.name}
-                          </span>
-                        </label>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {/* Specific users */}
-                <div className="space-y-2">
-                  <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    Specific Volunteers
-                  </Label>
-                  <SpecificUsersPicker
-                    selected={targetUsers}
-                    onChange={setTargetUsers}
-                  />
-                </div>
-
-                {/* Specific shifts */}
-                <div className="space-y-2">
-                  <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    Specific Shifts
-                  </Label>
-                  <SpecificShiftsPicker
-                    selected={targetShifts}
-                    onChange={setTargetShifts}
-                    locations={locations}
-                  />
-                </div>
-              </div>
-
-              {/* Delivery options */}
-              <div className="space-y-3 rounded-lg border bg-muted/20 p-4">
-                <label className="flex items-start gap-2 cursor-pointer">
-                  <Checkbox
-                    checked={sendNotification}
-                    onCheckedChange={(checked) =>
-                      setSendNotification(checked === true)
-                    }
-                    className="mt-0.5"
-                  />
-                  <div>
-                    <span className="font-medium text-sm flex items-center gap-2">
-                      <Bell className="w-4 h-4" />
-                      Also send as push notification
-                    </span>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      Each matched volunteer gets an in-app notification and
-                      a push to their mobile device. The push body uses a
-                      plain-text preview of the announcement.
-                    </p>
-                  </div>
-                </label>
-                <label className="flex items-start gap-2 cursor-pointer">
-                  <Checkbox
-                    checked={sendEmail}
-                    onCheckedChange={(checked) =>
-                      setSendEmail(checked === true)
-                    }
-                    className="mt-0.5"
-                  />
-                  <div>
-                    <span className="font-medium text-sm flex items-center gap-2">
-                      <Mail className="w-4 h-4" />
-                      Also send as email
-                    </span>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      Each matched volunteer receives a transactional email
-                      with the full announcement on top of seeing it in
-                      their feed.
-                    </p>
-                  </div>
-                </label>
-              </div>
-
-              {/* Submit */}
-              <div className="flex items-center gap-3 pt-2">
-                <Button type="submit" disabled={isSubmitting} className="gap-2">
-                  <Upload className="w-4 h-4" />
-                  {isSubmitting ? "Publishing…" : "Publish Announcement"}
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => {
-                    resetForm();
-                    setShowForm(false);
-                  }}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </form>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Announcements list */}
-      {announcements.length === 0 ? (
-        <Card>
-          <CardContent className="py-16 text-center">
-            <Megaphone className="w-10 h-10 mx-auto mb-3 text-muted-foreground/40" />
-            <p className="text-sm font-medium text-muted-foreground">
-              No announcements yet
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Create one above to broadcast to volunteers in their mobile
-              feed.
-            </p>
-          </CardContent>
-        </Card>
+      {composerOpen ? (
+        <Composer
+          key={composerKey}
+          labels={labels}
+          locations={locations}
+          authorName={authorName}
+          prefill={prefill}
+          onPublished={(announcement) => {
+            setAnnouncements((prev) => [announcement, ...prev]);
+            closeComposer();
+          }}
+          onClose={closeComposer}
+        />
       ) : (
-        <div className="space-y-3">
-          {announcements.map((ann) => {
-            const expired = isExpired(ann);
-            const expanded = expandedIds.has(ann.id);
-
-            return (
-              <Card
-                key={ann.id}
-                className={cn("transition-opacity", expired && "opacity-60")}
-              >
-                <CardContent className="pt-4 pb-3">
-                  <div className="flex items-start gap-3">
-                    {/* Icon */}
-                    <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-orange-50 dark:bg-orange-950 flex items-center justify-center">
-                      <Megaphone className="w-4 h-4 text-orange-500" />
-                    </div>
-
-                    {/* Main content */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-start justify-between gap-2">
-                        <div>
-                          <h3 className="font-semibold text-sm leading-snug">
-                            {ann.title}
-                          </h3>
-                          <div className="flex items-center gap-2 mt-1 flex-wrap">
-                            <span className="text-xs text-muted-foreground flex items-center gap-1">
-                              <Clock className="w-3 h-3" />
-                              {format(
-                                new Date(ann.createdAt),
-                                "d MMM yyyy, h:mm a"
-                              )}
-                            </span>
-                            <span className="text-xs text-muted-foreground">
-                              by{" "}
-                              {ann.author.firstName ??
-                                ann.author.name ??
-                                ann.author.email}
-                            </span>
-                            {expired && (
-                              <Badge
-                                variant="outline"
-                                className="text-xs py-0 border-orange-300 text-orange-600"
-                              >
-                                Expired
-                              </Badge>
-                            )}
-                            {ann.expiresAt && !expired && (
-                              <span className="text-xs text-muted-foreground">
-                                Expires{" "}
-                                {format(
-                                  new Date(ann.expiresAt),
-                                  "d MMM, h:mm a"
-                                )}
-                              </span>
-                            )}
-                            {ann.sendNotification && (
-                              <Badge
-                                variant="outline"
-                                className="text-xs py-0 gap-1 border-emerald-300 text-emerald-700"
-                              >
-                                <Bell className="w-3 h-3" />
-                                {ann.notificationSentAt
-                                  ? "Push sent"
-                                  : "Push queued"}
-                              </Badge>
-                            )}
-                            {ann.sendEmail && (
-                              <Badge
-                                variant="outline"
-                                className="text-xs py-0 gap-1 border-blue-300 text-blue-700"
-                              >
-                                <Mail className="w-3 h-3" />
-                                {ann.emailSentAt ? "Email sent" : "Email queued"}
-                              </Badge>
-                            )}
-                          </div>
-                          {/* Targeting badge */}
-                          <div className="mt-1.5 flex items-center gap-1">
-                            <Users className="w-3 h-3 text-muted-foreground flex-shrink-0" />
-                            <span className="text-xs text-muted-foreground">
-                              {getTargetingSummary(ann)}
-                            </span>
-                          </div>
-                        </div>
-
-                        {/* Actions */}
-                        <div className="flex items-center gap-1 flex-shrink-0">
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7"
-                            onClick={() =>
-                              setExpandedIds((prev) => {
-                                const next = new Set(prev);
-                                if (next.has(ann.id)) next.delete(ann.id);
-                                else next.add(ann.id);
-                                return next;
-                              })
-                            }
-                            aria-label={expanded ? "Collapse" : "Expand"}
-                          >
-                            {expanded ? (
-                              <ChevronUp className="w-4 h-4" />
-                            ) : (
-                              <ChevronDown className="w-4 h-4" />
-                            )}
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
-                            onClick={() => setDeleteTarget(ann)}
-                            aria-label="Delete announcement"
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </Button>
-                        </div>
-                      </div>
-
-                      {/* Expanded body preview */}
-                      {expanded && (
-                        <div className="mt-3 pt-3 border-t space-y-3">
-                          {ann.imageUrl && (
-                            // eslint-disable-next-line @next/next/no-img-element
-                            <img
-                              src={ann.imageUrl}
-                              alt=""
-                              className="h-32 w-auto rounded-md object-cover"
-                            />
-                          )}
-                          <div className="prose prose-sm dark:prose-invert max-w-none text-sm">
-                            <ReactMarkdown>{ann.body}</ReactMarkdown>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
+        <AnnouncementList
+          announcements={announcements}
+          labels={labels}
+          onDelete={setDeleteTarget}
+          onCompose={() => {
+            setComposerKey(`fresh-${Date.now()}`);
+            setPrefill(null);
+            setComposerOpen(true);
+          }}
+        />
       )}
 
       {/* Delete confirmation */}
@@ -1272,7 +194,7 @@ export function AnnouncementsContent({
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete Announcement?</AlertDialogTitle>
+            <AlertDialogTitle>Delete announcement?</AlertDialogTitle>
             <AlertDialogDescription>
               &ldquo;{deleteTarget?.title}&rdquo; will be permanently removed
               from the feed. This cannot be undone.
@@ -1283,7 +205,8 @@ export function AnnouncementsContent({
             <AlertDialogAction
               onClick={handleDelete}
               disabled={isDeleting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              className="bg-destructive text-white hover:bg-destructive/90"
+              data-testid="announcement-delete-confirm"
             >
               {isDeleting ? "Deleting…" : "Delete"}
             </AlertDialogAction>
@@ -1294,433 +217,14 @@ export function AnnouncementsContent({
   );
 }
 
-// ─── Specific Users picker ──────────────────────────────────────────────────
-
-function userDisplayName(u: UserOption) {
-  if (u.firstName && u.lastName) return `${u.firstName} ${u.lastName}`;
-  return u.name || u.email;
-}
-
-function SpecificUsersPicker({
-  selected,
-  onChange,
-}: {
-  selected: UserOption[];
-  onChange: (next: UserOption[]) => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-  const [results, setResults] = useState<UserOption[]>([]);
-  const [loading, setLoading] = useState(false);
-  const debouncedSearch = useDebounce(search, 250);
-
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    const controller = new AbortController();
-    const run = async () => {
-      setLoading(true);
-      try {
-        const params = new URLSearchParams();
-        if (debouncedSearch) params.set("q", debouncedSearch);
-        params.set("limit", "50");
-        const r = await fetch(`/api/admin/users?${params}`, {
-          signal: controller.signal,
-        });
-        if (!r.ok) throw new Error("fetch failed");
-        const data = await r.json();
-        if (!cancelled) setResults(data);
-      } catch {
-        if (!cancelled) setResults([]);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-    run();
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [open, debouncedSearch]);
-
-  const selectedIds = new Set(selected.map((u) => u.id));
-
-  const toggle = (u: UserOption) => {
-    onChange(
-      selectedIds.has(u.id)
-        ? selected.filter((s) => s.id !== u.id)
-        : [...selected, u]
-    );
+function prefillFromParams(params: URLSearchParams): ComposerPrefill {
+  return {
+    locations: parseCsv(params.get("locations")),
+    grades: parseCsv(params.get("grades")),
+    labelIds: parseCsv(params.get("labels")),
+    userIds: parseCsv(params.get("userIds")),
+    shiftIds: parseCsv(params.get("shiftIds")),
+    sendEmail:
+      params.get("sendEmail") === "1" || params.get("sendEmail") === "true",
   };
-
-  return (
-    <div className="space-y-2">
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-          >
-            <UserPlus2 className="w-4 h-4" />
-            {selected.length > 0
-              ? `${selected.length} selected · add more`
-              : "Pick volunteers"}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-[360px] p-0" align="start">
-          <div className="p-2 border-b">
-            <div className="relative">
-              <Search className="w-4 h-4 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search by name or email…"
-                className="pl-8 h-9"
-                autoFocus
-              />
-            </div>
-          </div>
-          <div className="max-h-72 overflow-y-auto py-1">
-            {loading ? (
-              <p className="text-xs text-muted-foreground px-3 py-4">
-                Searching…
-              </p>
-            ) : results.length === 0 ? (
-              <p className="text-xs text-muted-foreground px-3 py-4">
-                No matching volunteers.
-              </p>
-            ) : (
-              results.map((u) => {
-                const isSelected = selectedIds.has(u.id);
-                return (
-                  <button
-                    key={u.id}
-                    type="button"
-                    onClick={() => toggle(u)}
-                    className={cn(
-                      "w-full flex items-center justify-between gap-2 px-3 py-2 text-left hover:bg-muted/60",
-                      isSelected && "bg-muted"
-                    )}
-                  >
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium truncate">
-                        {userDisplayName(u)}
-                      </p>
-                      <p className="text-xs text-muted-foreground truncate">
-                        {u.email}
-                      </p>
-                    </div>
-                    {isSelected && (
-                      <CheckCircle2 className="w-4 h-4 text-primary flex-shrink-0" />
-                    )}
-                  </button>
-                );
-              })
-            )}
-          </div>
-        </PopoverContent>
-      </Popover>
-
-      {selected.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {selected.map((u) => (
-            <Badge
-              key={u.id}
-              variant="secondary"
-              className="gap-1 pl-2 pr-1 py-0.5"
-            >
-              <span className="text-xs">{userDisplayName(u)}</span>
-              <button
-                type="button"
-                onClick={() =>
-                  onChange(selected.filter((s) => s.id !== u.id))
-                }
-                className="hover:bg-background/60 rounded p-0.5"
-                aria-label={`Remove ${userDisplayName(u)}`}
-              >
-                <X className="w-3 h-3" />
-              </button>
-            </Badge>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ─── Specific Shifts picker ─────────────────────────────────────────────────
-
-function shiftDisplayLabel(s: ShiftOption) {
-  const start = new Date(s.start);
-  const datePart = format(start, "EEE d MMM");
-  const timePart = format(start, "h:mma").toLowerCase();
-  const loc = s.location ?? "—";
-  return `${s.shiftTypeName} · ${datePart} ${timePart} · ${loc}`;
-}
-
-function SpecificShiftsPicker({
-  selected,
-  onChange,
-  locations,
-}: {
-  selected: ShiftOption[];
-  onChange: (next: ShiftOption[]) => void;
-  locations: string[];
-}) {
-  const [open, setOpen] = useState(false);
-  const [locationFilter, setLocationFilter] = useState<string>("");
-  const [shifts, setShifts] = useState<ShiftOption[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    const controller = new AbortController();
-    setLoading(true);
-    const params = new URLSearchParams();
-    if (locationFilter) params.set("location", locationFilter);
-    fetch(`/api/admin/announcements/shifts?${params}`, {
-      signal: controller.signal,
-    })
-      .then((r) => (r.ok ? r.json() : Promise.reject(r)))
-      .then((data) => {
-        if (!cancelled) setShifts(data.shifts ?? []);
-      })
-      .catch(() => {
-        if (!cancelled) setShifts([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [open, locationFilter]);
-
-  const selectedIds = new Set(selected.map((s) => s.id));
-
-  const toggle = (s: ShiftOption) => {
-    onChange(
-      selectedIds.has(s.id)
-        ? selected.filter((x) => x.id !== s.id)
-        : [...selected, s]
-    );
-  };
-
-  // Group shifts by date for a scannable list.
-  const grouped = shifts.reduce<Record<string, ShiftOption[]>>((acc, s) => {
-    const key = format(new Date(s.start), "EEE d MMM yyyy");
-    (acc[key] ??= []).push(s);
-    return acc;
-  }, {});
-
-  return (
-    <div className="space-y-2">
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="gap-1.5"
-          >
-            <CalendarClock className="w-4 h-4" />
-            {selected.length > 0
-              ? `${selected.length} selected · add more`
-              : "Pick shifts"}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-[420px] p-0" align="start">
-          <div className="p-2 border-b flex items-center gap-2">
-            <Label className="text-xs text-muted-foreground">Location</Label>
-            <select
-              className="text-sm border rounded px-2 py-1 bg-background flex-1"
-              value={locationFilter}
-              onChange={(e) => setLocationFilter(e.target.value)}
-            >
-              <option value="">All locations</option>
-              {locations.map((loc) => (
-                <option key={loc} value={loc}>
-                  {loc}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="max-h-80 overflow-y-auto py-1">
-            {loading ? (
-              <p className="text-xs text-muted-foreground px-3 py-4">
-                Loading shifts…
-              </p>
-            ) : shifts.length === 0 ? (
-              <p className="text-xs text-muted-foreground px-3 py-4">
-                No upcoming shifts.
-              </p>
-            ) : (
-              Object.entries(grouped).map(([date, dayShifts]) => (
-                <div key={date} className="px-1 pb-1">
-                  <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground px-2 pt-2 pb-1">
-                    {date}
-                  </p>
-                  {dayShifts.map((s) => {
-                    const isSelected = selectedIds.has(s.id);
-                    return (
-                      <button
-                        key={s.id}
-                        type="button"
-                        onClick={() => toggle(s)}
-                        className={cn(
-                          "w-full flex items-center justify-between gap-2 px-3 py-2 text-left rounded hover:bg-muted/60",
-                          isSelected && "bg-muted"
-                        )}
-                      >
-                        <div className="min-w-0">
-                          <p className="text-sm font-medium truncate">
-                            {s.shiftTypeName}
-                          </p>
-                          <p className="text-xs text-muted-foreground truncate">
-                            {format(new Date(s.start), "h:mma").toLowerCase()}
-                            {" – "}
-                            {format(new Date(s.end), "h:mma").toLowerCase()}
-                            {" · "}
-                            {s.location ?? "—"}
-                            {" · "}
-                            {s.signupCount} signed up
-                          </p>
-                        </div>
-                        {isSelected && (
-                          <CheckCircle2 className="w-4 h-4 text-primary flex-shrink-0" />
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
-              ))
-            )}
-          </div>
-        </PopoverContent>
-      </Popover>
-
-      {selected.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {selected.map((s) => (
-            <Badge
-              key={s.id}
-              variant="secondary"
-              className="gap-1 pl-2 pr-1 py-0.5"
-            >
-              <span className="text-xs">{shiftDisplayLabel(s)}</span>
-              <button
-                type="button"
-                onClick={() =>
-                  onChange(selected.filter((x) => x.id !== s.id))
-                }
-                className="hover:bg-background/60 rounded p-0.5"
-                aria-label="Remove shift"
-              >
-                <X className="w-3 h-3" />
-              </button>
-            </Badge>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ─── Expiry Date+Time picker ────────────────────────────────────────────────
-
-/**
- * Lightweight date+time picker that stores the value as a `datetime-local`
- * string ("YYYY-MM-DDTHH:mm") so the form submit body stays simple. The
- * native datetime-local input has frustrating cross-browser styling and no
- * obvious clear affordance, hence the popover Calendar + time input + Clear
- * button combo.
- */
-function ExpiryDateTimePicker({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (next: string) => void;
-}) {
-  const [datePart, timePart] = value
-    ? [value.slice(0, 10), value.slice(11, 16)]
-    : ["", ""];
-  // Parse without UTC conversion: datetime-local strings are already in
-  // local time, so splitting and re-using the parts avoids timezone drift.
-  const dateValue = datePart ? new Date(`${datePart}T00:00:00`) : undefined;
-
-  const setDate = (d: Date | undefined) => {
-    if (!d) {
-      onChange("");
-      return;
-    }
-    const ymd = format(d, "yyyy-MM-dd");
-    onChange(`${ymd}T${timePart || "23:59"}`);
-  };
-
-  const setTime = (t: string) => {
-    if (!datePart) return; // ignore time changes until a date is picked
-    onChange(`${datePart}T${t || "23:59"}`);
-  };
-
-  const display = value
-    ? format(new Date(value), "EEE d MMM yyyy, h:mm a")
-    : "Pick a date and time";
-
-  return (
-    <div className="flex flex-wrap items-center gap-2">
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            className={cn(
-              "h-9 justify-start gap-2 font-normal",
-              !value && "text-muted-foreground"
-            )}
-          >
-            <CalendarIcon className="w-4 h-4" />
-            {display}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
-          <Calendar
-            mode="single"
-            selected={dateValue}
-            onSelect={setDate}
-            autoFocus
-          />
-        </PopoverContent>
-      </Popover>
-
-      <div className="relative">
-        <ClockIcon className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-        <Input
-          type="time"
-          value={timePart}
-          onChange={(e) => setTime(e.target.value)}
-          disabled={!datePart}
-          className="pl-8 h-9 w-[130px]"
-          aria-label="Expiry time"
-        />
-      </div>
-
-      {value && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => onChange("")}
-          className="gap-1 h-9 text-muted-foreground hover:text-foreground"
-        >
-          <X className="w-3.5 h-3.5" />
-          Clear
-        </Button>
-      )}
-    </div>
-  );
 }

--- a/web/src/app/admin/announcements/audience-builder.tsx
+++ b/web/src/app/admin/announcements/audience-builder.tsx
@@ -1,0 +1,985 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { format, subMonths } from "date-fns";
+import {
+  Award,
+  CalendarClock,
+  Check,
+  ChevronDown,
+  History,
+  MapPin,
+  Search,
+  Tag,
+  UserPlus2,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { useDebounce } from "@/hooks/use-debounce";
+import {
+  VOLUNTEER_GRADES,
+  describeActivityTargeting,
+  orJoin,
+  userDisplayName,
+  type LabelOption,
+  type ShiftOption,
+  type UserOption,
+} from "./types";
+
+/** Everything the audience section of the composer edits. */
+export interface AudienceDraft {
+  targetLocations: string[];
+  targetGrades: string[];
+  targetLabelIds: string[];
+  targetUsers: UserOption[];
+  targetShifts: ShiftOption[];
+  activityEnabled: boolean;
+  activityLocations: string[];
+  activityFrom: string; // yyyy-MM-dd or ""
+  activityTo: string;
+  activityMinShifts: number;
+  /** Upper bound on worked shifts; null = no limit. */
+  activityMaxShifts: number | null;
+}
+
+export const EMPTY_AUDIENCE: AudienceDraft = {
+  targetLocations: [],
+  targetGrades: [],
+  targetLabelIds: [],
+  targetUsers: [],
+  targetShifts: [],
+  activityEnabled: false,
+  activityLocations: [],
+  activityFrom: "",
+  activityTo: "",
+  activityMinShifts: 1,
+  activityMaxShifts: null,
+};
+
+export function countActiveAudienceFilters(d: AudienceDraft): number {
+  return [
+    d.targetLocations.length > 0,
+    d.activityEnabled,
+    d.targetGrades.length > 0,
+    d.targetLabelIds.length > 0,
+    d.targetUsers.length > 0,
+    d.targetShifts.length > 0,
+  ].filter(Boolean).length;
+}
+
+/** Quick date ranges for shift-history targeting, newest window first. */
+const ACTIVITY_RANGE_PRESETS = [
+  { months: 3, label: "Last 3 months" },
+  { months: 6, label: "Last 6 months" },
+  { months: 12, label: "Last 12 months" },
+];
+
+const GRADE_DOT: Record<string, string> = {
+  GREEN: "bg-emerald-500",
+  YELLOW: "bg-amber-400",
+  PINK: "bg-pink-400",
+};
+
+interface AudienceBuilderProps {
+  draft: AudienceDraft;
+  onPatch: (patch: Partial<AudienceDraft>) => void;
+  labels: LabelOption[];
+  locations: string[];
+}
+
+/**
+ * The audience section of the composer: six narrowing dimensions as
+ * collapsible rows. Every filter narrows the audience (AND across rows);
+ * choices inside a row widen it (OR within a row). Empty everywhere means
+ * every volunteer.
+ */
+export function AudienceBuilder({
+  draft,
+  onPatch,
+  labels,
+  locations,
+}: AudienceBuilderProps) {
+  const activeCount = countActiveAudienceFilters(draft);
+
+  const toggleIn = (list: string[], value: string) =>
+    list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+
+  const activitySummary = draft.activityEnabled
+    ? (describeActivityTargeting({
+        targetActivityLocations: draft.activityLocations,
+        targetActivityFrom: draft.activityFrom
+          ? new Date(`${draft.activityFrom}T00:00:00`).toISOString()
+          : null,
+        targetActivityTo: draft.activityTo
+          ? new Date(`${draft.activityTo}T00:00:00`).toISOString()
+          : null,
+        targetActivityMinShifts: draft.activityMinShifts,
+        targetActivityMaxShifts: draft.activityMaxShifts,
+      }) ?? "Worked at least one shift")
+    : null;
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">
+          {activeCount === 0
+            ? "No filters — every volunteer receives this."
+            : "Each filter narrows the audience; options inside a filter widen it."}
+        </p>
+        {activeCount > 0 && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 shrink-0 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => onPatch({ ...EMPTY_AUDIENCE })}
+            data-testid="audience-clear-filters"
+          >
+            <X className="h-3 w-3" />
+            Clear all
+          </Button>
+        )}
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-forest-500/15 dark:border-white/10">
+        {/* Location */}
+        <FilterGroup
+          icon={<MapPin className="h-4 w-4" />}
+          label="Location"
+          active={draft.targetLocations.length > 0}
+          summary={
+            draft.targetLocations.length > 0
+              ? `Based in ${orJoin(draft.targetLocations)}`
+              : "Anywhere"
+          }
+        >
+          <ChipRow>
+            {locations.map((loc) => (
+              <Chip
+                key={loc}
+                pressed={draft.targetLocations.includes(loc)}
+                onToggle={() =>
+                  onPatch({
+                    targetLocations: toggleIn(draft.targetLocations, loc),
+                  })
+                }
+                data-testid={`audience-location-${loc}`}
+              >
+                {loc}
+              </Chip>
+            ))}
+          </ChipRow>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Matches the locations on a volunteer&apos;s profile — including
+            people who have never worked a shift there. To reach volunteers who
+            actually turned up, use Shift history below.
+          </p>
+        </FilterGroup>
+
+        {/* Shift history */}
+        <FilterGroup
+          icon={<History className="h-4 w-4" />}
+          label="Shift history"
+          active={draft.activityEnabled}
+          summary={activitySummary ?? "Any history"}
+        >
+          <label className="flex cursor-pointer items-start gap-2.5">
+            <Checkbox
+              checked={draft.activityEnabled}
+              onCheckedChange={(checked) =>
+                onPatch({ activityEnabled: checked === true })
+              }
+              className="mt-0.5"
+              data-testid="announcement-activity-toggle"
+            />
+            <span className="text-sm leading-snug">
+              Only volunteers who have worked a shift
+              <span className="block text-xs text-muted-foreground">
+                Counts shifts they were confirmed on that have already
+                finished.
+              </span>
+            </span>
+          </label>
+
+          {draft.activityEnabled && (
+            <div
+              className="mt-3 space-y-4 rounded-lg border border-forest-500/15 bg-cream-50/60 p-3 dark:border-white/10 dark:bg-white/[0.03]"
+              data-testid="announcement-activity-filters"
+            >
+              {locations.length > 0 && (
+                <div>
+                  <Label className="mb-1.5 block text-xs font-medium">
+                    Worked at
+                  </Label>
+                  <div className="flex flex-wrap gap-x-4 gap-y-2">
+                    {locations.map((loc) => (
+                      <label
+                        key={loc}
+                        className="flex cursor-pointer items-center gap-1.5"
+                      >
+                        <Checkbox
+                          checked={draft.activityLocations.includes(loc)}
+                          onCheckedChange={() =>
+                            onPatch({
+                              activityLocations: toggleIn(
+                                draft.activityLocations,
+                                loc
+                              ),
+                            })
+                          }
+                          data-testid={`announcement-activity-location-${loc}`}
+                        />
+                        <span className="text-sm">{loc}</span>
+                      </label>
+                    ))}
+                  </div>
+                  <p className="mt-1.5 text-xs text-muted-foreground">
+                    Leave empty to count shifts at any location.
+                  </p>
+                </div>
+              )}
+
+              <div>
+                <Label className="mb-1.5 block text-xs font-medium">
+                  Shift finished between
+                </Label>
+                <div className="flex flex-wrap items-end gap-3">
+                  <div>
+                    <Label
+                      htmlFor="activity-from"
+                      className="mb-1 block text-xs text-muted-foreground"
+                    >
+                      From
+                    </Label>
+                    <Input
+                      id="activity-from"
+                      type="date"
+                      value={draft.activityFrom}
+                      max={draft.activityTo || undefined}
+                      onChange={(e) =>
+                        onPatch({ activityFrom: e.target.value })
+                      }
+                      className="h-9 w-[10.5rem]"
+                      data-testid="announcement-activity-from"
+                    />
+                  </div>
+                  <div>
+                    <Label
+                      htmlFor="activity-to"
+                      className="mb-1 block text-xs text-muted-foreground"
+                    >
+                      To
+                    </Label>
+                    <Input
+                      id="activity-to"
+                      type="date"
+                      value={draft.activityTo}
+                      min={draft.activityFrom || undefined}
+                      onChange={(e) => onPatch({ activityTo: e.target.value })}
+                      className="h-9 w-[10.5rem]"
+                      data-testid="announcement-activity-to"
+                    />
+                  </div>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {ACTIVITY_RANGE_PRESETS.map((preset) => {
+                    const presetFrom = format(
+                      subMonths(new Date(), preset.months),
+                      "yyyy-MM-dd"
+                    );
+                    const isActive =
+                      draft.activityFrom === presetFrom &&
+                      draft.activityTo === "";
+                    return (
+                      <Button
+                        key={preset.months}
+                        type="button"
+                        variant={isActive ? "default" : "outline"}
+                        size="sm"
+                        aria-pressed={isActive}
+                        className="h-7 text-xs"
+                        onClick={() =>
+                          onPatch({ activityFrom: presetFrom, activityTo: "" })
+                        }
+                        data-testid={`announcement-activity-preset-${preset.months}`}
+                      >
+                        {preset.label}
+                      </Button>
+                    );
+                  })}
+                  {(draft.activityFrom || draft.activityTo) && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 text-xs"
+                      onClick={() =>
+                        onPatch({ activityFrom: "", activityTo: "" })
+                      }
+                    >
+                      Clear dates
+                    </Button>
+                  )}
+                </div>
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  Leave both empty to count shifts from any time.
+                </p>
+              </div>
+
+              <div>
+                <Label className="mb-1.5 block text-xs font-medium">
+                  Number of shifts worked
+                </Label>
+                <div className="flex items-end gap-3">
+                  <div>
+                    <Label
+                      htmlFor="activity-min-shifts"
+                      className="mb-1 block text-xs text-muted-foreground"
+                    >
+                      At least
+                    </Label>
+                    <Input
+                      id="activity-min-shifts"
+                      type="number"
+                      min={1}
+                      max={999}
+                      value={draft.activityMinShifts}
+                      onChange={(e) => {
+                        const next = parseInt(e.target.value, 10);
+                        onPatch({
+                          activityMinShifts: Number.isNaN(next)
+                            ? 1
+                            : Math.min(Math.max(next, 1), 999),
+                        });
+                      }}
+                      className="h-9 w-24"
+                      data-testid="announcement-activity-min-shifts"
+                    />
+                  </div>
+                  <div>
+                    <Label
+                      htmlFor="activity-max-shifts"
+                      className="mb-1 block text-xs text-muted-foreground"
+                    >
+                      At most
+                    </Label>
+                    <Input
+                      id="activity-max-shifts"
+                      type="number"
+                      min={draft.activityMinShifts}
+                      max={999}
+                      value={draft.activityMaxShifts ?? ""}
+                      placeholder="No limit"
+                      onChange={(e) => {
+                        if (e.target.value === "") {
+                          onPatch({ activityMaxShifts: null });
+                          return;
+                        }
+                        const next = parseInt(e.target.value, 10);
+                        onPatch({
+                          activityMaxShifts: Number.isNaN(next)
+                            ? null
+                            : Math.min(Math.max(next, 1), 999),
+                        });
+                      }}
+                      className="h-9 w-28"
+                      data-testid="announcement-activity-max-shifts"
+                    />
+                  </div>
+                </div>
+                {draft.activityMaxShifts !== null &&
+                  draft.activityMaxShifts < draft.activityMinShifts && (
+                    <p className="mt-1.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+                      &ldquo;At most&rdquo; is below &ldquo;at least&rdquo; —
+                      it will be treated as {draft.activityMinShifts}.
+                    </p>
+                  )}
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  Set both to 1 to reach people after their first shift.
+                </p>
+              </div>
+            </div>
+          )}
+        </FilterGroup>
+
+        {/* Grade */}
+        <FilterGroup
+          icon={<Award className="h-4 w-4" />}
+          label="Volunteer grade"
+          active={draft.targetGrades.length > 0}
+          summary={
+            draft.targetGrades.length > 0
+              ? orJoin(
+                  draft.targetGrades.map(
+                    (g) =>
+                      VOLUNTEER_GRADES.find((vg) => vg.value === g)?.label ?? g
+                  )
+                )
+              : "Any grade"
+          }
+        >
+          <ChipRow>
+            {VOLUNTEER_GRADES.map((g) => (
+              <Chip
+                key={g.value}
+                pressed={draft.targetGrades.includes(g.value)}
+                onToggle={() =>
+                  onPatch({
+                    targetGrades: toggleIn(draft.targetGrades, g.value),
+                  })
+                }
+                data-testid={`audience-grade-${g.value}`}
+              >
+                <span
+                  className={cn(
+                    "h-2 w-2 rounded-full",
+                    GRADE_DOT[g.value] ?? "bg-muted-foreground"
+                  )}
+                />
+                {g.label}
+                <span className="font-normal opacity-70">
+                  {g.description}
+                </span>
+              </Chip>
+            ))}
+          </ChipRow>
+        </FilterGroup>
+
+        {/* Labels */}
+        {labels.length > 0 && (
+          <FilterGroup
+            icon={<Tag className="h-4 w-4" />}
+            label="Custom labels"
+            active={draft.targetLabelIds.length > 0}
+            summary={
+              draft.targetLabelIds.length > 0
+                ? orJoin(
+                    draft.targetLabelIds.map(
+                      (id) => labels.find((l) => l.id === id)?.name ?? id
+                    )
+                  )
+                : "Any label"
+            }
+          >
+            <ChipRow>
+              {labels.map((label) => {
+                const pressed = draft.targetLabelIds.includes(label.id);
+                return (
+                  <button
+                    key={label.id}
+                    type="button"
+                    aria-pressed={pressed}
+                    onClick={() =>
+                      onPatch({
+                        targetLabelIds: toggleIn(
+                          draft.targetLabelIds,
+                          label.id
+                        ),
+                      })
+                    }
+                    className={cn(
+                      "inline-flex cursor-pointer items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium transition-all",
+                      label.color,
+                      pressed
+                        ? "ring-2 ring-forest-500 ring-offset-1 ring-offset-background dark:ring-[#86d99b]"
+                        : "opacity-75 hover:opacity-100"
+                    )}
+                    data-testid={`audience-label-${label.id}`}
+                  >
+                    {pressed && <Check className="h-3 w-3" />}
+                    {label.icon && <span>{label.icon}</span>}
+                    {label.name}
+                  </button>
+                );
+              })}
+            </ChipRow>
+          </FilterGroup>
+        )}
+
+        {/* Specific volunteers */}
+        <FilterGroup
+          icon={<UserPlus2 className="h-4 w-4" />}
+          label="Specific volunteers"
+          active={draft.targetUsers.length > 0}
+          summary={
+            draft.targetUsers.length > 0
+              ? `Only ${draft.targetUsers.length} chosen volunteer${draft.targetUsers.length === 1 ? "" : "s"}`
+              : "Everyone who matches"
+          }
+        >
+          <SpecificUsersPicker
+            selected={draft.targetUsers}
+            onChange={(next) => onPatch({ targetUsers: next })}
+          />
+          <p className="mt-2 text-xs text-muted-foreground">
+            Restricts the announcement to these volunteers only — other
+            filters still apply on top.
+          </p>
+        </FilterGroup>
+
+        {/* Specific shifts */}
+        <FilterGroup
+          icon={<CalendarClock className="h-4 w-4" />}
+          label="Specific shifts"
+          active={draft.targetShifts.length > 0}
+          summary={
+            draft.targetShifts.length > 0
+              ? `Signed up to ${draft.targetShifts.length} chosen shift${draft.targetShifts.length === 1 ? "" : "s"}`
+              : "Any shift"
+          }
+          last
+        >
+          <SpecificShiftsPicker
+            selected={draft.targetShifts}
+            onChange={(next) => onPatch({ targetShifts: next })}
+            locations={locations}
+          />
+          <p className="mt-2 text-xs text-muted-foreground">
+            Reaches volunteers with a current signup on these shifts —
+            confirmed, pending or waitlisted.
+          </p>
+        </FilterGroup>
+      </div>
+    </div>
+  );
+}
+
+// ─── Filter group row ───────────────────────────────────────────────────────
+
+function FilterGroup({
+  icon,
+  label,
+  summary,
+  active,
+  last,
+  children,
+}: {
+  icon: ReactNode;
+  label: string;
+  summary: string;
+  active: boolean;
+  last?: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className={cn(
+        "bg-card",
+        !last && "border-b border-forest-500/10 dark:border-white/[0.07]"
+      )}
+    >
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-cream-50/70 dark:hover:bg-white/[0.03]"
+          aria-expanded={open}
+          data-testid={`audience-group-${label.toLowerCase().replace(/\s+/g, "-")}`}
+        >
+          <span
+            className={cn(
+              "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors",
+              active
+                ? "bg-forest-500 text-white dark:bg-[#86d99b] dark:text-[#0f1114]"
+                : "bg-forest-500/[0.07] text-forest-500 dark:bg-white/[0.06] dark:text-[#86d99b]"
+            )}
+          >
+            {icon}
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-sm font-medium leading-tight">
+              {label}
+            </span>
+            <span
+              className={cn(
+                "block truncate text-xs leading-tight",
+                active
+                  ? "font-medium text-forest-500 dark:text-[#86d99b]"
+                  : "text-muted-foreground"
+              )}
+            >
+              {summary}
+            </span>
+          </span>
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+              open && "rotate-180"
+            )}
+          />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="px-4 pb-4 pl-[3.75rem]">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function ChipRow({ children }: { children: ReactNode }) {
+  return <div className="flex flex-wrap gap-2">{children}</div>;
+}
+
+function Chip({
+  pressed,
+  onToggle,
+  children,
+  ...rest
+}: {
+  pressed: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+} & Record<`data-${string}`, string>) {
+  return (
+    <button
+      type="button"
+      aria-pressed={pressed}
+      onClick={onToggle}
+      className={cn(
+        "inline-flex min-h-8 cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1 text-sm transition-all",
+        pressed
+          ? "border-forest-500 bg-forest-500 font-medium text-white dark:border-[#86d99b] dark:bg-[#86d99b] dark:text-[#0f1114]"
+          : "border-forest-500/25 bg-transparent text-foreground hover:border-forest-500/60 hover:bg-forest-500/[0.05] dark:border-white/15 dark:hover:border-white/30 dark:hover:bg-white/[0.04]"
+      )}
+      {...rest}
+    >
+      {pressed && <Check className="h-3.5 w-3.5" />}
+      {children}
+    </button>
+  );
+}
+
+// ─── Specific volunteers picker ─────────────────────────────────────────────
+
+function SpecificUsersPicker({
+  selected,
+  onChange,
+}: {
+  selected: UserOption[];
+  onChange: (next: UserOption[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [results, setResults] = useState<UserOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const debouncedSearch = useDebounce(search, 250);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const controller = new AbortController();
+    const run = async () => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams();
+        if (debouncedSearch) params.set("q", debouncedSearch);
+        params.set("limit", "50");
+        const r = await fetch(`/api/admin/users?${params}`, {
+          signal: controller.signal,
+        });
+        if (!r.ok) throw new Error("fetch failed");
+        const data = await r.json();
+        if (!cancelled) setResults(data);
+      } catch {
+        if (!cancelled) setResults([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [open, debouncedSearch]);
+
+  const selectedIds = new Set(selected.map((u) => u.id));
+
+  const toggle = (u: UserOption) => {
+    onChange(
+      selectedIds.has(u.id)
+        ? selected.filter((s) => s.id !== u.id)
+        : [...selected, u]
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button type="button" variant="outline" size="sm" className="gap-1.5">
+            <UserPlus2 className="h-4 w-4" />
+            {selected.length > 0
+              ? `${selected.length} selected · add more`
+              : "Pick volunteers"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[360px] p-0" align="start">
+          <div className="border-b p-2">
+            <div className="relative">
+              <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search by name or email…"
+                className="h-9 pl-8"
+                autoFocus
+              />
+            </div>
+          </div>
+          <div className="max-h-72 overflow-y-auto py-1">
+            {loading ? (
+              <p className="px-3 py-4 text-xs text-muted-foreground">
+                Searching…
+              </p>
+            ) : results.length === 0 ? (
+              <p className="px-3 py-4 text-xs text-muted-foreground">
+                No matching volunteers.
+              </p>
+            ) : (
+              results.map((u) => {
+                const isSelected = selectedIds.has(u.id);
+                return (
+                  <button
+                    key={u.id}
+                    type="button"
+                    onClick={() => toggle(u)}
+                    className={cn(
+                      "flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left hover:bg-muted/60",
+                      isSelected && "bg-muted"
+                    )}
+                  >
+                    <span className="min-w-0">
+                      <span className="block truncate text-sm font-medium">
+                        {userDisplayName(u)}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {u.email}
+                      </span>
+                    </span>
+                    {isSelected && (
+                      <Check className="h-4 w-4 shrink-0 text-forest-500 dark:text-[#86d99b]" />
+                    )}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {selected.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {selected.map((u) => (
+            <Badge
+              key={u.id}
+              variant="secondary"
+              className="gap-1 py-0.5 pl-2 pr-1"
+            >
+              <span className="text-xs">{userDisplayName(u)}</span>
+              <button
+                type="button"
+                onClick={() => onChange(selected.filter((s) => s.id !== u.id))}
+                className="cursor-pointer rounded p-0.5 hover:bg-background/60"
+                aria-label={`Remove ${userDisplayName(u)}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Specific shifts picker ─────────────────────────────────────────────────
+
+function shiftDisplayLabel(s: ShiftOption) {
+  const start = new Date(s.start);
+  const datePart = format(start, "EEE d MMM");
+  const timePart = format(start, "h:mma").toLowerCase();
+  const loc = s.location ?? "—";
+  return `${s.shiftTypeName} · ${datePart} ${timePart} · ${loc}`;
+}
+
+function SpecificShiftsPicker({
+  selected,
+  onChange,
+  locations,
+}: {
+  selected: ShiftOption[];
+  onChange: (next: ShiftOption[]) => void;
+  locations: string[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [locationFilter, setLocationFilter] = useState<string>("");
+  const [shifts, setShifts] = useState<ShiftOption[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const controller = new AbortController();
+    setLoading(true);
+    const params = new URLSearchParams();
+    if (locationFilter) params.set("location", locationFilter);
+    fetch(`/api/admin/announcements/shifts?${params}`, {
+      signal: controller.signal,
+    })
+      .then((r) => (r.ok ? r.json() : Promise.reject(r)))
+      .then((data) => {
+        if (!cancelled) setShifts(data.shifts ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setShifts([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [open, locationFilter]);
+
+  const selectedIds = new Set(selected.map((s) => s.id));
+
+  const toggle = (s: ShiftOption) => {
+    onChange(
+      selectedIds.has(s.id)
+        ? selected.filter((x) => x.id !== s.id)
+        : [...selected, s]
+    );
+  };
+
+  // Group shifts by date for a scannable list.
+  const grouped = shifts.reduce<Record<string, ShiftOption[]>>((acc, s) => {
+    const key = format(new Date(s.start), "EEE d MMM yyyy");
+    (acc[key] ??= []).push(s);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button type="button" variant="outline" size="sm" className="gap-1.5">
+            <CalendarClock className="h-4 w-4" />
+            {selected.length > 0
+              ? `${selected.length} selected · add more`
+              : "Pick shifts"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[420px] p-0" align="start">
+          <div className="flex items-center gap-2 border-b p-2">
+            <Label className="text-xs text-muted-foreground">Location</Label>
+            <select
+              className="flex-1 rounded border bg-background px-2 py-1 text-sm"
+              value={locationFilter}
+              onChange={(e) => setLocationFilter(e.target.value)}
+            >
+              <option value="">All locations</option>
+              {locations.map((loc) => (
+                <option key={loc} value={loc}>
+                  {loc}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="max-h-80 overflow-y-auto py-1">
+            {loading ? (
+              <p className="px-3 py-4 text-xs text-muted-foreground">
+                Loading shifts…
+              </p>
+            ) : shifts.length === 0 ? (
+              <p className="px-3 py-4 text-xs text-muted-foreground">
+                No upcoming shifts.
+              </p>
+            ) : (
+              Object.entries(grouped).map(([date, dayShifts]) => (
+                <div key={date} className="px-1 pb-1">
+                  <p className="px-2 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {date}
+                  </p>
+                  {dayShifts.map((s) => {
+                    const isSelected = selectedIds.has(s.id);
+                    return (
+                      <button
+                        key={s.id}
+                        type="button"
+                        onClick={() => toggle(s)}
+                        className={cn(
+                          "flex w-full cursor-pointer items-center justify-between gap-2 rounded px-3 py-2 text-left hover:bg-muted/60",
+                          isSelected && "bg-muted"
+                        )}
+                      >
+                        <span className="min-w-0">
+                          <span className="block truncate text-sm font-medium">
+                            {s.shiftTypeName}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {format(new Date(s.start), "h:mma").toLowerCase()}
+                            {" – "}
+                            {format(new Date(s.end), "h:mma").toLowerCase()}
+                            {" · "}
+                            {s.location ?? "—"}
+                            {" · "}
+                            {s.signupCount} signed up
+                          </span>
+                        </span>
+                        {isSelected && (
+                          <Check className="h-4 w-4 shrink-0 text-forest-500 dark:text-[#86d99b]" />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              ))
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {selected.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {selected.map((s) => (
+            <Badge
+              key={s.id}
+              variant="secondary"
+              className="gap-1 py-0.5 pl-2 pr-1"
+            >
+              <span className="text-xs">{shiftDisplayLabel(s)}</span>
+              <button
+                type="button"
+                onClick={() => onChange(selected.filter((x) => x.id !== s.id))}
+                className="cursor-pointer rounded p-0.5 hover:bg-background/60"
+                aria-label="Remove shift"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/admin/announcements/composer.tsx
+++ b/web/src/app/admin/announcements/composer.tsx
@@ -8,7 +8,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { addDays, format } from "date-fns";
+import { addDays, format, startOfDay } from "date-fns";
 import { motion } from "motion/react";
 import {
   Bell,
@@ -55,6 +55,7 @@ import {
 import { FeedPreview } from "./feed-preview";
 import {
   audienceConditions,
+  isExpiryInPast,
   type Announcement,
   type LabelOption,
   type ShiftOption,
@@ -80,6 +81,15 @@ interface ComposerProps {
   onPublished: (announcement: Announcement) => void;
   onClose: () => void;
 }
+
+/** Mirrors the limits enforced by /api/admin/announcements/upload-image. */
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const ACCEPTED_IMAGE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+];
 
 const EXPIRY_PRESETS = [
   { days: 7, label: "1 week" },
@@ -205,7 +215,11 @@ export function Composer({
 
   const isDirty =
     title.trim() !== "" || body.trim() !== "" || imageUrl !== null;
-  const canPublish = title.trim() !== "" && body.trim() !== "";
+  // The calendar rules out past days, but the time input can still land
+  // earlier today — an expiry in the past publishes straight into the archive.
+  const expiryInPast = isExpiryInPast(expiresAt);
+  const canPublish =
+    title.trim() !== "" && body.trim() !== "" && !expiryInPast;
 
   const requestClose = () => {
     if (isDirty) setConfirmDiscard(true);
@@ -213,6 +227,17 @@ export function Composer({
   };
 
   const handleImageUpload = async (file: File) => {
+    // The upload route enforces these too, but checking here means a 50MB
+    // drop fails instantly instead of after uploading the whole thing. The
+    // file input's `accept` doesn't cover drag-and-drop.
+    if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+      toast.error("Image must be a JPEG, PNG, WebP or GIF");
+      return;
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+      toast.error("Image must be under 5MB");
+      return;
+    }
     setIsUploadingImage(true);
     try {
       const fd = new FormData();
@@ -237,6 +262,10 @@ export function Composer({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isExpiryInPast(expiresAt)) {
+      toast.error("Expiry must be in the future");
+      return;
+    }
     if (!canPublish) {
       toast.error("Title and message are required");
       return;
@@ -404,6 +433,15 @@ export function Composer({
               hint="How long it stays in the feed."
             >
               <ExpiryPicker value={expiresAt} onChange={setExpiresAt} />
+              {expiryInPast && (
+                <p
+                  className="mt-2 rounded-lg bg-amber-500/10 px-3 py-2 text-xs font-medium text-amber-700 dark:text-amber-400"
+                  data-testid="announcement-expiry-past-warning"
+                >
+                  That expiry has already passed — the announcement would never
+                  appear in the feed. Pick a later time.
+                </p>
+              )}
             </Section>
 
             <Section
@@ -531,7 +569,9 @@ export function Composer({
               </Button>
               {!canPublish && (
                 <p className="mt-2 text-center text-xs text-muted-foreground">
-                  Add a title and a message to publish.
+                  {expiryInPast
+                    ? "Pick an expiry in the future to publish."
+                    : "Add a title and a message to publish."}
                 </p>
               )}
               <Button
@@ -781,6 +821,10 @@ function ExpiryDateTimePicker({
             mode="single"
             selected={dateValue}
             onSelect={setDate}
+            // An expiry in the past would publish an announcement that is
+            // already hidden from the feed. Today stays selectable — the time
+            // input can still put it later this evening.
+            disabled={{ before: startOfDay(new Date()) }}
             autoFocus
           />
         </PopoverContent>
@@ -805,8 +849,8 @@ function ExpiryDateTimePicker({
 
 type RecipientPreview = {
   id: string;
-  name: string | null;
-  firstName: string | null;
+  /** Resolved server-side so the list's sort order matches what's rendered. */
+  displayName: string;
   email: string;
 };
 
@@ -916,7 +960,7 @@ function RecipientListToggle({
                     className="block px-3 py-1.5 transition-colors hover:bg-cream-50/70 dark:hover:bg-white/[0.03]"
                   >
                     <span className="block truncate text-xs font-medium">
-                      {r.name ?? r.firstName ?? r.email}
+                      {r.displayName}
                     </span>
                     <span className="block truncate text-[11px] text-muted-foreground">
                       {r.email}

--- a/web/src/app/admin/announcements/composer.tsx
+++ b/web/src/app/admin/announcements/composer.tsx
@@ -1,0 +1,989 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { addDays, format } from "date-fns";
+import { motion } from "motion/react";
+import {
+  Bell,
+  CalendarIcon,
+  ChevronDown,
+  ClockIcon,
+  ImageIcon,
+  Loader2,
+  Mail,
+  Newspaper,
+  Upload,
+  Users,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import {
+  AudienceBuilder,
+  EMPTY_AUDIENCE,
+  countActiveAudienceFilters,
+  type AudienceDraft,
+} from "./audience-builder";
+import { FeedPreview } from "./feed-preview";
+import {
+  audienceConditions,
+  type Announcement,
+  type LabelOption,
+  type ShiftOption,
+  type TargetingDraft,
+  type UserOption,
+} from "./types";
+
+/** Seed values arriving via the query string ("Announce" links elsewhere). */
+export interface ComposerPrefill {
+  locations: string[];
+  grades: string[];
+  labelIds: string[];
+  userIds: string[];
+  shiftIds: string[];
+  sendEmail: boolean;
+}
+
+interface ComposerProps {
+  labels: LabelOption[];
+  locations: string[];
+  authorName: string;
+  prefill: ComposerPrefill | null;
+  onPublished: (announcement: Announcement) => void;
+  onClose: () => void;
+}
+
+const EXPIRY_PRESETS = [
+  { days: 7, label: "1 week" },
+  { days: 14, label: "2 weeks" },
+  { days: 30, label: "1 month" },
+];
+
+/**
+ * The announcement composer: message, schedule, audience and delivery on the
+ * left; a sticky rail on the right with the live feed preview, the live
+ * recipient count and the publish action — so what it looks like, who gets
+ * it and how it goes out stay visible the whole time.
+ */
+export function Composer({
+  labels,
+  locations,
+  authorName,
+  prefill,
+  onPublished,
+  onClose,
+}: ComposerProps) {
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState(""); // "YYYY-MM-DDTHH:mm" or ""
+  const [audience, setAudience] = useState<AudienceDraft>(() => ({
+    ...EMPTY_AUDIENCE,
+    targetLocations: prefill?.locations ?? [],
+    targetGrades: prefill?.grades ?? [],
+    targetLabelIds: prefill?.labelIds ?? [],
+  }));
+  const [sendNotification, setSendNotification] = useState(false);
+  const [sendEmail, setSendEmail] = useState(prefill?.sendEmail ?? false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isUploadingImage, setIsUploadingImage] = useState(false);
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const patchAudience = useCallback(
+    (patch: Partial<AudienceDraft>) =>
+      setAudience((prev) => ({ ...prev, ...patch })),
+    []
+  );
+
+  // Hydrate prefilled user/shift IDs into full objects so badges show names.
+  const prefillUserIds = prefill?.userIds.join(",") ?? "";
+  const prefillShiftIds = prefill?.shiftIds.join(",") ?? "";
+  useEffect(() => {
+    if (!prefillUserIds && !prefillShiftIds) return;
+    let cancelled = false;
+    const run = async () => {
+      if (prefillUserIds) {
+        try {
+          const r = await fetch(
+            `/api/admin/users?ids=${encodeURIComponent(prefillUserIds)}`
+          );
+          if (r.ok) {
+            const data = (await r.json()) as UserOption[];
+            if (!cancelled)
+              setAudience((prev) => ({ ...prev, targetUsers: data }));
+          }
+        } catch {
+          // IDs without names aren't useful in the UI; leave empty on failure
+        }
+      }
+      if (prefillShiftIds) {
+        try {
+          const r = await fetch(
+            `/api/admin/announcements/shifts?ids=${encodeURIComponent(prefillShiftIds)}`
+          );
+          if (r.ok) {
+            const data = await r.json();
+            if (!cancelled)
+              setAudience((prev) => ({
+                ...prev,
+                targetShifts: (data.shifts ?? []) as ShiftOption[],
+              }));
+          }
+        } catch {
+          // see above
+        }
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [prefillUserIds, prefillShiftIds]);
+
+  // The request-body shape shared by the recipient-count preview and the
+  // create call, so the number the admin sees always describes the audience
+  // they're about to publish to.
+  const targeting: TargetingDraft = useMemo(
+    () => ({
+      targetLocations: audience.targetLocations,
+      targetGrades: audience.targetGrades,
+      targetLabelIds: audience.targetLabelIds,
+      targetUserIds: audience.targetUsers.map((u) => u.id),
+      targetShiftIds: audience.targetShifts.map((s) => s.id),
+      targetActivityLocations: audience.activityEnabled
+        ? audience.activityLocations
+        : [],
+      targetActivityFrom: audience.activityEnabled
+        ? audience.activityFrom || null
+        : null,
+      targetActivityTo: audience.activityEnabled
+        ? audience.activityTo || null
+        : null,
+      targetActivityMinShifts: audience.activityEnabled
+        ? audience.activityMinShifts
+        : null,
+      targetActivityMaxShifts: audience.activityEnabled
+        ? audience.activityMaxShifts
+        : null,
+    }),
+    [audience]
+  );
+
+  const { count: recipientCount, counting } = useRecipientCount(targeting);
+
+  const conditions = audienceConditions(targeting, labels);
+  const activeFilters = countActiveAudienceFilters(audience);
+
+  const isDirty =
+    title.trim() !== "" || body.trim() !== "" || imageUrl !== null;
+  const canPublish = title.trim() !== "" && body.trim() !== "";
+
+  const requestClose = () => {
+    if (isDirty) setConfirmDiscard(true);
+    else onClose();
+  };
+
+  const handleImageUpload = async (file: File) => {
+    setIsUploadingImage(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const response = await fetch("/api/admin/announcements/upload-image", {
+        method: "POST",
+        body: fd,
+      });
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.error ?? "Upload failed");
+      }
+      const { url } = await response.json();
+      setImageUrl(url);
+      toast.success("Image uploaded");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Image upload failed");
+    } finally {
+      setIsUploadingImage(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canPublish) {
+      toast.error("Title and message are required");
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const response = await fetch("/api/admin/announcements", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          body: body.trim(),
+          imageUrl,
+          expiresAt: expiresAt || null,
+          ...targeting,
+          sendEmail,
+          sendNotification,
+        }),
+      });
+
+      if (!response.ok) {
+        const err = await response.json();
+        throw new Error(err.error ?? "Failed to create announcement");
+      }
+
+      const { announcement } = await response.json();
+      const dispatchedVia = [
+        sendNotification ? "push notifications" : null,
+        sendEmail ? "emails" : null,
+      ].filter(Boolean) as string[];
+      toast.success(
+        dispatchedVia.length > 0
+          ? `Announcement published — ${dispatchedVia.join(" + ")} sending in the background`
+          : "Announcement published"
+      );
+      onPublished(announcement);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create announcement"
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const publishLabel = isSubmitting
+    ? "Publishing…"
+    : recipientCount !== null && !counting
+      ? `Publish to ~${recipientCount} volunteer${recipientCount === 1 ? "" : "s"}`
+      : "Publish announcement";
+
+  const channelSummary = [
+    "Feed",
+    sendNotification ? "Push" : null,
+    sendEmail ? "Email" : null,
+  ]
+    .filter(Boolean)
+    .join(" + ");
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, ease: "easeOut" }}
+    >
+      <form onSubmit={handleSubmit}>
+        <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+          {/* ── Left: the inputs ── */}
+          <div className="min-w-0 space-y-5">
+            <Section eyebrow="Message" hint="What volunteers will read.">
+              <div className="space-y-4">
+                <div>
+                  <Label htmlFor="ann-title" className="sr-only">
+                    Title
+                  </Label>
+                  <Input
+                    id="ann-title"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="Title — e.g. Kitchen closed this Friday"
+                    maxLength={200}
+                    required
+                    className="h-12 border-forest-500/20 text-base font-medium placeholder:font-normal md:text-base dark:border-white/15"
+                    data-testid="announcement-title"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="ann-body" className="sr-only">
+                    Message
+                  </Label>
+                  <Textarea
+                    id="ann-body"
+                    value={body}
+                    onChange={(e) => setBody(e.target.value)}
+                    placeholder="Write the announcement… it lands in the feed exactly as the preview shows."
+                    className="min-h-[220px] resize-y border-forest-500/20 font-mono text-sm leading-relaxed dark:border-white/15"
+                    required
+                    data-testid="announcement-body"
+                  />
+                  <p className="mt-1.5 text-xs text-muted-foreground">
+                    Markdown supported: **bold** · *italic* · [link](url) · -
+                    for bullets
+                  </p>
+                </div>
+
+                {/* Image */}
+                {imageUrl ? (
+                  <div className="relative inline-block">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={imageUrl}
+                      alt="Announcement image"
+                      className="h-36 w-auto rounded-lg border object-cover"
+                    />
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="icon"
+                      className="absolute -right-2 -top-2 h-6 w-6"
+                      onClick={() => setImageUrl(null)}
+                      aria-label="Remove image"
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className={cn(
+                      "flex w-full cursor-pointer items-center gap-3 rounded-lg border border-dashed border-forest-500/25 px-4 py-3 text-left transition-colors",
+                      "hover:border-forest-500/50 hover:bg-cream-50/70 dark:border-white/15 dark:hover:border-white/30 dark:hover:bg-white/[0.03]",
+                      isUploadingImage && "pointer-events-none opacity-50"
+                    )}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      const file = e.dataTransfer.files[0];
+                      if (file) handleImageUpload(file);
+                    }}
+                    onDragOver={(e) => e.preventDefault()}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <ImageIcon className="h-5 w-5 shrink-0 text-muted-foreground" />
+                    <span className="text-sm text-muted-foreground">
+                      {isUploadingImage
+                        ? "Uploading…"
+                        : "Add a featured image — drag & drop or click (JPEG, PNG, WebP, GIF · max 5MB)"}
+                    </span>
+                  </button>
+                )}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) handleImageUpload(file);
+                  }}
+                />
+              </div>
+            </Section>
+
+            <Section
+              eyebrow="Schedule"
+              hint="How long it stays in the feed."
+            >
+              <ExpiryPicker value={expiresAt} onChange={setExpiresAt} />
+            </Section>
+
+            <Section
+              eyebrow="Audience"
+              hint="Who receives it. Filters combine — each one narrows further."
+            >
+              <AudienceBuilder
+                draft={audience}
+                onPatch={patchAudience}
+                labels={labels}
+                locations={locations}
+              />
+            </Section>
+
+            <Section eyebrow="Delivery" hint="Where it reaches them.">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <ChannelCard
+                  icon={<Newspaper className="h-4 w-4" />}
+                  title="In-app feed"
+                  description="Every recipient sees it in their feed."
+                  locked
+                />
+                <ChannelCard
+                  icon={<Bell className="h-4 w-4" />}
+                  title="Push notification"
+                  description="Alerts their phone with a plain-text preview."
+                  checked={sendNotification}
+                  onCheckedChange={setSendNotification}
+                  testId="announcement-send-notification"
+                />
+                <ChannelCard
+                  icon={<Mail className="h-4 w-4" />}
+                  title="Email"
+                  description="Sends the full announcement to their inbox."
+                  checked={sendEmail}
+                  onCheckedChange={setSendEmail}
+                  testId="announcement-send-email"
+                />
+              </div>
+            </Section>
+          </div>
+
+          {/* ── Right: the consequences ── */}
+          <aside className="space-y-4 lg:sticky lg:top-6">
+            <div>
+              <RailEyebrow>Live preview</RailEyebrow>
+              <FeedPreview
+                title={title}
+                body={body}
+                imageUrl={imageUrl}
+                authorName={authorName}
+              />
+            </div>
+
+            <div className="rounded-2xl border border-forest-500/15 bg-card p-4 dark:border-white/10">
+              <RailEyebrow>Reach</RailEyebrow>
+              <div className="flex items-baseline gap-2">
+                <motion.span
+                  key={counting ? "counting" : `${recipientCount}`}
+                  initial={{ opacity: 0, y: 5 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.18 }}
+                  className="font-accent text-4xl font-semibold tabular-nums leading-none text-forest-500 dark:text-[#86d99b]"
+                  data-testid="announcement-recipient-count"
+                >
+                  {counting || recipientCount === null ? (
+                    <Loader2 className="mb-1 h-7 w-7 animate-spin opacity-50" />
+                  ) : (
+                    `~${recipientCount}`
+                  )}
+                </motion.span>
+                <span className="text-sm text-muted-foreground">
+                  volunteer{recipientCount === 1 ? "" : "s"} will receive this
+                </span>
+              </div>
+
+              {conditions.length === 0 ? (
+                <p className="mt-3 text-sm text-muted-foreground">
+                  Everyone with a volunteer account.
+                </p>
+              ) : (
+                <ul className="mt-3 space-y-1.5 border-l-2 border-forest-500/20 pl-3 dark:border-[#86d99b]/25">
+                  {conditions.map((c, i) => (
+                    <li key={c} className="text-sm leading-snug">
+                      {i > 0 && (
+                        <span className="mr-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                          and
+                        </span>
+                      )}
+                      {c}
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {recipientCount === 0 && !counting && activeFilters > 0 && (
+                <p className="mt-3 rounded-lg bg-amber-500/10 px-3 py-2 text-xs font-medium text-amber-700 dark:text-amber-400">
+                  No volunteers match these filters yet — loosen one to reach
+                  someone.
+                </p>
+              )}
+
+              <RecipientListToggle
+                targeting={targeting}
+                recipientCount={recipientCount}
+              />
+            </div>
+
+            <div className="rounded-2xl border border-forest-500/15 bg-card p-4 dark:border-white/10">
+              <div className="mb-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Users className="h-3.5 w-3.5" />
+                Goes out via {channelSummary}
+                {expiresAt
+                  ? ` · leaves the feed ${format(new Date(expiresAt), "d MMM, h:mm a")}`
+                  : " · stays until deleted"}
+              </div>
+              <Button
+                type="submit"
+                disabled={isSubmitting || !canPublish}
+                className="h-11 w-full gap-2 bg-forest-500 text-white hover:bg-forest-600 dark:bg-[#86d99b] dark:text-[#0f1114] dark:hover:bg-[#9be3ae]"
+                data-testid="announcement-publish"
+              >
+                <Upload className="h-4 w-4" />
+                {publishLabel}
+              </Button>
+              {!canPublish && (
+                <p className="mt-2 text-center text-xs text-muted-foreground">
+                  Add a title and a message to publish.
+                </p>
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                className="mt-2 w-full text-muted-foreground hover:text-foreground"
+                onClick={requestClose}
+              >
+                Cancel
+              </Button>
+            </div>
+          </aside>
+        </div>
+      </form>
+
+      {/* Discard confirmation */}
+      <AlertDialog open={confirmDiscard} onOpenChange={setConfirmDiscard}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Discard this announcement?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your draft hasn&apos;t been published — closing the composer
+              throws it away.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep writing</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setConfirmDiscard(false);
+                onClose();
+              }}
+              className="bg-destructive text-white hover:bg-destructive/90"
+            >
+              Discard draft
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </motion.div>
+  );
+}
+
+// ─── Building blocks ────────────────────────────────────────────────────────
+
+function Section({
+  eyebrow,
+  hint,
+  children,
+}: {
+  eyebrow: string;
+  hint: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-2xl border border-forest-500/15 bg-card p-5 dark:border-white/10">
+      <header className="mb-4 flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
+        <h2 className="font-accent text-lg font-semibold leading-none">
+          {eyebrow}
+        </h2>
+        <p className="text-xs text-muted-foreground">{hint}</p>
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function RailEyebrow({ children }: { children: ReactNode }) {
+  return (
+    <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-forest-500/70 dark:text-[#86d99b]/70">
+      {children}
+    </p>
+  );
+}
+
+function ChannelCard({
+  icon,
+  title,
+  description,
+  locked,
+  checked,
+  onCheckedChange,
+  testId,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  locked?: boolean;
+  checked?: boolean;
+  onCheckedChange?: (next: boolean) => void;
+  testId?: string;
+}) {
+  const active = locked || checked;
+  return (
+    <label
+      className={cn(
+        "flex flex-col gap-2 rounded-xl border p-3.5 transition-colors",
+        active
+          ? "border-forest-500/45 bg-forest-500/[0.05] dark:border-[#86d99b]/40 dark:bg-[#86d99b]/[0.06]"
+          : "border-forest-500/15 hover:border-forest-500/35 dark:border-white/10 dark:hover:border-white/25",
+        locked ? "cursor-default" : "cursor-pointer"
+      )}
+    >
+      <span className="flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            "flex h-8 w-8 items-center justify-center rounded-lg",
+            active
+              ? "bg-forest-500 text-white dark:bg-[#86d99b] dark:text-[#0f1114]"
+              : "bg-forest-500/[0.07] text-forest-500 dark:bg-white/[0.06] dark:text-[#86d99b]"
+          )}
+        >
+          {icon}
+        </span>
+        {locked ? (
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-forest-500/70 dark:text-[#86d99b]/70">
+            Always on
+          </span>
+        ) : (
+          <Switch
+            checked={checked}
+            onCheckedChange={onCheckedChange}
+            data-testid={testId}
+          />
+        )}
+      </span>
+      <span>
+        <span className="block text-sm font-medium leading-tight">
+          {title}
+        </span>
+        <span className="mt-0.5 block text-xs leading-snug text-muted-foreground">
+          {description}
+        </span>
+      </span>
+    </label>
+  );
+}
+
+// ─── Expiry picker ──────────────────────────────────────────────────────────
+
+function ExpiryPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const presetValue = (days: number) =>
+    `${format(addDays(new Date(), days), "yyyy-MM-dd")}T23:59`;
+
+  const activePreset = EXPIRY_PRESETS.find((p) => presetValue(p.days) === value);
+
+  return (
+    <div className="space-y-2.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant={value === "" ? "default" : "outline"}
+          size="sm"
+          aria-pressed={value === ""}
+          className="h-8 rounded-full text-xs"
+          onClick={() => onChange("")}
+        >
+          No expiry
+        </Button>
+        {EXPIRY_PRESETS.map((p) => {
+          const isActive = activePreset?.days === p.days;
+          return (
+            <Button
+              key={p.days}
+              type="button"
+              variant={isActive ? "default" : "outline"}
+              size="sm"
+              aria-pressed={isActive}
+              className="h-8 rounded-full text-xs"
+              onClick={() => onChange(presetValue(p.days))}
+              data-testid={`announcement-expiry-preset-${p.days}`}
+            >
+              {p.label}
+            </Button>
+          );
+        })}
+        <ExpiryDateTimePicker value={value} onChange={onChange} />
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {value
+          ? `Leaves the feed ${format(new Date(value), "EEE d MMM yyyy, h:mm a")}.`
+          : "Stays in the feed until you delete it."}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Date+time picker storing a `datetime-local` string ("YYYY-MM-DDTHH:mm") so
+ * the submit body stays simple. The native datetime-local input has
+ * frustrating cross-browser styling and no clear affordance, hence the
+ * popover Calendar + time input combo.
+ */
+function ExpiryDateTimePicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+}) {
+  const [datePart, timePart] = value
+    ? [value.slice(0, 10), value.slice(11, 16)]
+    : ["", ""];
+  // Parse without UTC conversion: datetime-local strings are already in
+  // local time, so splitting and re-using the parts avoids timezone drift.
+  const dateValue = datePart ? new Date(`${datePart}T00:00:00`) : undefined;
+
+  const setDate = (d: Date | undefined) => {
+    if (!d) {
+      onChange("");
+      return;
+    }
+    const ymd = format(d, "yyyy-MM-dd");
+    onChange(`${ymd}T${timePart || "23:59"}`);
+  };
+
+  const setTime = (t: string) => {
+    if (!datePart) return; // ignore time changes until a date is picked
+    onChange(`${datePart}T${t || "23:59"}`);
+  };
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(
+              "h-8 justify-start gap-1.5 rounded-full text-xs font-normal",
+              !value && "text-muted-foreground"
+            )}
+          >
+            <CalendarIcon className="h-3.5 w-3.5" />
+            {value ? format(new Date(value), "d MMM yyyy") : "Pick a date…"}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            mode="single"
+            selected={dateValue}
+            onSelect={setDate}
+            autoFocus
+          />
+        </PopoverContent>
+      </Popover>
+      {value && (
+        <span className="relative">
+          <ClockIcon className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="time"
+            value={timePart}
+            onChange={(e) => setTime(e.target.value)}
+            className="h-8 w-[110px] pl-7 text-xs"
+            aria-label="Expiry time"
+          />
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ─── Recipient list toggle ──────────────────────────────────────────────────
+
+type RecipientPreview = {
+  id: string;
+  name: string | null;
+  firstName: string | null;
+  email: string;
+};
+
+/**
+ * "See exactly who" — expands the reach count into the actual matched
+ * volunteers, fetched with the same matching logic the send path uses.
+ * Refetches (debounced) whenever the targeting changes while open.
+ */
+function RecipientListToggle({
+  targeting,
+  recipientCount,
+}: {
+  targeting: TargetingDraft;
+  recipientCount: number | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const serialized = JSON.stringify(targeting);
+  const [result, setResult] = useState<{
+    recipients: RecipientPreview[];
+    total: number;
+    key: string | null;
+  }>({ recipients: [], total: 0, key: null });
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      try {
+        const response = await fetch("/api/admin/announcements/recipients", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: serialized,
+          signal: controller.signal,
+        });
+        if (response.ok) {
+          const data = await response.json();
+          setResult({
+            recipients: data.recipients ?? [],
+            total: data.total ?? 0,
+            key: serialized,
+          });
+        } else {
+          setResult({ recipients: [], total: 0, key: serialized });
+        }
+      } catch (err) {
+        if (!(err instanceof DOMException && err.name === "AbortError")) {
+          setResult((prev) => ({ ...prev, key: serialized }));
+        }
+      }
+    }, 400);
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [open, serialized]);
+
+  if (recipientCount === 0) return null;
+
+  const loading = open && result.key !== serialized;
+  const capped = result.total > result.recipients.length;
+
+  return (
+    <div className="mt-3 border-t border-forest-500/10 pt-2 dark:border-white/[0.07]">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        className="flex w-full cursor-pointer items-center justify-between gap-2 py-1 text-xs font-medium text-forest-500 transition-colors hover:text-forest-600 dark:text-[#86d99b] dark:hover:text-[#9be3ae]"
+        data-testid="announcement-recipient-list-toggle"
+      >
+        {open ? "Hide the list" : "See exactly who"}
+        <ChevronDown
+          className={cn(
+            "h-3.5 w-3.5 transition-transform duration-200",
+            open && "rotate-180"
+          )}
+        />
+      </button>
+
+      {open && (
+        <div
+          className="mt-1.5 max-h-60 overflow-y-auto rounded-lg border border-forest-500/10 dark:border-white/[0.07]"
+          data-testid="announcement-recipient-list"
+        >
+          {loading ? (
+            <div className="space-y-2 p-3">
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="h-3.5 animate-pulse rounded bg-forest-500/[0.08] motion-reduce:animate-none dark:bg-white/[0.06]"
+                  style={{ width: `${80 - i * 15}%` }}
+                />
+              ))}
+            </div>
+          ) : result.recipients.length === 0 ? (
+            <p className="p-3 text-xs text-muted-foreground">
+              No one matches right now.
+            </p>
+          ) : (
+            <ul className="divide-y divide-forest-500/[0.07] dark:divide-white/[0.05]">
+              {result.recipients.map((r) => (
+                <li key={r.id}>
+                  <a
+                    href={`/admin/volunteers/${r.id}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block px-3 py-1.5 transition-colors hover:bg-cream-50/70 dark:hover:bg-white/[0.03]"
+                  >
+                    <span className="block truncate text-xs font-medium">
+                      {r.name ?? r.firstName ?? r.email}
+                    </span>
+                    <span className="block truncate text-[11px] text-muted-foreground">
+                      {r.email}
+                    </span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+          {!loading && capped && (
+            <p className="border-t border-forest-500/10 px-3 py-1.5 text-[11px] text-muted-foreground dark:border-white/[0.07]">
+              Showing the first {result.recipients.length} of {result.total}.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Live recipient count ───────────────────────────────────────────────────
+
+/**
+ * Debounced live count of volunteers matching the current targeting. Uses
+ * the same parse path as the create route, so the preview can't drift from
+ * what publishing would actually send. "Counting" is derived: the shown
+ * count belongs to `key`, and any newer targeting means we're mid-count.
+ */
+function useRecipientCount(targeting: TargetingDraft) {
+  const serialized = JSON.stringify(targeting);
+  const [result, setResult] = useState<{
+    count: number | null;
+    key: string | null;
+  }>({ count: null, key: null });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      try {
+        const response = await fetch(
+          "/api/admin/announcements/recipient-count",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: serialized,
+            signal: controller.signal,
+          }
+        );
+        if (response.ok) {
+          const data = await response.json();
+          setResult({ count: data.count ?? null, key: serialized });
+        } else {
+          setResult({ count: null, key: serialized });
+        }
+      } catch (err) {
+        // On abort a newer request owns the spinner; on real errors stop
+        // spinning and keep whatever count we last had.
+        if (!(err instanceof DOMException && err.name === "AbortError")) {
+          setResult((prev) => ({ ...prev, key: serialized }));
+        }
+      }
+    }, 500);
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [serialized]);
+
+  return { count: result.count, counting: result.key !== serialized };
+}

--- a/web/src/app/admin/announcements/feed-preview.tsx
+++ b/web/src/app/admin/announcements/feed-preview.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import { cn } from "@/lib/utils";
+
+interface FeedPreviewProps {
+  title: string;
+  body: string;
+  imageUrl: string | null;
+  authorName: string;
+  className?: string;
+}
+
+/**
+ * Live replica of the announcement card volunteers see in the mobile feed,
+ * framed in a phone silhouette. Mirrors the real rendering in
+ * mobile/app/(tabs)/index.tsx: yellow icon tile with the 📢 emoji (the app's
+ * actual glyph, not admin chrome), title, markdown body, author + timestamp.
+ */
+export function FeedPreview({
+  title,
+  body,
+  imageUrl,
+  authorName,
+  className,
+}: FeedPreviewProps) {
+  const empty = !title.trim() && !body.trim() && !imageUrl;
+
+  return (
+    <div className={cn("select-none", className)} aria-hidden="true">
+      {/* Phone silhouette */}
+      <div className="relative mx-auto w-full max-w-[300px] rounded-[2.25rem] border border-forest-500/20 dark:border-white/10 bg-[#101410] p-[7px] shadow-[0_24px_48px_-24px_rgb(29_83_55/0.45)]">
+        {/* Screen */}
+        <div className="overflow-hidden rounded-[1.85rem] bg-cream-50 dark:bg-[#0f1114]">
+          {/* Status bar */}
+          <div className="flex items-center justify-between px-6 pt-2.5 pb-1 text-[10px] font-semibold text-[#14181c] dark:text-cream-50">
+            <span>9:41</span>
+            <span className="h-[18px] w-[72px] rounded-full bg-[#101410] dark:bg-black" />
+            <span className="flex items-center gap-1">
+              <svg viewBox="0 0 16 12" className="h-2.5 w-3.5 fill-current">
+                <rect x="0" y="7" width="3" height="5" rx="0.75" />
+                <rect x="4.5" y="4.5" width="3" height="7.5" rx="0.75" />
+                <rect x="9" y="2" width="3" height="10" rx="0.75" />
+                <rect x="13" y="0" width="3" height="12" rx="0.75" opacity="0.35" />
+              </svg>
+              <svg viewBox="0 0 25 12" className="h-3 w-6">
+                <rect x="0.5" y="0.5" width="21" height="11" rx="3" className="fill-none stroke-current" strokeOpacity="0.4" />
+                <rect x="2" y="2" width="14" height="8" rx="1.5" className="fill-current" />
+                <path d="M23 4v4c1.1-.3 1.1-3.7 0-4z" className="fill-current" fillOpacity="0.4" />
+              </svg>
+            </span>
+          </div>
+
+          {/* Feed screen header, as in the app's home tab */}
+          <div className="px-4 pt-2 pb-2.5">
+            <p className="font-accent text-[15px] font-semibold leading-tight text-forest-500 dark:text-[#86d99b]">
+              Kia ora 👋
+            </p>
+            <p className="text-[10px] text-[#14181c]/50 dark:text-cream-50/50">
+              What&apos;s happening at Everybody Eats
+            </p>
+          </div>
+
+          {/* The announcement card */}
+          <div className="mx-3 overflow-hidden rounded-2xl bg-white shadow-sm dark:bg-[#16181d]">
+            {imageUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={imageUrl}
+                alt=""
+                className="h-[110px] w-full object-cover"
+              />
+            ) : null}
+            <div className="flex gap-2.5 p-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[#fef9c3] text-[15px] dark:bg-[#fef9c3]/15">
+                📢
+              </div>
+              <div className="min-w-0 flex-1">
+                {empty ? (
+                  <>
+                    <div className="mb-1.5 h-3 w-3/4 rounded bg-[#14181c]/10 dark:bg-white/10" />
+                    <div className="mb-1 h-2 w-full rounded bg-[#14181c]/[0.06] dark:bg-white/[0.06]" />
+                    <div className="h-2 w-2/3 rounded bg-[#14181c]/[0.06] dark:bg-white/[0.06]" />
+                  </>
+                ) : (
+                  <>
+                    <p className="break-words text-[13px] font-bold leading-snug text-[#14181c] dark:text-cream-50">
+                      {title.trim() || "Untitled announcement"}
+                    </p>
+                    {body.trim() ? (
+                      <div className="preview-markdown mt-0.5 break-words text-[11.5px] leading-[1.45] text-[#14181c]/65 dark:text-cream-50/65">
+                        <ReactMarkdown>{body}</ReactMarkdown>
+                      </div>
+                    ) : null}
+                  </>
+                )}
+                <div className="mt-2 flex items-center justify-between">
+                  <div className="min-w-0">
+                    <p className="truncate text-[10px] text-[#14181c]/45 dark:text-cream-50/45">
+                      {authorName}
+                    </p>
+                    <p className="text-[10px] text-[#14181c]/45 dark:text-cream-50/45">
+                      just now
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Ghost of the next feed card, for context */}
+          <div className="mx-3 mt-2.5 flex gap-2.5 rounded-t-2xl bg-white/60 p-3 pb-4 dark:bg-white/[0.04]">
+            <div className="h-9 w-9 shrink-0 rounded-xl bg-[#fce7f3] opacity-60 dark:bg-[#fce7f3]/10" />
+            <div className="flex-1 pt-1 opacity-60">
+              <div className="mb-1.5 h-2.5 w-1/2 rounded bg-[#14181c]/10 dark:bg-white/10" />
+              <div className="h-2 w-5/6 rounded bg-[#14181c]/[0.06] dark:bg-white/[0.06]" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  );
+}

--- a/web/src/app/admin/announcements/page.tsx
+++ b/web/src/app/admin/announcements/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from "next";
 import { connection } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
 import { prisma } from "@/lib/prisma";
 import { AdminPageWrapper } from "@/components/admin-page-wrapper";
 import { AnnouncementsContent } from "./announcements-content";
@@ -12,7 +14,8 @@ export const metadata: Metadata = {
 export default async function AnnouncementsPage() {
   await connection();
 
-  const [announcements, labels, locations] = await Promise.all([
+  const [session, announcements, labels, locations] = await Promise.all([
+    getServerSession(authOptions),
     prisma.announcement.findMany({
       include: {
         author: {
@@ -33,6 +36,17 @@ export default async function AnnouncementsPage() {
     }),
   ]);
 
+  // Shown as the author line in the live feed preview — same fallback chain
+  // the mobile feed API uses for real announcements.
+  const currentAdmin = session?.user?.email
+    ? await prisma.user.findUnique({
+        where: { email: session.user.email },
+        select: { firstName: true, name: true },
+      })
+    : null;
+  const authorName =
+    currentAdmin?.firstName ?? currentAdmin?.name ?? "Admin";
+
   return (
     <AdminPageWrapper
       title="Announcements"
@@ -50,6 +64,7 @@ export default async function AnnouncementsPage() {
         }))}
         labels={labels}
         locations={locations.map((l) => l.name)}
+        authorName={authorName}
       />
     </AdminPageWrapper>
   );

--- a/web/src/app/admin/announcements/types.test.ts
+++ b/web/src/app/admin/announcements/types.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { isExpiryInPast, stripMarkdown } from "./types";
+
+describe("isExpiryInPast", () => {
+  const offsetLocal = (ms: number) => {
+    // Build a "YYYY-MM-DDTHH:mm" string the way the composer's picker does —
+    // local time, no timezone suffix.
+    const d = new Date(Date.now() + ms);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  };
+
+  it("treats an empty value as no expiry", () => {
+    expect(isExpiryInPast("")).toBe(false);
+  });
+
+  it("accepts a future expiry", () => {
+    expect(isExpiryInPast(offsetLocal(60 * 60 * 1000))).toBe(false);
+  });
+
+  it("rejects an expiry earlier today", () => {
+    // The calendar blocks past days, but the time input can still land here.
+    expect(isExpiryInPast(offsetLocal(-60 * 60 * 1000))).toBe(true);
+  });
+
+  it("ignores an unparseable value rather than blocking the form", () => {
+    // The server rejects it with a clear message; the client shouldn't show a
+    // "already passed" warning for something that isn't a date at all.
+    expect(isExpiryInPast("not-a-date")).toBe(false);
+  });
+});
+
+describe("stripMarkdown", () => {
+  it("unwraps links and drops images for one-line previews", () => {
+    expect(stripMarkdown("See [the roster](https://x.nz) for times")).toBe(
+      "See the roster for times"
+    );
+    expect(stripMarkdown("![poster](img.png) Dinner is on")).toBe(
+      "Dinner is on"
+    );
+  });
+
+  it("strips emphasis, headings and list markers", () => {
+    expect(stripMarkdown("## Kia ora\n\n- **bold** item\n- *italic*")).toBe(
+      "Kia ora bold item italic"
+    );
+  });
+
+  it("collapses whitespace so previews stay on one line", () => {
+    expect(stripMarkdown("line one\n\n\nline two")).toBe("line one line two");
+  });
+});

--- a/web/src/app/admin/announcements/types.ts
+++ b/web/src/app/admin/announcements/types.ts
@@ -1,0 +1,223 @@
+import { format } from "date-fns";
+
+/** Serialized announcement row as the server page hands it to the client. */
+export type Announcement = {
+  id: string;
+  title: string;
+  body: string;
+  imageUrl: string | null;
+  createdAt: string;
+  expiresAt: string | null;
+  createdBy: string;
+  targetLocations: string[];
+  targetGrades: string[];
+  targetLabelIds: string[];
+  targetUserIds: string[];
+  targetShiftIds: string[];
+  targetActivityLocations: string[];
+  targetActivityFrom: string | null;
+  targetActivityTo: string | null;
+  targetActivityMinShifts: number | null;
+  targetActivityMaxShifts: number | null;
+  sendEmail: boolean;
+  emailSentAt: string | null;
+  sendNotification: boolean;
+  notificationSentAt: string | null;
+  author: {
+    id: string;
+    name: string | null;
+    firstName: string | null;
+    email: string;
+  };
+};
+
+export type LabelOption = {
+  id: string;
+  name: string;
+  color: string;
+  icon: string | null;
+};
+
+export type UserOption = {
+  id: string;
+  email: string;
+  name: string | null;
+  firstName: string | null;
+  lastName: string | null;
+};
+
+export type ShiftOption = {
+  id: string;
+  start: string;
+  end: string;
+  location: string | null;
+  shiftTypeName: string;
+  signupCount: number;
+};
+
+/** The request-body shape shared by recipient-count preview and create. */
+export type TargetingDraft = {
+  targetLocations: string[];
+  targetGrades: string[];
+  targetLabelIds: string[];
+  targetUserIds: string[];
+  targetShiftIds: string[];
+  targetActivityLocations: string[];
+  targetActivityFrom: string | null;
+  targetActivityTo: string | null;
+  targetActivityMinShifts: number | null;
+  targetActivityMaxShifts: number | null;
+};
+
+export const VOLUNTEER_GRADES = [
+  { value: "GREEN", label: "Green", description: "Standard volunteers" },
+  { value: "YELLOW", label: "Yellow", description: "Experienced volunteers" },
+  { value: "PINK", label: "Pink", description: "Shift leaders" },
+] as const;
+
+export function gradeLabel(value: string): string {
+  return VOLUNTEER_GRADES.find((g) => g.value === value)?.label ?? value;
+}
+
+export function userDisplayName(u: UserOption): string {
+  if (u.firstName && u.lastName) return `${u.firstName} ${u.lastName}`;
+  return u.name || u.email;
+}
+
+export function authorDisplayName(a: Announcement["author"]): string {
+  return a.firstName ?? a.name ?? a.email;
+}
+
+/** "or"-join for within-dimension lists: "Onehunga, Glen Innes or Wellington". */
+export function orJoin(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  return `${items.slice(0, -1).join(", ")} or ${items[items.length - 1]}`;
+}
+
+/**
+ * Plain-English summary of an announcement's shift-history targeting, e.g.
+ * "worked 1+ shift at Onehunga since 24 Apr 2026" or "worked exactly 1
+ * shift". Null when the dimension is off.
+ */
+export function describeActivityTargeting(t: {
+  targetActivityLocations: string[];
+  targetActivityFrom: string | null;
+  targetActivityTo: string | null;
+  targetActivityMinShifts: number | null;
+  targetActivityMaxShifts: number | null;
+}): string | null {
+  const min = t.targetActivityMinShifts;
+  if (min === null) return null;
+  const max = t.targetActivityMaxShifts;
+
+  const howMany =
+    max === null
+      ? `${min}+ shift${min === 1 ? "" : "s"}`
+      : max === min
+        ? `exactly ${min} shift${min === 1 ? "" : "s"}`
+        : `${min}–${max} shifts`;
+
+  const where =
+    t.targetActivityLocations.length > 0
+      ? ` at ${orJoin(t.targetActivityLocations)}`
+      : "";
+  const from = t.targetActivityFrom
+    ? format(new Date(t.targetActivityFrom), "d MMM yyyy")
+    : null;
+  const to = t.targetActivityTo
+    ? format(new Date(t.targetActivityTo), "d MMM yyyy")
+    : null;
+  const when = from
+    ? to
+      ? ` between ${from} and ${to}`
+      : ` since ${from}`
+    : to
+      ? ` up to ${to}`
+      : "";
+
+  return `worked ${howMany}${where}${when}`;
+}
+
+/**
+ * The audience as a list of human conditions (one per active dimension,
+ * joined with AND by the caller). Empty list = everyone.
+ */
+export function audienceConditions(
+  t: TargetingDraft,
+  labels: LabelOption[]
+): string[] {
+  const parts: string[] = [];
+  if (t.targetLocations.length > 0) {
+    parts.push(`based in ${orJoin(t.targetLocations)}`);
+  }
+  const activity = describeActivityTargeting(t);
+  if (activity) parts.push(activity);
+  if (t.targetGrades.length > 0) {
+    parts.push(`${orJoin(t.targetGrades.map(gradeLabel))} grade`);
+  }
+  if (t.targetLabelIds.length > 0) {
+    const names = t.targetLabelIds.map(
+      (id) => labels.find((l) => l.id === id)?.name ?? "a label"
+    );
+    parts.push(`labelled ${orJoin(names)}`);
+  }
+  if (t.targetUserIds.length > 0) {
+    parts.push(
+      t.targetUserIds.length === 1
+        ? "1 chosen volunteer"
+        : `${t.targetUserIds.length} chosen volunteers`
+    );
+  }
+  if (t.targetShiftIds.length > 0) {
+    parts.push(
+      `signed up to ${t.targetShiftIds.length} chosen shift${t.targetShiftIds.length === 1 ? "" : "s"}`
+    );
+  }
+  return parts;
+}
+
+/** One-line audience summary for list rows. */
+export function audienceSummary(
+  ann: Announcement,
+  labels: LabelOption[]
+): string {
+  const parts = audienceConditions(ann, labels);
+  return parts.length > 0 ? parts.join(" · ") : "All volunteers";
+}
+
+/**
+ * Rough markdown-to-text for one-line previews: drops images, unwraps links,
+ * strips emphasis/heading/list markers and collapses whitespace.
+ */
+export function stripMarkdown(md: string): string {
+  return md
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/`{1,3}[^`]*`{1,3}/g, (m) => m.replace(/`/g, ""))
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*+]\s+/gm, "")
+    .replace(/^\s*\d+\.\s+/gm, "")
+    .replace(/[*_~]{1,3}([^*_~]+)[*_~]{1,3}/g, "$1")
+    .replace(/^>\s?/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function isExpired(ann: Announcement): boolean {
+  return ann.expiresAt ? new Date(ann.expiresAt) < new Date() : false;
+}
+
+/** True when the announcement leaves the feed within the next `hours`. */
+export function expiresWithin(ann: Announcement, hours: number): boolean {
+  if (!ann.expiresAt) return false;
+  const remaining = new Date(ann.expiresAt).getTime() - Date.now();
+  return remaining > 0 && remaining < hours * 3_600_000;
+}
+
+export function parseCsv(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}

--- a/web/src/app/admin/announcements/types.ts
+++ b/web/src/app/admin/announcements/types.ts
@@ -207,6 +207,17 @@ export function isExpired(ann: Announcement): boolean {
   return ann.expiresAt ? new Date(ann.expiresAt) < new Date() : false;
 }
 
+/**
+ * True when a composer expiry value ("YYYY-MM-DDTHH:mm", or "" for none) is
+ * already in the past. Publishing one would drop the announcement straight
+ * into the archive without ever showing in the feed.
+ */
+export function isExpiryInPast(value: string): boolean {
+  if (value === "") return false;
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed <= new Date();
+}
+
 /** True when the announcement leaves the feed within the next `hours`. */
 export function expiresWithin(ann: Announcement, hours: number): boolean {
   if (!ann.expiresAt) return false;

--- a/web/src/app/api/admin/announcements/recipients/route.ts
+++ b/web/src/app/api/admin/announcements/recipients/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth-options";
+import {
+  findAnnouncementRecipients,
+  parseTargetingFromRequest,
+} from "@/lib/announcement-targeting";
+
+/** Cap the preview list so a broad audience doesn't ship thousands of rows. */
+const MAX_PREVIEW_RECIPIENTS = 300;
+
+/**
+ * POST /api/admin/announcements/recipients
+ *
+ * Returns the volunteers matched by the given targeting filters — the same
+ * matching logic the send path uses. Powers the "see exactly who" list under
+ * the recipient count in the composer. The list is alphabetised and capped
+ * at MAX_PREVIEW_RECIPIENTS; `total` always reflects the full audience.
+ */
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  if (session?.user?.role !== "ADMIN") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const recipients = await findAnnouncementRecipients(
+    parseTargetingFromRequest(body)
+  );
+
+  const displayName = (r: (typeof recipients)[number]) =>
+    r.firstName ?? r.name ?? r.email;
+  const sorted = [...recipients].sort((a, b) =>
+    displayName(a).localeCompare(displayName(b), "en", { sensitivity: "base" })
+  );
+
+  return NextResponse.json({
+    total: sorted.length,
+    recipients: sorted.slice(0, MAX_PREVIEW_RECIPIENTS).map((r) => ({
+      id: r.id,
+      name: r.name,
+      firstName: r.firstName,
+      email: r.email,
+    })),
+  });
+}

--- a/web/src/app/api/admin/announcements/recipients/route.ts
+++ b/web/src/app/api/admin/announcements/recipients/route.ts
@@ -28,19 +28,21 @@ export async function POST(request: Request) {
     parseTargetingFromRequest(body)
   );
 
-  const displayName = (r: (typeof recipients)[number]) =>
-    r.firstName ?? r.name ?? r.email;
-  const sorted = [...recipients].sort((a, b) =>
-    displayName(a).localeCompare(displayName(b), "en", { sensitivity: "base" })
+  // One display name, resolved server-side and used for both the sort and the
+  // rendered label. Deriving them separately lets the two fall out of step —
+  // a volunteer whose `name` and `firstName` disagree then sorts under one
+  // and renders as the other, and the list reads as unsorted.
+  const rows = recipients.map((r) => ({
+    id: r.id,
+    displayName: r.name ?? r.firstName ?? r.email,
+    email: r.email,
+  }));
+  rows.sort((a, b) =>
+    a.displayName.localeCompare(b.displayName, "en", { sensitivity: "base" })
   );
 
   return NextResponse.json({
-    total: sorted.length,
-    recipients: sorted.slice(0, MAX_PREVIEW_RECIPIENTS).map((r) => ({
-      id: r.id,
-      name: r.name,
-      firstName: r.firstName,
-      email: r.email,
-    })),
+    total: rows.length,
+    recipients: rows.slice(0, MAX_PREVIEW_RECIPIENTS),
   });
 }

--- a/web/src/app/api/admin/announcements/route.ts
+++ b/web/src/app/api/admin/announcements/route.ts
@@ -111,6 +111,28 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Body is required" }, { status: 400 });
   }
 
+  // An unparseable expiry would reach Prisma as an Invalid Date and fail the
+  // insert with an opaque error; a past one would publish an announcement that
+  // is already hidden from the feed. Reject both with something an admin can
+  // act on.
+  let expiresAtDate: Date | null = null;
+  if (expiresAt) {
+    const parsed = new Date(expiresAt);
+    if (Number.isNaN(parsed.getTime())) {
+      return NextResponse.json(
+        { error: "Expiry date is not a valid date" },
+        { status: 400 }
+      );
+    }
+    if (parsed.getTime() <= Date.now()) {
+      return NextResponse.json(
+        { error: "Expiry date must be in the future" },
+        { status: 400 }
+      );
+    }
+    expiresAtDate = parsed;
+  }
+
   const targeting = parseTargetingFromRequest(body);
 
   const announcement = await prisma.announcement.create({
@@ -118,7 +140,7 @@ export async function POST(request: Request) {
       title: title.trim(),
       body: announcementBody.trim(),
       imageUrl: imageUrl?.trim() || null,
-      expiresAt: expiresAt ? new Date(expiresAt) : null,
+      expiresAt: expiresAtDate,
       createdBy: adminUser.id,
       sendEmail: Boolean(sendEmail),
       sendNotification: Boolean(sendNotification),

--- a/web/src/app/api/admin/announcements/route.ts
+++ b/web/src/app/api/admin/announcements/route.ts
@@ -66,7 +66,7 @@ export async function GET() {
  *   targetLocations?, targetGrades?, targetLabelIds?,
  *   targetUserIds?, targetShiftIds?,
  *   targetActivityLocations?, targetActivityFrom?, targetActivityTo?,
- *   targetActivityMinShifts?,
+ *   targetActivityMinShifts?, targetActivityMaxShifts?,
  *   sendEmail?, sendNotification?
  * }
  */

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -507,3 +507,64 @@ h6 em,
     @apply bg-background text-foreground;
   }
 }
+
+/* ── Admin announcements: compact markdown inside the phone-feed preview ── */
+.preview-markdown p {
+  margin: 0 0 0.35em;
+}
+.preview-markdown p:last-child {
+  margin-bottom: 0;
+}
+.preview-markdown strong {
+  color: inherit;
+  font-weight: 700;
+}
+.preview-markdown a {
+  color: #1d5337;
+  text-decoration: underline;
+}
+.dark .preview-markdown a {
+  color: #86d99b;
+}
+.preview-markdown ul,
+.preview-markdown ol {
+  margin: 0.2em 0 0.35em;
+  padding-left: 1.1em;
+}
+.preview-markdown ul {
+  list-style: disc;
+}
+.preview-markdown ol {
+  list-style: decimal;
+}
+.preview-markdown li {
+  margin: 0.1em 0;
+}
+.preview-markdown h1,
+.preview-markdown h2,
+.preview-markdown h3,
+.preview-markdown h4 {
+  font-family: inherit;
+  font-size: 1em;
+  font-weight: 700;
+  margin: 0.4em 0 0.15em;
+  letter-spacing: 0;
+}
+.preview-markdown blockquote {
+  border-left: 2px solid rgb(29 83 55 / 0.3);
+  margin: 0.3em 0;
+  padding-left: 0.6em;
+}
+.preview-markdown code {
+  font-size: 0.9em;
+  background: rgb(20 24 28 / 0.06);
+  border-radius: 3px;
+  padding: 0 0.25em;
+}
+.dark .preview-markdown code {
+  background: rgb(255 255 255 / 0.08);
+}
+.preview-markdown img {
+  border-radius: 6px;
+  max-width: 100%;
+}

--- a/web/src/lib/announcement-targeting.test.ts
+++ b/web/src/lib/announcement-targeting.test.ts
@@ -13,6 +13,7 @@ function activity(overrides: Partial<ActivityTargeting> = {}): ActivityTargeting
     targetActivityFrom: null,
     targetActivityTo: null,
     targetActivityMinShifts: 1,
+    targetActivityMaxShifts: null,
     ...overrides,
   };
 }
@@ -79,6 +80,35 @@ describe("announcement-targeting", () => {
         parseTargetingFromRequest({ targetActivityMinShifts: 2.7 })
           .targetActivityMinShifts
       ).toBe(2);
+    });
+
+    it("drops the maximum when the dimension is off", () => {
+      const t = parseTargetingFromRequest({ targetActivityMaxShifts: 3 });
+
+      expect(t.targetActivityMinShifts).toBeNull();
+      expect(t.targetActivityMaxShifts).toBeNull();
+    });
+
+    it("clamps the maximum shift count and never lets it cross the minimum", () => {
+      expect(
+        parseTargetingFromRequest({
+          targetActivityMinShifts: 1,
+          targetActivityMaxShifts: 10_000,
+        }).targetActivityMaxShifts
+      ).toBe(999);
+      // A max below the min would silently match no one — raise it instead.
+      expect(
+        parseTargetingFromRequest({
+          targetActivityMinShifts: 5,
+          targetActivityMaxShifts: 2,
+        }).targetActivityMaxShifts
+      ).toBe(5);
+      expect(
+        parseTargetingFromRequest({
+          targetActivityMinShifts: 1,
+          targetActivityMaxShifts: "loads",
+        }).targetActivityMaxShifts
+      ).toBeNull();
     });
 
     it("ignores non-string entries in the targeting arrays", () => {
@@ -165,6 +195,38 @@ describe("announcement-targeting", () => {
       ).toBe(false);
       expect(
         userMatchesActivityTargeting([onehungaJune, onehungaApril], target)
+      ).toBe(true);
+    });
+
+    it("excludes volunteers over the maximum", () => {
+      const firstShiftOnly = activity({
+        targetActivityMinShifts: 1,
+        targetActivityMaxShifts: 1,
+      });
+
+      expect(userMatchesActivityTargeting([], firstShiftOnly)).toBe(false);
+      expect(
+        userMatchesActivityTargeting([onehungaJune], firstShiftOnly)
+      ).toBe(true);
+      expect(
+        userMatchesActivityTargeting(
+          [onehungaJune, onehungaApril],
+          firstShiftOnly
+        )
+      ).toBe(false);
+    });
+
+    it("counts only matching shifts against the maximum", () => {
+      // Two shifts overall, but only one at the targeted location — still
+      // inside a max of 1.
+      expect(
+        userMatchesActivityTargeting(
+          [onehungaJune, wellingtonJune],
+          activity({
+            targetActivityLocations: ["Onehunga"],
+            targetActivityMaxShifts: 1,
+          })
+        )
       ).toBe(true);
     });
   });

--- a/web/src/lib/announcement-targeting.ts
+++ b/web/src/lib/announcement-targeting.ts
@@ -39,6 +39,9 @@ export interface AnnouncementTargeting {
   targetActivityTo: Date | null;
   /** Minimum matching shifts. Null switches the whole dimension off. */
   targetActivityMinShifts: number | null;
+  /** Maximum matching shifts, e.g. 1 to reach first-shift volunteers only.
+   *  Null = no upper bound. Ignored while the dimension is off. */
+  targetActivityMaxShifts: number | null;
 }
 
 /** Pluck the targeting fields out of an Announcement row. */
@@ -55,6 +58,7 @@ export function targetingFromAnnouncement(
     targetActivityFrom: ann.targetActivityFrom,
     targetActivityTo: ann.targetActivityTo,
     targetActivityMinShifts: ann.targetActivityMinShifts,
+    targetActivityMaxShifts: ann.targetActivityMaxShifts,
   };
 }
 
@@ -65,6 +69,7 @@ export type ActivityTargeting = Pick<
   | "targetActivityFrom"
   | "targetActivityTo"
   | "targetActivityMinShifts"
+  | "targetActivityMaxShifts"
 >;
 
 /** Is the shift-history dimension switched on for this targeting? */
@@ -109,7 +114,14 @@ export function userMatchesActivityTargeting(
     return true;
   });
 
-  return matching.length >= (t.targetActivityMinShifts ?? 1);
+  if (matching.length < (t.targetActivityMinShifts ?? 1)) return false;
+  if (
+    t.targetActivityMaxShifts !== null &&
+    matching.length > t.targetActivityMaxShifts
+  ) {
+    return false;
+  }
+  return true;
 }
 
 const MAX_ACTIVITY_MIN_SHIFTS = 999;
@@ -129,11 +141,20 @@ export function parseTargetingFromRequest(
   const stringArray = (value: unknown): string[] =>
     Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
 
-  const rawMinShifts = body.targetActivityMinShifts;
-  const minShifts =
-    typeof rawMinShifts === "number" && Number.isFinite(rawMinShifts)
-      ? Math.min(Math.max(Math.trunc(rawMinShifts), 1), MAX_ACTIVITY_MIN_SHIFTS)
+  const clampShiftCount = (value: unknown): number | null =>
+    typeof value === "number" && Number.isFinite(value)
+      ? Math.min(Math.max(Math.trunc(value), 1), MAX_ACTIVITY_MIN_SHIFTS)
       : null;
+
+  const minShifts = clampShiftCount(body.targetActivityMinShifts);
+  // The max only exists while the dimension is on (min set), and can never
+  // sit below the min — a crossed range would silently match no one.
+  const rawMaxShifts =
+    minShifts !== null
+      ? clampShiftCount(body.targetActivityMaxShifts)
+      : null;
+  const maxShifts =
+    rawMaxShifts !== null ? Math.max(rawMaxShifts, minShifts!) : null;
 
   return {
     targetLocations: stringArray(body.targetLocations),
@@ -145,6 +166,7 @@ export function parseTargetingFromRequest(
     targetActivityFrom: parseActivityDate(body.targetActivityFrom, "start"),
     targetActivityTo: parseActivityDate(body.targetActivityTo, "end"),
     targetActivityMinShifts: minShifts,
+    targetActivityMaxShifts: maxShifts,
   };
 }
 
@@ -250,13 +272,17 @@ function buildRecipientConditions(t: AnnouncementTargeting): Prisma.Sql {
       activityFilters.push(Prisma.sql`"Shift"."end" <= ${t.targetActivityTo}`);
     }
 
-    conditions.push(
-      Prisma.sql`(
+    const workedShiftCount = Prisma.sql`(
         SELECT COUNT(DISTINCT "Signup"."shiftId")
         FROM "Signup"
         JOIN "Shift" ON "Shift".id = "Signup"."shiftId"
         WHERE ${Prisma.join(activityFilters, " AND ")}
-      ) >= ${t.targetActivityMinShifts}`
+      )`;
+
+    conditions.push(
+      t.targetActivityMaxShifts !== null
+        ? Prisma.sql`${workedShiftCount} BETWEEN ${t.targetActivityMinShifts} AND ${t.targetActivityMaxShifts}`
+        : Prisma.sql`${workedShiftCount} >= ${t.targetActivityMinShifts}`
     );
   }
 


### PR DESCRIPTION
# Pull Request

## Description

Complete visual and information-architecture overhaul of `/admin/announcements`. The old page was a single 1,726-line scrolling form that buried the two questions carrying the most operational risk: **what will volunteers actually see**, and **who exactly receives this**. Both answers only appeared after publishing.

The page is now a two-view console split across focused files:

**Overview** — a pulse strip (live in the feed / next to expire / published all-time) over a ledger split into "In the feed now" and "Expired". Each row is a date tile plus title, one-line preview, audience summary and delivery status. Expanding a row asks the API how many volunteers that stored audience matches *today*.

**Composer** — inputs on the left (Message, Schedule, Audience, Delivery), with a sticky rail on the right holding the consequences:

- A **phone silhouette rendering the volunteer's real feed card**, mirroring `mobile/app/(tabs)/index.tsx` down to the 📢 emoji tile and yellow chip, updating as you type.
- The live reach count, with the audience spelled out as plain-English conditions joined by "and" ("based in Wellington" / "and worked exactly 1 shift").
- A publish button labelled with the number it will actually send to — "Publish to ~79 volunteers".

**Targeting** moves from a wall of checkboxes to six collapsible filter rows, each showing its current state in the collapsed header, so the whole audience reads at a glance without opening anything.

Two capabilities were added to targeting along the way:

- **`targetActivityMaxShifts`** bounds shift-history targeting from above, so an announcement can reach volunteers who have worked *exactly one* shift. Threaded through the schema, the SQL condition (`BETWEEN` when a max is set), the in-memory mobile-feed twin, and request parsing — which clamps a crossed range up to the minimum rather than silently matching nobody.
- **`POST /api/admin/announcements/recipients`** returns the matched volunteers using the same `findAnnouncementRecipients` the send path uses (alphabetised, capped at 300). It powers a "see exactly who" toggle under the reach count, with each name linking to their admin profile.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Code refactoring (no functional changes)

## Version Bump Required
`version:minor` — new targeting capability and a new API route, backward compatible.

## Testing
- [x] Unit tests pass — 524 passed (50 files), including 6 new cases covering the max-shifts bound and its clamping
- [x] Manual testing completed
- [x] New tests added
- [ ] E2E tests pass — not run locally; no announcements e2e spec exists in the suite

Manual verification in the browser (light, dark, and 375px mobile):

- Published an announcement end-to-end and confirmed it lands in the ledger
- Confirmed the "see exactly who" list stays in step with the count — 87 names with no filters, dropping to 79 in lockstep when shift-history targeting was enabled
- Exercised delete-with-confirmation, and the expired-section split
- Confirmed existing deep links (`?userIds=`, `?shiftIds=`, `?locations=`, `?grades=`, `?labels=`, `?sendEmail=`) still seed and open the composer with real volunteer names hydrated

`npm run lint` and `tsc --noEmit` are both clean.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Migration**: `20260724144327_add_announcement_activity_max_shifts` adds one nullable column. No backfill needed — `NULL` means "no upper bound", which is the existing behaviour.

**Backward compatibility**: every existing announcement keeps rendering and matching identically; the new bound is dormant unless an admin sets it.

**Unrelated finding worth flagging** — `web/.env` in local dev has the Supabase variables set to *empty strings*, which look set when you grep. `src/lib/supabase.ts` throws at module load, so every route importing `@/lib/storage` returns 500 in dev: announcement delete, announcement image upload, and `/api/profile/photo`. Not a code bug and prod is unaffected, but it makes those routes look broken locally. Patching the local `.env` with dummy values fixes it.