### PR TITLE
fix(shifts): open the browse calendar on the next month that has shifts

### DIFF
--- a/web/src/app/shifts/page.tsx
+++ b/web/src/app/shifts/page.tsx
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { resolveInitialCalendarMonth } from "@/lib/shift-calendar-month";
 import Link from "next/link";
 import { PageHeader } from "@/components/page-header";
 import { MapPin } from "lucide-react";
@@ -298,6 +299,13 @@ export default async function ShiftsCalendarPage({
     friendSignups: friendSignupsMap[shift.id] || [],
   }));
 
+  // Resolved server-side so SSR and hydration agree regardless of the viewer's
+  // timezone (see the helper for why it can differ from the current month).
+  const initialMonth = resolveInitialCalendarMonth(
+    shiftSummaries.map((shift) => shift.start),
+    now
+  );
+
   // If no explicit location choice has been made, show location selection screen
   if (!hasExplicitLocationChoice) {
     return (
@@ -529,6 +537,7 @@ export default async function ShiftsCalendarPage({
         shifts={shiftSummaries}
         selectedLocation={selectedLocation}
         serverNow={now.getTime()}
+        initialMonth={initialMonth}
       />
     </PageContainer>
     </>

--- a/web/src/components/shifts-calendar.tsx
+++ b/web/src/components/shifts-calendar.tsx
@@ -58,6 +58,15 @@ interface ShiftsCalendarProps {
    * when the server's clock and the client's clock straddle a day/month boundary.
    */
   serverNow: number;
+  /**
+   * Month the calendar opens on, as "yyyy-MM". Usually the current month, but
+   * the server falls through to the month of the next shift when the current
+   * one has none left, so volunteers never land on an empty grid. Passed as a
+   * plain year-month string rather than a timestamp because a start-of-month
+   * instant would resolve to the previous month for viewers behind NZ time,
+   * desyncing hydration from the SSR output.
+   */
+  initialMonth: string;
 }
 
 interface DayShifts {
@@ -84,10 +93,14 @@ export function ShiftsCalendar({
   shifts,
   selectedLocation,
   serverNow,
+  initialMonth,
 }: ShiftsCalendarProps) {
   // All "now"-derived values come from the server timestamp so the initial
   // client render matches the SSR output exactly (prevents hydration errors).
-  const [currentMonth, setCurrentMonth] = useState(() => new Date(serverNow));
+  const [currentMonth, setCurrentMonth] = useState(() => {
+    const [year, month] = initialMonth.split("-").map(Number);
+    return new Date(year, month - 1, 1);
+  });
 
   // Stable references to "now" for the initial render.
   const nowDate = new Date(serverNow);

--- a/web/src/lib/shift-calendar-month.test.ts
+++ b/web/src/lib/shift-calendar-month.test.ts
@@ -1,13 +1,22 @@
 import { describe, it, expect } from "vitest";
 import { resolveInitialCalendarMonth } from "./shift-calendar-month";
 
+// Every case here turns on which month a date falls in, so the bare JS month
+// indices get names - `new Date(2026, 6, 31)` being July is exactly the kind of
+// off-by-one this suite exists to catch.
+const JAN = 0;
+const JUL = 6;
+const AUG = 7;
+const SEP = 8;
+const DEC = 11;
+
 describe("resolveInitialCalendarMonth", () => {
   it("opens on the current month when it still has shifts", () => {
-    const now = new Date(2026, 6, 15, 9, 0); // Wed 15 Jul 2026
+    const now = new Date(2026, JUL, 15, 9, 0); // Wed 15 Jul 2026
 
     expect(
       resolveInitialCalendarMonth(
-        [new Date(2026, 6, 19, 17, 30), new Date(2026, 7, 2, 17, 30)],
+        [new Date(2026, JUL, 19, 17, 30), new Date(2026, AUG, 2, 17, 30)],
         now
       )
     ).toBe("2026-07");
@@ -16,46 +25,46 @@ describe("resolveInitialCalendarMonth", () => {
   it("skips to the next month with shifts when the current one has none left", () => {
     // Fri 31 Jul 2026: the restaurant is closed Fri/Sat, so the next shift is
     // Sun 2 Aug and July has nothing left to show.
-    const now = new Date(2026, 6, 31, 21, 0);
+    const now = new Date(2026, JUL, 31, 21, 0);
 
     expect(
       resolveInitialCalendarMonth(
-        [new Date(2026, 7, 2, 17, 30), new Date(2026, 7, 3, 17, 30)],
+        [new Date(2026, AUG, 2, 17, 30), new Date(2026, AUG, 3, 17, 30)],
         now
       )
     ).toBe("2026-08");
   });
 
   it("picks the earliest shift regardless of input order", () => {
-    const now = new Date(2026, 6, 31, 21, 0);
+    const now = new Date(2026, JUL, 31, 21, 0);
 
     expect(
       resolveInitialCalendarMonth(
-        [new Date(2026, 8, 1, 17, 30), new Date(2026, 7, 2, 17, 30)],
+        [new Date(2026, SEP, 1, 17, 30), new Date(2026, AUG, 2, 17, 30)],
         now
       )
     ).toBe("2026-08");
   });
 
   it("crosses a year boundary", () => {
-    const now = new Date(2026, 11, 31, 21, 0); // Thu 31 Dec 2026
+    const now = new Date(2026, DEC, 31, 21, 0); // Thu 31 Dec 2026
 
     expect(
-      resolveInitialCalendarMonth([new Date(2027, 0, 3, 17, 30)], now)
+      resolveInitialCalendarMonth([new Date(2027, JAN, 3, 17, 30)], now)
     ).toBe("2027-01");
   });
 
   it("falls back to the current month when there are no shifts at all", () => {
-    const now = new Date(2026, 6, 31, 21, 0);
+    const now = new Date(2026, JUL, 31, 21, 0);
 
     expect(resolveInitialCalendarMonth([], now)).toBe("2026-07");
   });
 
   it("stays on the current month when a shift is later the same day", () => {
-    const now = new Date(2026, 6, 30, 16, 0); // Thu 30 Jul, before service
+    const now = new Date(2026, JUL, 30, 16, 0); // Thu 30 Jul, before service
 
     expect(
-      resolveInitialCalendarMonth([new Date(2026, 6, 30, 17, 30)], now)
+      resolveInitialCalendarMonth([new Date(2026, JUL, 30, 17, 30)], now)
     ).toBe("2026-07");
   });
 });

--- a/web/src/lib/shift-calendar-month.test.ts
+++ b/web/src/lib/shift-calendar-month.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { resolveInitialCalendarMonth } from "./shift-calendar-month";
+
+describe("resolveInitialCalendarMonth", () => {
+  it("opens on the current month when it still has shifts", () => {
+    const now = new Date(2026, 6, 15, 9, 0); // Wed 15 Jul 2026
+
+    expect(
+      resolveInitialCalendarMonth(
+        [new Date(2026, 6, 19, 17, 30), new Date(2026, 7, 2, 17, 30)],
+        now
+      )
+    ).toBe("2026-07");
+  });
+
+  it("skips to the next month with shifts when the current one has none left", () => {
+    // Fri 31 Jul 2026: the restaurant is closed Fri/Sat, so the next shift is
+    // Sun 2 Aug and July has nothing left to show.
+    const now = new Date(2026, 6, 31, 21, 0);
+
+    expect(
+      resolveInitialCalendarMonth(
+        [new Date(2026, 7, 2, 17, 30), new Date(2026, 7, 3, 17, 30)],
+        now
+      )
+    ).toBe("2026-08");
+  });
+
+  it("picks the earliest shift regardless of input order", () => {
+    const now = new Date(2026, 6, 31, 21, 0);
+
+    expect(
+      resolveInitialCalendarMonth(
+        [new Date(2026, 8, 1, 17, 30), new Date(2026, 7, 2, 17, 30)],
+        now
+      )
+    ).toBe("2026-08");
+  });
+
+  it("crosses a year boundary", () => {
+    const now = new Date(2026, 11, 31, 21, 0); // Thu 31 Dec 2026
+
+    expect(
+      resolveInitialCalendarMonth([new Date(2027, 0, 3, 17, 30)], now)
+    ).toBe("2027-01");
+  });
+
+  it("falls back to the current month when there are no shifts at all", () => {
+    const now = new Date(2026, 6, 31, 21, 0);
+
+    expect(resolveInitialCalendarMonth([], now)).toBe("2026-07");
+  });
+
+  it("stays on the current month when a shift is later the same day", () => {
+    const now = new Date(2026, 6, 30, 16, 0); // Thu 30 Jul, before service
+
+    expect(
+      resolveInitialCalendarMonth([new Date(2026, 6, 30, 17, 30)], now)
+    ).toBe("2026-07");
+  });
+});

--- a/web/src/lib/shift-calendar-month.ts
+++ b/web/src/lib/shift-calendar-month.ts
@@ -1,0 +1,33 @@
+import { format, isSameMonth } from "date-fns";
+
+/**
+ * Month the shifts browse calendar should open on, as a "yyyy-MM" string.
+ *
+ * Normally that's the current month. But shifts only run on some weekdays, so
+ * late in a month there can be none left in it - browsing on a Friday the 31st
+ * when the next shift is the following Sunday is enough. Opening on the current
+ * month then strands the volunteer on an empty grid behind a "next month"
+ * button, so fall through to the month of the next shift instead.
+ *
+ * Returns a year-month string rather than a Date because the result crosses
+ * into a client component: a start-of-month instant would resolve to the
+ * previous month for viewers behind NZ time and desync hydration from SSR.
+ *
+ * @param upcomingShiftStarts Start times of the shifts the calendar will show.
+ *   Only upcoming shifts, already filtered to the selected location.
+ */
+export function resolveInitialCalendarMonth(
+  upcomingShiftStarts: Date[],
+  now: Date
+): string {
+  const earliest = upcomingShiftStarts.reduce<Date | null>(
+    (min, start) => (min === null || start < min ? start : min),
+    null
+  );
+
+  if (earliest && !isSameMonth(earliest, now)) {
+    return format(earliest, "yyyy-MM");
+  }
+
+  return format(now, "yyyy-MM");
+}

--- a/web/tests/e2e/admin-surveys.spec.ts
+++ b/web/tests/e2e/admin-surveys.spec.ts
@@ -20,6 +20,17 @@ async function openSurveyActions(page: Page, surveyId: string) {
   await page.getByTestId(`survey-actions-${surveyId}`).click();
 }
 
+/**
+ * Survey titles must be unique per test, not per file. The surveys list is
+ * shared state: tests run across parallel workers against one database, so two
+ * tests seeding the same hardcoded title put two cards on the page at once and
+ * every `getByText(title)` blows up with a strict mode violation. A retry after
+ * a failed cleanup leaves the same footprint.
+ */
+function uniqueTitle(label: string) {
+  return `${label} ${randomUUID().slice(0, 8)}`;
+}
+
 test.describe("Admin Surveys Management", () => {
   test.describe("Page Access and Authentication", () => {
     test("should allow admin users to access the surveys page", async ({
@@ -97,7 +108,8 @@ test.describe("Admin Surveys Management", () => {
       await expect(dialog).toBeVisible();
 
       // Fill in title and description
-      await page.getByLabel(/title/i).fill("Test Text Survey");
+      const title = uniqueTitle("Test Text Survey");
+      await page.getByLabel(/title/i).fill(title);
       await page.locator("#description").fill("A test survey with text question");
 
       // The dialog auto-creates one question. Fill the question text.
@@ -111,7 +123,7 @@ test.describe("Admin Surveys Management", () => {
       await expect(dialog).not.toBeVisible({ timeout: 10000 });
 
       // Verify survey appears in list
-      await expect(page.getByText("Test Text Survey").first()).toBeVisible();
+      await expect(page.getByText(title)).toBeVisible();
     });
 
     test("should create survey with rating scale question", async ({
@@ -124,7 +136,8 @@ test.describe("Admin Surveys Management", () => {
       await expect(dialog).toBeVisible();
 
       // Fill in title
-      await page.getByLabel(/title/i).fill("Rating Test Survey");
+      const title = uniqueTitle("Rating Test Survey");
+      await page.getByLabel(/title/i).fill(title);
 
       // Fill question text
       await page.getByPlaceholder("Enter your question").first().fill("How would you rate your experience?");
@@ -138,7 +151,7 @@ test.describe("Admin Surveys Management", () => {
       await page.getByRole("button", { name: /create survey/i }).click();
       await expect(dialog).not.toBeVisible({ timeout: 10000 });
 
-      await expect(page.getByText("Rating Test Survey").first()).toBeVisible();
+      await expect(page.getByText(title)).toBeVisible();
     });
 
     test("should create survey with multiple choice question", async ({
@@ -151,7 +164,8 @@ test.describe("Admin Surveys Management", () => {
       await expect(dialog).toBeVisible();
 
       // Fill in title
-      await page.getByLabel(/title/i).fill("Multiple Choice Survey");
+      const title = uniqueTitle("Multiple Choice Survey");
+      await page.getByLabel(/title/i).fill(title);
 
       // Fill question text
       await page.getByPlaceholder("Enter your question").first().fill("Which role do you prefer?");
@@ -170,7 +184,7 @@ test.describe("Admin Surveys Management", () => {
       await page.getByRole("button", { name: /create survey/i }).click();
       await expect(dialog).not.toBeVisible({ timeout: 10000 });
 
-      await expect(page.getByText("Multiple Choice Survey").first()).toBeVisible();
+      await expect(page.getByText(title)).toBeVisible();
     });
 
     test("should validate required fields on creation", async ({ page }) => {
@@ -223,6 +237,8 @@ test.describe("Admin Surveys Management", () => {
     const adminEmail = `admin-survlist-${testId}@example.com`;
     const surveyIds: string[] = [];
     let adminUserId: string;
+    let activeTitle: string;
+    let inactiveTitle: string;
 
     test.beforeEach(async ({ page }) => {
       surveyIds.length = 0;
@@ -231,8 +247,10 @@ test.describe("Admin Surveys Management", () => {
       adminUserId = admin!.id;
 
       // Create test surveys
+      activeTitle = uniqueTitle("Active Feedback Survey");
+      inactiveTitle = uniqueTitle("Inactive Survey");
       const survey1 = await createTestSurvey(page, {
-        title: "Active Feedback Survey",
+        title: activeTitle,
         description: "An active survey for testing",
         questions: [
           { id: "q1", type: "text_short", text: "How was your experience?", required: true },
@@ -244,7 +262,7 @@ test.describe("Admin Surveys Management", () => {
       surveyIds.push(survey1.id);
 
       const survey2 = await createTestSurvey(page, {
-        title: "Inactive Survey",
+        title: inactiveTitle,
         description: "A deactivated survey",
         questions: [
           { id: "q1", type: "rating_scale", text: "Rate us", required: true, minValue: 1, maxValue: 5 },
@@ -284,8 +302,8 @@ test.describe("Admin Surveys Management", () => {
     test("should display survey cards with title and description", async ({
       page,
     }) => {
-      await expect(page.getByText("Active Feedback Survey").first()).toBeVisible();
-      await expect(page.getByText("Inactive Survey").first()).toBeVisible();
+      await expect(page.getByText(activeTitle)).toBeVisible();
+      await expect(page.getByText(inactiveTitle)).toBeVisible();
     });
 
     test("should display survey stats (assigned, completed, pending)", async ({
@@ -314,6 +332,7 @@ test.describe("Admin Surveys Management", () => {
     const adminEmail = `admin-survedit-${testId}@example.com`;
     const surveyIds: string[] = [];
     let adminUserId: string;
+    let surveyTitle: string;
 
     test.beforeEach(async ({ page }) => {
       surveyIds.length = 0;
@@ -321,8 +340,9 @@ test.describe("Admin Surveys Management", () => {
       const admin = await getUserByEmail(page, adminEmail);
       adminUserId = admin!.id;
 
+      surveyTitle = uniqueTitle("Edit Test Survey");
       const survey = await createTestSurvey(page, {
-        title: "Edit Test Survey",
+        title: surveyTitle,
         description: "Survey to test editing",
         questions: [
           { id: "q1", type: "text_short", text: "Original question?", required: true },
@@ -355,7 +375,7 @@ test.describe("Admin Surveys Management", () => {
 
       // Title should be pre-populated
       const titleInput = page.getByLabel(/title/i);
-      await expect(titleInput).toHaveValue("Edit Test Survey");
+      await expect(titleInput).toHaveValue(surveyTitle);
     });
 
     test("should allow updating survey title", async ({ page }) => {
@@ -367,16 +387,17 @@ test.describe("Admin Surveys Management", () => {
       await expect(dialog).toBeVisible();
 
       // Update title
+      const updatedTitle = uniqueTitle("Updated Survey Title");
       const titleInput = page.getByLabel(/title/i);
       await titleInput.clear();
-      await titleInput.fill("Updated Survey Title");
+      await titleInput.fill(updatedTitle);
 
       // Save
       await page.getByRole("button", { name: /update survey/i }).click();
       await expect(dialog).not.toBeVisible({ timeout: 10000 });
 
       // Verify updated title appears
-      await expect(page.getByText("Updated Survey Title").first()).toBeVisible();
+      await expect(page.getByText(updatedTitle)).toBeVisible();
     });
 
     test("should allow adding new questions to existing survey", async ({
@@ -439,6 +460,7 @@ test.describe("Admin Surveys Management", () => {
     const adminEmail = `admin-survtoggle-${testId}@example.com`;
     const surveyIds: string[] = [];
     let adminUserId: string;
+    let surveyTitle: string;
 
     test.beforeEach(async ({ page }) => {
       surveyIds.length = 0;
@@ -446,8 +468,9 @@ test.describe("Admin Surveys Management", () => {
       const admin = await getUserByEmail(page, adminEmail);
       adminUserId = admin!.id;
 
+      surveyTitle = uniqueTitle("Toggle Active Survey");
       const survey = await createTestSurvey(page, {
-        title: "Toggle Active Survey",
+        title: surveyTitle,
         questions: [
           { id: "q1", type: "text_short", text: "Question?", required: true },
         ],
@@ -468,7 +491,7 @@ test.describe("Admin Surveys Management", () => {
 
     test("should toggle survey active status", async ({ page }) => {
       // Find the toggle button (ToggleRight/ToggleLeft icon)
-      await expect(page.getByText("Toggle Active Survey")).toBeVisible();
+      await expect(page.getByText(surveyTitle)).toBeVisible();
 
       // Click deactivate button
       await openSurveyActions(page, surveyIds[0]);
@@ -517,8 +540,9 @@ test.describe("Admin Surveys Management", () => {
       page,
     }) => {
       // Create survey for this test
+      const title = uniqueTitle("Delete Confirm Survey");
       const survey = await createTestSurvey(page, {
-        title: "Delete Confirm Survey",
+        title,
         questions: [
           { id: "q1", type: "text_short", text: "Q?", required: true },
         ],
@@ -528,7 +552,7 @@ test.describe("Admin Surveys Management", () => {
       surveyIds.push(survey.id);
 
       await page.reload();
-      await expect(page.getByText("Delete Confirm Survey")).toBeVisible();
+      await expect(page.getByText(title)).toBeVisible();
 
       // Click delete button
       await openSurveyActions(page, survey.id);
@@ -541,8 +565,9 @@ test.describe("Admin Surveys Management", () => {
     });
 
     test("should delete survey with no assignments", async ({ page }) => {
+      const title = uniqueTitle("Delete No Assign Survey");
       const survey = await createTestSurvey(page, {
-        title: "Delete No Assign Survey",
+        title,
         questions: [
           { id: "q1", type: "text_short", text: "Q?", required: true },
         ],
@@ -552,7 +577,7 @@ test.describe("Admin Surveys Management", () => {
       surveyIds.push(survey.id);
 
       await page.reload();
-      await expect(page.getByText("Delete No Assign Survey")).toBeVisible();
+      await expect(page.getByText(title)).toBeVisible();
 
       // Click delete
       await openSurveyActions(page, survey.id);
@@ -564,7 +589,7 @@ test.describe("Admin Surveys Management", () => {
       await confirmButton.click();
 
       // Survey should be removed
-      await expect(page.getByText("Delete No Assign Survey")).not.toBeVisible({ timeout: 10000 });
+      await expect(page.getByText(title)).not.toBeVisible({ timeout: 10000 });
       // Remove from cleanup since it's been deleted
       surveyIds.pop();
     });
@@ -574,8 +599,9 @@ test.describe("Admin Surveys Management", () => {
     }) => {
       const volunteer = await getUserByEmail(page, volunteerEmail);
 
+      const title = uniqueTitle("Delete With Assign Survey");
       const survey = await createTestSurvey(page, {
-        title: "Delete With Assign Survey",
+        title,
         questions: [
           { id: "q1", type: "text_short", text: "Q?", required: true },
         ],
@@ -591,7 +617,7 @@ test.describe("Admin Surveys Management", () => {
       });
 
       await page.reload();
-      await expect(page.getByText("Delete With Assign Survey")).toBeVisible();
+      await expect(page.getByText(title)).toBeVisible();
 
       // Click delete
       await openSurveyActions(page, survey.id);
@@ -603,8 +629,9 @@ test.describe("Admin Surveys Management", () => {
     });
 
     test("should allow cancelling delete operation", async ({ page }) => {
+      const title = uniqueTitle("Cancel Delete Survey");
       const survey = await createTestSurvey(page, {
-        title: "Cancel Delete Survey",
+        title,
         questions: [
           { id: "q1", type: "text_short", text: "Q?", required: true },
         ],
@@ -614,7 +641,7 @@ test.describe("Admin Surveys Management", () => {
       surveyIds.push(survey.id);
 
       await page.reload();
-      await expect(page.getByText("Cancel Delete Survey")).toBeVisible();
+      await expect(page.getByText(title)).toBeVisible();
 
       // Click delete
       await openSurveyActions(page, survey.id);
@@ -625,7 +652,7 @@ test.describe("Admin Surveys Management", () => {
       await page.getByRole("button", { name: /cancel/i }).click();
 
       // Survey should still be there
-      await expect(page.getByText("Cancel Delete Survey")).toBeVisible();
+      await expect(page.getByText(title)).toBeVisible();
     });
   });
 
@@ -644,7 +671,7 @@ test.describe("Admin Surveys Management", () => {
       adminUserId = admin!.id;
 
       const survey = await createTestSurvey(page, {
-        title: "Assignment Test Survey",
+        title: uniqueTitle("Assignment Test Survey"),
         questions: [
           { id: "q1", type: "text_short", text: "Feedback?", required: true },
         ],
@@ -790,6 +817,7 @@ test.describe("Admin Surveys Management", () => {
     const adminEmail = `admin-survresp-${testId}@example.com`;
     const surveyIds: string[] = [];
     let adminUserId: string;
+    let surveyTitle: string;
 
     test.beforeEach(async ({ page }) => {
       surveyIds.length = 0;
@@ -797,8 +825,9 @@ test.describe("Admin Surveys Management", () => {
       const admin = await getUserByEmail(page, adminEmail);
       adminUserId = admin!.id;
 
+      surveyTitle = uniqueTitle("Responses Test Survey");
       const survey = await createTestSurvey(page, {
-        title: "Responses Test Survey",
+        title: surveyTitle,
         questions: [
           { id: "q1", type: "text_short", text: "Feedback?", required: true },
         ],
@@ -832,7 +861,7 @@ test.describe("Admin Surveys Management", () => {
       await page.waitForLoadState("load");
 
       // Should show the survey title in the hero
-      await expect(page.getByText("Responses Test Survey").first()).toBeVisible();
+      await expect(page.getByText(surveyTitle).first()).toBeVisible();
 
       // Should show the two-lens view switcher (Insights / Respondents)
       await expect(page.getByRole("tab", { name: /respondents/i })).toBeVisible();


### PR DESCRIPTION
# Pull Request

## Description

Fixes the Playwright "Test" workflow failing on `main` independently of any PR.

### Shard 14 - `parental-consent.spec.ts` (the calendar day link never rendered)

Three tests failed through every retry because `a[href*="/shifts/details"]` was never present on `/shifts?location=Wellington`.

Root cause is a real product bug, not a test problem. The shifts browse calendar always opened on the **current** month, and `seed-demo.ts` only creates shifts for operating days (Sunday to Thursday). The failing CI run seeded on **Friday 31 July 2026**, so the first upcoming shift was Sunday 2 August and **July contained no upcoming shifts at all**. The calendar rendered an empty July grid with "No shifts scheduled - check back soon", and the real shifts sat one click away behind the next-month button.

A volunteer hits this on the last Friday/Saturday of any month. CI hits it whenever the seed lands on such a day, which is why it broke on `main` with no code change.

**Fix:** resolve the opening month server-side - the current month when it still has upcoming shifts, otherwise the month of the next shift. Extracted as `resolveInitialCalendarMonth()` in `web/src/lib/shift-calendar-month.ts` with unit tests, so the month-end case is covered deterministically instead of only on the few days a year CI would trip over it.

The month crosses into a client component as a `"yyyy-MM"` string rather than a timestamp: a start-of-month instant would resolve to the *previous* month for any viewer behind NZ time and desync hydration from the SSR output. The existing `serverNow` prop guards the same class of bug.

No assertions were loosened - the spec is untouched.

### Shard 7 - `admin-surveys.spec.ts` (separate root cause)

Shard 7 failed in the same run but does **not** share a root cause. It failed with strict-mode violations (`getByText('Delete No Assign Survey') resolved to 2 elements`).

The surveys list is shared state - e2e tests run across parallel workers against one database - and surveys were seeded with hardcoded titles. Two overlapping tests, or a retry after a failed cleanup, put two identical cards on the page. Because the duplicate row persisted, every retry hit it too.

**Fix:** suffix each seeded survey title with a random id and assert against that value.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes

## Version Bump Required

`version:patch`

## Testing
- [x] Unit tests pass
- [x] E2E tests pass
- [x] Manual testing completed
- [x] New tests added (if applicable)

**Reproduced the CI failure locally** on a throwaway seeded database by pushing all upcoming shifts into a later month, so the current month had none left - the exact CI state. The same three tests failed at lines 267, 293 and 320 with "element(s) not found". After the fix they pass in both states:

| State | Before | After |
|---|---|---|
| Normal seed (current month has shifts) | 13 passed | 13 passed |
| Current month empty (the CI condition) | **3 failed** | 3 passed |

Also verified:
- `npm run typecheck`, `npm run lint` clean
- `npm run test:run` - 549 unit tests pass, including 6 new ones for `resolveInitialCalendarMonth`
- `shifts-browse.spec.ts` and the other calendar-dependent specs (`underage-guardian-signup`, `backup-shift-signup`, `auto-approval-signup`, `friend-profile`) show no regressions - the only failures there reproduce identically with the fix stashed
- Browser check on the running app: calendar opens on the correct month with day links, no console or hydration errors
- `admin-surveys.spec.ts` with `--workers=2`: from 2 failed / 11 flaky to **0 failed**

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**One known issue is deliberately left out of scope.** After the title fix, `admin-surveys.spec.ts` still has ~8 flaky tests that recover on retry. These are a different, pre-existing problem: the **entire admin layout subtree is transiently present in the DOM twice** during navigation. Evidence - `getByTestId('admin-page-header')` resolves to 2 elements even though it is rendered once in `admin/layout.tsx`, `survey-actions-<id>` resolves to 2 elements for the *same* survey id, and a per-test-unique title still momentarily matches twice. That looks like a Next 16 App Router streaming artifact and deserves its own investigation rather than being bundled in here. It does not fail CI, since the tests pass on retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
