### PR TITLE
refactor(api): replace raw SQL friends list query with Prisma query builder

### DIFF
--- a/web/src/app/api/mobile/friends/route.ts
+++ b/web/src/app/api/mobile/friends/route.ts
@@ -1,7 +1,20 @@
 import { NextResponse } from "next/server";
+import { Prisma } from "@/generated/client";
 import { prisma } from "@/lib/prisma";
 import { requireMobileUser } from "@/lib/mobile-auth";
 import { DAY_EVENING_CUTOFF_HOUR, shiftStartNZ } from "@/lib/concurrent-shifts";
+
+/** Fields needed to render a friend row in the mobile friends list. */
+const friendSelect = {
+  id: true,
+  name: true,
+  firstName: true,
+  lastName: true,
+  profilePhotoUrl: true,
+  volunteerGrade: true,
+} as const;
+
+type FriendRow = Prisma.UserGetPayload<{ select: typeof friendSelect }>;
 
 /**
  * GET /api/mobile/friends
@@ -19,45 +32,39 @@ export async function GET(request: Request) {
   const { userId } = auth;
 
   try {
-    // 1. Get all accepted friendships for the current user, newest first
-    const friendsRaw = await prisma.$queryRaw<
-      Array<{
-        friendId: string;
-        name: string | null;
-        firstName: string | null;
-        lastName: string | null;
-        profilePhotoUrl: string | null;
-        volunteerGrade: string;
-        friendedAt: Date;
-      }>
-    >`
-      SELECT DISTINCT ON (u.id)
-        u.id as "friendId",
-        u.name,
-        u."firstName",
-        u."lastName",
-        u."profilePhotoUrl",
-        u."volunteerGrade",
-        f."createdAt" as "friendedAt"
-      FROM "Friendship" f
-      JOIN "User" u ON (
-        (f."userId" = ${userId} AND u.id = f."friendId") OR
-        (f."friendId" = ${userId} AND u.id = f."userId")
-      )
-      WHERE f.status = 'ACCEPTED' AND u.id != ${userId}
-      ORDER BY u.id, f."createdAt" DESC
-    `;
+    // 1. Get all accepted friendships for the current user, newest first.
+    // Friendships are stored in a single direction, so the friend is whichever
+    // side of the row isn't the current user.
+    const friendships = await prisma.friendship.findMany({
+      where: {
+        status: "ACCEPTED",
+        OR: [{ userId }, { friendId: userId }],
+      },
+      orderBy: { createdAt: "desc" },
+      select: {
+        createdAt: true,
+        user: { select: friendSelect },
+        friend: { select: friendSelect },
+      },
+    });
 
-    // Re-sort in JS because DISTINCT ON requires ordering by the distinct key first.
-    friendsRaw.sort(
-      (a, b) => b.friendedAt.getTime() - a.friendedAt.getTime()
-    );
+    // De-duplicate by user id, keeping the most recent friendship (rows are
+    // already newest first) and skipping any self-friendship rows.
+    const friendsById = new Map<string, FriendRow>();
+    for (const friendship of friendships) {
+      const friend =
+        friendship.user.id === userId ? friendship.friend : friendship.user;
+      if (friend.id === userId || friendsById.has(friend.id)) continue;
+      friendsById.set(friend.id, friend);
+    }
 
-    if (friendsRaw.length === 0) {
+    const friendRows = [...friendsById.values()];
+
+    if (friendRows.length === 0) {
       return NextResponse.json({ friends: [] });
     }
 
-    const friendIds = friendsRaw.map((f) => f.friendId);
+    const friendIds = friendRows.map((f) => f.id);
 
     // 2. Get custom labels for grade overrides (GREEN/YELLOW/PINK label names)
     const gradeLabels = await prisma.userCustomLabel.findMany({
@@ -81,7 +88,7 @@ export async function GET(request: Request) {
     }
 
     // 3. Count shifts together — matched by day + AM/PM + location, past shifts only.
-    // Matches the definition used by /api/mobile/friends/[id] so counts are consistent.
+    // Matches the definition used by /api/mobile/users/[id] so counts are consistent.
     const shiftTogetherCounts = await prisma.$queryRaw<
       Array<{ friendId: string; count: bigint }>
     >`
@@ -182,25 +189,25 @@ export async function GET(request: Request) {
     }
 
     // 6. Build the response
-    const friends = friendsRaw.map((friend) => {
+    const friends = friendRows.map((friend) => {
       const displayName =
         friend.name ??
         [friend.firstName, friend.lastName].filter(Boolean).join(" ") ??
         "Volunteer";
 
       // Use custom label grade if available, otherwise fall back to volunteerGrade
-      const grade = (customGradeMap.get(friend.friendId) ??
+      const grade = (customGradeMap.get(friend.id) ??
         friend.volunteerGrade ??
         "GREEN") as "GREEN" | "YELLOW" | "PINK";
 
       return {
-        id: friend.friendId,
+        id: friend.id,
         name: displayName,
         profilePhotoUrl: friend.profilePhotoUrl ?? undefined,
         grade,
-        shiftsTogether: shiftsTogetherMap.get(friend.friendId) ?? 0,
-        mutualFriends: mutualFriendsMap.get(friend.friendId) ?? 0,
-        lastActive: formatLastActive(lastActiveMap.get(friend.friendId)),
+        shiftsTogether: shiftsTogetherMap.get(friend.id) ?? 0,
+        mutualFriends: mutualFriendsMap.get(friend.id) ?? 0,
+        lastActive: formatLastActive(lastActiveMap.get(friend.id)),
       };
     });
 


### PR DESCRIPTION
# Pull Request

## Description

Closes #688.

`GET /api/mobile/friends` built its friend list with a `$queryRaw` using `DISTINCT ON`. This replaces it with `prisma.friendship.findMany` plus a small in-memory de-duplication pass, so the query is type-safe and stays in sync with the schema.

The issue predates several changes to this file, but the query it targets was untouched, so it still applied.

**Note on the suggested fix in the issue:** the issue proposed a `prisma.user.findMany` with relation filters. That shape drops `Friendship.createdAt`, so the list would have lost its newest-first ordering. Querying `Friendship` and selecting both the `user` and `friend` relations keeps the ordering while achieving the same goal.

A side effect: the old `DISTINCT ON` required ordering by the distinct key first, which forced a manual JS re-sort afterwards. That workaround is gone — `orderBy: { createdAt: "desc" }` is now the only ordering.

Also corrects a stale comment that pointed at `/api/mobile/friends/[id]`; the shifts-together definition it references now lives in `/api/mobile/users/[id]`.

## What was deliberately left as raw SQL

The three remaining `$queryRaw` blocks did not exist when the issue was filed, and are not good candidates for the query builder:

| Query | Why it stays raw |
|---|---|
| Shifts together | Timezone-aware date bucketing with an NZ day/evening hour cutoff |
| Mutual friends | Set intersection across two friendship sets |
| Last active | `MAX` aggregate over a joined table |

Expressing these with the query builder means pulling every friend's full signup history into Node and aggregating there — a real performance regression, for no type-safety gain, since each already returns a narrow typed row shape.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes

## Version Bump Required

`version:patch` (label applied — matches the label already on #688).

## Testing

All verification was run against the dev database.

**Equivalence across real data** — compared the old and new friend-id lists for all 11 users with accepted friendships: 20 rows, zero mismatches.

**Forced edge cases** — seed data contains no duplicate or self-friendship rows, so these were inserted inside a rolled-back transaction: a reciprocal pair with rows in both directions and different `createdAt` dates, a self-friendship row, and a `PENDING` row. Both implementations returned the same result — newest friendship wins on the duplicate pair, self and pending excluded.

**Live endpoint diff** — hit the running endpoint, stashed the change, hit it again on the same server. The two responses diff clean, byte for byte, including the `shiftsTogether` / `mutualFriends` / `lastActive` fields whose map lookups were re-keyed from `friend.friendId` to `friend.id`.

- [x] Unit tests pass (51 files, 543 tests)
- [ ] E2E tests pass (not run locally — no e2e spec covers this endpoint; leaving to CI)
- [x] Manual testing completed
- [ ] New tests added (if applicable)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings (`tsc --noEmit` and `eslint` both clean)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

No behaviour change is intended, and none was observed — the endpoint's response is byte-identical before and after. The mobile friends list should be unaffected.
