### PR TITLE
fix(flaky): Admin Shift Edit and Delete beforeEach timeout

### DIFF
--- a/web/tests/e2e/admin-shift-edit-delete.spec.ts
+++ b/web/tests/e2e/admin-shift-edit-delete.spec.ts
@@ -35,8 +35,11 @@ test.describe("Admin Shift Edit and Delete", () => {
     // 30s timeout even though nothing is broken (see flaky-test report,
     // 2026-08-03: this hook flaked all 12 tests in this file on one shard).
     // Give it headroom, and create the two independent users concurrently
-    // instead of sequentially since neither depends on the other.
-    testInfo.setTimeout(testInfo.timeout + 20_000);
+    // instead of sequentially since neither depends on the other. Scoped to
+    // CI so local runs (reuseExistingServer, no shard contention) stay snappy.
+    if (process.env.CI) {
+      testInfo.setTimeout(testInfo.timeout + 20_000);
+    }
 
     await Promise.all([
       createTestUser(page, testEmails[0], "ADMIN"),

--- a/web/tests/e2e/admin-shift-edit-delete.spec.ts
+++ b/web/tests/e2e/admin-shift-edit-delete.spec.ts
@@ -29,10 +29,19 @@ test.describe("Admin Shift Edit and Delete", () => {
   ];
   const testShiftIds: string[] = [];
 
-  test.beforeEach(async ({ page }) => {
-    // Create test users with unique emails
-    await createTestUser(page, testEmails[0], "ADMIN");
-    await createTestUser(page, testEmails[1], "VOLUNTEER");
+  test.beforeEach(async ({ page }, testInfo) => {
+    // Under CI's 20-shard parallel load, two sequential bcrypt-hashed user
+    // creations plus login can occasionally push this hook past the default
+    // 30s timeout even though nothing is broken (see flaky-test report,
+    // 2026-08-03: this hook flaked all 12 tests in this file on one shard).
+    // Give it headroom, and create the two independent users concurrently
+    // instead of sequentially since neither depends on the other.
+    testInfo.setTimeout(testInfo.timeout + 20_000);
+
+    await Promise.all([
+      createTestUser(page, testEmails[0], "ADMIN"),
+      createTestUser(page, testEmails[1], "VOLUNTEER"),
+    ]);
     await loginAsAdmin(page);
   });
 


### PR DESCRIPTION
## Description

Weekly flaky-test review (CI runs 2026-07-27 → 2026-08-03) identified `web/tests/e2e/admin-shift-edit-delete.spec.ts` as the #1 flakiest test this week: its outer `beforeEach` hook flaked out **all 12 tests in the file in one shot** on run [30786313846](https://github.com/everybody-eats-nz/volunteer-portal/actions/runs/30786313846) (shard 5, dependabot `lucide-react-1.27.0` PR, commit `3100bef5`), then passed cleanly on a re-run of the identical commit — the textbook definition of flaky.

**Root cause:** the hook created two test users sequentially (`await createTestUser` × 2 — each a bcrypt-hashed `POST /api/test/users`) before logging in. Under CI's 20-shard parallel Playwright matrix, that sequential setup work occasionally pushed the hook past the default 30s test timeout (`Test timeout of 30000ms exceeded while running "beforeEach" hook`) even though nothing was actually broken — pure CI resource contention, not app or test logic.

**Fix:**
1. Run the two independent user-creation requests concurrently via `Promise.all` (they don't depend on each other) — roughly halves the hook's setup latency.
2. Give the hook 20s of extra timeout headroom via `testInfo.setTimeout(testInfo.timeout + 20_000)` as defense-in-depth against contention neither change alone can fully eliminate.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Tests (adding missing tests or correcting existing tests)

## Version Bump Required
`version:patch` (test-only reliability fix, no app behavior change)

## Testing
- [x] E2E tests pass — ran `admin-shift-edit-delete.spec.ts` twice locally (all 20 tests, 40 total `beforeEach` invocations across both runs): zero `beforeEach`/user-creation timeouts in either run.
- A separate comparison run of the 4 non-flaky tests that still failed locally (pre-existing local sandbox/seed-data gaps, e.g. capacity-input defaults) confirmed those failures are identical against the **unmodified** file — i.e. unrelated to this change, not introduced by it.
- CI's real 20-shard parallel contention that originally triggered the flake can't be fully reproduced in a single local run; the fix targets the documented root cause (sequential network calls in a shared setup hook) rather than papering over a symptom.

## Additional Notes

This week's flaky-test scan also surfaced a recurring `strict mode violation: … resolved to 2 elements` signature across `admin-surveys.spec.ts`, `admin-assign-past-shifts.spec.ts`, and `my-shifts.spec.ts` (6+ instances, mostly self-recovered via Playwright's built-in retry). It looks like the same class of bug fixed in #1163 (`fix(flaky): auto-accept-rules should validate rule creation form`) — an ambiguous locator matching an unrelated overlay/duplicate element — just in different files. Flagging for a possible follow-up but out of scope for this PR, which targets only the #1 ranked item.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ek1eowL8zGGHdYDcVLLp8t)_