### PR TITLE
fix(flaky): auto-accept-rules should validate rule creation form

### DIFF
--- a/web/tests/e2e/auto-accept-rules.spec.ts
+++ b/web/tests/e2e/auto-accept-rules.spec.ts
@@ -86,8 +86,13 @@ test.describe("Auto-Accept Rules Admin Interface", () => {
     await page.getByText("Create Rule").click();
 
     // Should see validation errors (exact messages may vary)
-    // At minimum, rule name should be required
-    const dialog = page.locator('[role="dialog"]');
+    // At minimum, rule name should be required. Scope to the dialog's own
+    // accessible name: a bare [role="dialog"] locator is a strict-mode trap
+    // here, because the background notification SSE connection (mounted
+    // admin-wide) intermittently fires a benign onerror that Next.js dev
+    // mode renders as its own role="dialog" console-error overlay, and the
+    // two dialogs being simultaneously present made this test flaky.
+    const dialog = page.getByRole("dialog", { name: "Create Auto-Accept Rule" });
     await expect(dialog).toBeVisible();
   });
 


### PR DESCRIPTION
## Description

Weekly flaky-test audit of CI runs (2026-07-20 → 2026-07-27) identified `tests/e2e/auto-accept-rules.spec.ts:77 "should validate rule creation form"` as the #1 flakiest test — it appeared flaky-or-failing in 5/5 fully-audited "Test" workflow runs this week, including one outright CI failure (run #3108, 2026-07-23).

**Root cause:** the test asserted on the ambiguous locator `page.locator('[role="dialog"]')`. The admin-wide notification SSE hook (`src/hooks/use-notification-stream.ts`) calls `console.error("[SSE] Connection error:", error)` on every `EventSource.onerror`, including benign/expected disconnects. In Next.js dev mode (which is what CI's Playwright `webServer` runs), any `console.error` gets rendered as a full-page `role="dialog"` console-error overlay. Whenever that overlay happened to be on screen at the same moment as the real "Create Auto-Accept Rule" dialog, `page.locator('[role="dialog"]')` matched two elements and Playwright's strict mode threw — sometimes clearing by the next retry (flaky), sometimes not (hard failure).

**Fix:** scope the locator to the dialog's own accessible name — `page.getByRole("dialog", { name: "Create Auto-Accept Rule" })` — so it can never match the unrelated overlay, regardless of whether the SSE hook's noisy logging is ever cleaned up separately. This is a minimal, test-only change; I deliberately did not touch `use-notification-stream.ts` since its `console.error` calls may be relied on by production error tracking (PostHog) and changing that behavior is a separate concern from de-flaking this test.

Verified locally: 20/20 repeated runs of the fixed test pass, including runs where the webserver log confirms the SSE error overlay still fired mid-test — the fix is robust to the actual triggering condition, not just timing luck.

## Type of Change
- [x] 🧪 Tests (adding missing tests or correcting existing tests)

## Version Bump Required
`version:skip` (test-only change, no production code touched)

## Testing
- [x] E2E tests pass (`auto-accept-rules.spec.ts`, full file, 9/9 passed; target test repeated 20x, 20/20 passed)
- [ ] Unit tests pass — n/a, no unit tests touched
- [ ] Manual testing completed — n/a, test-only change

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

This test was flagged by an automated weekly CI-health review, not a live user request. Full methodology: pulled all `Test`-workflow (test.yml) runs on `main` from the past 7 days (18 completed runs, push-triggered only), then fully audited all 20 Playwright shards for 5 of those 18 runs — the 2 that failed outright plus 3 spread across the week that passed — since Playwright's shard jobs can self-recover a failing test via built-in retries and still report the job/workflow as "success", hiding flakiness that never surfaces as a red build.

Other notable patterns surfaced by the same audit, not addressed in this PR (out of scope for a single-test fix):
- The same `[role="dialog"]`/`role="dialog"` strict-mode collision pattern (duplicate-element matches) recurs across many unrelated spec files (`admin-users`, `admin-surveys`, `my-shifts`, `admin-shifts`, `profile`), consistent with the same SSE-triggered dev-overlay root cause reaching further than just this one test.
- A recurring `Failed to create shift: 500` from the `createShift` e2e test helper affects several different tests in `admin-shift-edit-delete.spec.ts` and `shifts-browse.spec.ts` under parallel shard load — looks like a transient API/DB issue independent of the dialog problem above, worth a separate investigation.
- `admin-notes.spec.ts:174 "should delete an admin note with confirmation dialog"` was flaky in the same 5/5 runs (timeout waiting for `add-note-button`/`delete-note-button`) — a close second to the test fixed here, but with a distinct (UI-timing) root cause not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmFWSR3DmSYpNBAsxCsTLK)_