### PR TITLE
fix(admin): make shift transfers reversible

### DIFF
--- a/web/src/app/api/test/signups/route.ts
+++ b/web/src/app/api/test/signups/route.ts
@@ -48,13 +48,14 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { userId, shiftId, status = "CONFIRMED" } = body;
+    const { userId, shiftId, status = "CONFIRMED", backupForShiftIds = [] } = body;
 
     const signup = await prisma.signup.create({
       data: {
         userId,
         shiftId,
         status,
+        backupForShiftIds,
       },
     });
 

--- a/web/src/components/volunteer-actions.tsx
+++ b/web/src/components/volunteer-actions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Check, X, Clock, UserMinus, AlertTriangle, ArrowRightLeft, UserCheck, UserX } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -41,24 +42,69 @@ interface VolunteerActionsProps {
     };
   };
   volunteerName?: string;
-  backupShiftIds?: string[]; // Optional: filter available shifts to only backup options
+  backupShiftIds?: string[]; // Optional: shifts the volunteer nominated as backups - highlighted, not enforced
+}
+
+type MoveTargetShift = {
+  id: string;
+  start: string;
+  end: string;
+  location: string | null;
+  capacity: number;
+  confirmedCount: number;
+  shiftType: {
+    id: string;
+    name: string;
+  };
+  // True when the volunteer nominated this shift as a backup at signup time
+  isPreferred: boolean;
+};
+
+/**
+ * Options for the "move volunteer" target picker. Backup preferences are sorted
+ * to the top and badged, but every shift with a free spot stays selectable so a
+ * volunteer can always be moved back to where they came from.
+ */
+function MoveTargetOptions({ shifts }: { shifts: MoveTargetShift[] }) {
+  return (
+    <>
+      {shifts.map((shift) => {
+        const spotsLeft = shift.capacity - shift.confirmedCount;
+        return (
+          <SelectItem
+            key={shift.id}
+            value={shift.id}
+            textValue={shift.shiftType.name}
+            data-testid={`move-target-option-${shift.id}`}
+          >
+            <span className="flex min-w-0 flex-col! items-start! gap-0.5">
+              <span className="flex items-center gap-2">
+                <span className="truncate font-medium">{shift.shiftType.name}</span>
+                {shift.isPreferred && (
+                  <Badge
+                    variant="secondary"
+                    className="bg-blue-100 dark:bg-blue-900/60 text-blue-700 dark:text-blue-200"
+                  >
+                    <ArrowRightLeft aria-hidden="true" />
+                    Backup choice
+                  </Badge>
+                )}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {formatInNZT(new Date(shift.start), "h:mm a")} - {formatInNZT(new Date(shift.end), "h:mm a")} • {spotsLeft} {spotsLeft === 1 ? "spot" : "spots"} available
+              </span>
+            </span>
+          </SelectItem>
+        );
+      })}
+    </>
+  );
 }
 
 export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPrefix, currentShift, volunteerName, backupShiftIds }: VolunteerActionsProps) {
   const [loading, setLoading] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState<string | null>(null);
-  const [availableShifts, setAvailableShifts] = useState<{
-    id: string;
-    start: string;
-    end: string;
-    location: string | null;
-    capacity: number;
-    confirmedCount: number;
-    shiftType: {
-      id: string;
-      name: string;
-    };
-  }[]>([]);
+  const [availableShifts, setAvailableShifts] = useState<MoveTargetShift[]>([]);
   const [selectedTargetShift, setSelectedTargetShift] = useState<string>("");
   const [movementNotes, setMovementNotes] = useState("");
   const [sendEmailOnReject, setSendEmailOnReject] = useState(true); // Default to checked
@@ -71,18 +117,22 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
       const shiftDate = formatInNZT(currentShift.start, "yyyy-MM-dd");
       const response = await fetch(`/api/admin/shifts/available?date=${shiftDate}&location=${currentShift.location}`);
       if (response.ok) {
-        const data = await response.json();
-        // Filter out the current shift
-        let filtered = data.filter((shift: typeof availableShifts[0]) => shift.id !== currentShift.id);
+        const data: Omit<MoveTargetShift, "isPreferred">[] = await response.json();
 
-        // If backup shift IDs provided, only show those shifts
-        if (backupShiftIds && backupShiftIds.length > 0) {
-          filtered = filtered.filter((shift: typeof availableShifts[0]) =>
-            backupShiftIds.includes(shift.id)
-          );
-        }
+        // Every shift with a free spot stays selectable. The volunteer's backup
+        // preferences are only a hint - restricting the list to them made moves
+        // one-way, since the shift they came from is never in that list.
+        const targets: MoveTargetShift[] = data
+          .filter((shift) => shift.id !== currentShift.id)
+          .map((shift) => ({
+            ...shift,
+            isPreferred: backupShiftIds?.includes(shift.id) ?? false,
+          }));
 
-        setAvailableShifts(filtered);
+        // Surface the volunteer's own preferences first, then keep start-time order
+        targets.sort((a, b) => Number(b.isPreferred) - Number(a.isPreferred));
+
+        setAvailableShifts(targets);
       }
     } catch (error) {
       console.error("Error fetching available shifts:", error);
@@ -391,35 +441,35 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4">
-                <div>
-                  <Label htmlFor="targetShift">Select Target Shift</Label>
-                  <Select value={selectedTargetShift} onValueChange={setSelectedTargetShift}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Choose a shift..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {availableShifts.map(shift => (
-                        <SelectItem
-                          key={shift.id}
-                          value={shift.id}
-                          data-testid={`move-target-option-${shift.id}`}
-                        >
-                          {shift.shiftType.name} • {formatInNZT(new Date(shift.start), "h:mm a")} - {formatInNZT(new Date(shift.end), "h:mm a")} • {shift.capacity - shift.confirmedCount} {shift.capacity - shift.confirmedCount === 1 ? "spot" : "spots"} available
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <Label htmlFor="movementNotes">Movement Notes (optional)</Label>
-                  <Textarea
-                    id="movementNotes"
-                    value={movementNotes}
-                    onChange={(e) => setMovementNotes(e.target.value)}
-                    placeholder="Add any notes about this movement..."
-                    rows={3}
-                  />
-                </div>
+                {availableShifts.length === 0 ? (
+                  <p className="text-sm text-slate-500 dark:text-slate-400" data-testid="move-no-targets">
+                    No other shifts with a free spot on this day at {currentShift.location}.
+                  </p>
+                ) : (
+                  <>
+                    <div>
+                      <Label htmlFor="targetShift">Select Target Shift</Label>
+                      <Select value={selectedTargetShift} onValueChange={setSelectedTargetShift}>
+                        <SelectTrigger id="targetShift">
+                          <SelectValue placeholder="Choose a shift..." />
+                        </SelectTrigger>
+                        <SelectContent className="w-(--radix-select-trigger-width)">
+                          <MoveTargetOptions shifts={availableShifts} />
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <Label htmlFor="movementNotes">Movement Notes (optional)</Label>
+                      <Textarea
+                        id="movementNotes"
+                        value={movementNotes}
+                        onChange={(e) => setMovementNotes(e.target.value)}
+                        placeholder="Add any notes about this movement..."
+                        rows={3}
+                      />
+                    </div>
+                  </>
+                )}
               </div>
               <DialogFooter>
                 <Button
@@ -707,7 +757,9 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
             </DialogHeader>
             <div className="py-4 space-y-4">
               {availableShifts.length === 0 ? (
-                <p className="text-sm text-slate-500">No other shifts available on this day</p>
+                <p className="text-sm text-slate-500 dark:text-slate-400" data-testid="move-no-targets">
+                  No other shifts with a free spot on this day at {currentShift.location}.
+                </p>
               ) : (
                 <>
                   <div>
@@ -716,13 +768,8 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
                       <SelectTrigger id="target-shift" data-testid={testIdPrefix ? `${testIdPrefix}-move-shift-select` : `volunteer-move-shift-select-${signupId}`}>
                         <SelectValue placeholder="Choose a shift" />
                       </SelectTrigger>
-                      <SelectContent>
-                        {availableShifts.map((shift) => (
-                          <SelectItem key={shift.id} value={shift.id}>
-                            {shift.shiftType.name} ({formatInNZT(new Date(shift.start), "h:mm a")} - {formatInNZT(new Date(shift.end), "h:mm a")})
-                            {shift.confirmedCount >= shift.capacity && " - Full"}
-                          </SelectItem>
-                        ))}
+                      <SelectContent className="w-(--radix-select-trigger-width)">
+                        <MoveTargetOptions shifts={availableShifts} />
                       </SelectContent>
                     </Select>
                   </div>

--- a/web/tests/e2e/helpers/test-helpers.ts
+++ b/web/tests/e2e/helpers/test-helpers.ts
@@ -163,7 +163,12 @@ export async function getUserByEmail(
  */
 export async function createSignup(
   page: Page,
-  data: { userId: string; shiftId: string; status?: string }
+  data: {
+    userId: string;
+    shiftId: string;
+    status?: string;
+    backupForShiftIds?: string[];
+  }
 ): Promise<{ id: string }> {
   const response = await page.request.post("/api/test/signups", {
     data,

--- a/web/tests/e2e/volunteer-movement.spec.ts
+++ b/web/tests/e2e/volunteer-movement.spec.ts
@@ -162,6 +162,77 @@ test.describe("General Volunteer Movement System", () => {
       );
     });
 
+    /**
+     * Regression: moving a volunteer used to be one-way.
+     *
+     * The target dropdown filtered down to the volunteer's own backup shift
+     * preferences, and the shift they came from is never in that list. Once a
+     * volunteer with backup preferences had been moved, admins could not move
+     * them back - the dropdown came up empty. Backup preferences are now a
+     * hint (sorted first, badged), never a restriction.
+     */
+    test("admin can move a volunteer whose only backup preference is their current shift", async ({
+      page,
+    }) => {
+      // Volunteer sits on the source shift and nominated only that shift as a backup
+      await deleteSignupsByShiftIds(page, [sourceShiftId, targetShiftId]);
+      await createSignup(page, {
+        userId: volunteerUserId,
+        shiftId: sourceShiftId,
+        status: "CONFIRMED",
+        backupForShiftIds: [sourceShiftId],
+      });
+
+      await loginAsAdmin(page);
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const tomorrowStr = `${tomorrow.getFullYear()}-${String(
+        tomorrow.getMonth() + 1
+      ).padStart(2, "0")}-${String(tomorrow.getDate()).padStart(2, "0")}`;
+      await page.goto(`/admin/shifts?date=${tomorrowStr}&location=Wellington`);
+      await page.waitForLoadState("load");
+
+      const shiftCard = visibleShiftCard(page, sourceShiftId);
+      await expect(shiftCard).toBeVisible({ timeout: 15000 });
+
+      const moveButton = shiftCard.locator(
+        'button[title="Move to different shift"]'
+      );
+      await expect(moveButton).toBeVisible({ timeout: 10000 });
+      await moveButton.click();
+
+      await expect(page.getByText("to Different Shift")).toBeVisible({
+        timeout: 10000,
+      });
+
+      await page.getByRole("combobox").click();
+
+      // The target shift is not a backup preference, but must still be offered
+      const targetOption = page.locator(
+        `[data-testid="move-target-option-${targetShiftId}"]`
+      );
+      await expect(targetOption).toBeVisible({ timeout: 10000 });
+      await targetOption.click();
+
+      const moveVolunteerButton = page.getByRole("button", {
+        name: "Move Volunteer",
+      });
+      await expect(moveVolunteerButton).toBeEnabled();
+      await moveVolunteerButton.click();
+
+      await page.waitForTimeout(3000);
+
+      await page.goto(`/admin/shifts?date=${tomorrowStr}&location=Wellington`);
+      await page.waitForLoadState("load");
+
+      const movedToCard = visibleShiftCard(page, targetShiftId);
+      await expect(movedToCard).toBeVisible({ timeout: 15000 });
+      await expect(movedToCard.getByText("Test User")).toBeVisible({
+        timeout: 10000,
+      });
+    });
+
     test("admin can move volunteer to different shift", async ({
       page,
     }) => {


### PR DESCRIPTION
# Pull Request

## Description

Reported by a restaurant manager: *"I was wondering if the transfer shift option is set up to only be a one off transfer, because I am not able to move the same vollie back from dishes to service for tonight."*

It is not meant to be one-off, but it behaved that way. The move dialog filtered the target-shift dropdown down to the volunteer's own `backupForShiftIds` - the alternative shifts they ticked at signup:

```ts
let filtered = data.filter(shift => shift.id !== currentShift.id);   // drop current shift
if (backupShiftIds && backupShiftIds.length > 0) {                   // then keep ONLY backups
  filtered = filtered.filter(shift => backupShiftIds.includes(shift.id));
}
```

`backupForShiftIds` is set once at signup and never updated when a volunteer is moved, and the shift they came *from* is never in that list. So once a volunteer with backup preferences had been moved, they could not be moved back. When their only nominated backup was the shift they were now sitting on, the dropdown came up completely empty - no options, no explanation.

Backup preferences are now a hint rather than a gate. Every shift that day with a free spot stays selectable, with the volunteer's nominated backups sorted to the top and badged "Backup choice". This also unblocks the legitimate case where an admin needs to move someone somewhere they did not pre-nominate.

Two related fixes went in alongside, since the old behaviour hid the failure:

- The confirmed-volunteer dialog had **no empty state**, so an empty target list rendered as a working-looking dropdown with nothing in it. It now matches the pending dialog: *"No other shifts with a free spot on this day at [location]."*
- The two duplicated option renderers **disagreed with each other** - one showed spots remaining, the other had a dead `- Full` branch that the available-shifts API already filters out. They are now one `MoveTargetOptions` component with a two-line layout, and the popover is constrained to the trigger width so it no longer spills outside the dialog.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes

## Version Bump Required

`version:patch`

## Testing
- [x] Unit tests pass - 543 passed, 51 files
- [x] E2E tests pass - 8/8 in `volunteer-movement.spec.ts`
- [x] Manual testing completed
- [x] New tests added (if applicable)

Manually verified against a seeded Wellington evening with six shifts, a volunteer on a full Dishwasher shift with backup preferences:

- **The exact reported case** (volunteer's only backup is the shift they are already on): dropdown was empty before, now lists all five other shifts with free spots.
- **Full round trip**: Dishwasher → Front of House → Dishwasher, both confirmed in the database. Dishwasher reappeared in the list with "1 spot available" once she vacated it.
- Backup shifts sort first with the badge. Light and dark mode both check out - dark variants confirmed via computed styles, not just eyeballed.

The new regression test at `volunteer-movement.spec.ts:174` was verified to go **red against the old filtering logic** and green with the fix, so this cannot silently come back. It needed `backupForShiftIds` plumbed through the test-only signup endpoint and helper.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings - typecheck and lint clean
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Worth passing back to the manager who reported it: this fixes the case where the volunteer has backup preferences. If the target shift was genuinely **full** at the time, it still will not appear - the picker only offers shifts with a free spot, which is intended. The new empty state will at least say so rather than showing a silently empty dropdown.

`backupForShiftIds` remains stale after a move (it still lists the volunteer's original signup-time nominations). That is now cosmetic rather than blocking, since it only affects sort order and the badge, but it may be worth refreshing on move in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
