### PR TITLE
feat(admin): allow moving volunteers into full shifts

### DIFF
--- a/web/src/app/api/admin/shifts/available/route.ts
+++ b/web/src/app/api/admin/shifts/available/route.ts
@@ -8,7 +8,10 @@ import {
   shiftCapacityCountSelect,
 } from "@/lib/placeholder-utils";
 
-// GET /api/admin/shifts/available - Get available shifts with capacity for a specific date/location
+// GET /api/admin/shifts/available - Get shifts for a specific date/location.
+// Full shifts are returned too, with their counts, so admins can move a volunteer
+// into an over-capacity shift when they judge that the right call. Callers are
+// expected to label capacity rather than hide the option.
 export async function GET(request: Request) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.email) {
@@ -39,8 +42,8 @@ export async function GET(request: Request) {
 
   try {
     const selectedDate = new Date(date);
-    
-    // Fetch shifts for the selected date and location that have available capacity
+
+    // Fetch every shift for the selected date and location
     const shifts = await prisma.shift.findMany({
       where: {
         location,
@@ -58,21 +61,19 @@ export async function GET(request: Request) {
       },
     });
 
-    // Transform to include confirmed count and filter for available capacity
-    const availableShifts = shifts
-      .map(shift => ({
-        id: shift.id,
-        start: shift.start.toISOString(),
-        end: shift.end.toISOString(),
-        location: shift.location,
-        capacity: shift.capacity,
-        confirmedCount: getShiftEffectiveCount(shift),
-        shiftType: {
-          id: shift.shiftType.id,
-          name: shift.shiftType.name,
-        },
-      }))
-      .filter(shift => shift.confirmedCount < shift.capacity); // Only return shifts with available spots
+    // Transform to include confirmed count so callers can show remaining capacity
+    const availableShifts = shifts.map((shift) => ({
+      id: shift.id,
+      start: shift.start.toISOString(),
+      end: shift.end.toISOString(),
+      location: shift.location,
+      capacity: shift.capacity,
+      confirmedCount: getShiftEffectiveCount(shift),
+      shiftType: {
+        id: shift.shiftType.id,
+        name: shift.shiftType.name,
+      },
+    }));
 
     return NextResponse.json(availableShifts);
   } catch (error) {

--- a/web/src/app/api/admin/volunteer-movement/route.ts
+++ b/web/src/app/api/admin/volunteer-movement/route.ts
@@ -69,16 +69,13 @@ export async function POST(request: Request) {
       );
     }
 
-    // Verify target shift exists and has capacity
+    // Verify target shift exists. Capacity is deliberately not enforced here -
+    // admins can move a volunteer into a full shift and take it over capacity,
+    // the same way they can confirm a waitlisted volunteer beyond capacity.
     const targetShift = await prisma.shift.findUnique({
       where: { id: targetShiftId },
       include: {
         shiftType: true,
-        signups: {
-          where: {
-            status: "CONFIRMED",
-          },
-        },
       },
     });
 
@@ -86,14 +83,6 @@ export async function POST(request: Request) {
       return NextResponse.json(
         { error: "Target shift not found" },
         { status: 404 }
-      );
-    }
-
-    // Check if target shift has capacity
-    if (targetShift.signups.length >= targetShift.capacity) {
-      return NextResponse.json(
-        { error: "Target shift is at full capacity" },
-        { status: 400 }
       );
     }
 

--- a/web/src/components/volunteer-actions.tsx
+++ b/web/src/components/volunteer-actions.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Check, X, Clock, UserMinus, AlertTriangle, ArrowRightLeft, UserCheck, UserX } from "lucide-react";
+import { Check, X, Clock, UserMinus, AlertTriangle, ArrowRightLeft, CalendarOff, UserCheck, UserX } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
@@ -60,16 +60,30 @@ type MoveTargetShift = {
   isPreferred: boolean;
 };
 
+/** How much room is left on a move target, phrased for the option's meta line. */
+function describeCapacity(shift: MoveTargetShift) {
+  const spotsLeft = shift.capacity - shift.confirmedCount;
+  if (spotsLeft > 0) {
+    return `${spotsLeft} ${spotsLeft === 1 ? "spot" : "spots"} available`;
+  }
+  if (spotsLeft === 0) {
+    return "No spots left";
+  }
+  return `${-spotsLeft} over capacity`;
+}
+
 /**
- * Options for the "move volunteer" target picker. Backup preferences are sorted
- * to the top and badged, but every shift with a free spot stays selectable so a
- * volunteer can always be moved back to where they came from.
+ * Options for the "move volunteer" target picker. Every shift on the day stays
+ * selectable - backup preferences are sorted to the top and badged, and full
+ * shifts are badged so the admin knows they are going over capacity, but nothing
+ * is hidden. Hiding full shifts made moves one-way, since the shift a volunteer
+ * came from is often full once someone else takes their spot.
  */
 function MoveTargetOptions({ shifts }: { shifts: MoveTargetShift[] }) {
   return (
     <>
       {shifts.map((shift) => {
-        const spotsLeft = shift.capacity - shift.confirmedCount;
+        const isFull = shift.confirmedCount >= shift.capacity;
         return (
           <SelectItem
             key={shift.id}
@@ -89,15 +103,200 @@ function MoveTargetOptions({ shifts }: { shifts: MoveTargetShift[] }) {
                     Backup choice
                   </Badge>
                 )}
+                {isFull && (
+                  <Badge
+                    variant="secondary"
+                    className="bg-amber-100 dark:bg-amber-900/60 text-amber-700 dark:text-amber-200"
+                  >
+                    <AlertTriangle aria-hidden="true" />
+                    Full
+                  </Badge>
+                )}
               </span>
               <span className="text-xs text-muted-foreground">
-                {formatInNZT(new Date(shift.start), "h:mm a")} - {formatInNZT(new Date(shift.end), "h:mm a")} • {spotsLeft} {spotsLeft === 1 ? "spot" : "spots"} available
+                {formatInNZT(new Date(shift.start), "h:mm a")} - {formatInNZT(new Date(shift.end), "h:mm a")} • {describeCapacity(shift)}
               </span>
             </span>
           </SelectItem>
         );
       })}
     </>
+  );
+}
+
+/** Warns the admin that the shift they picked is already at or over capacity. */
+function MoveOverCapacityNotice({
+  shift,
+  volunteerName,
+}: {
+  shift: MoveTargetShift;
+  volunteerName?: string;
+}) {
+  return (
+    <p
+      className="flex items-start gap-1.5 text-xs text-amber-700 dark:text-amber-300"
+      data-testid="move-over-capacity-notice"
+    >
+      <AlertTriangle className="mt-px h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span>
+        {shift.shiftType.name} is already full. Moving {volunteerName || "this volunteer"} here takes it over capacity.
+      </span>
+    </p>
+  );
+}
+
+type MoveVolunteerDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tid: (suffix: string) => string;
+  currentShift: NonNullable<VolunteerActionsProps["currentShift"]>;
+  volunteerName?: string;
+  shifts: MoveTargetShift[];
+  selectedShiftId: string;
+  onSelectShift: (shiftId: string) => void;
+  notes: string;
+  onNotesChange: (notes: string) => void;
+  onConfirm: () => void;
+  loading: boolean;
+  fieldIdPrefix: string;
+};
+
+/**
+ * The "move volunteer to another shift" dialog, shared by the confirmed and
+ * pending action rows. One name in the title, the context in the description,
+ * and a single decision in the body - it has to stay readable on a phone, which
+ * is where admins run service.
+ */
+function MoveVolunteerDialog({
+  open,
+  onOpenChange,
+  tid,
+  currentShift,
+  volunteerName,
+  shifts,
+  selectedShiftId,
+  onSelectShift,
+  notes,
+  onNotesChange,
+  onConfirm,
+  loading,
+  fieldIdPrefix,
+}: MoveVolunteerDialogProps) {
+  const selectedShift = shifts.find((shift) => shift.id === selectedShiftId);
+  const selectedIsFull = selectedShift
+    ? selectedShift.confirmedCount >= selectedShift.capacity
+    : false;
+  const hasTargets = shifts.length > 0;
+  const shiftDay = formatInNZT(currentShift.start, "EEEE d MMMM");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DialogTrigger asChild>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-6 px-2 text-xs bg-blue-100 dark:bg-blue-900/60 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-800/60"
+              disabled={loading}
+              title="Move to different shift"
+              data-testid={tid("move-button")}
+            >
+              {loading ? (
+                <Clock className="h-3 w-3 animate-spin" />
+              ) : (
+                <ArrowRightLeft className="h-3 w-3" />
+              )}
+            </Button>
+          </DialogTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Move to different shift</TooltipContent>
+      </Tooltip>
+      <DialogContent className="sm:max-w-md" data-testid={tid("move-dialog")}>
+        <DialogHeader className="text-left">
+          <DialogTitle data-testid={tid("move-dialog-title")}>
+            Move {volunteerName || "volunteer"}
+          </DialogTitle>
+          <DialogDescription data-testid={tid("move-dialog-description")}>
+            Currently on {currentShift.shiftType.name}, {shiftDay}.
+            {hasTargets && " Pick another shift on the same day."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {hasTargets ? (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor={`${fieldIdPrefix}-target-shift`}>Move to</Label>
+              <Select value={selectedShiftId} onValueChange={onSelectShift}>
+                <SelectTrigger
+                  id={`${fieldIdPrefix}-target-shift`}
+                  className="w-full"
+                  data-testid={tid("move-shift-select")}
+                >
+                  <SelectValue placeholder="Choose a shift" />
+                </SelectTrigger>
+                <SelectContent className="w-(--radix-select-trigger-width)">
+                  <MoveTargetOptions shifts={shifts} />
+                </SelectContent>
+              </Select>
+              {selectedIsFull && selectedShift && (
+                <MoveOverCapacityNotice
+                  shift={selectedShift}
+                  volunteerName={volunteerName}
+                />
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`${fieldIdPrefix}-movement-notes`}>
+                Notes (optional)
+              </Label>
+              <Textarea
+                id={`${fieldIdPrefix}-movement-notes`}
+                value={notes}
+                onChange={(e) => onNotesChange(e.target.value)}
+                placeholder="Add any notes about this movement..."
+                rows={3}
+              />
+            </div>
+          </div>
+        ) : (
+          <div
+            className="rounded-lg border border-dashed p-6 text-center"
+            data-testid="move-no-targets"
+          >
+            <CalendarOff
+              className="mx-auto h-5 w-5 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <p className="mt-2 text-sm font-medium">No other shifts that day</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {currentShift.location} has nothing else scheduled on {shiftDay}.
+            </p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={loading}
+            data-testid={tid("move-dialog-cancel")}
+          >
+            {hasTargets ? "Cancel" : "Close"}
+          </Button>
+          {hasTargets && (
+            <Button
+              onClick={onConfirm}
+              disabled={!selectedShiftId || loading}
+              data-testid={tid("move-dialog-confirm")}
+            >
+              {loading ? <Clock className="h-3 w-3 animate-spin mr-2" /> : null}
+              Move Volunteer
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -119,9 +318,10 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
       if (response.ok) {
         const data: Omit<MoveTargetShift, "isPreferred">[] = await response.json();
 
-        // Every shift with a free spot stays selectable. The volunteer's backup
-        // preferences are only a hint - restricting the list to them made moves
-        // one-way, since the shift they came from is never in that list.
+        // Every other shift on the day stays selectable, full or not. Backup
+        // preferences and free spots only affect ordering - restricting the list
+        // made moves one-way, since the shift a volunteer came from is often
+        // full or not among their nominated backups.
         const targets: MoveTargetShift[] = data
           .filter((shift) => shift.id !== currentShift.id)
           .map((shift) => ({
@@ -129,8 +329,15 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
             isPreferred: backupShiftIds?.includes(shift.id) ?? false,
           }));
 
-        // Surface the volunteer's own preferences first, then keep start-time order
-        targets.sort((a, b) => Number(b.isPreferred) - Number(a.isPreferred));
+        // Preferences first, then shifts with room, then keep start-time order
+        targets.sort((a, b) => {
+          if (a.isPreferred !== b.isPreferred) {
+            return Number(b.isPreferred) - Number(a.isPreferred);
+          }
+          const aHasRoom = a.confirmedCount < a.capacity;
+          const bHasRoom = b.confirmedCount < b.capacity;
+          return Number(bHasRoom) - Number(aHasRoom);
+        });
 
         setAvailableShifts(targets);
       }
@@ -279,6 +486,35 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
   // Helper to check if shift has ended (use end time, not start time)
   const shiftCompleted = currentShift ? isShiftCompleted(currentShift.end) : false;
 
+  const tid = (suffix: string) =>
+    testIdPrefix ? `${testIdPrefix}-${suffix}` : `volunteer-${suffix}-${signupId}`;
+
+  const handleMoveDialogChange = (open: boolean) => {
+    setDialogOpen(open ? "move" : null);
+    if (!open) {
+      setSelectedTargetShift("");
+      setMovementNotes("");
+    }
+  };
+
+  const moveDialog = currentShift ? (
+    <MoveVolunteerDialog
+      open={dialogOpen === "move"}
+      onOpenChange={handleMoveDialogChange}
+      tid={tid}
+      currentShift={currentShift}
+      volunteerName={volunteerName}
+      shifts={availableShifts}
+      selectedShiftId={selectedTargetShift}
+      onSelectShift={setSelectedTargetShift}
+      notes={movementNotes}
+      onNotesChange={setMovementNotes}
+      onConfirm={handleVolunteerMove}
+      loading={loading === "move"}
+      fieldIdPrefix={`move-${signupId}`}
+    />
+  ) : null;
+
   if (currentStatus === "CONFIRMED") {
     const cancelDialogContent = getDialogContent("cancel");
     const cancelPastDialogContent = getDialogContent("cancel_past");
@@ -408,92 +644,7 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
     return (
       <div className="flex gap-1" data-testid={testIdPrefix ? `${testIdPrefix}-confirmed-actions` : `volunteer-actions-${signupId}-confirmed`}>
         {/* Move Button */}
-        {currentShift && !shiftCompleted && (
-          <Dialog open={dialogOpen === "move"} onOpenChange={(open) => setDialogOpen(open ? "move" : null)}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <DialogTrigger asChild>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-6 px-2 text-xs bg-blue-100 dark:bg-blue-900/60 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-800/60"
-                    disabled={loading === "move"}
-                    title="Move to different shift"
-                    data-testid={testIdPrefix ? `${testIdPrefix}-move-button` : `volunteer-move-${signupId}`}
-                  >
-                    {loading === "move" ? (
-                      <Clock className="h-3 w-3 animate-spin" />
-                    ) : (
-                      <ArrowRightLeft className="h-3 w-3" />
-                    )}
-                  </Button>
-                </DialogTrigger>
-              </TooltipTrigger>
-              <TooltipContent>Move to different shift</TooltipContent>
-            </Tooltip>
-            <DialogContent className="sm:max-w-md" data-testid={testIdPrefix ? `${testIdPrefix}-move-dialog` : `volunteer-move-dialog-${signupId}`}>
-              <DialogHeader>
-                <DialogTitle data-testid={testIdPrefix ? `${testIdPrefix}-move-dialog-title` : `volunteer-move-dialog-title-${signupId}`}>
-                  Move {volunteerName || 'Volunteer'} to Different Shift
-                </DialogTitle>
-                <DialogDescription className="text-sm text-slate-600" data-testid={testIdPrefix ? `${testIdPrefix}-move-dialog-description` : `volunteer-move-dialog-description-${signupId}`}>
-                  Move this volunteer from {currentShift.shiftType.name} to a different shift on the same day.
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4">
-                {availableShifts.length === 0 ? (
-                  <p className="text-sm text-slate-500 dark:text-slate-400" data-testid="move-no-targets">
-                    No other shifts with a free spot on this day at {currentShift.location}.
-                  </p>
-                ) : (
-                  <>
-                    <div>
-                      <Label htmlFor="targetShift">Select Target Shift</Label>
-                      <Select value={selectedTargetShift} onValueChange={setSelectedTargetShift}>
-                        <SelectTrigger id="targetShift">
-                          <SelectValue placeholder="Choose a shift..." />
-                        </SelectTrigger>
-                        <SelectContent className="w-(--radix-select-trigger-width)">
-                          <MoveTargetOptions shifts={availableShifts} />
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    <div>
-                      <Label htmlFor="movementNotes">Movement Notes (optional)</Label>
-                      <Textarea
-                        id="movementNotes"
-                        value={movementNotes}
-                        onChange={(e) => setMovementNotes(e.target.value)}
-                        placeholder="Add any notes about this movement..."
-                        rows={3}
-                      />
-                    </div>
-                  </>
-                )}
-              </div>
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={() => setDialogOpen(null)}
-                  disabled={loading === "move"}
-                  data-testid={testIdPrefix ? `${testIdPrefix}-move-dialog-cancel` : `volunteer-move-dialog-cancel-${signupId}`}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  onClick={handleVolunteerMove}
-                  disabled={!selectedTargetShift || loading === "move"}
-                  data-testid={testIdPrefix ? `${testIdPrefix}-move-dialog-confirm` : `volunteer-move-dialog-confirm-${signupId}`}
-                >
-                  {loading === "move" ? (
-                    <Clock className="h-3 w-3 animate-spin mr-2" />
-                  ) : null}
-                  Move Volunteer
-                </Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        )}
+        {!shiftCompleted && moveDialog}
 
         {/* Cancel Button - only for future shifts */}
         {!shiftCompleted && (
@@ -723,81 +874,7 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
       </Tooltip>
 
       {/* Move Button for Pending */}
-      {currentShift && (
-        <Dialog open={dialogOpen === "move"} onOpenChange={(open) => setDialogOpen(open ? "move" : null)}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DialogTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-6 px-2 text-xs bg-blue-100 dark:bg-blue-900/60 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200 hover:bg-blue-200 dark:hover:bg-blue-800/60"
-                  disabled={loading === "move"}
-                  title="Move to different shift"
-                  data-testid={testIdPrefix ? `${testIdPrefix}-move-button` : `volunteer-move-${signupId}`}
-                >
-                  {loading === "move" ? (
-                    <Clock className="h-3 w-3 animate-spin" />
-                  ) : (
-                    <ArrowRightLeft className="h-3 w-3" />
-                  )}
-                </Button>
-              </DialogTrigger>
-            </TooltipTrigger>
-            <TooltipContent>Move to different shift</TooltipContent>
-          </Tooltip>
-          <DialogContent className="sm:max-w-md" data-testid={testIdPrefix ? `${testIdPrefix}-move-dialog` : `volunteer-move-dialog-${signupId}`}>
-            <DialogHeader>
-              <DialogTitle data-testid={testIdPrefix ? `${testIdPrefix}-move-dialog-title` : `volunteer-move-dialog-title-${signupId}`}>
-                Move {volunteerName || 'Volunteer'} to Different Shift
-              </DialogTitle>
-              <DialogDescription className="text-sm text-slate-600" data-testid={testIdPrefix ? `${testIdPrefix}-move-dialog-description` : `volunteer-move-dialog-description-${signupId}`}>
-                Move this volunteer from {currentShift.shiftType.name} to a different shift on the same day.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="py-4 space-y-4">
-              {availableShifts.length === 0 ? (
-                <p className="text-sm text-slate-500 dark:text-slate-400" data-testid="move-no-targets">
-                  No other shifts with a free spot on this day at {currentShift.location}.
-                </p>
-              ) : (
-                <>
-                  <div>
-                    <Label htmlFor="target-shift">Select Target Shift</Label>
-                    <Select value={selectedTargetShift} onValueChange={setSelectedTargetShift}>
-                      <SelectTrigger id="target-shift" data-testid={testIdPrefix ? `${testIdPrefix}-move-shift-select` : `volunteer-move-shift-select-${signupId}`}>
-                        <SelectValue placeholder="Choose a shift" />
-                      </SelectTrigger>
-                      <SelectContent className="w-(--radix-select-trigger-width)">
-                        <MoveTargetOptions shifts={availableShifts} />
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div>
-                    <Label htmlFor="movement-notes">Notes (Optional)</Label>
-                    <Textarea
-                      id="movement-notes"
-                      placeholder="Add any notes about this movement..."
-                      value={movementNotes}
-                      onChange={(e) => setMovementNotes(e.target.value)}
-                      rows={3}
-                    />
-                  </div>
-                </>
-              )}
-            </div>
-            <DialogFooter>
-              <Button variant="outline" onClick={() => setDialogOpen(null)} disabled={loading === "move"}>
-                Cancel
-              </Button>
-              <Button onClick={handleVolunteerMove} disabled={loading === "move" || !selectedTargetShift}>
-                {loading === "move" && <Clock className="h-3 w-3 animate-spin mr-2" />}
-                Move Volunteer
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      )}
+      {moveDialog}
 
       <Dialog open={dialogOpen === "reject"} onOpenChange={(open) => setDialogOpen(open ? "reject" : null)}>
         <Tooltip>

--- a/web/src/components/volunteer-actions.tsx
+++ b/web/src/components/volunteer-actions.tsx
@@ -329,14 +329,19 @@ export function VolunteerActions({ signupId, currentStatus, onUpdate, testIdPref
             isPreferred: backupShiftIds?.includes(shift.id) ?? false,
           }));
 
-        // Preferences first, then shifts with room, then keep start-time order
         targets.sort((a, b) => {
+          // 1. The volunteer's own backup preferences first
           if (a.isPreferred !== b.isPreferred) {
-            return Number(b.isPreferred) - Number(a.isPreferred);
+            return a.isPreferred ? -1 : 1;
           }
+          // 2. Then shifts that still have room
           const aHasRoom = a.confirmedCount < a.capacity;
           const bHasRoom = b.confirmedCount < b.capacity;
-          return Number(bHasRoom) - Number(aHasRoom);
+          if (aHasRoom !== bHasRoom) {
+            return aHasRoom ? -1 : 1;
+          }
+          // 3. Otherwise keep the start-time order the API returned
+          return 0;
         });
 
         setAvailableShifts(targets);

--- a/web/tests/e2e/backup-shift-signup.spec.ts
+++ b/web/tests/e2e/backup-shift-signup.spec.ts
@@ -308,7 +308,7 @@ test.describe("Backup Shift Signup Feature", () => {
     await moveButton.click();
 
     // Dialog should open - wait for available shifts to load
-    await expect(page.getByText("Select Target Shift")).toBeVisible({
+    await expect(page.getByText("Move to", { exact: true })).toBeVisible({
       timeout: 10000,
     });
 
@@ -363,7 +363,7 @@ test.describe("Backup Shift Signup Feature", () => {
     await moveButton.click();
 
     // Wait for dialog and available shifts to load
-    await expect(page.getByText("Select Target Shift")).toBeVisible({
+    await expect(page.getByText("Move to", { exact: true })).toBeVisible({
       timeout: 10000,
     });
     await page.waitForTimeout(1000);

--- a/web/tests/e2e/volunteer-movement.spec.ts
+++ b/web/tests/e2e/volunteer-movement.spec.ts
@@ -308,6 +308,90 @@ test.describe("General Volunteer Movement System", () => {
       });
     });
 
+    test("admin can move volunteer into a full shift", async ({ page }) => {
+      // Ensure volunteer is on source shift
+      await deleteSignupsByShiftIds(page, [sourceShiftId, targetShiftId]);
+      await createSignup(page, {
+        userId: volunteerUserId,
+        shiftId: sourceShiftId,
+        status: "CONFIRMED",
+      });
+
+      // Fill the target shift (capacity 2) so it has no spots left
+      const fillerEmails = [
+        `filler-a-movement-${testId}@example.com`,
+        `filler-b-movement-${testId}@example.com`,
+      ];
+      testEmails.push(...fillerEmails);
+      for (const [index, fillerEmail] of fillerEmails.entries()) {
+        await createTestUser(page, fillerEmail, "VOLUNTEER", {
+          firstName: "Filler",
+          lastName: `Volunteer${index}`,
+        });
+        const filler = await getUserByEmail(page, fillerEmail);
+        await createSignup(page, {
+          userId: filler!.id,
+          shiftId: targetShiftId,
+          status: "CONFIRMED",
+        });
+      }
+
+      await loginAsAdmin(page);
+
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      const tomorrowStr = `${tomorrow.getFullYear()}-${String(
+        tomorrow.getMonth() + 1
+      ).padStart(2, "0")}-${String(tomorrow.getDate()).padStart(2, "0")}`;
+      await page.goto(`/admin/shifts?date=${tomorrowStr}&location=Wellington`);
+      await page.waitForLoadState("load");
+
+      const shiftCard = visibleShiftCard(page, sourceShiftId);
+      await expect(shiftCard).toBeVisible({ timeout: 15000 });
+
+      const moveButton = shiftCard.locator(
+        'button[title="Move to different shift"]'
+      );
+      await expect(moveButton).toBeVisible({ timeout: 10000 });
+      await moveButton.click();
+
+      await expect(page.getByRole("dialog")).toBeVisible({ timeout: 10000 });
+      await page.getByRole("combobox").click();
+
+      // The full shift is still offered, flagged rather than hidden
+      const fullOption = page.locator(
+        `[data-testid="move-target-option-${targetShiftId}"]`
+      );
+      await expect(fullOption).toBeVisible({ timeout: 10000 });
+      await expect(fullOption).toContainText("Full");
+      await expect(fullOption).toContainText("No spots left");
+      await fullOption.click();
+
+      // Picking it warns that the move takes the shift over capacity
+      await expect(page.getByTestId("move-over-capacity-notice")).toBeVisible();
+
+      const moveVolunteerButton = page.getByRole("button", {
+        name: "Move Volunteer",
+      });
+      await expect(moveVolunteerButton).toBeEnabled();
+      await moveVolunteerButton.click();
+
+      await page.waitForTimeout(3000);
+
+      // The move goes through and the shift is now over capacity
+      await page.goto(`/admin/shifts?date=${tomorrowStr}&location=Wellington`);
+      await page.waitForLoadState("load");
+
+      const movedToCard = visibleShiftCard(page, targetShiftId);
+      await expect(movedToCard).toBeVisible({ timeout: 15000 });
+      await expect(movedToCard.getByText("Test User")).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(movedToCard.getByText("3/2")).toBeVisible({
+        timeout: 10000,
+      });
+    });
+
     test("volunteer now appears in target shift", async ({ page }) => {
       // Move volunteer to target shift for this test
       await deleteSignupsByShiftIds(page, [sourceShiftId, targetShiftId]);

--- a/web/tests/e2e/volunteer-movement.spec.ts
+++ b/web/tests/e2e/volunteer-movement.spec.ts
@@ -202,9 +202,7 @@ test.describe("General Volunteer Movement System", () => {
       await expect(moveButton).toBeVisible({ timeout: 10000 });
       await moveButton.click();
 
-      await expect(page.getByText("to Different Shift")).toBeVisible({
-        timeout: 10000,
-      });
+      await expect(page.getByRole("dialog")).toBeVisible({ timeout: 10000 });
 
       await page.getByRole("combobox").click();
 
@@ -268,10 +266,8 @@ test.describe("General Volunteer Movement System", () => {
       await moveButton.click();
 
       // Dialog should open
-      await expect(page.getByText("to Different Shift")).toBeVisible({
-        timeout: 10000,
-      });
-      await expect(page.getByText("Move this volunteer from")).toBeVisible();
+      await expect(page.getByRole("dialog")).toBeVisible({ timeout: 10000 });
+      await expect(page.getByText("Currently on")).toBeVisible();
 
       // Open the target-shift dropdown
       const dropdown = page.getByRole("combobox");


### PR DESCRIPTION
# Pull Request

## Description

Admins could only move a volunteer to a shift that still had a free spot. Full shifts were filtered out of the target picker and rejected by the API, which made moves effectively one-way - once someone else took the vacated spot, the volunteer could not be moved back to where they came from.

Capacity is now shown rather than enforced on this action, the same posture as confirming a waitlisted volunteer over capacity:

- `GET /api/admin/shifts/available` returns every shift for the day/location with its counts, instead of dropping the full ones.
- `POST /api/admin/volunteer-movement` no longer rejects a full target shift. The one-shift-per-day and duplicate-signup guards are unchanged.
- Full targets stay clearly marked: an amber **Full** badge on the option, a `No spots left` / `N over capacity` meta line, and an inline warning once a full target is selected. Shifts with room sort above full ones; backup choices sort above both.

While in there, the move dialog itself was tidied. It was duplicated between the confirmed and pending action rows and cramped on mobile (long title wrapping to two lines, centred text, a dead disabled primary button in the empty state):

- One shared `MoveVolunteerDialog` replaces two near-identical copies.
- Shorter title (`Move Lily Thompson`) that fits one line on a phone; the shift/day context moved into the description; header left-aligned.
- Real empty state panel, and the disabled "Move Volunteer" button is replaced by a single "Close" when there is nothing to move to.
- Consistent labels ("Move to", "Notes (optional)") and spacing between both entry points.
- Per-signup field ids, replacing a duplicate `id="targetShift"` that repeated on every volunteer row on the page.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Code refactoring (no functional changes)

## Version Bump Required

`version:minor`

## Testing

- [x] Unit tests pass
- [x] E2E tests pass
- [x] Manual testing completed
- [ ] New tests added (if applicable)

Verified against the dev server with a seeded scenario (Wellington, one source shift plus a target shift already at 2/2): the full shift now appears in the picker with the Full badge, the over-capacity warning renders on selection, and the move succeeds - the target shift ends up at `3/2`. Checked in light and dark mode, and at 375px.

`volunteer-movement.spec.ts` (8) and `backup-shift-signup.spec.ts` (7) all pass, plus `npm run typecheck` and `npm run lint`. Two assertions in those specs referenced the old dialog copy (`"to Different Shift"`, `"Select Target Shift"`) and were updated to match the new wording.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The reason for showing full shifts rather than hiding them is recorded in a comment on `MoveTargetOptions` - hiding them is what made moves one-way, so it is worth keeping visible to whoever touches this next.

Worth a reviewer's opinion: the move now has no capacity ceiling at all. If the team would rather have a hard stop somewhere (say, a confirm step past N over capacity), that is easy to add on top - the warning component is already wired to the selected target.
