### PR TITLE
fix: stop React hydration mismatches and recover from global errors

### DIFF
--- a/web/src/app/global-error.tsx
+++ b/web/src/app/global-error.tsx
@@ -1,21 +1,37 @@
 "use client";
 
 import posthog from "posthog-js";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { claimGlobalErrorAutoReload } from "@/lib/global-error-recovery";
 
 export default function GlobalError({
   error,
-  reset,
 }: {
   error: Error & { digest?: string };
-  reset: () => void;
 }) {
+  const [reloading, setReloading] = useState(false);
+
   useEffect(() => {
     posthog.captureException(error, {
       digest: error.digest,
       scope: "global-error",
     });
   }, [error]);
+
+  // A global error tears down the whole React root, so Next's `reset()` can only
+  // re-render the same root in the same JS context — useless for crashes rooted
+  // in module-level React state, which just throw again straight away and trap
+  // the volunteer here. Reload the document instead; see
+  // `@/lib/global-error-recovery` for why this is capped at once per session.
+  useEffect(() => {
+    if (
+      claimGlobalErrorAutoReload(
+        typeof window === "undefined" ? null : window.sessionStorage
+      )
+    ) {
+      window.location.reload();
+    }
+  }, []);
 
   return (
     <html lang="en">
@@ -35,11 +51,15 @@ export default function GlobalError({
             Something went wrong
           </h1>
           <p style={{ color: "#666", marginBottom: "1.5rem" }}>
-            Kia ora — we hit an unexpected error. Please try again.
+            Kia ora — we hit an unexpected error. Reloading usually clears it.
           </p>
           <button
             type="button"
-            onClick={() => reset()}
+            onClick={() => {
+              setReloading(true);
+              window.location.reload();
+            }}
+            disabled={reloading}
             style={{
               display: "inline-block",
               padding: "0.625rem 1.25rem",
@@ -47,11 +67,12 @@ export default function GlobalError({
               background: "#111",
               color: "#fff",
               border: 0,
-              cursor: "pointer",
+              cursor: reloading ? "default" : "pointer",
+              opacity: reloading ? 0.6 : 1,
               font: "inherit",
             }}
           >
-            Try again
+            {reloading ? "Reloading…" : "Reload page"}
           </button>
         </div>
       </body>

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -57,9 +57,17 @@ export const metadata: Metadata = {
   authors: [{ name: "Everybody Eats" }],
   creator: "Everybody Eats",
   publisher: "Everybody Eats",
+  // iOS/WebKit Data Detectors rewrite the DOM before React hydrates, wrapping
+  // anything that looks like a date, time or address in its own <a>. Every shift
+  // page is dense with "Tuesday 25 August 2026" and "5:30 PM to 9:00 PM", so this
+  // injects elements React never rendered — an element-level React #418
+  // hydration mismatch, which is why iOS fails several times more often than
+  // Chrome on desktop. Volunteers get dates via the calendar export instead.
   formatDetection: {
     email: false,
     telephone: false,
+    date: false,
+    address: false,
   },
   icons: {
     icon: [{ url: "/favicon.png", type: "image/png" }],

--- a/web/src/components/dashboard-next-shift.tsx
+++ b/web/src/components/dashboard-next-shift.tsx
@@ -125,7 +125,10 @@ export async function DashboardNextShift({ userId }: DashboardNextShiftProps) {
                 )}
               </div>
               <div className="flex flex-col items-end gap-2">
-                <Badge variant="secondary">
+                {/* Relative time can tick over between SSR and hydration ("in
+                    about 2 hours" → "in 1 hour"), which is a hydration
+                    mismatch — keep whichever text the server rendered. */}
+                <Badge variant="secondary" suppressHydrationWarning>
                   {formatDistanceToNow(nextShift.shift.start, {
                     addSuffix: true,
                   })}

--- a/web/src/components/shifts-calendar.tsx
+++ b/web/src/components/shifts-calendar.tsx
@@ -5,11 +5,11 @@ import {
   startOfMonth,
   endOfMonth,
   eachDayOfInterval,
-  isSameDay,
   isSameMonth,
   startOfWeek,
   endOfWeek,
 } from "date-fns";
+import { formatInNZT } from "@/lib/timezone";
 import { useState } from "react";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
@@ -102,10 +102,16 @@ export function ShiftsCalendar({
     return new Date(year, month - 1, 1);
   });
 
-  // Stable references to "now" for the initial render.
-  const nowDate = new Date(serverNow);
-  const todayMidnight = new Date(serverNow);
-  todayMidnight.setHours(0, 0, 0, 0);
+  // Every day comparison below is done on "yyyy-MM-dd" keys resolved in
+  // Pacific/Auckland, never on the viewer's local calendar. A shift instant maps
+  // to a different local day for anyone off NZ time (a 5:30pm NZ shift is the
+  // previous day in UTC), which used to move it into a different grid cell on the
+  // client than on the server — and since a cell with shifts renders a <Link>
+  // while an empty or past one renders a plain <div>, that produced an
+  // element-level React #418 hydration mismatch. NZ keys are identical in every
+  // timezone, so server and client always agree.
+  const todayKey = formatInNZT(new Date(serverNow), "yyyy-MM-dd");
+  const thisMonthKey = todayKey.slice(0, 7);
 
   const monthStart = startOfMonth(currentMonth);
   const monthEnd = endOfMonth(currentMonth);
@@ -132,10 +138,21 @@ export function ShiftsCalendar({
   const getLocationDayShifts = (location: string): DayShifts[] => {
     const locationShifts = shiftsByLocation[location] || [];
 
+    // Bucket each shift by the NZ calendar day it starts on, once, so the grid
+    // lookup below is a key match rather than a per-cell scan.
+    const shiftsByDayKey = new Map<string, ShiftSummary[]>();
+    for (const shift of locationShifts) {
+      const key = formatInNZT(shift.start, "yyyy-MM-dd");
+      const bucket = shiftsByDayKey.get(key);
+      if (bucket) bucket.push(shift);
+      else shiftsByDayKey.set(key, [shift]);
+    }
+
     return calendarDays.map((date) => {
-      const dayShifts = locationShifts.filter((shift) =>
-        isSameDay(shift.start, date)
-      );
+      // Grid cells are built from plain year/month/day components, so their
+      // "yyyy-MM-dd" label is the same in every timezone.
+      const dayKey = format(date, "yyyy-MM-dd");
+      const dayShifts = shiftsByDayKey.get(dayKey) ?? [];
 
       const totalCapacity = dayShifts.reduce((sum, s) => sum + s.capacity, 0);
       const totalConfirmed = dayShifts.reduce(
@@ -254,9 +271,7 @@ export function ShiftsCalendar({
             variant="outline"
             size="sm"
             onClick={previousMonth}
-            disabled={
-              format(currentMonth, "yyyy-MM") <= format(nowDate, "yyyy-MM")
-            }
+            disabled={format(currentMonth, "yyyy-MM") <= thisMonthKey}
             data-testid="calendar-prev-month"
           >
             <ChevronLeft className="h-4 w-4" />
@@ -349,11 +364,11 @@ export function ShiftsCalendar({
                       dayShifts.date,
                       currentMonth
                     );
-                    const today = todayMidnight;
-                    const dayStart = new Date(dayShifts.date);
-                    dayStart.setHours(0, 0, 0, 0);
-                    const isPastDate = dayStart < today;
-                    const isToday = isSameDay(dayShifts.date, today);
+                    // ISO day keys sort lexicographically, so string comparison
+                    // is the same as date comparison — and stays in NZ days.
+                    const dayKey = format(dayShifts.date, "yyyy-MM-dd");
+                    const isPastDate = dayKey < todayKey;
+                    const isToday = dayKey === todayKey;
 
                     const dayContent = (
                       <div
@@ -375,10 +390,7 @@ export function ShiftsCalendar({
                             !isPastDate &&
                             "hover:border-primary/60 shadow-md"
                         )}
-                        data-testid={`calendar-day-${format(
-                          dayShifts.date,
-                          "yyyy-MM-dd"
-                        )}`}
+                        data-testid={`calendar-day-${dayKey}`}
                       >
                         {/* Header with date and today indicator */}
                         <div className="absolute inset-0 sm:top-0 sm:bottom-auto sm:left-0 sm:right-0 sm:relative p-3 sm:h-auto flex items-center justify-center sm:block">
@@ -476,10 +488,9 @@ export function ShiftsCalendar({
                         isCurrentMonth &&
                         !isPastDate ? (
                           <Link
-                            href={`/shifts/details?date=${format(
-                              dayShifts.date,
-                              "yyyy-MM-dd"
-                            )}&location=${encodeURIComponent(location)}`}
+                            href={`/shifts/details?date=${dayKey}&location=${encodeURIComponent(
+                              location
+                            )}`}
                             className="block"
                           >
                             {dayContent}
@@ -524,10 +535,9 @@ export function ShiftsCalendar({
                   )}.`}
             </p>
             <p className="text-sm text-muted-foreground">
-              {format(currentMonth, "yyyy-MM") > format(nowDate, "yyyy-MM")
+              {format(currentMonth, "yyyy-MM") > thisMonthKey
                 ? "Shifts are usually published closer to the date."
-                : format(currentMonth, "yyyy-MM") <
-                  format(nowDate, "yyyy-MM")
+                : format(currentMonth, "yyyy-MM") < thisMonthKey
                 ? "This month has passed. Try viewing current or future months."
                 : "Check back soon for upcoming shifts, or try a different location."}
             </p>

--- a/web/src/lib/global-error-recovery.test.ts
+++ b/web/src/lib/global-error-recovery.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { claimGlobalErrorAutoReload } from "./global-error-recovery";
+
+/** Minimal in-memory stand-in for `sessionStorage`. */
+function makeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, value),
+    size: () => map.size,
+  };
+}
+
+describe("claimGlobalErrorAutoReload", () => {
+  it("grants the first reload of a tab session", () => {
+    expect(claimGlobalErrorAutoReload(makeStorage())).toBe(true);
+  });
+
+  it("refuses a second reload so a crash on every load cannot loop", () => {
+    const storage = makeStorage();
+    expect(claimGlobalErrorAutoReload(storage)).toBe(true);
+    expect(claimGlobalErrorAutoReload(storage)).toBe(false);
+    expect(claimGlobalErrorAutoReload(storage)).toBe(false);
+  });
+
+  it("records the claim before reloading, so the marker survives the reload", () => {
+    const storage = makeStorage();
+    claimGlobalErrorAutoReload(storage);
+    expect(storage.size()).toBe(1);
+  });
+
+  it("refuses when storage is unavailable (server render, no window)", () => {
+    expect(claimGlobalErrorAutoReload(undefined)).toBe(false);
+    expect(claimGlobalErrorAutoReload(null)).toBe(false);
+  });
+
+  it("refuses when storage throws (private mode, blocked cookies)", () => {
+    const blocked = {
+      getItem: () => {
+        throw new Error("SecurityError");
+      },
+      setItem: () => {
+        throw new Error("SecurityError");
+      },
+    };
+    expect(claimGlobalErrorAutoReload(blocked)).toBe(false);
+  });
+
+  it("refuses when a write silently fails, rather than reloading every crash", () => {
+    const readOnly = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+    };
+    expect(claimGlobalErrorAutoReload(readOnly)).toBe(false);
+  });
+});

--- a/web/src/lib/global-error-recovery.ts
+++ b/web/src/lib/global-error-recovery.ts
@@ -1,0 +1,45 @@
+/**
+ * Recovery policy for `app/global-error.tsx`.
+ *
+ * A global error means the whole React root — the App Router included — has
+ * been torn down. Next's `reset()` only re-renders that same root in the same
+ * JS context, so it cannot recover from a crash rooted in module-level React
+ * state. The crash we see in production is exactly that: React's reconciler
+ * value stack gets out of balance, `suspenseHandlerStackCursor.current` ends up
+ * holding a lane number instead of a fiber, and the next `useDeferredValue`
+ * mount inside Next's `<Head>` throws
+ * `TypeError: Cannot create property 'flags' on number`. That state lives in
+ * module scope, so it survives `reset()` and the app crashes again immediately —
+ * leaving the volunteer stuck on the error screen with a button that does
+ * nothing.
+ *
+ * A full document reload is the only reliable recovery. We take it
+ * automatically, but only once per tab session, so an error that reproduces on
+ * every load shows the message instead of reload-looping.
+ */
+const RELOAD_MARKER_KEY = "ee:global-error-reloaded";
+
+type MarkerStorage = Pick<Storage, "getItem" | "setItem">;
+
+/**
+ * Claims the one automatic reload allowed per tab session.
+ *
+ * Returns `true` the first time it is called for a session (and records the
+ * claim), `false` afterwards or when session storage is unavailable — in which
+ * case the error screen's manual reload button is the fallback.
+ */
+export function claimGlobalErrorAutoReload(
+  storage: MarkerStorage | undefined | null
+): boolean {
+  if (!storage) return false;
+
+  try {
+    if (storage.getItem(RELOAD_MARKER_KEY) !== null) return false;
+    storage.setItem(RELOAD_MARKER_KEY, "1");
+    return true;
+  } catch {
+    // Storage blocked (private mode, cookie restrictions). Without a durable
+    // marker we cannot detect a loop, so never auto-reload.
+    return false;
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

Fixes the PostHog issue `TypeError: Cannot create property 'flags' on number` ([error tracking](https://us.posthog.com/project/211852/error_tracking/019fc6a5-81fe-7133-8e3c-75c63463d773)) and, while tracing its trigger, the portal's highest-volume client error — React #418 hydration mismatch.

Two independent problems, one commit each.

### 1. Calendar days were resolved in the viewer's timezone (`d5f8bc3`)

`shifts-calendar.tsx` is a Client Component that bucketed shifts with date-fns `isSameDay` and computed today/past via `setHours(0, 0, 0, 0)` — both in the **viewer's** timezone. A 9am NZ shift is stored as 21:00 UTC the previous day, so anyone off NZ time placed it in a different grid cell than the server did. A cell with shifts renders a `<Link>` while an empty or past one renders a plain `<div>`, so this produced an *element-level* hydration mismatch.

**This was not only a logged error.** Comparing the rendered day links per timezone before the fix:

```
Pacific/Auckland   ["2026-08-14" … "2026-08-19"]   today: 08-11
America/New_York   ["2026-08-13" … "2026-08-18"]   today: 08-10   ← wrong days
```

Overseas volunteers were shown shifts on the wrong date and clicked through to `/shifts/details?date=2026-08-13`, which has no shifts.

Every day comparison now runs on `formatInNZT(…, "yyyy-MM-dd")` keys, which are identical in every timezone. ISO keys sort lexicographically so `<` still works as date comparison. Shifts are bucketed by day key once instead of rescanning the whole list per grid cell.

Also in this commit:
- **iOS Data Detectors** — WebKit wraps anything resembling a date, time or address in its own `<a>` before React hydrates, injecting elements React never rendered. `formatDetection` already disabled `telephone` and `email`; this adds `date` and `address`.
- **`dashboard-next-shift.tsx`** — added the `suppressHydrationWarning` its `formatDistanceToNow` was missing, matching the existing treatment in `users-data-table.tsx:309` and `admin-dashboard-recent-activity.tsx:162`.

### 2. `global-error` trapped users instead of recovering (`f772f3b`)

A global error tears down the whole React root, router included, so Next's `reset()` can only re-render that same root in the same JS context. That cannot recover from a crash rooted in module-level React state — the corrupt state survives, the app throws again immediately, and the volunteer is stuck pressing a button that does nothing. All 36 occurrences of the `flags` crash were captured with `scope: "global-error"`, so every affected user saw the full-page crash screen.

A full document reload is the only reliable recovery, so we now take it automatically. `claimGlobalErrorAutoReload` caps it at one reload per tab session so an error that reproduces on every load shows the message rather than reload-looping.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes

## Version Bump Required
`version:patch`

## Testing
- [x] Unit tests pass — 555 passed / 53 files, including 6 new for `claimGlobalErrorAutoReload`
- [ ] E2E tests pass — see caveat below
- [x] Manual testing completed
- [x] New tests added (if applicable)

**Hydration fix**, with a Playwright probe across timezones against the dev server (which prints the full mismatch diff, unlike minified prod). Before, with the calendar change stashed:

```
clean     Pacific/Auckland  /shifts?location=Glen Innes
MISMATCH  America/New_York  /shifts?location=Glen Innes
MISMATCH  UTC               /shifts?location=Glen Innes
```

After: `TOTAL mismatch reports: 0`. And all four timezones tested (NZ, New York, UTC, Kolkata) now return an identical day-link set and the correct "Today".

**Recovery fix**, against a real production build with a forced global error: the reload fires once (`navigation.type === "reload"`), the second crash does *not* reload again, and the screen shows a working "Reload page" button.

**E2E caveat:** `shifts-browse.spec.ts` fails 11/17 locally, but **identically with and without these changes** — I ran the baseline to confirm. It's pre-existing local seed-data gaps (the dev DB has no shifts after 2026-08-05), not a regression. Worth confirming against CI's seeded database.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

### The `flags` crash root cause is upstream in React

Worth knowing, because this PR mitigates the symptom rather than removing the cause. The throwing line is inside React's `requestDeferredLane()`:

```js
lane = suspenseHandlerStackCursor.current;
null !== lane && (lane.flags |= 32);   // ← throws
```

That cursor should hold a fiber or `null`; it holds a lane number (`0`, `536870912`), meaning React's shared render-phase `valueStack`/`index` is out of balance. It surfaces through Next's own `Head` component, which calls `useDeferredValue` on every App Router render — so once the stack is corrupt the page is poisoned and every subsequent client navigation crashes.

Best candidate for the leak: `updateActivityComponent` pushes an Activity suspense handler and then throws a hydration mismatch *before* assigning `workInProgress.memoizedState`, while both `unwindWork` and `unwindInterruptedWork` for tag 31 pop only when `memoizedState !== null`, leaking two entries. Tag 13 (Suspense) pops unconditionally — that asymmetry looks like the bug.

Two things this means for reviewers:
- **Upgrading Next will not fix it.** The reconciler code is byte-identical in the React canaries vendored by next 16.2.12, 16.3.0 and 16.3.1-canary.10.
- **It is only reachable under `cacheComponents: true`**, which makes Next wrap every router segment in a hidden `<Activity>` (`layout-router.js:623`, gated on `__NEXT_CACHE_COMPONENTS`). There is no narrower flag. Turning `cacheComponents` off would eliminate the crash outright — it's used by only two files for `"use cache"` — but it changes prerendering semantics app-wide, so that's a separate decision, not this PR.

Since hydration mismatch is the suspected trigger, the #418 work here should also reduce the crash rate.

### One claim I could not verify on-device

The iOS Data Detectors fix rests on strong circumstantial evidence — iOS-specific skew (Mobile Safari 12.4%, Chrome iOS 17.2% versus 1.6-3.6% for Chrome on desktop), element-level rather than text-level mismatches on iOS (651 vs 36), date-dense pages, and the same mechanism the app already uses for telephone/email. I could **not** confirm it on a device: the iOS Simulator integration is blocked by local Xcode configuration. Worth watching the iOS #418 rate after deploy to confirm.

### Known hydration issues left open

Found by audit, deliberately out of scope:

- `achievements-list-client.tsx:246` — bare `toLocaleDateString()` with no locale or timezone, in a Client Component
- `dashboard/page.tsx:40` — the Mōrena/Kia ora greeting flips at NZ noon and could be baked into a cached shell
- `ui/responsive-dialog.tsx:68` — picks Radix Dialog vs vaul Drawer from `useMediaQuery`; safe only because the hook seeds `false`, but it swaps element types on the commit right after hydration
- `ui/sidebar.tsx:610` — `useState(() => Math.random())` (admin only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
