### PR TITLE
test(e2e): fix admin-surveys strict-mode flakes by waiting for SSR stream to settle

### DIFF
--- a/web/tests/e2e/admin-surveys.spec.ts
+++ b/web/tests/e2e/admin-surveys.spec.ts
@@ -8,6 +8,7 @@ import {
   assignSurveyToUser,
   deleteTestSurveys,
 } from "./helpers/test-helpers";
+import { gotoSettled, reloadSettled } from "./helpers/streaming";
 import { randomUUID } from "crypto";
 import type { Page } from "@playwright/test";
 
@@ -26,7 +27,7 @@ test.describe("Admin Surveys Management", () => {
       page,
     }) => {
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
 
       await expect(page).toHaveURL("/admin/surveys");
       // Use testid to avoid matching multiple headings
@@ -67,7 +68,7 @@ test.describe("Admin Surveys Management", () => {
   test.describe("Survey Creation", () => {
     test.beforeEach(async ({ page }) => {
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test("should display create survey button", async ({ page }) => {
@@ -257,7 +258,7 @@ test.describe("Admin Surveys Management", () => {
       surveyIds.push(survey2.id);
 
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test.afterEach(async ({ page }) => {
@@ -334,7 +335,7 @@ test.describe("Admin Surveys Management", () => {
       surveyIds.push(survey.id);
 
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test.afterEach(async ({ page }) => {
@@ -458,7 +459,7 @@ test.describe("Admin Surveys Management", () => {
       surveyIds.push(survey.id);
 
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test.afterEach(async ({ page }) => {
@@ -505,7 +506,7 @@ test.describe("Admin Surveys Management", () => {
       adminUserId = admin!.id;
 
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test.afterEach(async ({ page }) => {
@@ -527,7 +528,7 @@ test.describe("Admin Surveys Management", () => {
       });
       surveyIds.push(survey.id);
 
-      await page.reload();
+      await reloadSettled(page);
       await expect(page.getByText("Delete Confirm Survey")).toBeVisible();
 
       // Click delete button
@@ -551,7 +552,7 @@ test.describe("Admin Surveys Management", () => {
       });
       surveyIds.push(survey.id);
 
-      await page.reload();
+      await reloadSettled(page);
       await expect(page.getByText("Delete No Assign Survey")).toBeVisible();
 
       // Click delete
@@ -590,7 +591,7 @@ test.describe("Admin Surveys Management", () => {
         userId: volunteer!.id,
       });
 
-      await page.reload();
+      await reloadSettled(page);
       await expect(page.getByText("Delete With Assign Survey")).toBeVisible();
 
       // Click delete
@@ -613,7 +614,7 @@ test.describe("Admin Surveys Management", () => {
       });
       surveyIds.push(survey.id);
 
-      await page.reload();
+      await reloadSettled(page);
       await expect(page.getByText("Cancel Delete Survey")).toBeVisible();
 
       // Click delete
@@ -655,7 +656,7 @@ test.describe("Admin Surveys Management", () => {
       surveyIds.push(survey.id);
 
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test.afterEach(async ({ page }) => {
@@ -730,7 +731,7 @@ test.describe("Admin Surveys Management", () => {
         userId: volunteer!.id,
       });
 
-      await page.reload();
+      await reloadSettled(page);
 
       await openSurveyActions(page, surveyIds[0]);
       const assignButton = page.getByTestId(new RegExp(`assign-survey-${surveyIds[0]}`));
@@ -809,7 +810,7 @@ test.describe("Admin Surveys Management", () => {
       surveyIds.push(survey.id);
 
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test.afterEach(async ({ page }) => {
@@ -828,7 +829,7 @@ test.describe("Admin Surveys Management", () => {
     });
 
     test("should display list of responses", async ({ page }) => {
-      await page.goto(`/admin/surveys/${surveyIds[0]}/responses`);
+      await gotoSettled(page, `/admin/surveys/${surveyIds[0]}/responses`);
       await page.waitForLoadState("load");
 
       // Should show the survey title in the hero
@@ -841,7 +842,7 @@ test.describe("Admin Surveys Management", () => {
     test("should show response details when clicking a response", async ({
       page,
     }) => {
-      await page.goto(`/admin/surveys/${surveyIds[0]}/responses`);
+      await gotoSettled(page, `/admin/surveys/${surveyIds[0]}/responses`);
       await page.waitForLoadState("load");
 
       // Verify the view switcher tabs are present
@@ -850,7 +851,7 @@ test.describe("Admin Surveys Management", () => {
     });
 
     test("should allow filtering respondents by status", async ({ page }) => {
-      await page.goto(`/admin/surveys/${surveyIds[0]}/responses`);
+      await gotoSettled(page, `/admin/surveys/${surveyIds[0]}/responses`);
       await page.waitForLoadState("load");
 
       // Open the Respondents lens (default when there are no responses)
@@ -869,7 +870,7 @@ test.describe("Admin Surveys Management", () => {
   test.describe("Email Preview", () => {
     test.beforeEach(async ({ page }) => {
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test("should show preview email button in create dialog", async ({
@@ -947,7 +948,7 @@ test.describe("Admin Surveys Management", () => {
   test.describe("Question Types", () => {
     test.beforeEach(async ({ page }) => {
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test("should allow creating text_short question", async ({ page }) => {
@@ -1061,7 +1062,7 @@ test.describe("Admin Surveys Management", () => {
   test.describe("Trigger Types", () => {
     test.beforeEach(async ({ page }) => {
       await loginAsAdmin(page);
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
     });
 
     test("should allow creating MANUAL trigger survey", async ({ page }) => {
@@ -1160,7 +1161,7 @@ test.describe("Admin Surveys Management", () => {
 
     test("should be responsive on mobile viewport", async ({ page }) => {
       await page.setViewportSize({ width: 375, height: 667 });
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
 
       // Check main elements are visible
       await expect(page.getByTestId("admin-page-header")).toHaveText("Surveys");
@@ -1169,7 +1170,7 @@ test.describe("Admin Surveys Management", () => {
 
     test("should use responsive dialog on mobile", async ({ page }) => {
       await page.setViewportSize({ width: 375, height: 667 });
-      await page.goto("/admin/surveys");
+      await gotoSettled(page, "/admin/surveys");
 
       const createButton = page.getByTestId("create-survey-button");
       await createButton.click();

--- a/web/tests/e2e/helpers/auth.ts
+++ b/web/tests/e2e/helpers/auth.ts
@@ -15,10 +15,8 @@ export async function loginAsAdmin(page: Page) {
     await page.goto("/login");
     await page.waitForLoadState("load");
 
-    // Use .first() because for ~130ms after every load the subtree also
-    // exists in React's hidden streaming staging container, so the testid
-    // resolves to two elements. See helpers/streaming.ts for the full
-    // explanation (and `waitForStreamSettled`, the cleaner fix).
+    // Use .first(): the subtree briefly exists in React's hidden streaming
+    // staging container too. See helpers/streaming.ts for the full explanation.
     const adminLoginButton = page
       .getByTestId("quick-login-admin-button")
       .first();
@@ -28,9 +26,9 @@ export async function loginAsAdmin(page: Page) {
     await page.waitForURL("/admin");
     await page.waitForLoadState("load");
     // Wait for admin dashboard content — confirms the session is fully active.
-    // Use .first() for the same streaming reason as above. Any match is
-    // sufficient: if the session were invalid we'd be at /login instead of
-    // /admin, so this element wouldn't appear at all.
+    // .first() for the same streaming reason as above. Any match is sufficient:
+    // if the session were invalid we'd be at /login instead of /admin, so this
+    // element wouldn't appear at all.
     await page
       .getByTestId("admin-dashboard-page")
       .first()

--- a/web/tests/e2e/helpers/auth.ts
+++ b/web/tests/e2e/helpers/auth.ts
@@ -15,8 +15,10 @@ export async function loginAsAdmin(page: Page) {
     await page.goto("/login");
     await page.waitForLoadState("load");
 
-    // Use .first() because Next.js streaming can briefly render both
-    // loading.tsx and page.tsx simultaneously, producing two buttons.
+    // Use .first() because for ~130ms after every load the subtree also
+    // exists in React's hidden streaming staging container, so the testid
+    // resolves to two elements. See helpers/streaming.ts for the full
+    // explanation (and `waitForStreamSettled`, the cleaner fix).
     const adminLoginButton = page
       .getByTestId("quick-login-admin-button")
       .first();
@@ -26,10 +28,9 @@ export async function loginAsAdmin(page: Page) {
     await page.waitForURL("/admin");
     await page.waitForLoadState("load");
     // Wait for admin dashboard content — confirms the session is fully active.
-    // Use .first() because admin-dashboard-page appears in both page.tsx and
-    // loading.tsx; during Next.js streaming both can be in the DOM simultaneously,
-    // which triggers strict mode. Any match is sufficient: if the session were
-    // invalid we'd be at /login instead of /admin, so this element wouldn't appear.
+    // Use .first() for the same streaming reason as above. Any match is
+    // sufficient: if the session were invalid we'd be at /login instead of
+    // /admin, so this element wouldn't appear at all.
     await page
       .getByTestId("admin-dashboard-page")
       .first()

--- a/web/tests/e2e/helpers/streaming.ts
+++ b/web/tests/e2e/helpers/streaming.ts
@@ -4,6 +4,12 @@ import type { Page } from "@playwright/test";
  * Wait until React has finished flushing its streaming SSR output, so that
  * every `data-testid` in the document resolves to exactly one element.
  *
+ * **When to use**: call `gotoSettled` / `reloadSettled` instead of plain
+ * `page.goto` / `page.reload` when navigating to a page whose layout is an
+ * async server component — every `/admin/*` page, in practice — and the test
+ * then queries the DOM. Navigations that only assert on the resulting URL
+ * (redirect checks) do not need it.
+ *
  * ## Why this is needed
  *
  * `cacheComponents` is enabled (see `next.config.ts`), so anything that reads

--- a/web/tests/e2e/helpers/streaming.ts
+++ b/web/tests/e2e/helpers/streaming.ts
@@ -1,0 +1,79 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Wait until React has finished flushing its streaming SSR output, so that
+ * every `data-testid` in the document resolves to exactly one element.
+ *
+ * ## Why this is needed
+ *
+ * `cacheComponents` is enabled (see `next.config.ts`), so anything that reads
+ * request data — `getServerSession`, `cookies()`, `usePathname()` — renders as
+ * a deferred Suspense hole rather than part of the static shell. On an admin
+ * page that is essentially the whole tree: the root layout wraps `{children}`
+ * in `<Suspense>` (`src/app/layout.tsx`), and `src/app/admin/layout.tsx` is an
+ * async server component that awaits the session plus several Prisma counts.
+ *
+ * React streams the content of a deferred boundary in two parts:
+ *
+ *   1. a pending placeholder in position — `<!--$?--><template id="B:0">`
+ *   2. later, at the end of `<body>`, the real markup parked in a hidden
+ *      staging container — `<div hidden id="S:0">…</div>` — followed by a
+ *      `$RC("B:0","S:0")` script that relocates it and drops the container.
+ *
+ * Meanwhile the client has the inline RSC payload (`self.__next_f.push(…)`)
+ * and renders the same subtree in place. So between the staging container
+ * being parsed and React clearing it, the admin layout subtree exists twice:
+ * once live and visible, once inside `div[hidden]`. Every `data-testid` under
+ * it — `admin-page-header`, `survey-actions-<id>`, survey titles — resolves to
+ * two elements, and Playwright throws a strict-mode violation without
+ * retrying.
+ *
+ * Measured on `/admin/surveys` against the dev server: the window opens
+ * ~300ms into the load and lasts ~105-150ms, on *every* load. It is only
+ * intermittent in CI because whether a locator happens to be evaluated inside
+ * that window depends on machine load.
+ *
+ * ## Why it is not fixed at the source
+ *
+ * This is a React streaming/hydration intermediate state, not an application
+ * defect. The server sends exactly one copy of the subtree (verified by
+ * dumping the SSR HTML: one `admin-page-header` occurrence), and the extra
+ * copy lives inside React's own `<div hidden>` staging container, so it is
+ * never laid out or painted — 0x0 rect, null `offsetParent`, no flicker for
+ * admins. There is no app-level restructuring that avoids it: the admin
+ * layout cannot join the static shell while it awaits the session, and the
+ * page's own data would stream regardless.
+ *
+ * `.filter({ visible: true })` works for individual locators (the established
+ * convention elsewhere in this suite), but it cannot be applied uniformly —
+ * on a `not.toBeVisible()` assertion it is tautological. Waiting for the
+ * stream to settle fixes every locator on the page at once and keeps the
+ * assertions saying what they mean.
+ */
+export async function waitForStreamSettled(page: Page, timeout = 15_000) {
+  await page.waitForFunction(
+    () => {
+      if (document.readyState !== "complete") return false;
+      // React parks not-yet-relocated boundary content in `<div hidden>`
+      // containers appended to <body>. Match structurally rather than on the
+      // `S:` id prefix so this keeps working if React renames them.
+      return !Array.from(
+        document.querySelectorAll("body > div[hidden]")
+      ).some((staged) => staged.querySelector("[data-testid]"));
+    },
+    undefined,
+    { timeout }
+  );
+}
+
+/** `page.goto` followed by {@link waitForStreamSettled}. */
+export async function gotoSettled(page: Page, url: string) {
+  await page.goto(url);
+  await waitForStreamSettled(page);
+}
+
+/** `page.reload` followed by {@link waitForStreamSettled}. */
+export async function reloadSettled(page: Page) {
+  await page.reload();
+  await waitForStreamSettled(page);
+}


### PR DESCRIPTION
# Pull Request

## Description

Roughly 8 tests in `web/tests/e2e/admin-surveys.spec.ts` were intermittently failing with Playwright strict-mode violations - `locator resolved to 2 elements` - for locators that are only rendered once: `survey-actions-<id>` (unique survey ids, one card per id), `admin-page-header` (rendered once in `admin-layout-header.tsx`, mounted once from `admin/layout.tsx`), and survey titles that are unique per test.

**Root cause is React's streaming-SSR staging container, not duplicate test data or a responsive dual-layout.**

`cacheComponents` is enabled, so anything that reads request data becomes a deferred Suspense hole. On an admin page that is essentially the whole tree: the root layout wraps `{children}` in `<Suspense>` (`src/app/layout.tsx`), and `src/app/admin/layout.tsx` is an async server component that awaits `getServerSession` plus several Prisma counts. React streams such a boundary in two parts:

1. a pending placeholder in position - `<!--$?--><template id="B:0">`
2. later, at the end of `<body>`, the real markup parked in a hidden container - `<div hidden id="S:0">...</div>` - followed by a `$RC("B:0","S:0")` script that relocates it and drops the container

Meanwhile the client renders the same subtree in place from the inline RSC payload (`self.__next_f.push(...)`). So between the staging container being parsed and React clearing it, the admin layout subtree exists twice, and every `data-testid` under it resolves to two elements.

Verified by capturing the DOM on `/admin/surveys`:

- the SSR HTML contains **exactly one** `admin-page-header` occurrence, so the duplicate is created client-side
- the extra copy sits under `div#S:0` with `display: none`, a 0x0 rect and a null `offsetParent`, and shows stale values - it reads `Admin Panel` where the live one reads `Surveys` - plus a `_R_...` vs `_r_...` `useId` prefix mismatch, confirming two distinct renders
- the window opens ~300ms into the load and lasts ~105-150ms **on every load**; it is only intermittent in CI because whether a locator happens to be evaluated inside it depends on machine load
- Playwright throws strict-mode violations immediately without retrying, which is why this fails a test instead of self-healing

**It is not a UI defect.** A full-page screenshot taken while the window was open renders a single correct page, and the `:visible` count stays at 1 throughout. Nothing is ever painted twice, so admins see no flicker or duplicated content. There is also no app-level restructuring that avoids it: the admin layout cannot join the static shell while it awaits the session, and the page's own data would stream regardless.

### The fix

Adds `web/tests/e2e/helpers/streaming.ts` with `gotoSettled` / `reloadSettled` / `waitForStreamSettled`, which wait for `readyState === "complete"` **and** the absence of any `body > div[hidden]` containing a `[data-testid]`. Applied to the navigations in `admin-surveys.spec.ts` (the two redirect-assertion tests are left as plain `goto`, since they only assert on the URL).

This is preferred over per-locator `.filter({ visible: true })` - the existing convention elsewhere in this suite - because that cannot be applied uniformly here: on the `not.toBeVisible()` assertion at `admin-surveys.spec.ts:568` it is tautological. Settling the stream fixes every locator on the page at once and keeps the assertions saying what they mean. The helper carries the full root-cause write-up as its doc comment so the next person does not have to re-derive it.

Also corrects two comments in `helpers/auth.ts` that attributed the existing `.first()` workarounds to `loading.tsx` and `page.tsx` coexisting. That explanation was wrong and would misdirect future debugging. Comments only, no behaviour change - the shared login helper is used by ~50 specs, so its behaviour is deliberately left alone.

## Type of Change
- [x] 🧪 Tests (adding missing tests or correcting existing tests)

## Version Bump Required
`version:skip` - test-only change, no runtime code touched.

## Testing
- [x] E2E tests pass
- [x] Manual testing completed
- [x] New tests added (if applicable) - n/a, no new tests; existing ones stabilised

Reproduction and verification against a local dev server, `--project=chromium --workers=2`:

- **Before**: 13 of 54 failed, across all three locator families
- **After**: 54/54, on four consecutive full runs

`npm run lint` and `npm run typecheck` are both clean.

## Additional Notes

Two unrelated things noticed while investigating, neither addressed here:

- seeded surveys accumulate across e2e runs (duplicate titles with different ids, currently masked by `.first()`)
- `GET /api/profile/photo` 500s locally because the `.env` Supabase vars are empty - a local env artifact, not a code defect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
